### PR TITLE
Add a missing space after /LIBPATH linker options.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -198,9 +198,9 @@ i32 linker_stage(lbGenerator *gen) {
 
 		if (build_context.is_dll) {
 			output_ext = "dll";
-			link_settings = gb_string_append_fmt(link_settings, "/DLL");
+			link_settings = gb_string_append_fmt(link_settings, " /DLL");
 		} else {
-			link_settings = gb_string_append_fmt(link_settings, "/ENTRY:mainCRTStartup");
+			link_settings = gb_string_append_fmt(link_settings, " /ENTRY:mainCRTStartup");
 		}
 
 		if (build_context.pdb_filepath != "") {


### PR DESCRIPTION

The linker exec command line without the fix:

```
"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.25.28610\bin\Hostx64\x64\link.exe" "C:/src/omelette/rect.obj"  -OUT:"C:/src/omelette/rect.dll"  /LIBPATH:"C:\Program Files (x86)\Wind
ows Kits\10\Lib\10.0.17763.0\um\x64" /LIBPATH:"C:\Program Files (x86)\Windows Kits\10\Lib\10.0.17763.0\ucrt\x64" /LIBPATH:"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.25.28610\li
b\x64"/DLL /defaultlib:libcmt /nologo /incremental:no /opt:ref /subsystem:CONSOLE  /machine:x64    "kernel32.lib"
libcmt.lib(exe_main.obj) : error LNK2019: unresolved external symbol main referenced in function "int __cdecl __scrt_common_main_seh(void)" (?__scrt_common_main_seh@@YAHXZ)
C:\src\omelette\rect.dll : fatal error LNK1120: 1 unresolved externals
```

**Note the missing space between the double-quote and `/DLL`.** With the fix:

```
"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.25.28610\bin\Hostx64\x64\link.exe" "C:/src/omelette/rect.obj"  -OUT:"C:/src/omelette/rect.dll"  /LIBPATH:"C:\Program Files (x86)\Wind
ows Kits\10\Lib\10.0.17763.0\um\x64" /LIBPATH:"C:\Program Files (x86)\Windows Kits\10\Lib\10.0.17763.0\ucrt\x64" /LIBPATH:"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.25.28610\li
b\x64" /DLL /defaultlib:libcmt /nologo /incremental:no /opt:ref /subsystem:CONSOLE  /machine:x64    "kernel32.lib"
```
