### PR TITLE
Implement dynlib core library for unix/darwin

### DIFF
--- a/core/dynlib/lib_unix.odin
+++ b/core/dynlib/lib_unix.odin
@@ -1,0 +1,21 @@
+// +build linux, darwin
+package dynlib
+
+import "core:os"
+
+load_library :: proc(path: string, global_symbols := false) -> (Library, bool) {
+    flags := os.RTLD_NOW;
+    if global_symbols do flags |= os.RTLD_GLOBAL;
+    lib := os.dlopen(path, flags);
+    return Library(lib), lib != nil;
+}
+
+unload_library :: proc(library: Library) {
+    os.dlclose(rawptr(library));
+}
+
+symbol_address :: proc(library: Library, symbol: string) -> (ptr: rawptr, found: bool) {
+    ptr = os.dlsym(rawptr(library), symbol);
+    found = ptr != nil;
+    return;
+}

--- a/core/dynlib/lib_windows.odin
+++ b/core/dynlib/lib_windows.odin
@@ -1,3 +1,4 @@
+// +build windows
 package dynlib
 
 import "core:sys/win32"


### PR DESCRIPTION
I have implemented the `dynlib` core library for unix/darwin. I added `//build` tags; not sure if this was necessary or correct. Other than that, as far as I can tell, it just works. :)