### PR TITLE
Rename `yield_processor` to `cpu_relax`

### DIFF
--- a/core/sync/sync.odin
+++ b/core/sync/sync.odin
@@ -1,8 +1,9 @@
 package sync
 
-foreign {
-	@(link_name="llvm.x86.sse2.pause")
-	yield_processor :: proc() ---
+import "core:intrinsics"
+
+cpu_relax :: inline proc() {
+	intrinsics.cpu_relax();
 }
 
 Ticket_Mutex :: struct {
@@ -18,7 +19,7 @@ ticket_mutex_init :: proc(m: ^Ticket_Mutex) {
 ticket_mutex_lock :: inline proc(m: ^Ticket_Mutex) {
 	ticket := atomic_add(&m.ticket, 1, .Relaxed);
 	for ticket != m.serving {
-		yield_processor();
+		intrinsics.cpu_relax();
 	}
 }
 

--- a/core/thread/thread_unix.odin
+++ b/core/thread/thread_unix.odin
@@ -2,6 +2,7 @@
 package thread;
 
 import "core:runtime"
+import "core:intrinsics"
 import "core:sync"
 import "core:sys/unix"
 
@@ -134,7 +135,7 @@ join :: proc(t: ^Thread) {
 	if sync.atomic_swap(&t.already_joined, true, .Sequentially_Consistent) {
 		for {
 			if sync.atomic_load(&t.done, .Sequentially_Consistent) do return;
-			sync.yield_processor();
+			intrinsics.cpu_relax();
 		}
 	}
 


### PR DESCRIPTION
Renames `sync.yield_processor` to `sync.cpu_relax`, and have it just call `intrinsics.cpu_relax` instead.

It's quite convienient to have this alias in `core:sync` rather than having to import `core:intrinsics` and `core:sync` all the time, so I just left in.

If I should remove it, and just have people import both instead, let me know.