### PR TITLE
Fix 'fmt.string_to_enum_value' not compiling

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -837,8 +837,8 @@ enum_value_to_string :: proc(val: any) -> (string, bool) {
 }
 
 string_to_enum_value :: proc($T: typeid, s: string) -> (T, bool) {
-	ti := type_info_base(type_info_of(T));
-	if e, ok := ti.variant.(Type_Info_Enum); ok {
+	ti := runtime.type_info_base(type_info_of(T));
+	if e, ok := ti.variant.(runtime.Type_Info_Enum); ok {
 		for str, idx in e.names {
 			if s == str {
 				// NOTE(bill): Unsafe cast


### PR DESCRIPTION
The string_to_enum_value function was accessing `type_info_base` and `Type_Info_Enum` improperly, causing the following errors:
```
core/fmt/fmt.odin(840:8) Undeclared name: type_info_base
core/fmt/fmt.odin(841:5) Assignment count mismatch '2' = '1'
core/fmt/fmt.odin(842:21) Cannot iterate over 'e.names' of type 'invalid type'
```