### PR TITLE
Fix os.read / os.read_entire_file on Windows

### DIFF
--- a/core/os/os.odin
+++ b/core/os/os.odin
@@ -85,13 +85,13 @@ read_entire_file :: proc(name: string) -> (data: []byte, success: bool) {
 	if data == nil {
 		return nil, false;
 	}
+	defer if !success do delete(data);
 
 	bytes_read, read_err := read(fd, data);
-	if read_err != 0 {
-		delete(data);
+	if read_err != ERROR_NONE {
 		return nil, false;
 	}
-	return data[0:bytes_read], true;
+	return data[:bytes_read], true;
 }
 
 write_entire_file :: proc(name: string, data: []byte, truncate := true) -> (success: bool) {
@@ -100,11 +100,11 @@ write_entire_file :: proc(name: string, data: []byte, truncate := true) -> (succ
 		flags |= O_TRUNC;
 	}
 
-    mode: int = 0;
-    when OS == "linux" {
-        // NOTE(justasd): 644 (owner read, write; group read; others read)
-        mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
-    }
+	mode: int = 0;
+	when OS == "linux" {
+		// NOTE(justasd): 644 (owner read, write; group read; others read)
+		mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+	}
 
 	fd, err := open(name, flags, mode);
 	if err != 0 {

--- a/core/sys/win32/kernel32.odin
+++ b/core/sys/win32/kernel32.odin
@@ -58,8 +58,8 @@ foreign kernel32 {
 	                      creation, flags_and_attribs: u32, template_file: Handle) -> Handle ---;
 
 
-	@(link_name="ReadFile")  read_file  :: proc(h: Handle, buf: rawptr, to_read: u32, bytes_read: ^i32, overlapped: rawptr) -> Bool ---;
-	@(link_name="WriteFile") write_file :: proc(h: Handle, buf: rawptr, len: i32, written_result: ^i32, overlapped: rawptr) -> Bool ---;
+	@(link_name="ReadFile")  read_file  :: proc(h: Handle, buf: rawptr, to_read: u32, bytes_read: ^u32, overlapped: rawptr) -> Bool ---;
+	@(link_name="WriteFile") write_file :: proc(h: Handle, buf: rawptr, len: u32, written_result: ^u32, overlapped: rawptr) -> Bool ---;
 
 	@(link_name="GetFileSizeEx")              get_file_size_ex               :: proc(file_handle: Handle, file_size: ^i64) -> Bool ---;
 	@(link_name="GetFileInformationByHandle") get_file_information_by_handle :: proc(file_handle: Handle, file_info: ^By_Handle_File_Information) -> Bool ---;


### PR DESCRIPTION
`os.read_entire_file` currently breaks when trying to read very large files. (7GB was the example I found the problem with.)

This is because `DWORD` and `LPDWORD` was set up as `i32` and `^i32` -- however `DWORD` is actually `u32`.
I also found that `os.read` did not correctly read as much as possible, like `os.read_entire_file` expected it to.