### PR TITLE
"core:path" Path library and "core:strings" `split` Utilities

### DIFF
--- a/core/path/path.odin
+++ b/core/path/path.odin
@@ -81,7 +81,7 @@ ext :: proc(path: string, new := false, allocator := context.allocator) -> strin
 rel :: proc{rel_between, rel_current};
 
 // returns the relative path from one path to another
-rel_between :: proc(from, to: string, allocator := context.temp_allocator) -> string {
+rel_between :: proc(from, to: string, allocator := context.allocator) -> string {
     if from == "" || to == "" do return "";
 
     from = full(from, context.temp_allocator);
@@ -190,7 +190,7 @@ rel_between :: proc(from, to: string, allocator := context.temp_allocator) -> st
 
 // returns the relative path from the current directory to another path
 rel_current :: proc(to: string, allocator := context.temp_allocator) -> string {
-    return inline rel_between(current(allocator), to);
+    return inline rel_between(current(context.temp_allocator), to, allocator);
 }
 
 

--- a/core/path/path.odin
+++ b/core/path/path.odin
@@ -1,0 +1,200 @@
+package path
+
+import "core:strings"
+import "core:unicode/utf8"
+
+
+// returns everything preceding the last path element
+dir :: proc(path: string, new := false, allocator := context.allocator) -> string {
+    if path == "" do return "";
+
+    for i := len(path) - 1; i >= 0; i -= 1 {
+        if path[i] == '/' || path[i] == '\\' {
+            if path[:i] == "" {
+                // path is root
+                return new ? strings.new_string(SEPARATOR_STRING, allocator) : SEPARATOR_STRING;
+            } else {
+                return new ? strings.new_string(path[:i], allocator) : path[:i];
+            }
+        }
+    }
+
+    // path doesn't contain any folder structure
+    return "";
+}
+
+// returns the final path element
+base :: proc(path: string, new := false, allocator := context.allocator) -> string {
+    if path == "" do return "";
+
+    end := len(path) - 1;
+
+    for i := end; i >= 0; i -= 1 {
+        switch path[i] {
+        case '/', '\\':
+            if i != end {
+                return new ? strings.new_string(path[i+1:], allocator) : path[i+1:];
+            } else {
+                end = i; // we don't want trailing slashes
+            }
+        }
+    }
+
+    // path doesn't contain any folder structure, return entire path
+    return new ? strings.new_string(path, allocator) : path;
+}
+
+// returns the final path element, excluding the file extension if there is one
+name :: proc(path: string, new := false, allocator := context.allocator) -> string {
+    if path == "" do return "";
+
+    dot := len(path);
+    end := dot - 1;
+
+    for i := end; i >= 0; i -= 1 {
+        switch path[i] {
+        case '.':       dot = (dot == end ? i : dot);
+        case '/', '\\': return new ? strings.new_string(path[i+1:dot], allocator) : path[i+1:dot];
+        }
+    }
+
+    // path doesn't contain any folder structure or file extensions; assumed to be a valid file name
+    return new ? strings.new_string(path, allocator) : path;
+}
+
+// returns the file extension, if there is one
+ext :: proc(path: string, new := false, allocator := context.allocator) -> string {
+    if path == "" do return "";
+
+    for i := len(path)-1; i >= 0; i -= 1 {
+        switch path[i] {
+        case '/', '\\': return "";
+        case '.':       return new ? strings.new_string(path[i+1:], allocator) : path[i+1:];
+        }
+    }
+
+    // path does not include a file extension
+    return "";
+}
+
+
+rel :: proc{rel_between, rel_current};
+
+// returns the relative path from one path to another
+rel_between :: proc(from, to: string, allocator := context.temp_allocator) -> string {
+    if from == "" || to == "" do return "";
+
+    from = full(from, context.temp_allocator);
+    to   = full(to,   context.temp_allocator);
+
+    from_is_dir := is_dir(from);
+    to_is_dir   := is_dir(to);
+
+    index, slash := 0, 0;
+
+    for {
+        if index >= len(from) {
+            if index >= len(to) || (from_is_dir && index < len(to) && (to[index] == '/' || to[index] == '\\')) {
+                slash = index;
+            }
+
+            break;
+        }
+        else if index >= len(to) {
+            if index >= len(from) || (to_is_dir && index < len(from) && (from[index] == '/' || from[index] == '\\')) {
+                slash = index;
+            }
+
+            break;
+        }
+
+        lchar, skip := utf8.decode_rune_in_string(from[index:]);
+        rchar, _    := utf8.decode_rune_in_string(to[index:]);
+
+        if (lchar == '/' || lchar == '\\') && (rchar == '/' || lchar == '\\') {
+            slash = index;
+        }
+        else if lchar != rchar {
+            break;
+        }
+
+        index += skip;
+    }
+
+    if slash < 1 {
+        // there is no common path, use the absolute `to` path
+        return strings.new_string(to, allocator);
+    }
+
+    from_slashes, to_slashes := 0, 0;
+
+    if slash < len(from) {
+        from = from[slash+1:];
+        
+        if from_is_dir {
+            from_slashes += 1;
+        }
+    }
+    else {
+        from = "";
+    }
+
+    if slash < len(to) {
+        to = to[slash+1:];
+
+        if to_is_dir {
+            to_slashes += 1;
+        }
+    }
+    else {
+        to = "";
+    }
+
+    for char in from {
+        if char == '/' || char == '\\' {
+            from_slashes += 1;
+        }
+    }
+
+    for char in to {
+        if char == '/' || char == '\\' {
+            to_slashes += 1;
+        }
+    }
+
+    if from_slashes == 0 {
+        buffer := make([]byte, 2 + len(to), allocator);
+
+        buffer[0] = '.';
+        buffer[1] = SEPARATOR;
+        copy(buffer[2:], ([]byte)(to));
+
+        return string(buffer);
+    }
+    else {
+        buffer := make([]byte, from_slashes*3 + len(to), allocator);
+
+        for i in 0..from_slashes-1 {
+            buffer[i*3+0] = '.';
+            buffer[i*3+1] = '.';
+            buffer[i*3+2] = SEPARATOR;
+        }
+
+        copy(buffer[from_slashes*3:], ([]byte)(to));
+
+        return string(buffer);
+    }
+
+    return "";
+}
+
+// returns the relative path from the current directory to another path
+rel_current :: proc(to: string, allocator := context.temp_allocator) -> string {
+    return inline rel_between(current(allocator), to);
+}
+
+
+// splits the path elements into slices of the original path string
+split :: proc(s: string, allocator := context.temp_allocator) -> []string #no_bounds_check {
+    return inline strings.split(s, []string{"\\", "/"}, true, allocator);
+}

--- a/core/path/path_linux.odin
+++ b/core/path/path_linux.odin
@@ -1,0 +1,7 @@
+package path
+
+
+SEPARATOR        :: '/';
+SEPARATOR_STRING :: "/";
+
+#compile_assert("Linux is not yet supported");

--- a/core/path/path_linux.odin
+++ b/core/path/path_linux.odin
@@ -23,7 +23,7 @@ null_term :: proc(str: string) -> string {
 }
 
 
-full :: proc(path: string, allocator := context.allocator) -> string {
+full :: proc(path: string, allocator := context.temp_allocator) -> string {
     cpath := strings.clone_to_cstring(path, context.temp_allocator);
     
     foreign libc {
@@ -41,7 +41,7 @@ full :: proc(path: string, allocator := context.allocator) -> string {
     return null_term(string(buf[:]));
 }
 
-current :: proc(allocator := context.allocator) -> string {
+current :: proc(allocator := context.temp_allocator) -> string {
     foreign libc{
         getcwd :: proc(buf: ^u8, size: int) -> cstring ---;
     }

--- a/core/path/path_linux.odin
+++ b/core/path/path_linux.odin
@@ -1,7 +1,0 @@
-package path
-
-
-SEPARATOR        :: '/';
-SEPARATOR_STRING :: "/";
-
-#compile_assert("Linux is not yet supported");

--- a/core/path/path_linux.odin
+++ b/core/path/path_linux.odin
@@ -1,0 +1,80 @@
+package path
+
+foreign import libc "system:c"
+
+import "core:os"
+import "core:strings"
+
+
+MAX :: 4096; // @note(bp): apparently PATH_MAX is bullshit
+
+SEPARATOR        :: '/';
+SEPARATOR_STRING :: "/";
+
+
+@(private)
+null_term :: proc(str: string) -> string {
+    for c, i in str {
+        if c == '\x00' {
+            return str[:i];
+        }
+    }
+    return str;
+}
+
+
+full :: proc(path: string, allocator := context.allocator) -> string {
+    cpath := strings.clone_to_cstring(path, context.temp_allocator);
+    
+    foreign libc {
+        realpath :: proc(path: cstring, resolved_path: ^u8) -> cstring ---;
+    }
+
+    buf := make([dynamic]u8, MAX, MAX, allocator);
+
+    cstr := realpath(cpath, &buf[0]);
+    for cstr == nil && os.get_last_error() == int(os.ENAMETOOLONG) {
+        resize(&buf, len(buf) + MAX);
+        cstr = realpath(cpath, &buf[0]);
+    }
+
+    return null_term(string(buf[:]));
+}
+
+current :: proc(allocator := context.allocator) -> string {
+    foreign libc{
+        getcwd :: proc(buf: ^u8, size: int) -> cstring ---;
+    }
+
+    buf := make([dynamic]u8, MAX, MAX, allocator);
+
+    cstr := getcwd(&buf[0], len(buf));
+    for cstr == nil && os.get_last_error() == int(os.ENAMETOOLONG) {
+        resize(&buf, len(buf) + MAX);
+        cstr = getcwd(&buf[0], len(buf));
+    }
+
+    return null_term(string(buf[:]));
+}
+
+
+exists :: proc(path: string) -> bool {
+    if _, err := os.stat(path); err != os.ERROR_NONE {
+        return true;
+    }
+    return false;
+}
+
+is_dir :: proc(path: string) -> bool {
+    if stat, err := os.stat(path); err == os.ERROR_NONE {
+        return os.S_ISDIR(stat.mode);
+    }
+    return false;
+}
+
+is_file :: proc(path: string) -> bool {
+    if stat, err := os.stat(path); err == os.ERROR_NONE {
+        return os.S_ISREG(stat.mode);
+    }
+    return false;
+}

--- a/core/path/path_windows.odin
+++ b/core/path/path_windows.odin
@@ -11,78 +11,62 @@ SEPARATOR_STRING :: "\\";
 
 
 long :: proc(path: string, allocator := context.temp_allocator) -> string {
-    foreign kernel32 {
-        GetLongPathNameW :: proc "std" (short, long: win32.Wstring, len: u32) -> u32 ---;
-    }
-
     c_path := win32.utf8_to_wstring(path, context.temp_allocator);
     length := GetLongPathNameW(c_path, nil, 0);
 
-    if length > 0 {
-        buf := make([]u16, length-1, context.temp_allocator);
+    if length == 0 do return "";
 
-        GetLongPathNameW(c_path, win32.Wstring(&buf[0]), length);
+    buf := make([]u16, length, context.temp_allocator);
 
-        return win32.ucs2_to_utf8(buf[:length-1], allocator);
-    }
+    GetLongPathNameW(c_path, win32.Wstring(&buf[0]), length);
 
-    return "";
+    res := win32.ucs2_to_utf8(buf[:length], allocator);
+
+    return strings.trim_null(res);
 }
 
 short :: proc(path: string, allocator := context.temp_allocator) -> string {
-    foreign kernel32 {
-        GetShortPathNameW :: proc "std" (long, short: win32.Wstring, len: u32) -> u32 ---;
-    }
-
     c_path := win32.utf8_to_wstring(path, context.temp_allocator);
     length := GetShortPathNameW(c_path, nil, 0);
 
-    if length > 0 {
-        buf := make([]u16, length-1, context.temp_allocator);
+    if length == 0 do return "";
+    
+    buf := make([]u16, length, context.temp_allocator);
 
-        GetShortPathNameW(c_path, win32.Wstring(&buf[0]), length);
+    GetShortPathNameW(c_path, win32.Wstring(&buf[0]), length);
 
-        return win32.ucs2_to_utf8(buf[:length-1], allocator);
-    }
+    res := win32.ucs2_to_utf8(buf[:length], allocator);
 
-    return "";
+    return strings.trim_null(res);
 }
 
 full :: proc(path: string, allocator := context.temp_allocator) -> string {
-    foreign kernel32 {
-        GetFullPathNameW :: proc "std" (filename: win32.Wstring, buffer_length: u32, buffer: win32.Wstring, file_part: ^win32.Wstring) -> u32 ---;
-    }
-
     c_path := win32.utf8_to_wstring(path, context.temp_allocator);
     length := GetFullPathNameW(c_path, 0, nil, nil);
 
-    if length > 0 {
-        buf := make([]u16, length, context.temp_allocator);
+    if length == 0 do return "";
 
-        GetFullPathNameW(c_path, length, win32.Wstring(&buf[0]), nil);
+    buf := make([]u16, length, context.temp_allocator);
 
-        return win32.ucs2_to_utf8(buf[:len(buf)-1], allocator);
-    }
+    GetFullPathNameW(c_path, length, win32.Wstring(&buf[0]), nil);
 
-    return "";
+    res := win32.ucs2_to_utf8(buf[:length], allocator);
+
+    return strings.trim_null(res);
 }
 
 current :: proc(allocator := context.temp_allocator) -> string {
-    foreign kernel32 {
-        GetCurrentDirectoryW :: proc "std" (buffer_length: u32, buffer: win32.Wstring) -> u32 ---;
-    }
-
     length := GetCurrentDirectoryW(0, nil);
 
-    if length > 0 {
-        buf := make([]u16, length, context.temp_allocator);
+    if length == 0 do return "";
 
-        GetCurrentDirectoryW(length, win32.Wstring(&buf[0]));
+    buf := make([]u16, length, context.temp_allocator);
 
-        return win32.ucs2_to_utf8(buf[:length-1], allocator);
-    }
+    GetCurrentDirectoryW(length, win32.Wstring(&buf[0]));
 
-    return "";
+    res := win32.ucs2_to_utf8(buf[:length], allocator);
+
+    return strings.trim_null(res);
 }
 
 

--- a/core/path/path_windows.odin
+++ b/core/path/path_windows.odin
@@ -1,7 +1,5 @@
 package path
 
-foreign import "system:kernel32.lib"
-
 import "core:strings"
 import "core:sys/win32"
 
@@ -10,59 +8,70 @@ SEPARATOR        :: '\\';
 SEPARATOR_STRING :: "\\";
 
 
+@(private)
+null_term :: proc"contextless"(str: string) -> string {
+    for c, i in str {
+        if c == '\x00' {
+            return str[:i];
+        }
+    }
+    return str;
+}
+
+
 long :: proc(path: string, allocator := context.temp_allocator) -> string {
     c_path := win32.utf8_to_wstring(path, context.temp_allocator);
-    length := GetLongPathNameW(c_path, nil, 0);
+    length := win32.get_long_path_name_w(c_path, nil, 0);
 
     if length == 0 do return "";
 
     buf := make([]u16, length, context.temp_allocator);
 
-    GetLongPathNameW(c_path, win32.Wstring(&buf[0]), length);
+    win32.get_long_path_name_w(c_path, win32.Wstring(&buf[0]), length);
 
     res := win32.ucs2_to_utf8(buf[:length], allocator);
 
-    return strings.trim_null(res);
+    return null_term(res);
 }
 
 short :: proc(path: string, allocator := context.temp_allocator) -> string {
     c_path := win32.utf8_to_wstring(path, context.temp_allocator);
-    length := GetShortPathNameW(c_path, nil, 0);
+    length := win32.get_short_path_name_w(c_path, nil, 0);
 
     if length == 0 do return "";
     
     buf := make([]u16, length, context.temp_allocator);
 
-    GetShortPathNameW(c_path, win32.Wstring(&buf[0]), length);
+    win32.get_short_path_name_w(c_path, win32.Wstring(&buf[0]), length);
 
     res := win32.ucs2_to_utf8(buf[:length], allocator);
 
-    return strings.trim_null(res);
+    return null_term(res);
 }
 
 full :: proc(path: string, allocator := context.temp_allocator) -> string {
     c_path := win32.utf8_to_wstring(path, context.temp_allocator);
-    length := GetFullPathNameW(c_path, 0, nil, nil);
+    length := win32.get_full_path_name_w(c_path, 0, nil, nil);
 
     if length == 0 do return "";
 
     buf := make([]u16, length, context.temp_allocator);
 
-    GetFullPathNameW(c_path, length, win32.Wstring(&buf[0]), nil);
+    win32.get_full_path_name_w(c_path, length, win32.Wstring(&buf[0]), nil);
 
     res := win32.ucs2_to_utf8(buf[:length], allocator);
 
-    return strings.trim_null(res);
+    return null_term(res);
 }
 
 current :: proc(allocator := context.temp_allocator) -> string {
-    length := GetCurrentDirectoryW(0, nil);
+    length := win32.get_current_directory_w(0, nil);
 
     if length == 0 do return "";
 
     buf := make([]u16, length, context.temp_allocator);
 
-    GetCurrentDirectoryW(length, win32.Wstring(&buf[0]));
+    win32.get_current_directory_w(length, win32.Wstring(&buf[0]));
 
     res := win32.ucs2_to_utf8(buf[:length], allocator);
 

--- a/core/path/path_windows.odin
+++ b/core/path/path_windows.odin
@@ -1,0 +1,121 @@
+package path
+
+foreign import "system:kernel32.lib"
+
+import "core:strings"
+import "core:sys/win32"
+
+
+SEPARATOR        :: '\\';
+SEPARATOR_STRING :: "\\";
+
+
+long :: proc(path: string, allocator := context.temp_allocator) -> string {
+    foreign kernel32 {
+        GetLongPathNameW :: proc "std" (short, long: win32.Wstring, len: u32) -> u32 ---;
+    }
+
+    c_path := win32.utf8_to_wstring(path, context.temp_allocator);
+    length := GetLongPathNameW(c_path, nil, 0);
+
+    if length > 0 {
+        buf := make([]u16, length-1, context.temp_allocator);
+
+        GetLongPathNameW(c_path, win32.Wstring(&buf[0]), length);
+
+        return win32.ucs2_to_utf8(buf[:length-1], allocator);
+    }
+
+    return "";
+}
+
+short :: proc(path: string, allocator := context.temp_allocator) -> string {
+    foreign kernel32 {
+        GetShortPathNameW :: proc "std" (long, short: win32.Wstring, len: u32) -> u32 ---;
+    }
+
+    c_path := win32.utf8_to_wstring(path, context.temp_allocator);
+    length := GetShortPathNameW(c_path, nil, 0);
+
+    if length > 0 {
+        buf := make([]u16, length-1, context.temp_allocator);
+
+        GetShortPathNameW(c_path, win32.Wstring(&buf[0]), length);
+
+        return win32.ucs2_to_utf8(buf[:length-1], allocator);
+    }
+
+    return "";
+}
+
+full :: proc(path: string, allocator := context.temp_allocator) -> string {
+    foreign kernel32 {
+        GetFullPathNameW :: proc "std" (filename: win32.Wstring, buffer_length: u32, buffer: win32.Wstring, file_part: ^win32.Wstring) -> u32 ---;
+    }
+
+    c_path := win32.utf8_to_wstring(path, context.temp_allocator);
+    length := GetFullPathNameW(c_path, 0, nil, nil);
+
+    if length > 0 {
+        buf := make([]u16, length, context.temp_allocator);
+
+        GetFullPathNameW(c_path, length, win32.Wstring(&buf[0]), nil);
+
+        return win32.ucs2_to_utf8(buf[:len(buf)-1], allocator);
+    }
+
+    return "";
+}
+
+current :: proc(allocator := context.temp_allocator) -> string {
+    foreign kernel32 {
+        GetCurrentDirectoryW :: proc "std" (buffer_length: u32, buffer: win32.Wstring) -> u32 ---;
+    }
+
+    length := GetCurrentDirectoryW(0, nil);
+
+    if length > 0 {
+        buf := make([]u16, length, context.temp_allocator);
+
+        GetCurrentDirectoryW(length, win32.Wstring(&buf[0]));
+
+        return win32.ucs2_to_utf8(buf[:length-1], allocator);
+    }
+
+    return "";
+}
+
+
+exists :: proc(path: string) -> bool {
+    c_path  := win32.utf8_to_wstring(path, context.temp_allocator);
+    attribs := win32.get_file_attributes_w(c_path);
+
+    return i32(attribs) != win32.INVALID_FILE_ATTRIBUTES;
+}
+
+is_dir :: proc(path: string) -> bool {
+    c_path  := win32.utf8_to_wstring(path, context.temp_allocator);
+    attribs := win32.get_file_attributes_w(c_path);
+
+    return (i32(attribs) != win32.INVALID_FILE_ATTRIBUTES) && (attribs & win32.FILE_ATTRIBUTE_DIRECTORY == win32.FILE_ATTRIBUTE_DIRECTORY);
+}
+
+is_file :: proc(path: string) -> bool {
+    c_path  := win32.utf8_to_wstring(path, context.temp_allocator);
+    attribs := win32.get_file_attributes_w(c_path);
+
+    return (i32(attribs) != win32.INVALID_FILE_ATTRIBUTES) && (attribs & win32.FILE_ATTRIBUTE_DIRECTORY != win32.FILE_ATTRIBUTE_DIRECTORY);
+}
+
+
+drive :: proc(path: string, new := false, allocator := context.allocator) -> string {
+    if len(path) >= 3 {
+        letter := path[:2];
+
+        if path[1] == ':' && (path[2] == '\\' || path[2] == '/') {
+            return new ? strings.new_string(path[:2], allocator) : path[:2];
+        }
+    }
+
+    return "";
+}

--- a/core/sys/win32/kernel32.odin
+++ b/core/sys/win32/kernel32.odin
@@ -174,7 +174,7 @@ foreign kernel32 {
 	@(link_name="GetShortPathNameA") get_short_path_name_a :: proc(long, short: cstring, len: u32) -> u32 ---;
 	@(link_name="GetShortPathNameW") get_short_path_name_w :: proc(long, short: Wstring, len: u32) -> u32 ---;
 
-	@(link_name="GetCurrentDirectorya") get_current_directory_a :: proc(buffer_length: u32, buffer: cstring) -> u32 ---;
+	@(link_name="GetCurrentDirectoryA") get_current_directory_a :: proc(buffer_length: u32, buffer: cstring) -> u32 ---;
 	@(link_name="GetCurrentDirectoryW") get_current_directory_w :: proc(buffer_length: u32, buffer: Wstring) -> u32 ---;
 }
 

--- a/core/sys/win32/kernel32.odin
+++ b/core/sys/win32/kernel32.odin
@@ -167,4 +167,13 @@ foreign kernel32 {
 	@(link_name="FreeLibrary")    free_library     :: proc(h: Hmodule) ---;
 	@(link_name="GetProcAddress") get_proc_address :: proc(h: Hmodule, c_str: cstring) -> rawptr ---;
 
+	@(link_name="GetFullPathNameA")  get_full_path_name_a  :: proc(filename: cstring, buffer_length: u32, buffer: cstring, file_part: ^Wstring) -> u32 ---;
+	@(link_name="GetFullPathNameW")  get_full_path_name_w  :: proc(filename: Wstring, buffer_length: u32, buffer: Wstring, file_part: ^Wstring) -> u32 ---;
+	@(link_name="GetLongPathNameA")  get_long_path_name_a  :: proc(short, long: cstring, len: u32) -> u32 ---;
+	@(link_name="GetLongPathNameW")  get_long_path_name_w  :: proc(short, long: Wstring, len: u32) -> u32 ---;
+	@(link_name="GetShortPathNameA") get_short_path_name_a :: proc(long, short: cstring, len: u32) -> u32 ---;
+	@(link_name="GetShortPathNameW") get_short_path_name_w :: proc(long, short: Wstring, len: u32) -> u32 ---;
+
+	@(link_name="GetCurrentDirectorya") get_current_directory_a :: proc(buffer_length: u32, buffer: cstring) -> u32 ---;
+	@(link_name="GetCurrentDirectoryW") get_current_directory_w :: proc(buffer_length: u32, buffer: Wstring) -> u32 ---;
 }


### PR DESCRIPTION
I've added a path library which can extract components of file paths (drive letter, parent directory, base, file name, file extension), get the current working directory, get the absolute version of a path relative to the current directory, convert between Windows' "short" and "long" path names (because why not), verify a path's existence, determine whether a valid path is a file or a directory, get the relative path between two paths, as well as the current directory and another path, and split a path into its constituent elements.

In order to facilitate the latter, I've also added two quite useful `string.split` variants to the `core:strings` library, which split a given string into sub-slices along one or more given sub-strings. Both the single and multiple sub-string variants have an option not to include empty sub-slices in the results.

If you have any concerns or edits you'd like me to make before pulling, just let me know. Of course, feel free to edit the code/comments as you see fit.

There are a couple of outstanding design issues that I'd be happy to discuss if they're problematic; most notably with the behavior of `path.dir`, `path.base`, `path.name`, and `path.ext` in terms of what they return in certain cases. I've tried to use [Go's path package](https://golang.org/pkg/path/) as a reference, though I opted not to follow some of its choices such as returning `"."` from `path.base` when the `path` parameter is empty. Ultimately I think the best way to figure out what design works best for the edge cases is to put `core:path` into the wild and see which choices people respond negatively to.