### PR TITLE
Add bool flag to AST data in the parser in the core library

### DIFF
--- a/core/odin/ast/ast.odin
+++ b/core/odin/ast/ast.odin
@@ -282,6 +282,7 @@ Block_Stmt :: struct {
 	open:  tokenizer.Pos,
 	stmts: []^Stmt,
 	close: tokenizer.Pos,
+	uses_do: bool,
 }
 
 If_Stmt :: struct {

--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -1217,6 +1217,7 @@ convert_stmt_to_body :: proc(p: ^Parser, stmt: ^ast.Stmt) -> ^ast.Stmt {
 	bs.stmts = make([]^ast.Stmt, 1);
 	bs.stmts[0] = stmt;
 	bs.close = stmt.end;
+	bs.uses_do = true;
 	return bs;
 }
 


### PR DESCRIPTION
I'm creating an AST printer and this info was missing until now.
It now tells you if "do" was used vs "{...}" in a block statement.