### PR TITLE
Add a simple file-, console- and multi-logger to core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
-
+![Cc]ore/[Ll]og/
 # Visual Studio 2015 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot
@@ -263,7 +263,6 @@ bin/
 # - Linux/MacOS
 odin
 odin.dSYM
-
 
 # shared collection
 shared/

--- a/core/log/file_console_logger.odin
+++ b/core/log/file_console_logger.odin
@@ -1,0 +1,121 @@
+package log
+
+import "core:fmt";
+import "core:os";
+
+Level_Headers := []string{
+    "[DEBUG] --- ",
+    "[INFO ] --- ",
+    "[WARN ] --- ",
+    "[ERROR] --- ",
+    "[FATAL] --- ",
+};
+
+Default_Console_Logger_Opts :: Options{
+    Option.Level, 
+    Option.Terminal_Color,
+    Option.Short_File_Path,
+    Option.Line, 
+    Option.Procedure, 
+} | Full_Timestamp_Opts;
+
+Default_File_Logger_Opts :: Options{
+    Option.Level, 
+    Option.Short_File_Path,
+    Option.Line, 
+    Option.Procedure, 
+} | Full_Timestamp_Opts;
+
+
+File_Console_Logger_Data :: struct {
+    lowest_level: Level,
+    file_handle:  os.Handle,
+}
+
+file_logger :: proc(h: os.Handle, lowest := Level.Debug, opt := Default_File_Logger_Opts, ident := "") -> Logger {
+    data := new(File_Console_Logger_Data);
+    data.lowest_level = lowest;
+    data.file_handle = h;
+    return Logger{file_console_logger_proc, data, opt, ident};
+}
+ 
+console_logger :: proc(lowest := Level.Debug, opt := Default_Console_Logger_Opts, ident := "") -> Logger {
+    data := new(File_Console_Logger_Data);
+    data.lowest_level = lowest;
+    data.file_handle = os.INVALID_HANDLE;
+    return Logger{file_console_logger_proc, data, opt, ident};
+}
+
+file_console_logger_proc :: proc(logger_data: rawptr, level: Level, ident: string, text: string, options: Options, location := #caller_location) {
+    data := cast(^File_Console_Logger_Data)logger_data;
+    if level < data.lowest_level do return;
+
+    h : os.Handle;
+    if(data.file_handle != os.INVALID_HANDLE) do h = data.file_handle;
+    else                                      do h = level <= Level.Error ? os.stdout : os.stderr;
+    backing: [1024]byte; //NOTE(Hoej): 1024 might be too much for a header backing, unless somebody has really long paths.
+    buf := fmt.string_buffer_from_slice(backing[:]);
+    
+    do_level_header(options, level, &buf);
+
+
+    /*if Full_Timestamp_Opts & options != nil {
+        time := os.get_current_system_time();
+        if Option.Date in options do fmt.sbprintf(&buf, "%d-%d-%d ", time.year, time.month, time.day);
+        if Option.Time in options do fmt.sbprintf(&buf, "%d:%d:%d ", time.hour, time.minute, time.second);
+    }
+*/
+    do_location_header(options, &buf, location);
+
+    if ident != "" do fmt.sbprintf(&buf, "[%s] ", ident);
+    //TODO(Hoej): When we have better atomics and such, make this thread-safe
+    fmt.fprintf(h, "%s %s\n", fmt.to_string(buf), text); 
+}
+
+do_level_header :: proc(opts : Options, level : Level, buf : ^fmt.String_Buffer) {
+
+    RESET     :: "\x1b[0m";
+    RED       :: "\x1b[31m";
+    YELLOW    :: "\x1b[33m";
+    DARK_GREY :: "\x1b[90m";
+
+    col := RESET;
+    switch level {
+    case Level.Debug              : col = DARK_GREY;
+    case Level.Info               : col = RESET;
+    case Level.Warning            : col = YELLOW;
+    case Level.Error, Level.Fatal : col = RED;
+    }
+
+    if Option.Level in opts {
+        if Option.Terminal_Color in opts do fmt.sbprint(buf, col);
+        fmt.sbprint(buf, Level_Headers[level]);
+        if Option.Terminal_Color in opts do fmt.sbprint(buf, RESET);
+    }
+}
+
+do_location_header :: proc(opts : Options, buf : ^fmt.String_Buffer, location := #caller_location) {
+    if Location_Header_Opts & opts != nil do fmt.sbprint(buf, "["); else do return;
+
+    file := location.file_path;
+    if Option.Short_File_Path in opts {
+        when os.OS == "windows" do delimiter := '\\'; else do delimiter := '/'; 
+        last := 0;
+        for r, i in location.file_path do if r == delimiter do last = i+1;
+        file = location.file_path[last:];
+    }
+
+    if Location_File_Opts & opts != nil do fmt.sbprint(buf, file);
+
+    if Option.Procedure in opts {
+        if Location_File_Opts & opts != nil do fmt.sbprint(buf, ".");
+        fmt.sbprintf(buf, "%s()", location.procedure);
+    }
+
+    if Option.Line in opts {
+        if Location_File_Opts & opts != nil || Option.Procedure in opts do fmt.sbprint(buf, ":");
+        fmt.sbprint(buf, location.line);
+    }
+
+    fmt.sbprint(buf, "] ");
+}

