### PR TITLE
Fixes for yielding and semaphore posting on unix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ bld/
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
+demo
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/core/sync/sync_darwin.odin
+++ b/core/sync/sync_darwin.odin
@@ -28,9 +28,11 @@ semaphore_destroy :: proc(s: ^Semaphore) {
 }
 
 semaphore_post :: proc(s: ^Semaphore, count := 1) {
-	assert(count == 1);
-	res := darwin.semaphore_signal(s.handle);
-	assert(res == 0);
+	// NOTE: SPEED: If there's one syscall to do this, we should use it instead of the loop.
+	for in 0..count-1 {
+		res := darwin.semaphore_signal(s.handle);
+		assert(res == 0);
+	}
 }
 
 semaphore_wait_for :: proc(s: ^Semaphore) {

--- a/core/sync/sync_linux.odin
+++ b/core/sync/sync_linux.odin
@@ -20,7 +20,10 @@ semaphore_destroy :: proc(s: ^Semaphore) {
 }
 
 semaphore_post :: proc(s: ^Semaphore, count := 1) {
-	assert(unix.sem_post(&s.handle) == 0);
+    // NOTE: SPEED: If there's one syscall to do this, we should use it instead of the loop.
+    for in 0..count-1 {
+	    assert(unix.sem_post(&s.handle) == 0);
+    }
 }
 
 semaphore_wait_for :: proc(s: ^Semaphore) {

--- a/core/sys/unix/pthread_linux.odin
+++ b/core/sys/unix/pthread_linux.odin
@@ -104,5 +104,7 @@ foreign pthread {
 	sem_trywait :: proc(sem: ^sem_t) -> c.int ---;
 	// sem_timedwait :: proc(sem: ^sem_t, timeout: time.TimeSpec) -> c.int ---;
 
+	// NOTE: unclear whether pthread_yield is well-supported on Linux systems,
+	// see https://linux.die.net/man/3/pthread_yield
 	pthread_yield :: proc() -> c.int ---;
 }

--- a/core/sys/unix/pthread_linux.odin
+++ b/core/sys/unix/pthread_linux.odin
@@ -103,4 +103,6 @@ foreign pthread {
 	sem_wait :: proc(sem: ^sem_t) -> c.int ---;
 	sem_trywait :: proc(sem: ^sem_t) -> c.int ---;
 	// sem_timedwait :: proc(sem: ^sem_t, timeout: time.TimeSpec) -> c.int ---;
+
+	pthread_yield :: proc() -> c.int ---;
 }

--- a/core/sys/unix/pthread_unix.odin
+++ b/core/sys/unix/pthread_unix.odin
@@ -52,7 +52,8 @@ foreign pthread {
 	pthread_attr_setstack :: proc(attrs: ^pthread_attr_t, stack_ptr: rawptr, stack_size: u64) -> c.int ---;
 	pthread_attr_getstack :: proc(attrs: ^pthread_attr_t, stack_ptr: ^rawptr, stack_size: ^u64) -> c.int ---;
 
-	pthread_yield :: proc() -> c.int ---;
+	sched_yield :: proc() -> c.int ---;
+	
 }
 
 @(default_calling_convention="c")

--- a/core/thread/thread_unix.odin
+++ b/core/thread/thread_unix.odin
@@ -158,5 +158,5 @@ destroy :: proc(t: ^Thread) {
 
 
 yield :: proc() {
-	unix.pthread_yield();
+	unix.sched_yield();
 }


### PR DESCRIPTION
- replaced pthread_yield with sched_yield
- fixed semaphore post procedures
Note to Tetralux, please double-test this