### PR TITLE
Added union_type_compare to core:reflect

### DIFF
--- a/core/reflect/reflect.odin
+++ b/core/reflect/reflect.odin
@@ -583,7 +583,7 @@ union_variant_typeid :: proc(a: any) -> typeid {
 union_type_compare :: proc( a, b : any ) -> bool
 {
 	if a == nil || b == nil do return b == nil && a == nil;
-	if a.id != b.id do return reflect.union_variant_typeid(a) == reflect.union_variant_typeid(b);
+	if a.id != b.id do return union_variant_typeid(a) == union_variant_typeid(b);
 	
 	ti := runtime.type_info_base(type_info_of(a.id));
 	if info, ok := ti.variant.(runtime.Type_Info_Union); ok {

--- a/core/reflect/reflect.odin
+++ b/core/reflect/reflect.odin
@@ -579,3 +579,17 @@ union_variant_typeid :: proc(a: any) -> typeid {
 
 	return nil;
 }
+
+union_type_compare :: proc( a, b : any ) -> bool
+{
+	if a == nil || b == nil do return b == nil && a == nil;
+	if a.id != b.id do return reflect.union_variant_typeid(a) == reflect.union_variant_typeid(b);
+	
+	ti := runtime.type_info_base(type_info_of(a.id));
+	if info, ok := ti.variant.(runtime.Type_Info_Union); ok {
+		a_tag := (cast(^u64)(uintptr(a.data) + info.tag_offset))^;
+		b_tag := (cast(^u64)(uintptr(b.data) + info.tag_offset))^;
+		return a_tag == b_tag;
+	}
+	return false;
+}


### PR DESCRIPTION
union_type_compare function to enable the comparing of two unions to see if their active types are the same.