### PR TITLE
Added to core:sys win32 package

### DIFF
--- a/core/sys/win32/gdi32.odin
+++ b/core/sys/win32/gdi32.odin
@@ -3,6 +3,8 @@ package win32
 
 foreign import "system:gdi32.lib"
 
+WHITENESS :: 0x00FF0062;
+BLACKNESS :: 0x00FF0062;
 
 @(default_calling_convention = "std")
 foreign gdi32 {
@@ -20,4 +22,5 @@ foreign gdi32 {
 	@(link_name="ChoosePixelFormat") choose_pixel_format :: proc(hdc: Hdc, pfd: ^Pixel_Format_Descriptor) -> i32 ---;
 	@(link_name="SwapBuffers")       swap_buffers        :: proc(hdc: Hdc) -> Bool ---;
 
+	@(link_name="PatBlt") pat_blt :: proc(hdc: Hdc, x, y, w, h: i32, rop: u32) -> Bool ---;
 }

--- a/core/sys/win32/gdi32.odin
+++ b/core/sys/win32/gdi32.odin
@@ -4,7 +4,7 @@ package win32
 foreign import "system:gdi32.lib"
 
 WHITENESS :: 0x00FF0062;
-BLACKNESS :: 0x00FF0062;
+BLACKNESS :: 0x00000042;
 
 @(default_calling_convention = "std")
 foreign gdi32 {

--- a/core/sys/win32/general.odin
+++ b/core/sys/win32/general.odin
@@ -35,6 +35,28 @@ Point :: struct {
 	x, y: i32,
 }
 
+Wnd_Class_A :: struct {
+	style:                 u32,
+	wnd_proc:              Wnd_Proc,
+	cls_extra, wnd_extra:  i32,
+	instance:              Hinstance,
+	icon:                  Hicon,
+	cursor:                Hcursor,
+	background:            Hbrush,
+	menu_name, class_name: cstring
+}
+
+Wnd_Class_W :: struct {
+	style:                 u32,
+	wnd_proc:              Wnd_Proc,
+	cls_extra, wnd_extra:  i32,
+	instance:              Hinstance,
+	icon:                  Hicon,
+	cursor:                Hcursor,
+	background:            Hbrush,
+	menu_name, class_name: Wstring
+}
+
 Wnd_Class_Ex_A :: struct {
 	size, style:           u32,
 	wnd_proc:              Wnd_Proc,
@@ -532,7 +554,7 @@ WM_CHAR              :: 0x0102;
 WM_CLOSE             :: 0x0010;
 WM_CREATE            :: 0x0001;
 WM_DESTROY           :: 0x0002;
-WM_INPUT             :: 0x00ff;
+WM_INPUT             :: 0x00FF;
 WM_KEYDOWN           :: 0x0100;
 WM_KEYUP             :: 0x0101;
 WM_KILLFOCUS         :: 0x0008;
@@ -546,6 +568,7 @@ WM_SYSKEYUP          :: 0x0105;
 WM_USER              :: 0x0400;
 WM_WINDOWPOSCHANGED  :: 0x0047;
 WM_COMMAND           :: 0x0111;
+WM_PAINT             :: 0x000F;
 
 WM_MOUSEWHEEL    :: 0x020A;
 WM_MOUSEMOVE     :: 0x0200;
@@ -902,6 +925,15 @@ Bitmap_Info_Header :: struct {
 Bitmap_Info :: struct {
 	using header: Bitmap_Info_Header,
 	colors:       [1]Rgb_Quad,
+}
+
+Paint_Struct :: struct {
+	hdc:          Hdc,
+	erase:        Bool,
+	rc_paint:     Rect,
+	restore:      Bool,
+	inc_update:   Bool,
+	rgb_reserved: [32]byte
 }
 
 

--- a/core/sys/win32/user32.odin
+++ b/core/sys/win32/user32.odin
@@ -103,6 +103,8 @@ foreign user32 {
 	@(link_name="PostQuitMessage")  post_quit_message   :: proc(exit_code: i32) ---;
 	@(link_name="SetWindowTextA")   set_window_text_a   :: proc(hwnd: Hwnd, c_string: cstring) -> Bool ---;
 	@(link_name="SetWindowTextW")   set_window_text_w   :: proc(hwnd: Hwnd, c_string: Wstring) -> Bool ---;
+	@(link_name="RegisterClassA")   register_class_a    :: proc(wc: ^Wnd_Class_A) -> i16 ---;
+	@(link_name="RegisterClassW")   register_class_w    :: proc(wc: ^Wnd_Class_W) -> i16 ---;
 	@(link_name="RegisterClassExA") register_class_ex_a :: proc(wc: ^Wnd_Class_Ex_A) -> i16 ---;
 	@(link_name="RegisterClassExW") register_class_ex_w :: proc(wc: ^Wnd_Class_Ex_W) -> i16 ---;
 
@@ -230,9 +232,14 @@ foreign user32 {
 	@(link_name="GetPropA") get_prop_a :: proc(wnd: Hwnd, s: cstring) -> Handle ---
 	@(link_name="GetPropW") get_prop_w :: proc(wnd: Hwnd, s: Wstring) -> Handle ---
 
+	@(link_name="MessageBoxA") message_box_a :: proc(wnd: Hwnd, text, caption: cstring, type: u32) -> i32 ---
+	@(link_name="MessageBoxW") message_box_w :: proc(wnd: Hwnd, text, caption: Wstring, type: u32) -> i32 ---
 
 	@(link_name="MessageBoxExA") message_box_ex_a :: proc(wnd: Hwnd, text, caption: cstring, type: u32, language_id: u16) -> i32 ---
 	@(link_name="MessageBoxExW") message_box_ex_w :: proc(wnd: Hwnd, text, caption: Wstring, type: u32, language_id: u16) -> i32 ---
+
+	@(link_name="BeginPaint") begin_paint :: proc(wnd: Hwnd, paint: ^Paint_Struct) -> Hdc ---
+	@(link_name="EndPaint")   end_paint :: proc(wnd: Hwnd, paint: ^Paint_Struct) -> Bool ---
 }
 
 


### PR DESCRIPTION
Added to the win32 package any missing constants, structs, or function bindings needed for Handmade Hero days 001 and 002. 

Functions: PatBlt, RegisterClass*, MessageBox*, BeginPaint, EndPaint
Constants: WHITENESS, BLACKNESS, WM_PAINT
Structs: WNDCLASS*, PAINTSTRUCT

*A and W

Additionally updated WM_INPUT to utilize upper case alphabetical characters for consistency with surrounding values.