### PR TITLE
Improve nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,7 @@ name:  Nightly
 on:
   schedule:
     - cron: 0 20 * * *
+  push:
 
 jobs:
   build_windows:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,8 +31,11 @@ jobs:
           odin run examples/demo/demo.odin
       - name: Copy artifacts
         run: |
+# We delete the lib here since it's only used for building
+          rm bin/llvm/windows/LLVM-C.lib
           mkdir dist
           cp odin.exe dist
+          cp LLVM-C.dll dist
           cp -r shared dist
           cp -r core dist
           cp -r bin dist

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,6 +17,7 @@ jobs:
           cd bin
           curl -sL https://github.com/odin-lang/Odin/releases/download/llvm-windows/llvm-binaries.zip --output llvm-binaries.zip
           7z x llvm-binaries.zip > nul
+          rm -f llvm-binaries.zip
       - name: build Odin
         shell: cmd
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,7 +31,6 @@ jobs:
           odin run examples/demo/demo.odin
       - name: Copy artifacts
         run: |
-# We delete the lib here since it's only used for building
           rm bin/llvm/windows/LLVM-C.lib
           mkdir dist
           cp odin.exe dist

--- a/ci/create_nightly_json.py
+++ b/ci/create_nightly_json.py
@@ -18,6 +18,7 @@ def main():
             name = remove_prefix(data['fileName'], "nightly/")
             url = f"https://f001.backblazeb2.com/file/{bucket}/nightly/{urllib.parse.quote_plus(name)}"
             sha1 = data['contentSha1']
+            size = int(data['contentLength'])
             ts = int(data['fileInfo']['src_last_modified_millis'])
             date = datetime.datetime.fromtimestamp(ts/1000).strftime('%Y-%m-%d')
             
@@ -28,6 +29,7 @@ def main():
                                             'name': name,
                                             'url': url,
                                             'sha1': sha1,
+                                            'sizeInBytes': size,
                                          })
 
     now = datetime.datetime.utcnow().isoformat()


### PR DESCRIPTION
This adds some extra little niceties and reduces windows artifacts sizes by not including LLVM-C.lib and llvm-binaries.zip

 - Add `sizeInBytes` to nightly.json generation
 - Include LLVM-C.dll in windows artifacts (and remove LLVM-C.lib)
 - Remove llvm-binaries.zip from windows artifacts