### PR TITLE
Fixed int_from_arg not consuming argument.

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -489,6 +489,10 @@ int_from_arg :: proc(args: []any, arg_index: int) -> (int, int, bool) {
 		}
 	}
 
+	if ok {
+		new_arg_index += 1;
+	}
+
 	return num, new_arg_index, ok;
 }
 


### PR DESCRIPTION
int_from_arg did not increment its new_arg_index variable if an argument was consumed.