### PR TITLE
Unix: Fix improper _unix_open binding; make write_entire_file set sane file permissions.

### DIFF
--- a/core/os/os.odin
+++ b/core/os/os.odin
@@ -99,7 +99,14 @@ write_entire_file :: proc(name: string, data: []byte, truncate := true) -> (succ
 	if truncate {
 		flags |= O_TRUNC;
 	}
-	fd, err := open(name, flags, 0);
+
+    mode: int = 0;
+    when OS == "linux" {
+        // NOTE(justasd): 644 (owner read, write; group read; others read)
+        mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+    }
+
+	fd, err := open(name, flags, mode);
 	if err != 0 {
 		return false;
 	}

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -259,7 +259,7 @@ foreign libc {
 	@(link_name="__errno_location") __errno_location    :: proc() -> ^int ---;
 	@(link_name="syscall")          syscall             :: proc(number: Syscall, #c_vararg args: ..any) -> int ---;
 
-	@(link_name="open")             _unix_open          :: proc(path: cstring, flags: int, #c_vararg mode: ..any) -> Handle ---;
+	@(link_name="open")             _unix_open          :: proc(path: cstring, flags: int, mode: int) -> Handle ---;
 	@(link_name="close")            _unix_close         :: proc(fd: Handle) -> int ---;
 	@(link_name="read")             _unix_read          :: proc(fd: Handle, buf: rawptr, size: int) -> int ---;
 	@(link_name="write")            _unix_write         :: proc(fd: Handle, buf: rawptr, size: int) -> int ---;


### PR DESCRIPTION
`os.write_entire_file` was previously creating a file and only setting the execute permission, making the function a pain to work with as you had to set the file permissions manually. With these changes, the function now sets owner read, write; group read; others read permissions.