### PR TITLE
Add the missing INVALID_HANDLE so that the demo will build and run on Linux

### DIFF
--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -12,6 +12,7 @@ Handle    :: distinct i32;
 File_Time :: distinct u64;
 Errno     :: distinct i32;
 
+INVALID_HANDLE :: ~Handle(0);
 
 O_RDONLY   :: 0x00000;
 O_WRONLY   :: 0x00001;


### PR DESCRIPTION
The demo wouldn't run or build on Linux. I copied this line from the os_windows.odin file. Pretty straightforward. 