### PR TITLE
Context bug fix

### DIFF
--- a/core/mem.odin
+++ b/core/mem.odin
@@ -42,6 +42,10 @@ ptr_to_bytes :: proc "contextless" (ptr: ^$T, len := 1) -> []byte {
     return transmute([]byte)raw.Slice{ptr, len*size_of(T)};
 }
 
+any_to_bytes :: proc "contextless" (val: any) -> []byte {
+	return transmute([]byte)raw.Slice{val.data, val.type_info.size};
+}
+
 
 kilobytes :: inline proc "contextless" (x: int) -> int do return          (x) * 1024;
 megabytes :: inline proc "contextless" (x: int) -> int do return kilobytes(x) * 1024;

--- a/core/sys/windows.odin
+++ b/core/sys/windows.odin
@@ -626,6 +626,10 @@ foreign kernel32 {
 	@(link_name="HeapFree")       heap_free        :: proc(h: Handle, flags: u32, memory: rawptr) -> Bool ---;
 	@(link_name="GetProcessHeap") get_process_heap :: proc() -> Handle ---;
 
+	@(link_name="LocalAlloc")     local_alloc      :: proc(flags: u32, bytes: int) -> rawptr ---;
+	@(link_name="LocalReAlloc")   local_realloc    :: proc(mem: rawptr, bytes: int, flags: uint) -> rawptr ---;
+	@(link_name="LocalFree")      local_free       :: proc(mem: rawptr) -> rawptr ---;
+
 	@(link_name="FindFirstChangeNotificationA") find_first_change_notification_a :: proc(path: ^byte, watch_subtree: Bool, filter: u32) -> Handle ---;
 	@(link_name="FindNextChangeNotification")   find_next_change_notification    :: proc(h: Handle) -> Bool ---;
 	@(link_name="FindCloseChangeNotification")  find_close_change_notification   :: proc(h: Handle) -> Bool ---;

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -1650,6 +1650,12 @@ irValue *ir_find_or_generate_context_ptr(irProcedure *proc) {
 	if (proc->context_stack.count > 0) {
 		return proc->context_stack[proc->context_stack.count-1];
 	}
+
+	irBlock *tmp_block = proc->curr_block;
+	proc->curr_block = proc->blocks[0];
+
+	defer (proc->curr_block = tmp_block);
+	
 	irValue *c = ir_add_local_generated(proc, t_context);
 	array_add(&proc->context_stack, c);
 	ir_emit_store(proc, c, ir_emit_load(proc, proc->module->global_default_context));


### PR DESCRIPTION
fixed the uninitialized context bug, added bindings for `LocalAlloc` et al, and added `any_to_bytes`

not sure why the diff for `core:sys/windows.odin` is the whole file, it shouldn't be