### PR TITLE
Fixed 'sh: main: command not found' error on linux.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1084,6 +1084,7 @@ int main(int arg_count, char **arg_ptr) {
 		remove_temp_files(output_base);
 
 		if (run_output) {
+			output_base = path_to_full_path(heap_allocator(), output_base);
 			system_exec_command_line_app("odin run", false, "\"%.*s\"", LIT(output_base));
 		}
 	#endif


### PR DESCRIPTION
The error happens because the full path to executable is resolved before the executable is generated.
This works on windows as the `GetFullPathName` function doesn't check if the actual file exists, while ealpath` relies on the file existing.