### PR TITLE
Fix assert when printing IR of pointer with endianness

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1041,6 +1041,8 @@ bool is_type_integer_endian_big(Type *t) {
 		return build_context.endian_kind == TargetEndian_Big;
 	} else if (t->kind == Type_BitSet) {
 		return is_type_integer_endian_big(bit_set_to_int(t));
+	} else if (t->kind == Type_Pointer) {
+		return is_type_integer_endian_big(&basic_types[Basic_uintptr]);
 	} else {
 		GB_PANIC("Unsupported type: %s", type_to_string(t));
 	}
@@ -1058,6 +1060,8 @@ bool is_type_integer_endian_little(Type *t) {
 		return build_context.endian_kind == TargetEndian_Little;
 	} else if (t->kind == Type_BitSet) {
 		return is_type_integer_endian_little(bit_set_to_int(t));
+	} else if (t->kind == Type_Pointer) {
+		return is_type_integer_endian_little(&basic_types[Basic_uintptr]);
 	} else {
 		GB_PANIC("Unsupported type: %s", type_to_string(t));
 	}


### PR DESCRIPTION
When printing out the IR for a pointer value it in `ir_print_exact_value`, `is_type_integer_endian_{little,big}`
did not correct handle being asked about pointer types.

They now reply with whether the endianness of `uintptr` matches the
endianness being asked about.

I'm not 100% sure if this is all that needs to be done or not, but this fixed the problem I had in my own code where I was getting an assert in `is_type_integer_endian_little` with the `^u8` type.
I'm not very familiar with the codebase as yet.
I debugged it and at first glance seemed like an easy fix. So... here it is...? xD