### PR TITLE
Fix make and reserve

### DIFF
--- a/core/mem/alloc.odin
+++ b/core/mem/alloc.odin
@@ -124,8 +124,10 @@ make_dynamic_array_len :: proc($T: typeid/[dynamic]$E, auto_cast len: int, alloc
 make_dynamic_array_len_cap :: proc($T: typeid/[dynamic]$E, auto_cast len: int, auto_cast cap: int, allocator := context.allocator, loc := #caller_location) -> T {
 	runtime.make_dynamic_array_error_loc(loc, len, cap);
 	data := alloc(size_of(E)*cap, align_of(E), allocator, loc);
-	if data == nil do return nil;
 	s := Raw_Dynamic_Array{data, len, cap, allocator};
+	if data == nil {
+		s.len, s.cap = 0, 0;
+	}
 	return transmute(T)s;
 }
 make_map :: proc($T: typeid/map[$K]$E, auto_cast cap: int = 16, allocator := context.allocator, loc := #caller_location) -> T {

--- a/core/runtime/core.odin
+++ b/core/runtime/core.odin
@@ -628,8 +628,10 @@ make_dynamic_array_len :: proc($T: typeid/[dynamic]$E, auto_cast len: int, alloc
 make_dynamic_array_len_cap :: proc($T: typeid/[dynamic]$E, auto_cast len: int, auto_cast cap: int, allocator := context.allocator, loc := #caller_location) -> T {
 	make_dynamic_array_error_loc(loc, len, cap);
 	data := mem_alloc(size_of(E)*cap, align_of(E), allocator, loc);
-	if data == nil do return nil;
 	s := Raw_Dynamic_Array{data, len, cap, allocator};
+	if data == nil {
+		s.len, s.cap = 0, 0;
+	}
 	return transmute(T)s;
 }
 


### PR DESCRIPTION
- Set the allocator, even if memory allocation fails.
  Right now it doesn't, which means that if allocation fails, it'll use the context allocator instead.
  This memory will be leaked if the user doesn't understand that this happened, which they probably won't.

- Only set `len` and `cap` of the array returned from make iif the memory allocation succeeded.
  This means that reserve will return `false` if you do this:
  ```go
  a := make([dynamic]int, failing_allocator);
  if !reserve(&a, 5) do return; // or whatever indicates failure
  ```
  Currently, it returns `true` in this situation.