### PR TITLE
Fix syntax error in core/os/os_linux.odin

### DIFF
--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -139,7 +139,7 @@ foreign libc {
 	@(link_name="calloc")  _unix_calloc  :: proc(num, size: int) -> rawptr ---;
 	@(link_name="free")    _unix_free    :: proc(ptr: rawptr) ---;
 	@(link_name="realloc") _unix_realloc :: proc(ptr: rawptr, size: int) -> rawptr ---;
-	@(link_name="getenv")  _unix_getenv  :: proc(cstring) -> cstring --- -> !;
+	@(link_name="getenv")  _unix_getenv  :: proc(cstring) -> cstring ---;
 
 	@(link_name="exit")    _unix_exit    :: proc(status: int) ---;
 }


### PR DESCRIPTION
Fixes issue #272 