### PR TITLE
Fix strings.clone and strings.clone_to_cstring if allocation fails

### DIFF
--- a/core/dynlib/lib_windows.odin
+++ b/core/dynlib/lib_windows.odin
@@ -18,7 +18,7 @@ unload_library :: proc(library: Library) -> bool {
 }
 
 symbol_address :: proc(library: Library, symbol: string) -> (ptr: rawptr, found: bool) {
-	c_str := strings.clone_to_cstring(symbol, context.temp_allocator);
+	c_str, _ := strings.clone_to_cstring(symbol, context.temp_allocator);
 	ptr = win32.get_proc_address(cast(win32.Hmodule)library, c_str);
 	found = ptr != nil;
 	return;

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -298,9 +298,8 @@ get_last_error :: proc() -> int {
 }
 
 open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Errno) {
-	cstr := strings.clone_to_cstring(path);
+	cstr, _ := strings.clone_to_cstring(path, context.temp_allocator);
 	handle := _unix_open(cstr, c.int(flags), c.int(mode));
-	delete(cstr);
 	if handle == -1 {
 		return INVALID_HANDLE, Errno(get_last_error());
 	}
@@ -378,9 +377,7 @@ last_write_time_by_name :: proc(name: string) -> (File_Time, Errno) {
 }
 
 stat :: inline proc(path: string) -> (Stat, Errno) {
-	cstr := strings.clone_to_cstring(path);
-	defer delete(cstr);
-
+	cstr, _ := strings.clone_to_cstring(path, context.temp_allocator);
 	s: Stat;
 	result := _unix_stat(cstr, &s);
 	if result == -1 {
@@ -399,8 +396,7 @@ fstat :: inline proc(fd: Handle) -> (Stat, Errno) {
 }
 
 access :: inline proc(path: string, mask: int) -> (bool, Errno) {
-	cstr := strings.clone_to_cstring(path);
-	defer delete(cstr);
+	cstr, _ := strings.clone_to_cstring(path, context.temp_allocator);
 	result := _unix_access(cstr, c.int(mask));
 	if result == -1 {
 		return false, Errno(get_last_error());
@@ -422,8 +418,7 @@ heap_free :: proc(ptr: rawptr) {
 }
 
 getenv :: proc(name: string) -> (string, bool) {
-	path_str := strings.clone_to_cstring(name);
-	defer delete(path_str);
+	path_str, _ := strings.clone_to_cstring(name, context.temp_allocator);
 	cstr := _unix_getenv(path_str);
 	if cstr == nil {
 		return "", false;
@@ -452,7 +447,7 @@ get_current_directory :: proc() -> string {
 }
 
 set_current_directory :: proc(path: string) -> (err: Errno) {
-	cstr := strings.clone_to_cstring(path, context.temp_allocator);
+	cstr, _ := strings.clone_to_cstring(path, context.temp_allocator);
 	res := _unix_chdir(cstr);
 	if res == -1 do return Errno(get_last_error());
 	return ERROR_NONE;
@@ -467,15 +462,13 @@ current_thread_id :: proc "contextless" () -> int {
 }
 
 dlopen :: inline proc(filename: string, flags: int) -> rawptr {
-	cstr := strings.clone_to_cstring(filename);
-	defer delete(cstr);
+	cstr, _ := strings.clone_to_cstring(filename, context.temp_allocator);
 	handle := _unix_dlopen(cstr, c.int(flags));
 	return handle;
 }
 dlsym :: inline proc(handle: rawptr, symbol: string) -> rawptr {
 	assert(handle != nil);
-	cstr := strings.clone_to_cstring(symbol);
-	defer delete(cstr);
+	cstr, _ := strings.clone_to_cstring(symbol, context.temp_allocator);
 	proc_handle := _unix_dlsym(handle, cstr);
 	return proc_handle;
 }

--- a/core/strings/builder.odin
+++ b/core/strings/builder.odin
@@ -17,8 +17,8 @@ destroy_builder :: proc(b: ^Builder) {
 	clear(&b.buf);
 }
 
-grow_builder :: proc(b: ^Builder, cap: int) {
-	reserve(&b.buf, cap);
+grow_builder :: proc(b: ^Builder, cap: int) -> bool {
+	return reserve(&b.buf, cap);
 }
 
 reset_builder :: proc(b: ^Builder) {

--- a/core/strings/strings.odin
+++ b/core/strings/strings.odin
@@ -25,8 +25,8 @@ clone_to_cstring :: proc(s: string, allocator := context.allocator) -> (str: cst
 
 @(deprecated="Please use 'strings.clone'")
 new_string :: proc(s: string, allocator := context.allocator) -> string {
-	s, _ := clone(s, allocator);
-	return s;
+	str, _ := clone(s, allocator);
+	return str;
 }
 
 @(deprecated="Please use 'strings.clone_to_cstring'")

--- a/core/strings/strings.odin
+++ b/core/strings/strings.odin
@@ -5,6 +5,7 @@ import "core:unicode/utf8"
 
 clone :: proc(s: string, allocator := context.allocator) -> string {
 	c := make([]byte, len(s)+1, allocator);
+	if c == nil do return "";
 	copy(c, s);
 	c[len(s)] = 0;
 	return string(c[:len(s)]);
@@ -12,6 +13,7 @@ clone :: proc(s: string, allocator := context.allocator) -> string {
 
 clone_to_cstring :: proc(s: string, allocator := context.allocator) -> cstring {
 	c := make([]byte, len(s)+1, allocator);
+	if c == nil do return nil;
 	copy(c, s);
 	c[len(s)] = 0;
 	return cstring(&c[0]);
@@ -19,18 +21,12 @@ clone_to_cstring :: proc(s: string, allocator := context.allocator) -> cstring {
 
 @(deprecated="Please use 'strings.clone'")
 new_string :: proc(s: string, allocator := context.allocator) -> string {
-	c := make([]byte, len(s)+1, allocator);
-	copy(c, s);
-	c[len(s)] = 0;
-	return string(c[:len(s)]);
+	return clone(s, allocator);
 }
 
 @(deprecated="Please use 'strings.clone_to_cstring'")
 new_cstring :: proc(s: string, allocator := context.allocator) -> cstring {
-	c := make([]byte, len(s)+1, allocator);
-	copy(c, s);
-	c[len(s)] = 0;
-	return cstring(&c[0]);
+	return clone_to_cstring(s, allocator);
 }
 
 @(deprecated="Please use a standard cast for cstring to string")

--- a/core/strings/strings.odin
+++ b/core/strings/strings.odin
@@ -3,30 +3,36 @@ package strings
 import "core:mem"
 import "core:unicode/utf8"
 
-clone :: proc(s: string, allocator := context.allocator) -> string {
+clone :: proc(s: string, allocator := context.allocator) -> (str: string, ok: bool) {
 	c := make([]byte, len(s)+1, allocator);
-	if c == nil do return "";
+	if c == nil {
+		return;
+	}
 	copy(c, s);
 	c[len(s)] = 0;
-	return string(c[:len(s)]);
+	return string(c[:len(s)]), true;
 }
 
-clone_to_cstring :: proc(s: string, allocator := context.allocator) -> cstring {
+clone_to_cstring :: proc(s: string, allocator := context.allocator) -> (str: cstring, ok: bool) {
 	c := make([]byte, len(s)+1, allocator);
-	if c == nil do return nil;
+	if c == nil {
+		return;
+	}
 	copy(c, s);
 	c[len(s)] = 0;
-	return cstring(&c[0]);
+	return cstring(&c[0]), true;
 }
 
 @(deprecated="Please use 'strings.clone'")
 new_string :: proc(s: string, allocator := context.allocator) -> string {
-	return clone(s, allocator);
+	s, _ := clone(s, allocator);
+	return s;
 }
 
 @(deprecated="Please use 'strings.clone_to_cstring'")
 new_cstring :: proc(s: string, allocator := context.allocator) -> cstring {
-	return clone_to_cstring(s, allocator);
+	s, _ := clone_to_cstring(s, allocator);
+	return s;
 }
 
 @(deprecated="Please use a standard cast for cstring to string")
@@ -777,7 +783,7 @@ partition :: proc(str, sep: string) -> (head, match, tail: string) {
 center_justify :: centre_justify; // NOTE(bill): Because Americans exist
 
 // centre_justify returns a string with a pad string at boths sides if the str's rune length is smaller than length
-centre_justify :: proc(str: string, length: int, pad: string, allocator := context.allocator) -> string {
+centre_justify :: proc(str: string, length: int, pad: string, allocator := context.allocator) -> (res: string, ok: bool) {
 	n := rune_count(str);
 	if n >= length || pad == "" {
 		return clone(str, allocator);
@@ -787,17 +793,18 @@ centre_justify :: proc(str: string, length: int, pad: string, allocator := conte
 	pad_len := rune_count(pad);
 
 	b := make_builder(allocator);
-	grow_builder(&b, len(str) + (remains/pad_len + 1)*len(pad));
+	if !grow_builder(&b, len(str) + (remains/pad_len + 1)*len(pad)) {
+		return;
+	}
 
 	write_pad_string(&b, pad, pad_len, remains/2);
 	write_string(&b, str);
 	write_pad_string(&b, pad, pad_len, (remains+1)/2);
-
-	return to_string(b);
+	return to_string(b), true; // NOTE(tetra): assumes the math above is right
 }
 
 // left_justify returns a string with a pad string at left side if the str's rune length is smaller than length
-left_justify :: proc(str: string, length: int, pad: string, allocator := context.allocator) -> string {
+left_justify :: proc(str: string, length: int, pad: string, allocator := context.allocator) -> (res: string, ok: bool) {
 	n := rune_count(str);
 	if n >= length || pad == "" {
 		return clone(str, allocator);
@@ -807,16 +814,17 @@ left_justify :: proc(str: string, length: int, pad: string, allocator := context
 	pad_len := rune_count(pad);
 
 	b := make_builder(allocator);
-	grow_builder(&b, len(str) + (remains/pad_len + 1)*len(pad));
+	if !grow_builder(&b, len(str) + (remains/pad_len + 1)*len(pad)) {
+		return;
+	}
 
 	write_string(&b, str);
 	write_pad_string(&b, pad, pad_len, remains);
-
-	return to_string(b);
+	return to_string(b), true; // NOTE(tetra): assumes the math above is right
 }
 
 // right_justify returns a string with a pad string at right side if the str's rune length is smaller than length
-right_justify :: proc(str: string, length: int, pad: string, allocator := context.allocator) -> string {
+right_justify :: proc(str: string, length: int, pad: string, allocator := context.allocator) -> (res: string, ok: bool) {
 	n := rune_count(str);
 	if n >= length || pad == "" {
 		return clone(str, allocator);
@@ -826,12 +834,13 @@ right_justify :: proc(str: string, length: int, pad: string, allocator := contex
 	pad_len := rune_count(pad);
 
 	b := make_builder(allocator);
-	grow_builder(&b, len(str) + (remains/pad_len + 1)*len(pad));
+	if !grow_builder(&b, len(str) + (remains/pad_len + 1)*len(pad)) {
+		return;
+	}
 
 	write_pad_string(&b, pad, pad_len, remains);
 	write_string(&b, str);
-
-	return to_string(b);
+	return to_string(b), true; // NOTE(tetra): assumes the math above is right
 }
 
 


### PR DESCRIPTION
They currently fail a bounds check, now they return ~~an empty value~~ `(result: string, ok: bool)`.

I also fixed an oversight in `core:os` where the strings on Linux and Darwin were being allocated and deleted, rather than using the temporary allocator.

In the course of changing the return types, I made `grow_builder` return `bool` so that---like `reserve`---you can check if it succeeded or not.