### PR TITLE
Fix os.read, os.write, os.read_entire_file, os.write_entire_file on Windows

### DIFF
--- a/core/os/os.odin
+++ b/core/os/os.odin
@@ -85,6 +85,7 @@ read_entire_file :: proc(name: string) -> (data: []byte, success: bool) {
 	if data == nil {
 		return nil, false;
 	}
+	// defer if !success do delete(data);
 
 	bytes_read, read_err := read(fd, data);
 	if read_err != ERROR_NONE {

--- a/core/os/os.odin
+++ b/core/os/os.odin
@@ -85,11 +85,13 @@ read_entire_file :: proc(name: string) -> (data: []byte, success: bool) {
 	if data == nil {
 		return nil, false;
 	}
+	// TODO(tetra, 2020-05-29): Can't do this until named return values
+	// are properly set when returning normally ...
 	// defer if !success do delete(data);
 
 	bytes_read, read_err := read(fd, data);
 	if read_err != ERROR_NONE {
-		delete(data);
+		delete(data); // ... so we do this instead.
 		return nil, false;
 	}
 	return data[:bytes_read], true;

--- a/core/os/os_windows.odin
+++ b/core/os/os_windows.odin
@@ -125,7 +125,7 @@ write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 
 	written := 0;
 	for {
-		to_write := u32(min(1<<29-1, len(data)-written));
+		to_write := u32(min(1<<32-1, len(data)-written));
 		if to_write <= 0 do break;
 
 		n: u32 = ---;
@@ -145,7 +145,7 @@ read :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 
 	read := 0;
 	for {
-		to_read := u32(min(1<<29-1, len(data)-read));
+		to_read := u32(min(1<<32-1, len(data)-read));
 		if to_read <= 0 do break;
 
 		n: u32 = ---;

--- a/core/os/os_windows.odin
+++ b/core/os/os_windows.odin
@@ -123,9 +123,9 @@ close :: proc(fd: Handle) -> Errno {
 write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 	if len(data) == 0 do return 0, ERROR_NONE;
 
-	written := 0;
+	written := i64(0);
 	for {
-		to_write := u32(min(1<<32-1, len(data)-written));
+		to_write := u32(min(1<<31-1, i64(len(data))-written));
 		if to_write <= 0 do break;
 
 		n: u32 = ---;
@@ -134,7 +134,7 @@ write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 			return int(written), Errno(win32.get_last_error());
 		}
 
-		written += int(n);
+		written += i64(n);
 	}
 
 	return int(written), ERROR_NONE;
@@ -145,9 +145,9 @@ write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 read :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 	if len(data) == 0 do return 0, ERROR_NONE;
 
-	read := 0;
+	read := i64(0);
 	for {
-		to_read := u32(min(1<<32-1, len(data)-read));
+		to_read := u32(min(1<<31-1, i64(len(data))-read));
 		if to_read <= 0 do break;
 
 		n: u32 = ---;
@@ -156,7 +156,7 @@ read :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 			return int(read), Errno(win32.get_last_error());
 		}
 
-		read += int(n);
+		read += i64(n);
 	}
 
 	return int(read), ERROR_NONE;

--- a/core/os/os_windows.odin
+++ b/core/os/os_windows.odin
@@ -140,6 +140,8 @@ write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 	return int(written), ERROR_NONE;
 }
 
+// Reads up to len(data) bytes.
+// Reads as much as possible.
 read :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 	if len(data) == 0 do return 0, ERROR_NONE;
 

--- a/core/sys/win32/kernel32.odin
+++ b/core/sys/win32/kernel32.odin
@@ -58,8 +58,8 @@ foreign kernel32 {
 	                      creation, flags_and_attribs: u32, template_file: Handle) -> Handle ---;
 
 
-	@(link_name="ReadFile")  read_file  :: proc(h: Handle, buf: rawptr, to_read: u32, bytes_read: ^i32, overlapped: rawptr) -> Bool ---;
-	@(link_name="WriteFile") write_file :: proc(h: Handle, buf: rawptr, len: i32, written_result: ^i32, overlapped: rawptr) -> Bool ---;
+	@(link_name="ReadFile")  read_file  :: proc(h: Handle, buf: rawptr, to_read: u32, bytes_read: ^u32, overlapped: rawptr) -> Bool ---;
+	@(link_name="WriteFile") write_file :: proc(h: Handle, buf: rawptr, len: u32, written_result: ^u32, overlapped: rawptr) -> Bool ---;
 
 	@(link_name="GetFileSizeEx")              get_file_size_ex               :: proc(file_handle: Handle, file_size: ^i64) -> Bool ---;
 	@(link_name="GetFileInformationByHandle") get_file_information_by_handle :: proc(file_handle: Handle, file_info: ^By_Handle_File_Information) -> Bool ---;


### PR DESCRIPTION
The second attempt of https://github.com/odin-lang/Odin/pull/586.

I also tested `write`/`write_entire_file` and discovered they have the same problem.

Currently, you cannot read/write more than a certain amount of data with `os.read`/`os.write`, which causes `read_entire_file` and `write_entire_file` to fail if the data length is very long. Reading a large file results in an empty slice, for example.

This is due to the foreign signature for `read_file`/`write_file` being incorrect. (`i32` instead of `u32`.)
I also rewrote `os.write` and `os.read`, since, even with that fixed, they do not fill the provided buffer, even if they can, which they are supposed to.

I'll be interested in the results of your tests @gingerBill 😛 
