### PR TITLE
Fix #345: panic when using enum as map key

### DIFF
--- a/examples/demo/demo.odin
+++ b/examples/demo/demo.odin
@@ -703,9 +703,9 @@ map_type :: proc() {
 		A = 0,
 		B = 1 << 64 - 1,
 	}
-	Enum_i32 :: enum i32 {
+	Enum_i8 :: enum i8 {
 		A = 0,
-		B = -(1 << 31),
+		B = -(1 << 7),
 	}
 	Enum_i64 :: enum i64 {
 		A = 0,

--- a/examples/demo/demo.odin
+++ b/examples/demo/demo.odin
@@ -530,7 +530,7 @@ parametric_polymorphism :: proc() {
 			// `I` is the type of N
 			// `T` is the type passed
 			fmt.printf("Generating an array of type %v from the value %v of type %v\n",
-			           typeid_of(type_of(res)), N, typeid_of(I));
+					   typeid_of(type_of(res)), N, typeid_of(I));
 			for i in 0..N-1 {
 				res[i] = T(i*i);
 			}
@@ -689,6 +689,61 @@ using_enum :: proc() {
 	f2 := C;
 	fmt.println(f0, f1, f2);
 	fmt.println(len(Foo));
+}
+
+map_type :: proc() {
+	fmt.println("# map type");
+
+	// enums of type u16, u32, i16 & i32 also work
+	Enum_u8 :: enum u8 {
+		A = 0,
+		B = 1 << 8 - 1,
+	}
+	Enum_u64 :: enum u64 {
+		A = 0,
+		B = 1 << 64 - 1,
+	}
+	Enum_i32 :: enum i32 {
+		A = 0,
+		B = -(1 << 31),
+	}
+	Enum_i64 :: enum i64 {
+		A = 0,
+		B = -(1 << 63),
+	}
+
+	map_u8: map[Enum_u8]u8;
+	map_u8[Enum_u8.A] = u8(Enum_u8.B);
+	assert(map_u8[Enum_u8.A] == u8(Enum_u8.B));
+	fmt.println(map_u8);
+
+	map_u64: map[Enum_u64]u64;
+	map_u64[Enum_u64.A] = u64(Enum_u64.B);
+	assert(map_u64[Enum_u64.A] == u64(Enum_u64.B));
+	fmt.println(map_u64);
+
+	map_i8: map[Enum_i8]i8;
+	map_i8[Enum_i8.A] = i8(Enum_i8.B);
+	assert(map_i8[Enum_i8.A] == i8(Enum_i8.B));
+	fmt.println(map_i8);
+
+	map_i64: map[Enum_i64]i64;
+	map_i64[Enum_i64.A] = i64(Enum_i64.B);
+	assert(map_i64[Enum_i64.A] == i64(Enum_i64.B));
+	fmt.println(map_i64);
+
+	demo_struct :: struct {
+		member: Enum_i64,
+	}
+
+	map_string: map[string]demo_struct;
+	map_string["Hellope!"] = demo_struct{Enum_i64.B};
+	assert(map_string["Hellope!"].member == Enum_i64.B);
+	assert("Hellope?" notin map_string);
+	fmt.println(map_string);
+	fmt.println("Hellope! in map_string:", "Hellope!" in map_string);
+	fmt.println("Hellope? in map_string:", "Hellope?" in map_string);
+
 }
 
 explicit_procedure_overloading :: proc() {
@@ -884,6 +939,7 @@ main :: proc() {
 		array_programming();
 		named_proc_return_parameters();
 		using_enum();
+		map_type();
 		explicit_procedure_overloading();
 		complete_switch();
 		cstring_example();

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -3215,6 +3215,9 @@ irValue *ir_gen_map_key(irProcedure *proc, irValue *key, Type *key_type) {
 	key = ir_emit_conv(proc, key, key_type);
 	if (is_type_integer(t)) {
 		ir_emit_store(proc, ir_emit_struct_ep(proc, v, 0), ir_emit_conv(proc, key, hash_type));
+	} else if (is_type_enum(t)) {
+		irValue *e = ir_emit_bitcast(proc, key, t_uint);
+		ir_emit_store(proc, ir_emit_struct_ep(proc, v, 0), ir_emit_conv(proc, e, hash_type));
 	} else if (is_type_typeid(t)) {
 		irValue *i = ir_emit_bitcast(proc, key, t_uint);
 		ir_emit_store(proc, ir_emit_struct_ep(proc, v, 0), ir_emit_conv(proc, i, hash_type));

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -3216,8 +3216,7 @@ irValue *ir_gen_map_key(irProcedure *proc, irValue *key, Type *key_type) {
 	if (is_type_integer(t)) {
 		ir_emit_store(proc, ir_emit_struct_ep(proc, v, 0), ir_emit_conv(proc, key, hash_type));
 	} else if (is_type_enum(t)) {
-		irValue *e = ir_emit_bitcast(proc, key, t_uint);
-		ir_emit_store(proc, ir_emit_struct_ep(proc, v, 0), ir_emit_conv(proc, e, hash_type));
+		ir_emit_store(proc, ir_emit_struct_ep(proc, v, 0), ir_emit_conv(proc, key, hash_type));
 	} else if (is_type_typeid(t)) {
 		irValue *i = ir_emit_bitcast(proc, key, t_uint);
 		ir_emit_store(proc, ir_emit_struct_ep(proc, v, 0), ir_emit_conv(proc, i, hash_type));


### PR DESCRIPTION
Fix for issue #345 
```cpp
package minrep
import "core:fmt";

Enum :: enum {
    A = 0,
    B = 1,
}

main :: proc() {
    foos : map[Enum]int;
    foos[Enum.A] = int{};
    fmt.println(foos);
}

```
Without the patch it panics: `src/ir.cpp(3251): Panic: Unhandled map type`
With the patch it doesn't panic and the output is as expected: `map[A=0]`