### PR TITLE
[WIP] Provide llvm with more debug info (for Visual Studio debugger support)

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -573,10 +573,23 @@ void init_build_context(void) {
 
 	bc->optimization_level = gb_clamp(bc->optimization_level, 0, 3);
 
-	gbString opt_flags = gb_string_make_reserve(heap_allocator(), 16);
+	gbString opt_flags = gb_string_make_reserve(heap_allocator(), 64);
+	opt_flags = gb_string_append_fmt(opt_flags, "-O%d ", bc->optimization_level);
 	if (bc->optimization_level != 0) {
-		opt_flags = gb_string_append_fmt(opt_flags, "-O%d", bc->optimization_level);
+		// NOTE(lachsinc): The following options were previously passed during call
+		// to opt in main.cpp:exec_llvm_opt().
+		//   -die:       Dead instruction elimination
+		//   -memcpyopt: MemCpy optimization
+		opt_flags = gb_string_appendc(opt_flags, "-memcpyopt -die ");
 	}
+
+	// NOTE(lachsinc): This optimization option was previously required to get
+	// around an issue in fmt.odin. Thank bp for tracking it down! Leaving for now until the issue
+	// is resolved and confirmed by Bill. Maybe it should be readded in non-debug builds.
+	// if (bc->ODIN_DEBUG == false) {
+	// 	opt_flags = gb_string_appendc(opt_flags, "-mem2reg ");
+	// }
+
 	bc->opt_flags = make_string_c(opt_flags);
 
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -28,7 +28,6 @@ struct irModule {
 	irDebugInfo *         debug_compile_unit;
 	irDebugInfo *         debug_all_enums;   // TODO(lachsinc): Move into irDebugInfo_CompileUnit
 	irDebugInfo *         debug_all_globals; // TODO(lachsinc): Move into irDebugInfo_CompileUnit
-	irDebugInfo *         curr_debug_loc;    // TODO(lachsinc): Temporary, remove me.
 	Array<irDebugInfo *>  debug_location_stack; 
 
 
@@ -599,7 +598,6 @@ struct irDebugInfo {
 		struct {
 			irDebugEncoding      tag;
 			String               name;
-			String               identifier; // TODO(lachsinc): Unused?
 			irDebugInfo *        scope;
 			irDebugInfo *        file;
 			TokenPos             pos;
@@ -624,7 +622,6 @@ struct irDebugInfo {
 			TokenPos     pos;
 			irDebugInfo *type;
 			irValue     *variable;
-			// irDebugInfo *declaration;
 		} GlobalVariable;
 		struct {
 			String       name;
@@ -1612,6 +1609,7 @@ irDebugEncoding ir_debug_encoding_for_basic(BasicKind kind) {
 	case Basic_i64: 
 	case Basic_int:
 	case Basic_rune: // TODO(lachsinc) signed or unsigned?
+	case Basic_typeid:
 		return irDebugBasicEncoding_signed;
 
 	case Basic_u16:
@@ -1619,7 +1617,6 @@ irDebugEncoding ir_debug_encoding_for_basic(BasicKind kind) {
 	case Basic_u64:
 	case Basic_uint:
 	case Basic_uintptr: // TODO(lachsinc) unsigned or address?
-	case Basic_typeid:  // TODO(lachsinc) underlying type?
 		return irDebugBasicEncoding_unsigned;
 
 	// case Basic_f16:

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -577,7 +577,7 @@ struct irDebugInfo {
 		} Proc;
 		struct {
 			Array<irDebugInfo *> procs;
-		} AllProcs; // TODO(lach): Redundant w/ DebugInfoArray. Merge.
+		} AllProcs; // TODO(lachsinc): Redundant w/ DebugInfoArray. Merge.
 
 		// NOTE(lachsinc): Many of the following fields could be removed/resolved as we print it?
 		struct {
@@ -613,7 +613,7 @@ struct irDebugInfo {
 			i32                  size;
 			i32                  align;
 			irDebugInfo *        elements;
-			i32                  array_count; // TODO(lach): We could define a new !DISubrange and place ptr to it inside above elements array instead.
+			i32                  array_count; // for DISubrange
 		} CompositeType;
 		struct {
 			String name;
@@ -1680,16 +1680,13 @@ irDebugInfo *ir_add_debug_info_enumerator(irModule *module, Entity *e) {
 }
 
 irDebugInfo *ir_add_debug_info_dynamic_array(irModule *module, irDebugInfo *scope, Entity *e, Type *type, irDebugInfo *file) {
-	//
-	// TODO(lachsinc): Hardcode McGee.
-	//
+	// TODO(lachsinc): Cleanup hardcode.
 
 	// TODO(lachsinc): SPEED? I assume this will create a bunch of new debug infos for _every single_
 	// dynamic array type. Maybe that's what we want, but with ability to refer to the _same_
 	// derived types for the len/cap/allocator fields.
 
-	// TODO(lachsinc): HACK we should handle named's as derived types to
-	// minimise duplication of work / ir output
+	// TODO(lachsinc): HACK named should be handled as derived types, see above.
 	Type *named = nullptr;
 	if (is_type_named(type)) {
 		named = type;
@@ -1754,7 +1751,7 @@ irDebugInfo *ir_add_debug_info_dynamic_array(irModule *module, irDebugInfo *scop
 		array_add(&di->CompositeType.elements->DebugInfoArray.elements, cap_di);
 		array_add(&di->CompositeType.elements->DebugInfoArray.elements, alloc_di);
 
-		// NOTE(lach): This isn't particularly robust; we create a new one for every type. A potential workaround
+		// NOTE(lachsinc): This isn't particularly robust; we create a new one for every type. A potential workaround
 		// is to store a pointer for each of these "custom" types inside irModule, creating if not exists
 		// (and either adding to debug_info map, or assigning id's manually to them).
 		map_set(&module->debug_info, hash_pointer(data_ptr_di), data_ptr_di);
@@ -1770,11 +1767,7 @@ irDebugInfo *ir_add_debug_info_dynamic_array(irModule *module, irDebugInfo *scop
 }
 
 irDebugInfo *ir_add_debug_info_string(irModule *module, irDebugInfo *scope, Entity *e, Type *type, irDebugInfo *file) {
-	// TODO(lach): Is there a cleaner way to set up these types without hardcoding values ??
-	// Also we may want to just create hardcoded "base type" for things like strings etc.
-	// and just create a derived (named) type to "inherit" from. That way we can look them up directly
-	// inside irModule, and avoid lots of map lookups and array creations for their elements.
-	// In theory this should only occur once, as we hash the type t_string once and return it.
+	// TODO(lachsinc): Cleanup hardcode.
 
 	GB_ASSERT(type->kind == Type_Basic);
 	GB_ASSERT(type->Basic.kind == Basic_string);
@@ -1803,7 +1796,7 @@ irDebugInfo *ir_add_debug_info_string(irModule *module, irDebugInfo *scope, Enti
 	array_add(&di->CompositeType.elements->DebugInfoArray.elements, data_di);
 	array_add(&di->CompositeType.elements->DebugInfoArray.elements, len_di);
 
-	// NOTE(lach): This isn't particularly robust, it assumes all strings will be caught
+	// NOTE(lachsinc): This isn't particularly robust, it assumes all strings will be caught
 	// by the map lookup (ie this will only be created once).
 	map_set(&module->debug_info, hash_pointer(data_di), data_di);
 	map_set(&module->debug_info, hash_pointer(len_di), len_di);
@@ -2062,7 +2055,7 @@ irDebugInfo *ir_add_debug_info_proc(irProcedure *proc, Entity *entity, String na
 			if (e->kind != Entity_Variable) {
 				continue; // TODO(lachsinc): Confirm correct?
 			}
-			// TODO(lach): Could technically be a local?
+			// TODO(lachsinc): Could technically be a local?
 			irDebugInfo *type_di = ir_add_debug_info_type(proc->module, di, e, e->type, file);
 			GB_ASSERT_NOT_NULL(type_di);
 			array_add(&di->Proc.types->DebugInfoArray.elements, type_di);

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -1432,13 +1432,11 @@ irValue *ir_add_local(irProcedure *proc, Entity *e, Ast *expr, bool zero_initial
 
 	if (expr != nullptr && proc->entity != nullptr) {	
 		GB_ASSERT_NOT_NULL(proc->debug_scope);
-		ir_push_debug_location(proc->module, expr, proc->debug_scope);
-
+		
 		ir_emit(proc, ir_instr_debug_declare(proc, expr, e, true, instr));
 
 		// TODO(lachsinc): "Arg" is not used yet but should be eventually, if applicable, set to param index.
 		ir_add_debug_info_local(proc, e, 0);
-		ir_pop_debug_location(proc->module);
 	}
 
 	return instr;

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -2368,21 +2368,6 @@ irDebugInfo *ir_add_debug_info_type(irModule *module, Type *type, Entity *e, irD
 
 	GB_PANIC("Unreachable");
 	return nullptr;
-
-	//
-	// TODO(lachsinc): HACK For now any remaining types interpreted as a rawptr.
-	//
-	// {
-	// 	irDebugInfo *di = ir_alloc_debug_info(irDebugInfo_BasicType);
-	// 	di->BasicType.align = ir_debug_align_bits(type);
-	// 	di->BasicType.encoding = irDebugBasicEncoding_address;
-	// 	di->BasicType.name = str_lit("type_todo");
-	// 	di->BasicType.size = ir_debug_size_bits(type);
-
-	// 	map_set(&module->debug_info, hash_type(type), di);
-
-	// 	return di;
-	// }
 }
 
 irDebugInfo *ir_add_debug_info_global(irModule *module, irValue *v) {

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -2067,19 +2067,21 @@ void print_llvm_ir(irGen *ir) {
 				} else {
 					ir_fprintf(f, "!DICompositeType("
 					              "name: \"%.*s\""
-					            ", scope: !%d"
-					            ", file: !%d"
-					            ", line: %td"
 					            ", size: %d"
 					            ", align: %d"
 					            ", tag: ",
 					            LIT(di->CompositeType.name),
-					            di->CompositeType.scope->id,
-					            di->CompositeType.file->id,
-					            di->CompositeType.pos.line,
 					            di->CompositeType.size,
 					            di->CompositeType.align);
 					ir_print_debug_encoding(f, irDebugInfo_CompositeType, di->CompositeType.tag);
+					if (di->CompositeType.scope) {
+						ir_fprintf(f, ", scope: !%d"
+						              ", file: !%d"
+						              ", line: %td",
+						              di->CompositeType.scope->id,
+						              di->CompositeType.file->id,
+						              di->CompositeType.pos.line);
+					}
 					if (di->CompositeType.base_type) {
 						GB_ASSERT(di->CompositeType.tag == irDebugBasicEncoding_enumeration_type);
 						ir_fprintf(f, ", baseType: !%d", di->CompositeType.base_type->id);

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -2147,16 +2147,6 @@ void print_llvm_ir(irGen *ir) {
 				            di->Enumerator.value);
 				break;
 			}
-			// TODO(lachsinc): Merge w/ DebugInfoArray
-			case irDebugInfo_AllProcs:
-				ir_fprintf(f, "!{");
-				for_array(proc_index, di->AllProcs.procs) {
-					irDebugInfo *p = di->AllProcs.procs[proc_index];
-					if (proc_index > 0) {ir_fprintf(f, ",");}
-					ir_fprintf(f, "!%d", p->id);
-				}
-				ir_write_byte(f, '}');
-				break;
 			case irDebugInfo_DebugInfoArray:
 				ir_fprintf(f, "!{");
 				for_array(element_index, di->DebugInfoArray.elements) {

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -1955,7 +1955,7 @@ void print_llvm_ir(irGen *ir) {
 				            ", runtimeVersion: 0"
 				            ", isOptimized: false"
 				            ", emissionKind: FullDebug"
-				            ", retainedTypes: !0"    // TODO(lachsinc)
+				            ", retainedTypes: !0" // TODO(lachsinc)
 				            ", enums: !%d"
 				            ", globals: !%d"
 				            ")",
@@ -1966,7 +1966,6 @@ void print_llvm_ir(irGen *ir) {
 				break;
 			}
 			case irDebugInfo_File:
-				// TODO(lachsinc): Does windows debug info expect '/' or '\5C' path separators ??
 				ir_fprintf(f, "!DIFile(filename: \""); ir_print_escape_path(f, di->File.filename);
 				ir_fprintf(f, "\", directory: \""); ir_print_escape_path(f, di->File.directory);
 				ir_fprintf(f, "\"");
@@ -2004,7 +2003,6 @@ void print_llvm_ir(irGen *ir) {
 				           di->GlobalVariableExpression.var->id);
 				if (di->GlobalVariableExpression.var->GlobalVariable.variable->Global.is_constant) {
 					ir_write_str_lit(f, "DW_OP_constu, ");
-					// TODO(lachsinc): Confirm this prints the type as llvm expects eg. hex representation for float is safe etc.
 					ir_print_value(f, m, di->GlobalVariable.variable, ir_type(di->GlobalVariable.variable));
 					ir_write_str_lit(f, ", DW_OP_stack_value");
 				} else {
@@ -2043,7 +2041,7 @@ void print_llvm_ir(irGen *ir) {
 				            di->LocalVariable.pos.line,
 				            di->LocalVariable.type->id);
 				if (di->LocalVariable.arg > 0) {
-					GB_ASSERT(false); // TODO(lachsinc): "Arg" debug info not implemented yet
+					GB_PANIC("Param 'Arg' debug info not yet implemented"); // TODO(lachsinc):
 					ir_fprintf(f, ", arg: %d", di->LocalVariable.arg);
 				}
 				ir_write_byte(f, ')');
@@ -2127,7 +2125,7 @@ void print_llvm_ir(irGen *ir) {
 			case irDebugInfo_Enumerator: {
 				ir_fprintf(f, "!DIEnumerator("
 				              "name: \"%.*s\""
-				            ", value: %d)", // TODO(lachsinc): PRId64 equiv?
+				            ", value: %lld)",
 				            LIT(di->Enumerator.name),
 				            di->Enumerator.value);
 				break;

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -2058,32 +2058,30 @@ void print_llvm_ir(irGen *ir) {
 				ir_write_byte(f, ')');
 				break;
 			case irDebugInfo_DerivedType:
-				ir_fprintf(f, "!DIDerivedType("
-				              "name: \"%.*s\""
-				            ", size: %d"
-				            ", tag: ",
-				            LIT(di->DerivedType.name),
-				            di->DerivedType.size,
-				            di->DerivedType.align);
+				ir_write_str_lit(f, "!DIDerivedType(tag: ");
 				ir_print_debug_encoding(f, irDebugInfo_DerivedType, di->DerivedType.tag);
+				if (di->DerivedType.name.len > 0) {
+					ir_fprintf(f, ", name: \"%.*s\"", LIT(di->DerivedType.name));
+				}
 				if (di->DerivedType.base_type != nullptr) {
 					ir_fprintf(f, ", baseType: !%d", di->DerivedType.base_type->id);
 				} else {
 					ir_write_str_lit(f, ", baseType: null"); // Valid/required for rawptr
 				}
+				if (di->DerivedType.size > 0) {
+					ir_fprintf(f, ", size: %d", di->DerivedType.size);
+				}
 				if (di->DerivedType.align > 0) {
-					ir_fprintf(f, ", align: %d",
-					           di->DerivedType.align);
+					ir_fprintf(f, ", align: %d", di->DerivedType.align);
 				}
 				if (di->DerivedType.offset > 0) {
-					ir_fprintf(f, ", offset: %d",
-					           di->DerivedType.offset);
+					ir_fprintf(f, ", offset: %d", di->DerivedType.offset);
 				}
 				ir_write_byte(f, ')');
 				break;
 			case irDebugInfo_CompositeType: {
 				if (di->CompositeType.tag == irDebugBasicEncoding_array_type) {
-					GB_ASSERT(di->CompositeType.base_type);
+					GB_ASSERT_NOT_NULL(di->CompositeType.base_type);
 					ir_fprintf(f, "!DICompositeType("
 					              "tag: DW_TAG_array_type"
 					            ", size: %d"
@@ -2106,10 +2104,11 @@ void print_llvm_ir(irGen *ir) {
 					            di->CompositeType.align);
 					ir_print_debug_encoding(f, irDebugInfo_CompositeType, di->CompositeType.tag);
 					if (di->CompositeType.scope != nullptr) {
-						ir_fprintf(f, ", scope: !%d"
-						              ", file: !%d"
+						ir_fprintf(f, ", scope: !%d", di->CompositeType.scope->id);
+					}
+					if (di->CompositeType.file != nullptr) {
+						ir_fprintf(f, ", file: !%d"
 						              ", line: %td",
-						              di->CompositeType.scope->id,
 						              di->CompositeType.file->id,
 						              di->CompositeType.pos.line);
 					}

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -2087,6 +2087,10 @@ void print_llvm_ir(irGen *ir) {
 					GB_ASSERT(di->CompositeType.size > 0);
 				}
 
+				if (di->CompositeType.tag == irDebugBasicEncoding_union_type) {
+					GB_ASSERT_NOT_NULL(di->CompositeType.file); // Union _requires_ file to be valid.
+				}
+
 				ir_write_str_lit(f, "!DICompositeType(tag: ");
 				ir_print_debug_encoding(f, irDebugInfo_CompositeType, di->CompositeType.tag);
 				if (di->CompositeType.name.len > 0) {

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -2058,7 +2058,11 @@ void print_llvm_ir(irGen *ir) {
 				ir_print_debug_encoding(f, irDebugInfo_BasicType, di->BasicType.encoding);
 				ir_write_byte(f, ')');
 				break;
-			case irDebugInfo_DerivedType:
+			case irDebugInfo_DerivedType: {
+				if (di->DerivedType.tag == irDebugBasicEncoding_member) {
+					// NOTE(lachsinc): We crash llvm super hard if we don't specify a name :)
+					GB_ASSERT(di->DerivedType.name.len > 0);
+				}
 				ir_write_str_lit(f, "!DIDerivedType(tag: ");
 				ir_print_debug_encoding(f, irDebugInfo_DerivedType, di->DerivedType.tag);
 				if (di->DerivedType.name.len > 0) {
@@ -2072,8 +2076,13 @@ void print_llvm_ir(irGen *ir) {
 				if (di->DerivedType.size > 0)   ir_fprintf(f, ", size: %d", di->DerivedType.size);
 				if (di->DerivedType.align > 0)  ir_fprintf(f, ", align: %d", di->DerivedType.align);
 				if (di->DerivedType.offset > 0) ir_fprintf(f, ", offset: %d", di->DerivedType.offset);
+				if (di->DerivedType.flags > 0) {
+					// TODO(lachsinc): Handle in a more generic manner.
+					if (di->DerivedType.flags & irDebugInfoFlag_Bitfield) ir_write_str_lit(f, ", flags: DIFlagBitField, extraData: i64 0");
+				}
 				ir_write_byte(f, ')');
 				break;
+			}
 			case irDebugInfo_CompositeType: {
 				if (di->CompositeType.tag == irDebugBasicEncoding_array_type) {
 					GB_ASSERT_NOT_NULL(di->CompositeType.base_type);

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -1951,31 +1951,36 @@ void print_llvm_ir(irGen *ir) {
 				            ", globals: !0"
 				            ")",
 				            file->id, LIT(build_context.ODIN_VERSION));
-
 				break;
 			}
 			case irDebugInfo_File:
+				// TODO(lachsinc): Does windows debug info expect '/' or '\5C' path separators ??
 				ir_fprintf(f, "!DIFile(filename: \""); ir_print_escape_path(f, di->File.filename);
 				ir_fprintf(f, "\", directory: \""); ir_print_escape_path(f, di->File.directory);
 				ir_fprintf(f, "\"");
 				ir_fprintf(f, ")");
 				break;
 			case irDebugInfo_Proc:
+				// TODO(lach): We need to store scope info inside di, not just file info, for procs.
 				ir_fprintf(f, "distinct !DISubprogram("
 				              "name: \"%.*s\""
 				            ", linkageName: \"%.*s\""
+				            ", scope: !%d"
 				            ", file: !%d"
 				            ", line: %td"
+				            ", scopeLine: %td"
 				            ", isDefinition: true"
-				            ", isLocal: true"
+				            ", isLocal: false" // TODO(lach): This used to be always set to true, pretend no local for now. We need to check if scope == file.
 				            ", flags: DIFlagPrototyped"
 				            ", isOptimized: false"
 				            ", unit: !%d"
 				            ", type: !DISubroutineType(types: !{",
 				            LIT(di->Proc.entity->token.string),
 				            LIT(di->Proc.name),
+				            di->Proc.file->id, // TODO(lachsinc): HACK For now lets pretend all procs scope's == file.
 				            di->Proc.file->id,
 				            di->Proc.pos.line,
+				            di->Proc.pos.line, // NOTE(lachsinc): Assume scopeLine always same as line.
 				            m->debug_compile_unit->id);
 				if (di->Proc.return_types.count == 0) {
 					ir_fprintf(f, "null})");

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -1943,7 +1943,6 @@ void print_llvm_ir(irGen *ir) {
 				              "language: DW_LANG_C_plus_plus" // Is this good enough?
 				            ", file: !%d"
 				            ", producer: \"Odin %.*s\""
-				            // ", flags: \"\"" // TODO(lachsinc): Removed for now, check if correct
 				            ", runtimeVersion: 0"
 				            ", isOptimized: false"
 				            ", emissionKind: FullDebug"
@@ -1973,7 +1972,7 @@ void print_llvm_ir(irGen *ir) {
 				            ", line: %td"
 				            ", scopeLine: %td"
 				            ", isDefinition: true"
-				            ", isLocal: false" // TODO(lachsinc): This used to be always set to true, pretend no local for now. We need to check if scope == file.
+				            ", isLocal: false" // TODO(lachsinc): Is this fine?
 				            ", flags: DIFlagPrototyped"
 				            ", isOptimized: false"
 				            ", unit: !%d"
@@ -1990,9 +1989,6 @@ void print_llvm_ir(irGen *ir) {
 				break;
 			case irDebugInfo_Location: {
 				GB_ASSERT_NOT_NULL(di->Location.scope);
-				// TODO(lachsinc): Temporary.
-				GB_ASSERT(di->Location.pos.line >= 0 && di->Location.pos.line < 65536);
-				GB_ASSERT(di->Location.pos.column >= 0 && di->Location.pos.column < 65536);
 				ir_fprintf(f, "!DILocation("
 				              "line: %td"
 				            ", column: %td"
@@ -2024,8 +2020,8 @@ void print_llvm_ir(irGen *ir) {
 				            ", file: !%d"
 				            ", line: %d"
 				            ", type: !%d"
-				            ", isLocal: true"        // TODO(lachsinc): Check is_foreign ??
-				            ", isDefinition: true)", // TODO(lachsinc): Check is_foreign ??
+				            ", isLocal: true"        // TODO(lachsinc): Check locality ??
+				            ", isDefinition: true)", // TODO(lachsinc): ??
 				            LIT(di->GlobalVariable.name),
 				            di->GlobalVariable.scope->id,
 				            di->GlobalVariable.file->id,
@@ -2046,7 +2042,7 @@ void print_llvm_ir(irGen *ir) {
 				            di->LocalVariable.pos.line,
 				            di->LocalVariable.type->id);
 				if (di->LocalVariable.arg > 0) {
-					GB_PANIC("Param 'Arg' debug info not yet implemented"); // TODO(lachsinc):
+					GB_PANIC("Param 'Arg' debug info not yet implemented"); // TODO(lachsinc): Proper param index support.
 					ir_fprintf(f, ", arg: %d", di->LocalVariable.arg);
 				}
 				ir_write_byte(f, ')');

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -2074,6 +2074,15 @@ void print_llvm_ir(irGen *ir) {
 				ir_write_byte(f, ')');
 				break;
 			}
+			case irDebugInfo_Enumerator: {
+				ir_fprintf(f, "!DIEnumerator("
+				              "name: \"%.*s\""
+				            ", value: %d", // TODO(lachsinc): PRId64 equiv?
+				            LIT(di->Enumerator.name),
+				            di->Enumerator.value);
+				ir_write_byte(f, ')');
+				break;
+			}
 			case irDebugInfo_AllProcs:
 				ir_fprintf(f, "!{");
 				for_array(proc_index, di->AllProcs.procs) {

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -2055,7 +2055,6 @@ void print_llvm_ir(irGen *ir) {
 				            di->LocalVariable.pos.line,
 				            di->LocalVariable.type->id);
 				if (di->LocalVariable.arg > 0) {
-					GB_PANIC("Param 'Arg' debug info not yet implemented"); // TODO(lachsinc): Proper param index support.
 					ir_fprintf(f, ", arg: %d", di->LocalVariable.arg);
 				}
 				ir_write_byte(f, ')');

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -212,31 +212,38 @@ void ir_print_encoded_global(irFileBuffer *f, String name, bool remove_prefix) {
 }
 
 
-bool ir_print_debug_location(irFileBuffer *f, irModule *m, irValue *v, irProcedure *proc = nullptr) {
-#if 1
-	if (m->generate_debug_info && v != nullptr) {
-		TokenPos pos = v->loc.pos;
-		irDebugInfo *scope = v->loc.debug_scope;
-		i32 id = 0;
-		if (scope != nullptr) {
-			id = scope->id;
-		} else if (proc != nullptr) {
-			if (proc->debug_scope != nullptr) {
-				id = proc->debug_scope->id;
-				pos = proc->entity->token.pos;
+bool ir_print_debug_location(irFileBuffer *f, irModule *m, irValue *v) {
+	if (!m->generate_debug_info) {
+		return false;
+	}
+
+	GB_ASSERT_NOT_NULL(v);
+
+	if (v->loc) {
+		// Update curr_debug_loc
+		m->curr_debug_loc = v->loc;
+	}
+	if (m->curr_debug_loc != nullptr) {
+		GB_ASSERT(m->curr_debug_loc->kind == irDebugInfo_Location);
+		ir_fprintf(f, ", !dbg !%d", m->curr_debug_loc->id);
+		return true;
+	}
+	// TODO(lachsinc): HACK HACK HACK
+	// For now, since inlinable call instructions _require_ a valid !dbg attachment. If there is no valid
+	// we just set to first line of the containing procedure (like before). This is not great,
+	// and continues to exhibit bad stepping behabiour, but now should occur much less often
+	// thanks to above. The proper fix is to, in ir.cpp, set valid loc for all irValues that require
+	// it.
+	if (v->kind == irValue_Instr) {
+		if (v->Instr.kind == irInstr_Call) {
+			if (v->Instr.Call.inlining == ProcInlining_no_inline) {
+				return false;
 			}
-		}
-		if (id > 0 && pos.line > 0) {
-			ir_fprintf(f, ", !dbg !DILocation(line: %td, column: %td, scope: !%d)", pos.line, pos.column, id);
-			return true;
+			GB_PANIC("Inlinable 'call' instructions in a debuggable proc must have !dbg metadata attachment");
 		}
 	}
 	return false;
-#else
-	return true;
-#endif
 }
-
 
 void ir_print_type(irFileBuffer *f, irModule *m, Type *t, bool in_struct = false);
 void ir_print_value(irFileBuffer *f, irModule *m, irValue *value, Type *type_hint);
@@ -1516,7 +1523,7 @@ void ir_print_instr(irFileBuffer *f, irModule *m, irValue *value) {
 		case ProcInlining_inline:    ir_write_str_lit(f, " alwaysinline"); break;
 		case ProcInlining_no_inline: ir_write_str_lit(f, " noinline");     break;
 		}
-		ir_print_debug_location(f, m, value, instr->block->proc);
+		ir_print_debug_location(f, m, value);
 
 		break;
 	}

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -1982,16 +1982,21 @@ void print_llvm_ir(irGen *ir) {
 				            di->Proc.pos.line,
 				            di->Proc.pos.line, // NOTE(lachsinc): Assume scopeLine always same as line.
 				            m->debug_compile_unit->id);
-				if (di->Proc.return_types.count == 0) {
-					ir_fprintf(f, "null})");
-				} else {
-					for_array(return_type_index, di->Proc.return_types) {
-						ir_fprintf(f, "%s!%d",
-						           return_type_index > 0 ? ", " : "",
-						           di->Proc.return_types[return_type_index]->id);
+				if (di->Proc.types.count > 0) {
+					for_array(type_index, di->Proc.types) {
+						if (type_index > 0) {
+							ir_write_byte(f, ',');
+						}
+						if (di->Proc.types[type_index]) {
+							ir_fprintf(f, "!%d", di->Proc.types[type_index]->id);
+						} else {
+							ir_write_str_lit(f, "null");
+						}
 					}
-					ir_write_str_lit(f, "})");
+				} else {
+					ir_write_str_lit(f, "null");
 				}
+				ir_write_str_lit(f, "})"); // !DISubroutineTypes close
 				ir_write_byte(f, ')');
 				break;
 			case irDebugInfo_LocalVariable: {

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -2044,16 +2044,17 @@ void print_llvm_ir(irGen *ir) {
 			}
 			case irDebugInfo_LocalVariable: {
 				ir_fprintf(f, "!DILocalVariable("
-				              "name: \"%.*s\""
-				            ", scope: !%d"
+				              "scope: !%d"
 				            ", file: !%d"
 				            ", line: %d"
 				            ", type: !%d",
-				            LIT(di->LocalVariable.name),
 				            di->LocalVariable.scope->id,
 				            di->LocalVariable.file->id,
 				            di->LocalVariable.pos.line,
 				            di->LocalVariable.type->id);
+				if (di->DerivedType.name.len > 0) {
+					ir_fprintf(f, ", name: \"%.*s\"", LIT(di->LocalVariable.name));
+				}
 				if (di->LocalVariable.arg > 0) {
 					ir_fprintf(f, ", arg: %d", di->LocalVariable.arg);
 				}

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -1964,6 +1964,7 @@ void print_llvm_ir(irGen *ir) {
 				break;
 			case irDebugInfo_Proc:
 				// TODO(lachsinc): We need to store scope info inside di, not just file info, for procs.
+				// Should all subprograms have distinct ??
 				ir_fprintf(f, "distinct !DISubprogram("
 				              "name: \"%.*s\""
 				            ", linkageName: \"%.*s\""
@@ -1976,7 +1977,7 @@ void print_llvm_ir(irGen *ir) {
 				            ", flags: DIFlagPrototyped"
 				            ", isOptimized: false"
 				            ", unit: !%d"
-				            ", type: !DISubroutineType(types: !%d)",
+				            ", type: !%d",
 				            LIT(di->Proc.entity->token.string),
 				            LIT(di->Proc.name),
 				            di->Proc.file->id, // TODO(lachsinc): HACK For now lets pretend all procs scope's == file.
@@ -1984,8 +1985,12 @@ void print_llvm_ir(irGen *ir) {
 				            di->Proc.pos.line,
 				            di->Proc.pos.line, // NOTE(lachsinc): Assume scopeLine always same as line.
 				            m->debug_compile_unit->id,
-							di->Proc.types->id);
+							di->Proc.type->id);
 				ir_write_byte(f, ')'); // !DISubprogram(
+				break;
+			case irDebugInfo_ProcType:
+				ir_fprintf(f, "!DISubroutineType(types: !%d)",
+				            di->ProcType.types->id);
 				break;
 			case irDebugInfo_Location:
 				GB_ASSERT_NOT_NULL(di->Location.scope);

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -1550,7 +1550,6 @@ void ir_print_instr(irFileBuffer *f, irModule *m, irValue *value) {
 
 		irInstrDebugDeclare *dd = &instr->DebugDeclare;
 		Type *vt = ir_type(dd->value);
-		irDebugInfo *di = dd->scope;
 		Entity *e = dd->entity;
 		String name = e->token.string;
 		TokenPos pos = e->token.pos;
@@ -1565,8 +1564,8 @@ void ir_print_instr(irFileBuffer *f, irModule *m, irValue *value) {
 		ir_write_byte(f, ' ');
 		ir_print_value(f, m, dd->value, vt);
 		ir_fprintf(f, ", metadata !%d", local_var_di->id);
-		ir_write_str_lit(f, ", metadata !DIExpression())"); 
-		ir_fprintf(f, ", !dbg !DILocation(line: %td, column: %td, scope: !%d)", pos.line, pos.column, di->id);
+		ir_write_str_lit(f, ", metadata !DIExpression())");
+		ir_print_debug_location(f, m, value);
 		break;
 	}
 	}

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -1987,7 +1987,7 @@ void print_llvm_ir(irGen *ir) {
 							di->Proc.types->id);
 				ir_write_byte(f, ')'); // !DISubprogram(
 				break;
-			case irDebugInfo_Location: {
+			case irDebugInfo_Location:
 				GB_ASSERT_NOT_NULL(di->Location.scope);
 				ir_fprintf(f, "!DILocation("
 				              "line: %td"
@@ -1996,7 +1996,20 @@ void print_llvm_ir(irGen *ir) {
 				            di->Location.pos.line,
 				            di->Location.pos.column,
 				            di->Location.scope->id);
-				break;}
+				break;
+			case irDebugInfo_LexicalBlock:
+				GB_ASSERT_NOT_NULL(di->LexicalBlock.file);
+				GB_ASSERT_NOT_NULL(di->LexicalBlock.scope);
+				ir_fprintf(f, "distinct !DILexicalBlock("
+				              "line: %td"
+				            ", column: %td"
+				            ", file: !%d"
+				            ", scope: !%d)",
+				            di->LexicalBlock.pos.line,
+				            di->LexicalBlock.pos.column,
+				            di->LexicalBlock.file->id,
+				            di->LexicalBlock.scope->id);
+				break;
 			case irDebugInfo_GlobalVariableExpression: {
 				ir_fprintf(f, "!DIGlobalVariableExpression("
 				              "var: !%d"

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -2073,15 +2073,9 @@ void print_llvm_ir(irGen *ir) {
 				} else {
 					ir_write_str_lit(f, ", baseType: null"); // Valid/required for rawptr
 				}
-				if (di->DerivedType.size > 0) {
-					ir_fprintf(f, ", size: %d", di->DerivedType.size);
-				}
-				if (di->DerivedType.align > 0) {
-					ir_fprintf(f, ", align: %d", di->DerivedType.align);
-				}
-				if (di->DerivedType.offset > 0) {
-					ir_fprintf(f, ", offset: %d", di->DerivedType.offset);
-				}
+				if (di->DerivedType.size > 0)   ir_fprintf(f, ", size: %d", di->DerivedType.size);
+				if (di->DerivedType.align > 0)  ir_fprintf(f, ", align: %d", di->DerivedType.align);
+				if (di->DerivedType.offset > 0) ir_fprintf(f, ", offset: %d", di->DerivedType.offset);
 				ir_write_byte(f, ')');
 				break;
 			case irDebugInfo_CompositeType: {
@@ -2110,12 +2104,8 @@ void print_llvm_ir(irGen *ir) {
 					              di->CompositeType.file->id,
 					              di->CompositeType.pos.line);
 				}
-				if (di->CompositeType.size > 0) {
-					ir_fprintf(f, ", size: %d", di->CompositeType.size);
-				}
-				if (di->CompositeType.align > 0) {
-					ir_fprintf(f, ", align: %d", di->CompositeType.align);
-				}
+				if (di->CompositeType.size > 0)  ir_fprintf(f, ", size: %d", di->CompositeType.size);
+				if (di->CompositeType.align > 0) ir_fprintf(f, ", align: %d", di->CompositeType.align);
 				if (di->CompositeType.base_type != nullptr) {
 					GB_ASSERT(di->CompositeType.tag != irDebugBasicEncoding_structure_type);
 					GB_ASSERT(di->CompositeType.tag != irDebugBasicEncoding_union_type);
@@ -2153,8 +2143,8 @@ void print_llvm_ir(irGen *ir) {
 				ir_fprintf(f, "!{");
 				for_array(element_index, di->DebugInfoArray.elements) {
 					irDebugInfo *elem = di->DebugInfoArray.elements[element_index];
-					if (element_index > 0) {ir_write_str_lit(f, ", ");}
-					if (elem) {
+					if (element_index > 0) ir_write_str_lit(f, ", ");
+					if (elem != nullptr) {
 						ir_fprintf(f, "!%d", elem->id);
 					} else {
 						ir_fprintf(f, "null"); // NOTE(lachsinc): Proc's can contain "nullptr" entries to represent void return values.

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -2058,17 +2058,19 @@ void print_llvm_ir(irGen *ir) {
 				ir_write_byte(f, ')');
 				break;
 			case irDebugInfo_DerivedType:
-				GB_ASSERT(di->DerivedType.base_type);
 				ir_fprintf(f, "!DIDerivedType("
 				              "name: \"%.*s\""
-				            ", baseType: !%d"
 				            ", size: %d"
 				            ", tag: ",
 				            LIT(di->DerivedType.name),
-				            di->DerivedType.base_type->id,
 				            di->DerivedType.size,
 				            di->DerivedType.align);
 				ir_print_debug_encoding(f, irDebugInfo_DerivedType, di->DerivedType.tag);
+				if (di->DerivedType.base_type != nullptr) {
+					ir_fprintf(f, ", baseType: !%d", di->DerivedType.base_type->id);
+				} else {
+					ir_write_str_lit(f, ", baseType: null"); // Valid/required for rawptr
+				}
 				if (di->DerivedType.align > 0) {
 					ir_fprintf(f, ", align: %d",
 					           di->DerivedType.align);

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -2082,45 +2082,44 @@ void print_llvm_ir(irGen *ir) {
 			case irDebugInfo_CompositeType: {
 				if (di->CompositeType.tag == irDebugBasicEncoding_array_type) {
 					GB_ASSERT_NOT_NULL(di->CompositeType.base_type);
-					ir_fprintf(f, "!DICompositeType("
-					              "tag: DW_TAG_array_type"
-					            ", size: %d"
-					            ", align: %d"
-					            ", baseType: !%d"
-					            ", elements: !{!DISubrange(count: %d)}"
-					            ")",
-					            di->CompositeType.size,
-					            di->CompositeType.align,
-					            di->CompositeType.base_type->id,
-					            di->CompositeType.array_count);
+					GB_ASSERT(di->CompositeType.array_count > 0);
+					GB_ASSERT(di->CompositeType.name.len == 0);
+					GB_ASSERT(di->CompositeType.size > 0);
+				}
+
+				ir_write_str_lit(f, "!DICompositeType(tag: ");
+				ir_print_debug_encoding(f, irDebugInfo_CompositeType, di->CompositeType.tag);
+				if (di->CompositeType.name.len > 0) {
+					ir_fprintf(f, ", name: \"%.*s\"", LIT(di->CompositeType.name));
+				}
+				if (di->CompositeType.scope != nullptr) {
+					ir_fprintf(f, ", scope: !%d", di->CompositeType.scope->id);
+				}
+				if (di->CompositeType.file != nullptr) {
+					ir_fprintf(f, ", file: !%d"
+					              ", line: %td",
+					              di->CompositeType.file->id,
+					              di->CompositeType.pos.line);
+				}
+				if (di->CompositeType.size > 0) {
+					ir_fprintf(f, ", size: %d", di->CompositeType.size);
+				}
+				if (di->CompositeType.align > 0) {
+					ir_fprintf(f, ", align: %d", di->CompositeType.align);
+				}
+				if (di->CompositeType.base_type != nullptr) {
+					GB_ASSERT(di->CompositeType.tag != irDebugBasicEncoding_structure_type);
+					GB_ASSERT(di->CompositeType.tag != irDebugBasicEncoding_union_type);
+					ir_fprintf(f, ", baseType: !%d", di->CompositeType.base_type->id);
+				}
+				if (di->CompositeType.tag == irDebugBasicEncoding_array_type) {
+					ir_fprintf(f, ", elements: !{!DISubrange(count: %d)}", di->CompositeType.array_count);
 				} else {
-					ir_fprintf(f, "!DICompositeType("
-					              "name: \"%.*s\""
-					            ", size: %d"
-					            ", align: %d"
-					            ", tag: ",
-					            LIT(di->CompositeType.name),
-					            di->CompositeType.size,
-					            di->CompositeType.align);
-					ir_print_debug_encoding(f, irDebugInfo_CompositeType, di->CompositeType.tag);
-					if (di->CompositeType.scope != nullptr) {
-						ir_fprintf(f, ", scope: !%d", di->CompositeType.scope->id);
-					}
-					if (di->CompositeType.file != nullptr) {
-						ir_fprintf(f, ", file: !%d"
-						              ", line: %td",
-						              di->CompositeType.file->id,
-						              di->CompositeType.pos.line);
-					}
-					if (di->CompositeType.base_type != nullptr) {
-						GB_ASSERT(di->CompositeType.tag == irDebugBasicEncoding_enumeration_type);
-						ir_fprintf(f, ", baseType: !%d", di->CompositeType.base_type->id);
-					}
 					if (di->CompositeType.elements != nullptr) {
 						ir_fprintf(f, ", elements: !%d", di->CompositeType.elements->id);
 					}
-					ir_write_byte(f, ')');
 				}
+				ir_write_byte(f, ')');
 				break;
 			}
 			case irDebugInfo_Enumerator: {

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -1952,8 +1952,8 @@ void print_llvm_ir(irGen *ir) {
 				            ")",
 				            file->id,
 				            LIT(build_context.ODIN_VERSION),
-				            m->debug_all_enums->id,
-				            m->debug_all_globals->id);
+				            m->debug_compile_unit->CompileUnit.enums->id,
+				            m->debug_compile_unit->CompileUnit.globals->id);
 				break;
 			}
 			case irDebugInfo_File:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -661,16 +661,10 @@ void remove_temp_files(String output_base) {
 }
 
 i32 exec_llvm_opt(String output_base) {
-    // NOTE(lachsinc): See note below in exec_llvm_llc.
-	if (build_context.ODIN_DEBUG == true) return 0;
-
 #if defined(GB_SYSTEM_WINDOWS)
 	// For more passes arguments: http://llvm.org/docs/Passes.html
 	return system_exec_command_line_app("llvm-opt", false,
 		"\"%.*sbin/opt\" \"%.*s.ll\" -o \"%.*s.bc\" %.*s "
-		"-mem2reg "
-		"-memcpyopt "
-		"-die "
 		"",
 		LIT(build_context.ODIN_ROOT),
 		LIT(output_base), LIT(output_base),
@@ -680,9 +674,6 @@ i32 exec_llvm_opt(String output_base) {
 	//   with the Windows version, while they will be system-provided on MacOS and GNU/Linux
 	return system_exec_command_line_app("llvm-opt", false,
 		"opt \"%.*s.ll\" -o \"%.*s.bc\" %.*s "
-		"-mem2reg "
-		"-memcpyopt "
-		"-die "
 		"",
 		LIT(output_base), LIT(output_base),
 		LIT(build_context.opt_flags));
@@ -690,21 +681,15 @@ i32 exec_llvm_opt(String output_base) {
 }
 
 i32 exec_llvm_llc(String output_base) {
-	// NOTE(lachsinc): HACK!! opt.exe seems to strip away CodeView/PDB symbols regardless of
-	// To get around this we will use the non-optimized (.ll) version during debug build.
-	// There's probably better way to deal with this involving arguments or passing
-	// additional things (.ll file) into llc.
-
 #if defined(GB_SYSTEM_WINDOWS)
 	// For more arguments: http://llvm.org/docs/CommandGuide/llc.html
 	return system_exec_command_line_app("llvm-llc", false,
-		"\"%.*sbin\\llc\" \"%.*s%s\" -filetype=obj -O%d "
+		"\"%.*sbin\\llc\" \"%.*s.bc\" -filetype=obj -O%d "
 		"-o \"%.*s.obj\" "
 		"%.*s "
 		"",
 		LIT(build_context.ODIN_ROOT),
 		LIT(output_base),
-		build_context.ODIN_DEBUG ? ".ll" : ".bc",
 		build_context.optimization_level,
 		LIT(output_base),
 		LIT(build_context.llc_flags));
@@ -712,12 +697,11 @@ i32 exec_llvm_llc(String output_base) {
 	// NOTE(zangent): Linux / Unix is unfinished and not tested very well.
 	// For more arguments: http://llvm.org/docs/CommandGuide/llc.html
 	return system_exec_command_line_app("llc", false,
-		"llc \"%.*s%s\" -filetype=obj -relocation-model=pic -O%d "
+		"llc \"%.*s.bc\" -filetype=obj -relocation-model=pic -O%d "
 		"%.*s "
 		"%s"
 		"",
 		LIT(output_base),
-		build_context.ODIN_DEBUG ? ".ll" : ".bc",
 		build_context.optimization_level,
 		LIT(build_context.llc_flags),
 		str_eq_ignore_case(cross_compile_target, str_lit("Essence")) ? "-mtriple=x86_64-pc-none-elf" : "");


### PR DESCRIPTION
High chance this pr may break IR output so testing / review appreciated.

#### TODO
- [x] Watch/Locals support for Primitives/Enums/Strings/Arrays/Slices/DynamicArrays/Map/Any/Union/typeid/Bitset/Bitfield/Type Info/Tuple/Proc/Complex
- [x] Improved "location" info (jump between procedures, files)
- [x] Stepping

Note: Stepping now works but it still needs a lot more attention; Would be nice if we didn't step into mem.zero / context setup stuff, could step _over_ for loops, return instructions jump to closing brace, breakpoints on proc header get missed etc. I will leave that for a separate pull request though.