### PR TITLE
Fix potential bad optimization bug in sync.Ticket_Mutex

### DIFF
--- a/core/sync/sync.odin
+++ b/core/sync/sync.odin
@@ -17,7 +17,7 @@ ticket_mutex_init :: proc(m: ^Ticket_Mutex) {
 
 ticket_mutex_lock :: inline proc(m: ^Ticket_Mutex) {
 	ticket := atomic_add(&m.ticket, 1, .Relaxed);
-	for ticket != m.serving {
+	for ticket != atomic_load(&m.serving, .Acquire) {
 		yield_processor();
 	}
 }


### PR DESCRIPTION
When locking, we were not loading `m.serving` atomically and so the optimizer
could have hoisted the check out of the loop, thus resulting in an infinite loop.

Thanks to @MasterQ32 and @SpexGuy for noticing and explaining this.