### PR TITLE
Fix #552: Fix strings.compare for empty strings and different-length strings.

### DIFF
--- a/core/strings/strings.odin
+++ b/core/strings/strings.odin
@@ -52,6 +52,8 @@ unsafe_string_to_cstring :: proc(str: string) -> cstring {
 	return cstring(d.data);
 }
 
+// Compares two strings, returning a value representing which one comes first lexiographically.
+// -1 for `a`; 1 for `b`, or 0 if they are equal.
 compare :: proc(lhs, rhs: string) -> int {
 	return mem.compare(transmute([]byte)lhs, transmute([]byte)rhs);
 }


### PR DESCRIPTION
Fixes #552.

- Fix comparisons involving one or more empty string.
- Fix comparisons against two strings of different lengths.
```odin
compare("a", "ab"); // before=0, after=-1
compare("", "a"); // before=crash, after=-1
compare("", ""); // before=crash, after=0
```