### PR TITLE
Fixed heap alloc not allowing empty structs on Linux

### DIFF
--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -219,7 +219,7 @@ access :: inline proc(path: string, mask: int) -> bool {
 }
 
 heap_alloc :: proc(size: int) -> rawptr {
-	assert(size > 0);
+	assert(size >= 0);
 	return _unix_calloc(1, size);
 }
 


### PR DESCRIPTION
Fixes #267