### PR TITLE
Added INVALID_HANDLE constant os_linux.odin.

### DIFF
--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -12,6 +12,7 @@ Handle    :: distinct i32;
 File_Time :: distinct u64;
 Errno     :: distinct i32;
 
+INVALID_HANDLE :: Handle(-1);
 
 O_RDONLY   :: 0x00000;
 O_WRONLY   :: 0x00001;


### PR DESCRIPTION
`core/os/os_linux.odin` was missing a INVALID_HANDLE constant, this PR adds it with the value of `-1` as this is what `open()` and `creat()` will return on failure.

This constant was required by the new `core/log` library and without this the demo won't run on linux.