--- a/core/log/file_console_logger.odin
+++ b/core/log/file_console_logger.odin
@@ -30,23 +30,26 @@ Default_File_Logger_Opts :: Options{
 File_Console_Logger_Data :: struct {
     lowest_level: Level,
     file_handle:  os.Handle,
+    ident : string,
 }
 
 file_logger :: proc(h: os.Handle, lowest := Level.Debug, opt := Default_File_Logger_Opts, ident := "") -> Logger {
     data := new(File_Console_Logger_Data);
     data.lowest_level = lowest;
     data.file_handle = h;
-    return Logger{file_console_logger_proc, data, opt, ident};
+    data.ident = ident;
+    return Logger{file_console_logger_proc, data, opt};
 }
  
 console_logger :: proc(lowest := Level.Debug, opt := Default_Console_Logger_Opts, ident := "") -> Logger {
     data := new(File_Console_Logger_Data);
     data.lowest_level = lowest;
     data.file_handle = os.INVALID_HANDLE;
-    return Logger{file_console_logger_proc, data, opt, ident};
+    data.ident = ident;
+    return Logger{file_console_logger_proc, data, opt};
 }
 
-file_console_logger_proc :: proc(logger_data: rawptr, level: Level, ident: string, text: string, options: Options, location := #caller_location) {
+file_console_logger_proc :: proc(logger_data: rawptr, level: Level, text: string, options: Options, location := #caller_location) {
     data := cast(^File_Console_Logger_Data)logger_data;
     if level < data.lowest_level do return;
 
@@ -67,7 +70,7 @@ file_console_logger_proc :: proc(logger_data: rawptr, level: Level, ident: strin
 */
     do_location_header(options, &buf, location);
 
-    if ident != "" do fmt.sbprintf(&buf, "[%s] ", ident);
+    if data.ident != "" do fmt.sbprintf(&buf, "[%s] ", data.ident);
     //TODO(Hoej): When we have better atomics and such, make this thread-safe
     fmt.fprintf(h, "%s %s\n", fmt.to_string(buf), text); 
 }

--- a/core/log/log.odin
+++ b/core/log/log.odin
@@ -1,5 +1,8 @@
 package log
 
+import "core:fmt";
+import "core:runtime";
+
 Level :: enum {
 	Debug,
 	Info,
@@ -9,26 +12,75 @@ Level :: enum {
 }
 
 Option :: enum {
-	Level,
-	Time,
-	File,
-	Line,
-	Procedure,
+    Level,
+    Date,
+    Time,
+    Short_File_Path,
+    Long_File_Path,
+    Line,
+    Procedure,
+    Terminal_Color
 }
+
 Options :: bit_set[Option];
+Full_Timestamp_Opts :: Options{
+    Option.Date,
+    Option.Time
+};
+Location_Header_Opts :: Options{
+    Option.Short_File_Path,
+    Option.Long_File_Path,
+    Option.Line,
+    Option.Procedure,
+};
+Location_File_Opts :: Options{
+    Option.Short_File_Path,
+    Option.Long_File_Path
+};
 
 Logger_Proc :: #type proc(data: rawptr, level: Level, ident, text: string, options: Options, location := #caller_location);
 
 Logger :: struct {
 	procedure: Logger_Proc,
 	data:      rawptr,
+    options:   Options,
+    ident:     string
 }
 
+Multi_Logger_Data :: struct {
+    loggers : []Logger,
+}
+
+multi_logger :: proc(logs: ..Logger) -> Logger {
+    data := new(Multi_Logger_Data);
+    data.loggers = make([]Logger, len(logs));
+    for log, i in logs do data.loggers[i] = log;
+    return Logger{multi_logger_proc, data, nil, ""};
+}
+
+multi_logger_proc :: proc(logger_data: rawptr, level: Level, ident: string, text: string, 
+                          options: Options, location := #caller_location) {
+    data := cast(^Multi_Logger_Data)logger_data;
+    if data.loggers == nil || len(data.loggers) == 0 do return;
+    for log in data.loggers do log.procedure(log.data, level, log.ident, text, log.options, location);
+}
 
 nil_logger_proc :: proc(data: rawptr, level: Level, ident, text: string, options: Options, location := #caller_location) {
 	// Do nothing
 }
 
 nil_logger :: proc() -> Logger {
-	return Logger{nil_logger_proc, nil};
+	return Logger{nil_logger_proc, nil, nil, ""};
+}
+
+debug :: proc(fmt_str : string, args : ..any, location := #caller_location) do log(level=Level.Debug,   fmt_str=fmt_str, args=args, location=location);
+info  :: proc(fmt_str : string, args : ..any, location := #caller_location) do log(level=Level.Info,    fmt_str=fmt_str, args=args, location=location);
+warn  :: proc(fmt_str : string, args : ..any, location := #caller_location) do log(level=Level.Warning, fmt_str=fmt_str, args=args, location=location);
+error :: proc(fmt_str : string, args : ..any, location := #caller_location) do log(level=Level.Error,   fmt_str=fmt_str, args=args, location=location);
+fatal :: proc(fmt_str : string, args : ..any, location := #caller_location) do log(level=Level.Fatal,   fmt_str=fmt_str, args=args, location=location);
+
+log :: proc(level : Level, fmt_str : string, args : ..any, location := #caller_location) {
+    logger := context.logger;
+    str := fmt.tprintf(fmt_str, ..args); //NOTE(Hoej): While tprint isn't thread-safe, no logging is.
+    logger.procedure(logger.data, level, logger.ident, str, logger.options, location);
 }

--- a/core/log/log.odin
+++ b/core/log/log.odin
@@ -38,13 +38,12 @@ Location_File_Opts :: Options{
     Option.Long_File_Path
 };
 
-Logger_Proc :: #type proc(data: rawptr, level: Level, ident, text: string, options: Options, location := #caller_location);
+Logger_Proc :: #type proc(data: rawptr, level: Level, text: string, options: Options, location := #caller_location);
 
 Logger :: struct {
 	procedure: Logger_Proc,
 	data:      rawptr,
     options:   Options,
-    ident:     string
 }
 
 Multi_Logger_Data :: struct {
@@ -55,32 +54,32 @@ multi_logger :: proc(logs: ..Logger) -> Logger {
     data := new(Multi_Logger_Data);
     data.loggers = make([]Logger, len(logs));
     for log, i in logs do data.loggers[i] = log;
-    return Logger{multi_logger_proc, data, nil, ""};
+    return Logger{multi_logger_proc, data, nil};
 }
 
-multi_logger_proc :: proc(logger_data: rawptr, level: Level, ident: string, text: string, 
+multi_logger_proc :: proc(logger_data: rawptr, level: Level, text: string, 
                           options: Options, location := #caller_location) {
     data := cast(^Multi_Logger_Data)logger_data;
     if data.loggers == nil || len(data.loggers) == 0 do return;
-    for log in data.loggers do log.procedure(log.data, level, log.ident, text, log.options, location);
+    for log in data.loggers do log.procedure(log.data, level, text, log.options, location);
 }
 
-nil_logger_proc :: proc(data: rawptr, level: Level, ident, text: string, options: Options, location := #caller_location) {
+nil_logger_proc :: proc(data: rawptr, level: Level, text: string, options: Options, location := #caller_location) {
 	// Do nothing
 }
 
 nil_logger :: proc() -> Logger {
-	return Logger{nil_logger_proc, nil, nil, ""};
+	return Logger{nil_logger_proc, nil, nil};
 }
 
-debug :: proc(fmt_str : string, args : ..any, location := #caller_location) do log(level=Level.Debug,   fmt_str=fmt_str, args=args, location=location);
-info  :: proc(fmt_str : string, args : ..any, location := #caller_location) do log(level=Level.Info,    fmt_str=fmt_str, args=args, location=location);
-warn  :: proc(fmt_str : string, args : ..any, location := #caller_location) do log(level=Level.Warning, fmt_str=fmt_str, args=args, location=location);
-error :: proc(fmt_str : string, args : ..any, location := #caller_location) do log(level=Level.Error,   fmt_str=fmt_str, args=args, location=location);
-fatal :: proc(fmt_str : string, args : ..any, location := #caller_location) do log(level=Level.Fatal,   fmt_str=fmt_str, args=args, location=location);
+debug :: proc(fmt_str : string, args : ..any, location := #caller_location) do logf(level=Level.Debug,   fmt_str=fmt_str, args=args, location=location);
+info  :: proc(fmt_str : string, args : ..any, location := #caller_location) do logf(level=Level.Info,    fmt_str=fmt_str, args=args, location=location);
+warn  :: proc(fmt_str : string, args : ..any, location := #caller_location) do logf(level=Level.Warning, fmt_str=fmt_str, args=args, location=location);
+error :: proc(fmt_str : string, args : ..any, location := #caller_location) do logf(level=Level.Error,   fmt_str=fmt_str, args=args, location=location);
+fatal :: proc(fmt_str : string, args : ..any, location := #caller_location) do logf(level=Level.Fatal,   fmt_str=fmt_str, args=args, location=location);
 
-log :: proc(level : Level, fmt_str : string, args : ..any, location := #caller_location) {
+logf :: proc(level : Level, fmt_str : string, args : ..any, location := #caller_location) {
     logger := context.logger;
-    str := fmt.tprintf(fmt_str, ..args); //NOTE(Hoej): While tprint isn't thread-safe, no logging is.
-    logger.procedure(logger.data, level, logger.ident, str, logger.options, location);
+    str := len(args) > 0 ? fmt.tprintf(fmt_str, ..args) : fmt.tprint(fmt_str); //NOTE(Hoej): While tprint isn't thread-safe, no logging is.
+    logger.procedure(logger.data, level, str, logger.options, location);
 }

--- a/core/log/log.odin
+++ b/core/log/log.odin
@@ -53,7 +53,7 @@ Multi_Logger_Data :: struct {
 create_multi_logger :: proc(logs: ..Logger) -> Logger {
     data := new(Multi_Logger_Data);
     data.loggers = make([]Logger, len(logs));
-    for log, i in logs do data.loggers[i] = log;
+    copy(data.loggers, logs);
     return Logger{multi_logger_proc, data, nil};
 }
 

--- a/core/log/log.odin
+++ b/core/log/log.odin
@@ -50,11 +50,16 @@ Multi_Logger_Data :: struct {
     loggers : []Logger,
 }
 
-multi_logger :: proc(logs: ..Logger) -> Logger {
+create_multi_logger :: proc(logs: ..Logger) -> Logger {
     data := new(Multi_Logger_Data);
     data.loggers = make([]Logger, len(logs));
     for log, i in logs do data.loggers[i] = log;
     return Logger{multi_logger_proc, data, nil};
+}
+
+destroy_multi_logger ::proc(log : ^Logger) {
+    free(log.data);
+    log^ = nil_logger();
 }
 
 multi_logger_proc :: proc(logger_data: rawptr, level: Level, text: string, 

--- a/core/time/time_linux.odin
+++ b/core/time/time_linux.odin
@@ -1,0 +1,3 @@
+package time
+
+IS_SUPPORTED :: false;

--- a/core/time/time_osx.odin
+++ b/core/time/time_osx.odin
@@ -1,0 +1,3 @@
+package time
+
+IS_SUPPORTED :: false;

--- a/core/time/time_windows.odin
+++ b/core/time/time_windows.odin
@@ -2,6 +2,8 @@ package time
 
 import "core:sys/win32"
 
+IS_SUPPORTED :: true;
+
 now :: proc() -> Time {
 	file_time: win32.Filetime;
 
@@ -18,5 +20,5 @@ now :: proc() -> Time {
 
 
 sleep :: proc(d: Duration) {
-	win32.Sleep(u32(d/Millisecond));
+	win32.sleep(i32(d/Millisecond));
 }


### PR DESCRIPTION
## Actual PR
The primary interfaces to actually log by are these in `log.odin`;
```
debug :: proc(fmt_str : string, args : ..any, location := #caller_location)
info  :: proc(fmt_str : string, args : ..any, location := #caller_location)
warn  :: proc(fmt_str : string, args : ..any, location := #caller_location)
error :: proc(fmt_str : string, args : ..any, location := #caller_location)
fatal :: proc(fmt_str : string, args : ..any, location := #caller_location)
```
These will use `fmt.tprintf` first on the `fmt_str` and `args` to produce the logged text.
Then it's up to the individual logger to take the specified options and indentifier and prefix (or postfix) that the logging content.
This also includes 3 types of basic loggers. A console and file logger whose format is identical if the same options are set, you just simply either log to the console (stdout or stderr) or a `os.Handle` which points to a file. There is also an option to limit what is actually logged by defining a "lowest level".
The file and console logger will output in a format similar to this;
```
[DEBUG] --- [main.odin.main():49] [System API]  We are debug now
[INFO ] --- [main.odin.main():50] [System API]  We are info now
[WARN ] --- [main.odin.main():51] [System API]  We are warn now
[ERROR] --- [main.odin.main():52] [System API]  We are error now
[FATAL] --- [main.odin.main():53] [System API]  We are fatal now
[WARN ] --- [main.odin.main():60] [Program API]  We are warn now
[ERROR] --- [main.odin.main():61] [Program API]  We are error now
[FATAL] --- [main.odin.main():62] [Program API]  We are fatal now
[DEBUG] --- [2018-12-08 14:57:46] [main.odin.main():26]  We are debug now
[INFO ] --- [2018-12-08 14:57:46] [main.odin.main():27]  We are info now
[WARN ] --- [2018-12-08 14:57:46] [main.odin.main():28]  We are warn now
[ERROR] --- [2018-12-08 14:57:46] [main.odin.main():29]  We are error now
[FATAL] --- [2018-12-08 14:57:46] [main.odin.main():30]  We are fatal now
```
Though how it exactly looks is based on what `log.Options` you specify.
The multi logger simple carries multiple loggers in it, and calls each `Logger_Proc` whenever something is logged.

_While options are manually specified here there are default options for both [the file- and console-logger](https://github.com/odin-lang/Odin/commit/a16344d0964f656e06024466054103be64ac666c#diff-7c510ccc05d5ab19450316377f2ef214R14) so you can just do `l := log.console_logger();`, the file logger does always need a file handle_
Example; 
```
h, err := os.open("test.log", os.O_RDWR|os.O_APPEND);
fl := log.file_logger(h, log.Level.Debug,{    
    log.Option.Level, 
    log.Option.Long_File_Path, 
    log.Option.Line, 
}, "System API");
cls := log.console_logger(log.Level.Debug,{    
    log.Option.Level, 
    log.Option.Short_File_Path, 
    log.Option.Line, 
    log.Option.Procedure, 
    log.Option.Terminal_Color
}, "System API");

clp := log.console_logger(log.Level.Warning,{    
    log.Option.Level, 
    log.Option.Short_File_Path, 
    log.Option.Line, 
    log.Option.Procedure, 
    log.Option.Terminal_Color
}, "Program API");

m1 := log.multi_logger(fl, cls);
m2 := log.multi_logger(fl, clp);

{
    context.logger = m1;

    log.debug("We are debug now");
    log.info("We are info now");
    log.warn("We are warn now");
    log.error("We are error now");
    log.fatal("We are fatal now");
}
{
    context.logger = m2;

    log.debug("We are debug now");
    log.info("We are info now");
    log.warn("We are warn now");
    log.error("We are error now");
    log.fatal("We are fatal now");
}
```