### PR TITLE
Provide a way to pass arguments to compiled executable during 'odin run program.odin'.

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -137,8 +137,8 @@ GB_ALLOCATOR_PROC(heap_allocator_proc) {
 }
 
 #include "unicode.cpp"
-#include "string.cpp"
 #include "array.cpp"
+#include "string.cpp"
 #include "murmurhash3.cpp"
 
 #define for_array(index_, array_) for (isize index_ = 0; index_ < (array_).count; index_++)

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -318,13 +318,33 @@ String concatenate_strings(gbAllocator a, String const &x, String const &y) {
 	return make_string(data, len);
 }
 
+String string_join_and_quote(gbAllocator a, Array<String> strings) {
+	if (!strings.count) {
+		return make_string(nullptr, 0);
+	}
+
+	isize str_len = 0;
+	for (isize i = 0; i < strings.count; i++) {
+		str_len += strings[i].len;
+	}
+
+	gbString s = gb_string_make_reserve(a, str_len+strings.count); // +strings.count for spaces after args.
+	for (isize i = 0; i < strings.count; i++) {
+		if (i > 0) {
+			s = gb_string_append_fmt(s, " ");
+		}
+		s = gb_string_append_fmt(s, "\"%.*s\" ", LIT(strings[i]));
+	}
+
+	return make_string(cast(u8 *) s, gb_string_length(s));
+}
+
 String copy_string(gbAllocator a, String const &s) {
 	u8 *data = gb_alloc_array(a, u8, s.len+1);
 	gb_memmove(data, s.text, s.len);
 	data[s.len] = 0;
 	return make_string(data, s.len);
 }
-
 
 
 


### PR DESCRIPTION
Allows you to pass arguments through to the program you are compiling with `odin run ...`.

`odin run program.odin -opt=1 -- <args-for-program.exe>`

... is equivalent to:
```
$ odin build program.odin -opt=1
$ program.exe <args-for-program.exe>
```