### PR TITLE
Fix parsing of single-digit numbers

### DIFF
--- a/core/strconv/strconv.odin
+++ b/core/strconv/strconv.odin
@@ -47,18 +47,19 @@ parse_i64_of_base :: proc(str: string, base: int) -> (value: i64, ok: bool) {
 
 	i := 0;
 	for r in s {
-		i += 1;
-		if r == '_' do continue;
-		v := i64(_digit_value(r));
-		if v >= i64(base) {
-			break;
+		if r == '_' {
+			i += 1;
+			continue;
 		}
+		v := i64(_digit_value(r));
+		if v >= i64(base) do break;
 		value *= i64(base);
 		value += v;
+		i += 1;
 	}
 
 	if neg do value = -value;
-	ok = i > 1;
+	ok = i > 0;
 	return;
 }
 
@@ -100,18 +101,19 @@ parse_i64_maybe_prefixed :: proc(str: string) -> (value: i64, ok: bool) {
 
 	i := 0;
 	for r in s {
-		i += 1;
-		if r == '_' do continue;
-		v := i64(_digit_value(r));
-		if v >= base {
-			break;
+		if r == '_' {
+			i += 1;
+			continue;
 		}
+		v := i64(_digit_value(r));
+		if v >= base do break;
 		value *= base;
 		value += v;
+		i += 1;
 	}
 
 	if neg do value = -value;
-	ok = i > 1;
+	ok = i > 0;
 	return;
 }
 
@@ -138,17 +140,18 @@ parse_u64_of_base :: proc(str: string, base: int) -> (value: u64, ok: bool) {
 
 	i := 0;
 	for r in s {
-		i += 1;
-		if r == '_' do continue;
-		v := u64(_digit_value(r));
-		if v >= u64(base) {
-			break;
+		if r == '_' {
+			i += 1;
+			continue;
 		}
+		v := u64(_digit_value(r));
+		if v >= u64(base) do break;
 		value *= u64(base);
 		value += v;
+		i += 1;
 	}
 
-	ok = i > 1;
+	ok = i > 0;
 	return;
 }
 
@@ -184,15 +187,18 @@ parse_u64_maybe_prefixed :: proc(str: string) -> (value: u64, ok: bool) {
 
 	i := 0;
 	for r in s {
-		i += 1;
-		if r == '_' do continue;
+		if r == '_' {
+			i += 1;
+			continue;
+		}
 		v := u64(_digit_value(r));
 		if v >= base do break;
 		value *= base;
 		value += u64(v);
+		i += 1;
 	}
 
-	ok = i > 1;
+	ok = i > 0;
 	return;
 }
 


### PR DESCRIPTION
Follow up on #630.

I wrote out a bunch of tests for #630 which all passed before I made that PR, however, it appears I forgot a case.

On master:
```odin
v, ok := strconv.parse_int("9"); // v=9, ok=false - BAD!
```

With this PR, it now returns `v=9, ok=true`, which is obviously better.

More importantly, I wrote more tests; including ones that check that underscores work.

Perhaps we should consider adding them to CI or something?

At any rate, all of these pass now:
(Most of which we're unaltered, but I added 19 more.)
```odin
package main

import "core:fmt"
import "core:strconv"

main :: proc() {
    using fmt;

    a, a_ok := strconv.parse_int("0x1234");
    assert(a == 0x1234 && a_ok);

    a, a_ok = strconv.parse_int("");
    assert(a == 0 && !a_ok);

    a, a_ok = strconv.parse_int("0j1234");
    assert(a == 0 && a_ok);

    a, a_ok = strconv.parse_int("asd");
    assert(a == 0 && !a_ok);

    a, a_ok = strconv.parse_int("1234");
    assert(a == 1234 && a_ok);

    a, a_ok = strconv.parse_int("9");
    assert(a == 9 && a_ok);

    a, a_ok = strconv.parse_int("_9");
    assert(a == 9 && a_ok);

    a, a_ok = strconv.parse_int("9_");
    assert(a == 9 && a_ok);

    a, a_ok = strconv.parse_int("9_000");
    assert(a == 9000 && a_ok);

    a, a_ok = strconv.parse_int("9_000_000");
    assert(a == 9_000_000 && a_ok);

    a, a_ok = strconv.parse_int("0xff_ff_ff_ff");
    assert(a == 0xff_ff_ff_ff && a_ok);


    a, a_ok = strconv.parse_int("0x1234", 16);
    assert(a == 0 && a_ok);

    a, a_ok = strconv.parse_int("", 16);
    assert(a == 0 && !a_ok);

    a, a_ok = strconv.parse_int("asd", 16);
    assert(a == 10 && a_ok);

    a, a_ok = strconv.parse_int("xxx", 16);
    assert(a == 0 && !a_ok);

    a, a_ok = strconv.parse_int("9", 16);
    assert(a == 0x9 && a_ok);

    a, a_ok = strconv.parse_int("1234", 16);
    assert(a == 0x1234 && a_ok);

    a, a_ok = strconv.parse_int("-1234", 16);
    assert(a == -0x1234 && a_ok);


    b, b_ok := strconv.parse_uint("0x5678eeee");
    assert(b == 0x5678eeee && b_ok);

    b, b_ok = strconv.parse_uint("");
    assert(b == 0 && !b_ok);

    b, b_ok = strconv.parse_uint("0j1234");
    assert(b == 0 && b_ok);

    b, b_ok = strconv.parse_uint("asd");
    assert(b == 0 && !b_ok);

    b, b_ok = strconv.parse_uint("1234");
    assert(b == 1234 && b_ok);

    b, b_ok = strconv.parse_uint("9");
    assert(b == 9 && b_ok);

    b, b_ok = strconv.parse_uint("-1234");
    assert(b == 0 && !b_ok);

    b, b_ok = strconv.parse_uint("_9");
    assert(b == 9 && b_ok);

    b, b_ok = strconv.parse_uint("9_");
    assert(b == 9 && b_ok);

    b, b_ok = strconv.parse_uint("9_000");
    assert(b == 9000 && b_ok);

    b, b_ok = strconv.parse_uint("9_000_000");
    assert(b == 9_000_000 && b_ok);

    b, b_ok = strconv.parse_uint("0xff_ff_ff_ff");
    assert(b == 0xff_ff_ff_ff && b_ok);


    c, c_ok := strconv.parse_uint("0x1234", 16);
    assert(c == 0 && c_ok);

    c, c_ok = strconv.parse_uint("", 16);
    assert(c == 0 && !c_ok);

    c, c_ok = strconv.parse_uint("asd", 16);
    assert(c == 10 && c_ok);

    c, c_ok = strconv.parse_uint("1234", 16);
    assert(c == 0x1234 && c_ok);

    c, c_ok = strconv.parse_uint("9", 16);
    assert(c == 0x9 && c_ok);


    d, d_ok := strconv.parse_f64("0x1234");
    assert(d == 0 && d_ok);

    d, d_ok = strconv.parse_f64("asd");
    assert(d == 0 && !d_ok);

    d, d_ok = strconv.parse_f64("1234");
    assert(d == 1234 && d_ok);

    d, d_ok = strconv.parse_f64("9");
    assert(d == 9 && d_ok);

    d, d_ok = strconv.parse_f64("_9");
    assert(d == 9 && d_ok);

    d, d_ok = strconv.parse_f64("9_");
    assert(d == 9 && d_ok);

    d, d_ok = strconv.parse_f64("9_000");
    assert(d == 9000 && d_ok);

    d, d_ok = strconv.parse_f64("9_000_000");
    assert(d == 9_000_000 && d_ok);

    d, d_ok = strconv.parse_f64("1234.567");
    assert(d == 1234.567 && d_ok);

    d, d_ok = strconv.parse_f64("12.34eee");
    assert(d == 12.34 && d_ok);
}
```