### PR TITLE
Fix mistake in .Short_File_Path option in file_console_logger.odin

### DIFF
--- a/core/log/file_console_logger.odin
+++ b/core/log/file_console_logger.odin
@@ -121,9 +121,8 @@ do_location_header :: proc(opts : Options, buf : ^strings.Builder, location := #
 
     file := location.file_path;
     if .Short_File_Path in opts {
-        when os.OS == "windows" do delimiter := '\\'; else do delimiter := '/';
         last := 0;
-        for r, i in location.file_path do if r == delimiter do last = i+1;
+        for r, i in location.file_path do if r == '/' do last = i+1;
         file = location.file_path[last:];
     }
 


### PR DESCRIPTION
The location file path has apparently changed from keeping OS path delimiter to always just be '/'.
So  .Short_File_Path actually output all of the path instead of shorting it.