### PR TITLE
Fix os.open on linux/osx

### DIFF
--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -80,37 +80,37 @@ Stat :: struct {
 };
 
 // File type
-S_IFMT   :: 0170000; // Type of file mask
-S_IFIFO  :: 0010000; // Named pipe (fifo)
-S_IFCHR  :: 0020000; // Character special
-S_IFDIR  :: 0040000; // Directory
-S_IFBLK  :: 0060000; // Block special
-S_IFREG  :: 0100000; // Regular
-S_IFLNK  :: 0120000; // Symbolic link
-S_IFSOCK :: 0140000; // Socket
+S_IFMT   :: 0o170000; // Type of file mask
+S_IFIFO  :: 0o010000; // Named pipe (fifo)
+S_IFCHR  :: 0o020000; // Character special
+S_IFDIR  :: 0o040000; // Directory
+S_IFBLK  :: 0o060000; // Block special
+S_IFREG  :: 0o100000; // Regular
+S_IFLNK  :: 0o120000; // Symbolic link
+S_IFSOCK :: 0o140000; // Socket
 
 // File mode
 // Read, write, execute/search by owner
-S_IRWXU :: 0000700; // RWX mask for owner
-S_IRUSR :: 0000400; // R for owner
-S_IWUSR :: 0000200; // W for owner
-S_IXUSR :: 0000100; // X for owner
+S_IRWXU :: 0o0700; // RWX mask for owner
+S_IRUSR :: 0o0400; // R for owner
+S_IWUSR :: 0o0200; // W for owner
+S_IXUSR :: 0o0100; // X for owner
 
 	// Read, write, execute/search by group
-S_IRWXG :: 0000070; // RWX mask for group
-S_IRGRP :: 0000040; // R for group
-S_IWGRP :: 0000020; // W for group
-S_IXGRP :: 0000010; // X for group
+S_IRWXG :: 0o0070; // RWX mask for group
+S_IRGRP :: 0o0040; // R for group
+S_IWGRP :: 0o0020; // W for group
+S_IXGRP :: 0o0010; // X for group
 
 	// Read, write, execute/search by others
-S_IRWXO :: 0000007; // RWX mask for other
-S_IROTH :: 0000004; // R for other
-S_IWOTH :: 0000002; // W for other
-S_IXOTH :: 0000001; // X for other
+S_IRWXO :: 0o0007; // RWX mask for other
+S_IROTH :: 0o0004; // R for other
+S_IWOTH :: 0o0002; // W for other
+S_IXOTH :: 0o0001; // X for other
 
-S_ISUID :: 0004000; // Set user id on execution
-S_ISGID :: 0002000; // Set group id on execution
-S_ISVTX :: 0001000; // Directory restrcted delete
+S_ISUID :: 0o4000; // Set user id on execution
+S_ISGID :: 0o2000; // Set group id on execution
+S_ISVTX :: 0o1000; // Directory restrcted delete
 
 
 S_ISLNK  :: inline proc(m: u32) -> bool do return (m & S_IFMT) == S_IFLNK;
