### PR TITLE
fix string reversal

### DIFF
--- a/core/strings/strings.odin
+++ b/core/strings/strings.odin
@@ -700,10 +700,11 @@ reverse :: proc(s: string, allocator := context.allocator) -> string {
 	str := s;
 	n := len(str);
 	buf := make([]byte, n);
-	i := 0;
+	i := n;
 
 	for len(str) > 0 {
 		_, w := utf8.decode_rune_in_string(str);
+		i -= w;
 		copy(buf[i:], cast([]byte)str[:w]);
 		str = str[w:];
 	}


### PR DESCRIPTION
The reverse proc from the strings package is broken. It results in a string with only the last character.

The following test demonstrates the bug. If you run the program you get 'd' as the result of reversing 'hello world'.

```
package bug

import "core:strings"
import "core:fmt"

main :: proc() {
    t := "hello world";
    fmt.println("odin-string:", t);
    t = strings.reverse(t);
    ct := strings.clone_to_cstring(t);
    fmt.println("reversed odin-string:", t);
    fmt.println("c-string:", ct);
}
```
