### PR TITLE
Fix mem.align_backward when pointer is already aligned

### DIFF
--- a/core/mem/mem.odin
+++ b/core/mem/mem.odin
@@ -186,9 +186,7 @@ align_backward :: inline proc(ptr: rawptr, align: uintptr) -> rawptr {
 
 align_backward_uintptr :: proc(ptr, align: uintptr) -> uintptr {
 	assert(is_power_of_two(align));
-
-	ptr := rawptr(ptr - align);
-	return uintptr(align_forward(ptr, align));
+	return align_forward_uintptr(ptr - align + 1, align);
 }
 
 align_backward_int :: inline proc(ptr, align: int) -> int {


### PR DESCRIPTION
Previously, it would always go back - now it only goes back if it's not aligned already.

```odin
assert(mem.align_backward_uintptr(34, 32) == 32);
assert(mem.align_backward_uintptr(31, 32) == 0);
assert(mem.align_backward_uintptr(32, 32) == 32); // failed before, passes now
```