@@ -143,7 +143,7 @@ CLOCK_REALTIME_ALARM     :: 8;
 CLOCK_BOOTTIME_ALARM     :: 9;
 
 foreign libc {
-	@(link_name="open")             _unix_open          :: proc(path: cstring, mode: int) -> Handle ---;
+	@(link_name="open")             _unix_open          :: proc(path: cstring, flags: int, #c_vararg mode: ..any) -> Handle ---;
 	@(link_name="close")            _unix_close         :: proc(fd: Handle) -> i32 ---;
 	@(link_name="read")             _unix_read          :: proc(fd: Handle, buf: rawptr, size: int) -> int ---;
 	@(link_name="write")            _unix_write         :: proc(fd: Handle, buf: rawptr, size: int) -> int ---;
@@ -171,19 +171,14 @@ foreign dl {
 	@(link_name="dlerror")          _unix_dlerror       :: proc() -> cstring ---;
 }
 
-// TODO(zangent): Change this to just `open` when Bill fixes overloading.
-open_simple :: proc(path: string, mode: int) -> (Handle, Errno) {
+open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Errno) {
 	cstr := strings.new_cstring(path);
-	handle := _unix_open(cstr, mode);
+	handle := _unix_open(cstr, flags, mode);
 	delete(cstr);
-	if(handle == -1) {
+	if handle == -1 {
 		return 0, 1;
 	}
 	return handle, 0;
-}
-// NOTE(zangent): This is here for compatability reasons. Should this be here?
-open :: proc(path: string, mode: int = O_RDONLY, perm: u32 = 0) -> (Handle, Errno) {
-	return open_simple(path, mode);
 }
 
 close :: proc(fd: Handle) {

--- a/core/os/os_osx.odin
+++ b/core/os/os_osx.odin
@@ -81,37 +81,37 @@ Stat :: struct {
 };
 
 // File type
-S_IFMT   :: 0170000; // Type of file mask
-S_IFIFO  :: 0010000; // Named pipe (fifo)
-S_IFCHR  :: 0020000; // Character special
-S_IFDIR  :: 0040000; // Directory
-S_IFBLK  :: 0060000; // Block special
-S_IFREG  :: 0100000; // Regular
-S_IFLNK  :: 0120000; // Symbolic link
-S_IFSOCK :: 0140000; // Socket
+S_IFMT   :: 0o170000; // Type of file mask
+S_IFIFO  :: 0o010000; // Named pipe (fifo)
+S_IFCHR  :: 0o020000; // Character special
+S_IFDIR  :: 0o040000; // Directory
+S_IFBLK  :: 0o060000; // Block special
+S_IFREG  :: 0o100000; // Regular
+S_IFLNK  :: 0o120000; // Symbolic link
+S_IFSOCK :: 0o140000; // Socket
 
 // File mode
 // Read, write, execute/search by owner
-S_IRWXU :: 0000700; // RWX mask for owner
-S_IRUSR :: 0000400; // R for owner
-S_IWUSR :: 0000200; // W for owner
-S_IXUSR :: 0000100; // X for owner
+S_IRWXU :: 0o0700; // RWX mask for owner
+S_IRUSR :: 0o0400; // R for owner
+S_IWUSR :: 0o0200; // W for owner
+S_IXUSR :: 0o0100; // X for owner
 
 // Read, write, execute/search by group
-S_IRWXG :: 0000070; // RWX mask for group
-S_IRGRP :: 0000040; // R for group
-S_IWGRP :: 0000020; // W for group
-S_IXGRP :: 0000010; // X for group
+S_IRWXG :: 0o0070; // RWX mask for group
+S_IRGRP :: 0o0040; // R for group
+S_IWGRP :: 0o0020; // W for group
+S_IXGRP :: 0o0010; // X for group
 
 // Read, write, execute/search by others
-S_IRWXO :: 0000007; // RWX mask for other
-S_IROTH :: 0000004; // R for other
-S_IWOTH :: 0000002; // W for other
-S_IXOTH :: 0000001; // X for other
+S_IRWXO :: 0o0007; // RWX mask for other
+S_IROTH :: 0o0004; // R for other
+S_IWOTH :: 0o0002; // W for other
+S_IXOTH :: 0o0001; // X for other
 
-S_ISUID :: 0004000; // Set user id on execution
-S_ISGID :: 0002000; // Set group id on execution
-S_ISVTX :: 0001000; // Directory restrcted delete
+S_ISUID :: 0o4000; // Set user id on execution
+S_ISGID :: 0o2000; // Set group id on execution
+S_ISVTX :: 0o1000; // Directory restrcted delete
 
 S_ISLNK  :: inline proc(m: u32) -> bool do return (m & S_IFMT) == S_IFLNK;
 S_ISREG  :: inline proc(m: u32) -> bool do return (m & S_IFMT) == S_IFREG;
@@ -127,7 +127,7 @@ X_OK :: 1; // Test for execute permission
 F_OK :: 0; // Test for file existance
 
 foreign libc {
-	@(link_name="open")    _unix_open    :: proc(path: cstring, mode: int) -> Handle ---;
+	@(link_name="open")    _unix_open    :: proc(path: cstring, flags: int, #c_vararg mode: ..any) -> Handle ---;
 	@(link_name="close")   _unix_close   :: proc(handle: Handle) ---;
 	@(link_name="read")    _unix_read    :: proc(handle: Handle, buffer: rawptr, count: int) -> int ---;
 	@(link_name="write")   _unix_write   :: proc(handle: Handle, buffer: rawptr, count: int) -> int ---;
@@ -152,20 +152,14 @@ foreign dl {
 	@(link_name="dlerror") _unix_dlerror :: proc() -> cstring ---;
 }
 
-// TODO(zangent): Change this to just `open` when Bill fixes overloading.
-open_simple :: proc(path: string, mode: int) -> (Handle, Errno) {
+open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Errno) {
 	cstr := strings.new_cstring(path);
-	defer delete(cstr);
-	handle := _unix_open(cstr, mode);
+	handle := _unix_open(cstr, flags, mode);
+	delete(cstr);
 	if handle == -1 {
 		return 0, 1;
 	}
 	return handle, 0;
-}
-
-// NOTE(zangent): This is here for compatability reasons. Should this be here?
-open :: proc(path: string, mode: int = O_RDONLY, perm: u32 = 0) -> (Handle, Errno) {
-	return open_simple(path, mode);
 }
 
 close :: proc(fd: Handle) {


### PR DESCRIPTION
Exposes the vararg parameter to [open](http://pubs.opengroup.org/onlinepubs/009695399/functions/open.html) that allows setting of file permissions when creating a file. Also fixes many constants that are supposed to be octal.

Tested this very lightly with my own code on Linux, but no testing was done on OSX.