### PR TITLE
Fix `make(map[K]V, 0)` by ensuring `reserve` always sets an allocator

### DIFF
--- a/core/runtime/core.odin
+++ b/core/runtime/core.odin
@@ -1125,12 +1125,14 @@ __dynamic_array_make :: proc(array_: rawptr, elem_size, elem_align: int, len, ca
 __dynamic_array_reserve :: proc(array_: rawptr, elem_size, elem_align: int, cap: int, loc := #caller_location) -> bool {
 	array := (^Raw_Dynamic_Array)(array_);
 
-	if cap <= array.cap do return true;
-
+	// NOTE(tetra, 2020-01-26): We set the allocator before earlying-out below, because user code is usually written
+	// assuming that appending/reserving will set the allocator, if it is not already set.
 	if array.allocator.procedure == nil {
 		array.allocator = context.allocator;
 	}
 	assert(array.allocator.procedure != nil);
+	
+	if cap <= array.cap do return true;
 
 	old_size  := array.cap * elem_size;
 	new_size  := cap * elem_size;


### PR DESCRIPTION
Currently, `make(map[K]V, 0)` asserts, because trying to `reserve` zero items does not set the allocator; it early-outs.

`__dynamic_map_reserve` assumed that `__dynamic_array_reserve` would always set the allocator - even if given a desired capacity of `0`.

Rather than making `__slice_resize` just _also_ set the default allocator if there isn't one, this makes `__dynamic_array_reserve` always set the allocator, even if it is about to early out.
This is because users are lead to understand that `append` will set the allocator if one is not already set - `reserve` should work the same way.

Also:
```odin
a: [dynamic]int;
reserve(&a, 0);
assert(a.allocator.procedure != nil); // fails
```
This means the context will not be used for the allocator at the time the user expects it to, which means it could be set elsewhere, and cause confusion.