### PR TITLE
LLVM C backend: Obey directives on blocks, procedures, and expressions

### DIFF
--- a/src/llvm_backend.hpp
+++ b/src/llvm_backend.hpp
@@ -64,6 +64,8 @@ struct lbModule {
 	LLVMModuleRef mod;
 	LLVMContextRef ctx;
 
+	u64 state_flags;
+
 	CheckerInfo *info;
 
 	gbMutex mutex;


### PR DESCRIPTION
Add tracking of directives on enclosing procedures and blocks---namely `#no_bounds_check` and `#bounds_check`---and wire up bounds checking to react accordingly.