### PR TITLE
Fix style of core:sys/win32 foreign procedures

### DIFF
--- a/core/dynlib/lib_windows.odin
+++ b/core/dynlib/lib_windows.odin
@@ -8,18 +8,18 @@ load_library :: proc(path: string, global_symbols := false) -> (Library, bool) {
 	// NOTE(bill): 'global_symbols' is here only for consistency with POSIX which has RTLD_GLOBAL
 
 	wide_path := win32.utf8_to_wstring(path, context.temp_allocator);
-	handle := cast(Library)win32.load_library_w(wide_path);
+	handle := cast(Library)win32.LoadLibraryW(wide_path);
 	return handle, handle != nil;
 }
 
 unload_library :: proc(library: Library) -> bool {
-	ok := win32.free_library(cast(win32.Hmodule)library);
+	ok := win32.FreeLibrary(cast(win32.HMODULE)library);
 	return bool(ok);
 }
 
 symbol_address :: proc(library: Library, symbol: string) -> (ptr: rawptr, found: bool) {
 	c_str := strings.clone_to_cstring(symbol, context.temp_allocator);
-	ptr = win32.get_proc_address(cast(win32.Hmodule)library, c_str);
+	ptr = win32.GetProcAddress(cast(win32.HMODULE)library, c_str);
 	found = ptr != nil;
 	return;
 }

--- a/core/os/os_windows.odin
+++ b/core/os/os_windows.odin
@@ -85,8 +85,8 @@ open :: proc(path: string, mode: int = O_RDONLY, perm: int = 0) -> (Handle, Errn
 	}
 
 	share_mode := u32(win32.FILE_SHARE_READ|win32.FILE_SHARE_WRITE);
-	sa: ^win32.Security_Attributes = nil;
-	sa_inherit := win32.Security_Attributes{length = size_of(win32.Security_Attributes), inherit_handle = true};
+	sa: ^win32.SECURITY_ATTRIBUTES = nil;
+	sa_inherit := win32.SECURITY_ATTRIBUTES{length = size_of(win32.SECURITY_ATTRIBUTES), inherit_handle = true};
 	if mode&O_CLOEXEC == 0 {
 		sa = &sa_inherit;
 	}
@@ -105,16 +105,16 @@ open :: proc(path: string, mode: int = O_RDONLY, perm: int = 0) -> (Handle, Errn
 		create_mode = win32.OPEN_EXISTING;
 	}
 	wide_path := win32.utf8_to_wstring(path);
-	handle := Handle(win32.create_file_w(wide_path, access, share_mode, sa, create_mode, win32.FILE_ATTRIBUTE_NORMAL, nil));
+	handle := Handle(win32.CreateFileW(wide_path, access, share_mode, sa, create_mode, win32.FILE_ATTRIBUTE_NORMAL, nil));
 	if handle != INVALID_HANDLE do return handle, ERROR_NONE;
 
-	err := Errno(win32.get_last_error());
+	err := Errno(win32.GetLastError());
 	return INVALID_HANDLE, err;
 }
 
 close :: proc(fd: Handle) -> Errno {
-	if win32.close_handle(win32.Handle(fd)) == 0 {
-		return Errno(win32.get_last_error());
+	if win32.CloseHandle(win32.HANDLE(fd)) == 0 {
+		return Errno(win32.GetLastError());
 	}
 	return ERROR_NONE;
 }
@@ -132,9 +132,9 @@ write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 		MAX :: 1<<31-1;
 		to_write: i32 = min(i32(remaining), MAX);
 
-		e := win32.write_file(win32.Handle(fd), &data[total_write], to_write, &single_write_length, nil);
+		e := win32.WriteFile(win32.HANDLE(fd), &data[total_write], to_write, &single_write_length, nil);
 		if single_write_length <= 0 || !e {
-			err := Errno(win32.get_last_error());
+			err := Errno(win32.GetLastError());
 			return int(total_write), err;
 		}
 		total_write += i64(single_write_length);
@@ -154,9 +154,9 @@ read :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 		MAX :: 1<<32-1;
 		to_read: u32 = min(u32(remaining), MAX);
 
-		e := win32.read_file(win32.Handle(fd), &data[total_read], to_read, &single_read_length, nil);
+		e := win32.ReadFile(win32.HANDLE(fd), &data[total_read], to_read, &single_read_length, nil);
 		if single_read_length <= 0 || !e {
-			err := Errno(win32.get_last_error());
+			err := Errno(win32.GetLastError());
 			return int(total_read), err;
 		}
 		total_read += i64(single_read_length);
@@ -173,12 +173,12 @@ seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
 	}
 	hi := i32(offset>>32);
 	lo := i32(offset);
-	ft := win32.get_file_type(win32.Handle(fd));
+	ft := win32.GetFileType(win32.HANDLE(fd));
 	if ft == win32.FILE_TYPE_PIPE do return 0, ERROR_FILE_IS_PIPE;
 
-	dw_ptr := win32.set_file_pointer(win32.Handle(fd), lo, &hi, w);
+	dw_ptr := win32.SetFilePointer(win32.HANDLE(fd), lo, &hi, w);
 	if dw_ptr == win32.INVALID_SET_FILE_POINTER {
-		err := Errno(win32.get_last_error());
+		err := Errno(win32.GetLastError());
 		return 0, err;
 	}
 	return i64(hi)<<32 + i64(dw_ptr), ERROR_NONE;
@@ -187,8 +187,8 @@ seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
 file_size :: proc(fd: Handle) -> (i64, Errno) {
 	length: i64;
 	err: Errno;
-	if !win32.get_file_size_ex(win32.Handle(fd), &length) {
-		err = Errno(win32.get_last_error());
+	if !win32.GetFileSizeEx(win32.HANDLE(fd), &length) {
+		err = Errno(win32.GetLastError());
 	}
 	return length, err;
 }
@@ -202,8 +202,8 @@ stderr := get_std_handle(win32.STD_ERROR_HANDLE);
 
 
 get_std_handle :: proc "contextless" (h: int) -> Handle {
-	fd := win32.get_std_handle(i32(h));
-	win32.set_handle_information(fd, win32.HANDLE_FLAG_INHERIT, 0);
+	fd := win32.GetStdHandle(i32(h));
+	win32.SetHandleInformation(fd, win32.HANDLE_FLAG_INHERIT, 0);
 	return Handle(fd);
 }
 
@@ -212,9 +212,9 @@ get_std_handle :: proc "contextless" (h: int) -> Handle {
 
 
 last_write_time :: proc(fd: Handle) -> (File_Time, Errno) {
-	file_info: win32.By_Handle_File_Information;
-	if !win32.get_file_information_by_handle(win32.Handle(fd), &file_info) {
-		return 0, Errno(win32.get_last_error());
+	file_info: win32.BY_HANDLE_FILE_INFORMATION;
+	if !win32.GetFileInformationByHandle(win32.HANDLE(fd), &file_info) {
+		return 0, Errno(win32.GetLastError());
 	}
 	lo := File_Time(file_info.last_write_time.lo);
 	hi := File_Time(file_info.last_write_time.hi);
@@ -222,11 +222,11 @@ last_write_time :: proc(fd: Handle) -> (File_Time, Errno) {
 }
 
 last_write_time_by_name :: proc(name: string) -> (File_Time, Errno) {
-	data: win32.File_Attribute_Data;
+	data: win32.WIN32_FILE_ATTRIBUTE_DATA;
 
 	wide_path := win32.utf8_to_wstring(name);
-	if !win32.get_file_attributes_ex_w(wide_path, win32.GetFileExInfoStandard, &data) {
-		return 0, Errno(win32.get_last_error());
+	if !win32.GetFileAttributesExW(wide_path, win32.GetFileExInfoStandard, &data) {
+		return 0, Errno(win32.GetLastError());
 	}
 
 	l := File_Time(data.last_write_time.lo);
@@ -237,7 +237,7 @@ last_write_time_by_name :: proc(name: string) -> (File_Time, Errno) {
 
 
 heap_alloc :: proc(size: int) -> rawptr {
-	return win32.heap_alloc(win32.get_process_heap(), win32.HEAP_ZERO_MEMORY, size);
+	return win32.HeapAlloc(win32.GetProcessHeap(), win32.HEAP_ZERO_MEMORY, size);
 }
 heap_resize :: proc(ptr: rawptr, new_size: int) -> rawptr {
 	if new_size == 0 {
@@ -246,11 +246,11 @@ heap_resize :: proc(ptr: rawptr, new_size: int) -> rawptr {
 	}
 	if ptr == nil do return heap_alloc(new_size);
 
-	return win32.heap_realloc(win32.get_process_heap(), win32.HEAP_ZERO_MEMORY, ptr, new_size);
+	return win32.HeapReAlloc(win32.GetProcessHeap(), win32.HEAP_ZERO_MEMORY, ptr, new_size);
 }
 heap_free :: proc(ptr: rawptr) {
 	if ptr == nil do return;
-	win32.heap_free(win32.get_process_heap(), 0, ptr);
+	win32.HeapFree(win32.GetProcessHeap(), 0, ptr);
 }
 
 get_page_size :: proc() -> int {
@@ -259,8 +259,8 @@ get_page_size :: proc() -> int {
 	@static page_size := -1;
 	if page_size != -1 do return page_size;
 
-	info: win32.System_Info;
-	win32.get_system_info(&info);
+	info: win32.SYSTEM_INFO;
+	win32.GetSystemInfo(&info);
 	page_size = int(info.page_size);
 	return page_size;
 }
@@ -274,10 +274,10 @@ get_page_size :: proc() -> int {
 get_current_directory :: proc() -> string {
 	for intrinsics.atomic_xchg(&cwd_gate, true) {}
 
-	sz_utf16 := win32.get_current_directory_w(0, nil);
+	sz_utf16 := win32.GetCurrentDirectoryW(0, nil);
 	dir_buf_wstr := make([]u16, sz_utf16, context.temp_allocator); // the first time, it _includes_ the NUL.
 
-	sz_utf16 = win32.get_current_directory_w(u32(len(dir_buf_wstr)), cast(win32.Wstring) &dir_buf_wstr[0]);
+	sz_utf16 = win32.GetCurrentDirectoryW(u32(len(dir_buf_wstr)), cast(win32.LPCWSTR) &dir_buf_wstr[0]);
 	assert(int(sz_utf16)+1 == len(dir_buf_wstr)); // the second time, it _excludes_ the NUL.
 
 	intrinsics.atomic_store(&cwd_gate, false);
@@ -291,8 +291,8 @@ set_current_directory :: proc(path: string) -> (err: Errno) {
 	for intrinsics.atomic_xchg(&cwd_gate, true) {}
 	defer intrinsics.atomic_store(&cwd_gate, false);
 
-	res := win32.set_current_directory_w(wstr);
-	if res == 0 do return Errno(win32.get_last_error());
+	res := win32.SetCurrentDirectoryW(wstr);
+	if res == 0 do return Errno(win32.GetLastError());
 
 	return;
 }
@@ -300,28 +300,28 @@ set_current_directory :: proc(path: string) -> (err: Errno) {
 
 
 exit :: proc(code: int) -> ! {
-	win32.exit_process(u32(code));
+	win32.ExitProcess(u32(code));
 }
 
 
 
 current_thread_id :: proc "contextless" () -> int {
-	return int(win32.get_current_thread_id());
+	return int(win32.GetCurrentThreadId());
 }
 
 
 
 _alloc_command_line_arguments :: proc() -> []string {
 	arg_count: i32;
-	arg_list_ptr := win32.command_line_to_argv_w(win32.get_command_line_w(), &arg_count);
+	arg_list_ptr := win32.CommandLineToArgvW(win32.GetCommandLineW(), &arg_count);
 	arg_list := make([]string, int(arg_count));
 	for _, i in arg_list {
-		wc_str := (^win32.Wstring)(uintptr(arg_list_ptr) + size_of(win32.Wstring)*uintptr(i))^;
-		olen := win32.wide_char_to_multi_byte(win32.CP_UTF8, 0, wc_str, -1,
+		wc_str := (^win32.LPCWSTR)(uintptr(arg_list_ptr) + size_of(win32.LPCWSTR)*uintptr(i))^;
+		olen := win32.WideCharToMultiByte(win32.CP_UTF8, 0, wc_str, -1,
 		                                      nil, 0, nil, nil);
 
 		buf := make([]byte, int(olen));
-		n := win32.wide_char_to_multi_byte(win32.CP_UTF8, 0, wc_str, -1,
+		n := win32.WideCharToMultiByte(win32.CP_UTF8, 0, wc_str, -1,
 		                                   cstring(&buf[0]), olen, nil, nil);
 		if n > 0 {
 			n -= 1;
@@ -332,10 +332,10 @@ _alloc_command_line_arguments :: proc() -> []string {
 	return arg_list;
 }
 
-get_windows_version_ansi :: proc() -> win32.OS_Version_Info_Ex_A {
-	osvi : win32.OS_Version_Info_Ex_A;
-	osvi.os_version_info_size = size_of(win32.OS_Version_Info_Ex_A);
-    win32.get_version(&osvi);
+get_windows_version_ansi :: proc() -> win32.OSVERSIONINFOEXA {
+	osvi : win32.OSVERSIONINFOEXA;
+	osvi.os_version_info_size = size_of(win32.OSVERSIONINFOEXA);
+    win32.GetVersionExA(&osvi);
     return osvi;
 }
 

--- a/core/sync/sync_windows.odin
+++ b/core/sync/sync_windows.odin
@@ -7,7 +7,7 @@ foreign import kernel32 "system:kernel32.lib"
 
 // A lock that can only be held by one thread at once.
 Mutex :: struct {
-	_critical_section: win32.Critical_Section,
+	_critical_section: win32.CRITICAL_SECTION,
 }
 
 
@@ -22,47 +22,47 @@ Condition :: struct {
 // When waited upon, blocks until the internal count is greater than zero, then subtracts one.
 // Posting to the semaphore increases the count by one, or the provided amount.
 Semaphore :: struct {
-	_handle: win32.Handle,
+	_handle: win32.HANDLE,
 }
 
 
 semaphore_init :: proc(s: ^Semaphore, initial_count := 0) {
-	s._handle = win32.create_semaphore_w(nil, i32(initial_count), 1<<31-1, nil);
+	s._handle = win32.CreateSemaphoreW(nil, i32(initial_count), 1<<31-1, nil);
 }
 
 semaphore_destroy :: proc(s: ^Semaphore) {
-	win32.close_handle(s._handle);
+	win32.CloseHandle(s._handle);
 }
 
 semaphore_post :: proc(s: ^Semaphore, count := 1) {
-	win32.release_semaphore(s._handle, i32(count), nil);
+	win32.ReleaseSemaphore(s._handle, i32(count), nil);
 }
 
 semaphore_wait_for :: proc(s: ^Semaphore) {
-	// NOTE(tetra, 2019-10-30): wait_for_single_object decrements the count before it returns.
-	result := win32.wait_for_single_object(s._handle, win32.INFINITE);
+	// NOTE(tetra, 2019-10-30): WaitForSingleObject decrements the count before it returns.
+	result := win32.WaitForSingleObject(s._handle, win32.INFINITE);
 	assert(result != win32.WAIT_FAILED);
 }
 
 
 mutex_init :: proc(m: ^Mutex, spin_count := 0) {
-	win32.initialize_critical_section_and_spin_count(&m._critical_section, u32(spin_count));
+	win32.InitializeCriticalSectionAndSpinCount(&m._critical_section, u32(spin_count));
 }
 
 mutex_destroy :: proc(m: ^Mutex) {
-	win32.delete_critical_section(&m._critical_section);
+	win32.DeleteCriticalSection(&m._critical_section);
 }
 
 mutex_lock :: proc(m: ^Mutex) {
-	win32.enter_critical_section(&m._critical_section);
+	win32.EnterCriticalSection(&m._critical_section);
 }
 
 mutex_try_lock :: proc(m: ^Mutex) -> bool {
-	return bool(win32.try_enter_critical_section(&m._critical_section));
+	return bool(win32.TryEnterCriticalSection(&m._critical_section));
 }
 
 mutex_unlock :: proc(m: ^Mutex) {
-	win32.leave_critical_section(&m._critical_section);
+	win32.LeaveCriticalSection(&m._critical_section);
 }
 
 @private WIN32_CONDITION_VARIABLE :: distinct rawptr;
@@ -71,7 +71,7 @@ foreign kernel32 {
 	InitializeConditionVariable :: proc(ConditionVariable: ^WIN32_CONDITION_VARIABLE) ---
 	WakeConditionVariable :: proc(ConditionVariable: ^WIN32_CONDITION_VARIABLE) ---
 	WakeAllConditionVariable :: proc(ConditionVariable: ^WIN32_CONDITION_VARIABLE) ---
-	SleepConditionVariableCS :: proc(ConditionVariable: ^WIN32_CONDITION_VARIABLE, CriticalSection: ^win32.Critical_Section, dwMilliseconds: u32) -> b32 ---
+	SleepConditionVariableCS :: proc(ConditionVariable: ^WIN32_CONDITION_VARIABLE, CriticalSection: ^win32.CRITICAL_SECTION, dwMilliseconds: u32) -> b32 ---
 }
 
 condition_init :: proc(c: ^Condition, mutex: ^Mutex) -> bool {

--- a/core/sys/win32/comdlg32.odin
+++ b/core/sys/win32/comdlg32.odin
@@ -4,12 +4,12 @@ package win32
 foreign import "system:comdlg32.lib"
 import "core:strings"
 
-OFN_Hook_Proc :: #type proc "stdcall" (hdlg: Hwnd, msg: u32, wparam: Wparam, lparam: Lparam) -> Uint_Ptr;
+OFN_Hook_Proc :: #type proc "stdcall" (hdlg: HWND, msg: u32, wparam: WPARAM, lparam: LPARAM) -> UINT_PTR;
 
-Open_File_Name_A :: struct {
+OPENFILENAMEA :: struct {
 	struct_size:     u32,
-	hwnd_owner:      Hwnd,
-	instance:        Hinstance,
+	hwnd_owner:      HWND,
+	instance:        HINSTANCE,
 	filter:          cstring,
 	custom_filter:   cstring,
 	max_cust_filter: u32,
@@ -24,7 +24,7 @@ Open_File_Name_A :: struct {
 	file_offset:     u16,
 	file_extension:  u16,
 	def_ext:         cstring,
-	cust_data:       Lparam,
+	cust_data:       LPARAM,
 	hook:            OFN_Hook_Proc,
 	template_name:   cstring,
 	pv_reserved:     rawptr,
@@ -32,27 +32,27 @@ Open_File_Name_A :: struct {
 	flags_ex:        u32,
 }
 
-Open_File_Name_W :: struct {
+OPENFILENAMEW :: struct {
 	struct_size:     u32,
-	hwnd_owner:      Hwnd,
-	instance:        Hinstance,
-	filter:          Wstring,
-	custom_filter:   Wstring,
+	hwnd_owner:      HWND,
+	instance:        HINSTANCE,
+	filter:          LPCWSTR,
+	custom_filter:   LPCWSTR,
 	max_cust_filter: u32,
 	filter_index:    u32,
-	file:            Wstring,
+	file:            LPCWSTR,
 	max_file:        u32,
-	file_title:      Wstring,
+	file_title:      LPCWSTR,
 	max_file_title:  u32,
-	initial_dir:     Wstring,
-	title:           Wstring,
+	initial_dir:     LPCWSTR,
+	title:           LPCWSTR,
 	flags:           u32,
 	file_offset:     u16,
 	file_extension:  u16,
-	def_ext:         Wstring,
-	cust_data:       Lparam,
+	def_ext:         LPCWSTR,
+	cust_data:       LPARAM,
 	hook:            OFN_Hook_Proc,
-	template_name:   Wstring,
+	template_name:   LPCWSTR,
 	pv_reserved:     rawptr,
 	dw_reserved:     u32,
 	flags_ex:        u32,
@@ -60,12 +60,18 @@ Open_File_Name_W :: struct {
 
 @(default_calling_convention = "c")
 foreign comdlg32 {
-	@(link_name="GetOpenFileNameA") get_open_file_name_a :: proc(arg1: ^Open_File_Name_A) -> Bool ---
-	@(link_name="GetOpenFileNameW") get_open_file_name_w :: proc(arg1: ^Open_File_Name_W) -> Bool ---
-	@(link_name="GetSaveFileNameA") get_save_file_name_a :: proc(arg1: ^Open_File_Name_A) -> Bool ---
-	@(link_name="GetSaveFileNameW") get_save_file_name_w :: proc(arg1: ^Open_File_Name_W) -> Bool ---
-	@(link_name="CommDlgExtendedError") comm_dlg_extended_error :: proc() -> u32 ---
+	GetOpenFileNameA :: proc(arg1: ^OPENFILENAMEA) -> BOOL ---
+	GetOpenFileNameW :: proc(arg1: ^OPENFILENAMEW) -> BOOL ---
+	GetSaveFileNameA :: proc(arg1: ^OPENFILENAMEA) -> BOOL ---
+	GetSaveFileNameW :: proc(arg1: ^OPENFILENAMEW) -> BOOL ---
+	CommDlgExtendedError :: proc() -> u32 ---
 }
+
+get_open_file_name_a    :: GetOpenFileNameA;
+get_open_file_name_w    :: GetOpenFileNameW;
+get_save_file_name_a    :: GetSaveFileNameA;
+get_save_file_name_w    :: GetSaveFileNameW;
+comm_dlg_extended_error :: CommDlgExtendedError;
 
 OPEN_TITLE :: "Select file to open";
 OPEN_FLAGS :: u32(OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST);
@@ -94,9 +100,9 @@ _open_file_dialog :: proc(title: string, dir: string,
 	filter = strings.join(filters, "\u0000", context.temp_allocator);
 	filter = strings.concatenate({filter, "\u0000"}, context.temp_allocator);
 
-	ofn := Open_File_Name_W{
-		struct_size  = size_of(Open_File_Name_W),
-		file         = Wstring(&file_buf[0]),
+	ofn := OPENFILENAMEW{
+		struct_size  = size_of(OPENFILENAMEW),
+		file         = LPCWSTR(&file_buf[0]),
 		max_file     = MAX_PATH_WIDE,
 		title        = utf8_to_wstring(title, context.temp_allocator),
 		filter       = utf8_to_wstring(filter, context.temp_allocator),

--- a/core/sys/win32/crt.odin
+++ b/core/sys/win32/crt.odin
@@ -3,12 +3,13 @@ package win32
 import "core:strings";
 
 foreign {
-	@(link_name="_wgetcwd") _get_cwd_wide :: proc(buffer: Wstring, buf_len: int) ->  ^Wstring ---
+	_wgetcwd :: proc(buffer: LPCWSTR, buf_len: int) ->  ^LPCWSTR ---
 }
+_get_cwd_wide :: _wgetcwd;
 
 get_cwd :: proc(allocator := context.temp_allocator) -> string {
 	buffer := make([]u16, MAX_PATH_WIDE, allocator);
-	_get_cwd_wide(Wstring(&buffer[0]), MAX_PATH_WIDE);
+	_get_cwd_wide(LPCWSTR(&buffer[0]), MAX_PATH_WIDE);
 	file := utf16_to_utf8(buffer[:], allocator);
 	return strings.trim_right_null(file);
 }

--- a/core/sys/win32/gdi32.odin
+++ b/core/sys/win32/gdi32.odin
@@ -8,19 +8,25 @@ BLACKNESS :: 0x00000042;
 
 @(default_calling_convention = "std")
 foreign gdi32 {
-	@(link_name="GetStockObject") get_stock_object :: proc(fn_object: i32) -> Hgdiobj ---;
+	GetStockObject :: proc(fn_object: i32) -> HGDIOBJ ---;
 
-	@(link_name="StretchDIBits")
-	stretch_dibits :: proc(hdc: Hdc,
+	StretchDIBits :: proc(hdc: HDC,
 	                       x_dst, y_dst, width_dst, height_dst: i32,
 	                       x_src, y_src, width_src, header_src: i32,
-	                       bits: rawptr, bits_info: ^Bitmap_Info,
+	                       bits: rawptr, bits_info: ^BITMAPINFO,
 	                       usage: u32,
 	                       rop: u32) -> i32 ---;
 
-	@(link_name="SetPixelFormat")    set_pixel_format    :: proc(hdc: Hdc, pixel_format: i32, pfd: ^Pixel_Format_Descriptor) -> Bool ---;
-	@(link_name="ChoosePixelFormat") choose_pixel_format :: proc(hdc: Hdc, pfd: ^Pixel_Format_Descriptor) -> i32 ---;
-	@(link_name="SwapBuffers")       swap_buffers        :: proc(hdc: Hdc) -> Bool ---;
+	SetPixelFormat    :: proc(hdc: HDC, pixel_format: i32, pfd: ^PIXELFORMATDESCRIPTOR) -> BOOL ---;
+	ChoosePixelFormat :: proc(hdc: HDC, pfd: ^PIXELFORMATDESCRIPTOR) -> i32 ---;
+	SwapBuffers       :: proc(hdc: HDC) -> BOOL ---;
 
-	@(link_name="PatBlt") pat_blt :: proc(hdc: Hdc, x, y, w, h: i32, rop: u32) -> Bool ---;
+	PatBlt :: proc(hdc: HDC, x, y, w, h: i32, rop: u32) -> BOOL ---;
 }
+
+get_stock_object    :: GetStockObject;
+stretch_dibits      :: StretchDIBits;
+set_pixel_format    :: SetPixelFormat;
+choose_pixel_format :: ChoosePixelFormat;
+swap_buffers        :: SwapBuffers;
+pat_blt             :: PatBlt;

--- a/core/sys/win32/general.odin
+++ b/core/sys/win32/general.odin
@@ -1,118 +1,152 @@
 // +build windows
 package win32
 
-Uint_Ptr :: distinct uint;
-Long_Ptr :: distinct int;
-
-Handle    :: distinct rawptr;
-Hwnd      :: distinct Handle;
-Hdc       :: distinct Handle;
-Hinstance :: distinct Handle;
-Hicon     :: distinct Handle;
-Hcursor   :: distinct Handle;
-Hmenu     :: distinct Handle;
-Hbitmap   :: distinct Handle;
-Hbrush    :: distinct Handle;
-Hgdiobj   :: distinct Handle;
-Hmodule   :: distinct Handle;
-Hmonitor  :: distinct Handle;
-Hrawinput :: distinct Handle;
-Hresult   :: distinct i32;
-HKL       :: distinct Handle;
-Wparam    :: distinct Uint_Ptr;
-Lparam    :: distinct Long_Ptr;
-Lresult   :: distinct Long_Ptr;
-Wnd_Proc  :: distinct #type proc "std" (Hwnd, u32, Wparam, Lparam) -> Lresult;
-Monitor_Enum_Proc :: distinct #type proc "std" (Hmonitor, Hdc, ^Rect, Lparam) -> bool;
+UINT_PTR :: distinct uint;
+LONG_PTR :: distinct int;
+Uint_Ptr :: UINT_PTR;
+Long_Ptr :: LONG_PTR;
 
 
+HANDLE    :: distinct rawptr;
+HWND      :: distinct HANDLE;
+HDC       :: distinct HANDLE;
+HINSTANCE :: distinct HANDLE;
+HICON     :: distinct HANDLE;
+HCURSOR   :: distinct HANDLE;
+HMENU     :: distinct HANDLE;
+HBITMAP   :: distinct HANDLE;
+HBRUSH    :: distinct HANDLE;
+HGDIOBJ   :: distinct HANDLE;
+HMODULE   :: distinct HANDLE;
+HMONITOR  :: distinct HANDLE;
+HRAWINPUT :: distinct HANDLE;
+HRESULT   :: distinct i32;
+HKL       :: distinct HANDLE;
+WPARAM    :: distinct UINT_PTR;
+LPARAM    :: distinct LONG_PTR;
+LRESULT   :: distinct LONG_PTR;
+WNDPROC  :: distinct #type proc "std" (HWND, u32, WPARAM, LPARAM) -> LRESULT;
+MONITORENUMPROC :: distinct #type proc "std" (HMONITOR, HDC, ^RECT, LPARAM) -> bool;
 
-Bool :: distinct b32;
+Handle    :: HANDLE;
+Hwnd      :: HWND;
+Hdc       :: HDC;
+Hinstance :: HINSTANCE;
+Hicon     :: HICON;
+Hcursor   :: HCURSOR;
+Hmenu     :: HMENU;
+Hbitmap   :: HBITMAP;
+Hbrush    :: HBRUSH;
+Hgdiobj   :: HGDIOBJ;
+Hmodule   :: HMODULE;
+Hmonitor  :: HMONITOR;
+Hrawinput :: HRAWINPUT;
+Hresult   :: HRESULT;
+Wparam    :: WPARAM;
+Lparam    :: LPARAM;
+Lresult   :: LRESULT;
+Wnd_Proc  :: WNDPROC;
+Monitor_Enum_Proc :: MONITORENUMPROC;
 
-Wstring :: distinct ^u16;
 
-Point :: struct {
+
+BOOL :: distinct b32;
+Bool :: BOOL;
+
+LPCWSTR :: distinct ^u16;
+Wstring :: LPCWSTR;
+
+POINT :: struct {
 	x, y: i32,
 }
+Point :: POINT;
 
-Wnd_Class_A :: struct {
+WNDCLASSA :: struct {
 	style:                 u32,
-	wnd_proc:              Wnd_Proc,
+	wnd_proc:              WNDPROC,
 	cls_extra, wnd_extra:  i32,
-	instance:              Hinstance,
-	icon:                  Hicon,
-	cursor:                Hcursor,
-	background:            Hbrush,
+	instance:              HINSTANCE,
+	icon:                  HICON,
+	cursor:                HCURSOR,
+	background:            HBRUSH,
 	menu_name, class_name: cstring
 }
+Wnd_Class_A :: WNDCLASSA;
 
-Wnd_Class_W :: struct {
+WNDCLASSW :: struct {
 	style:                 u32,
-	wnd_proc:              Wnd_Proc,
+	wnd_proc:              WNDPROC,
 	cls_extra, wnd_extra:  i32,
-	instance:              Hinstance,
-	icon:                  Hicon,
-	cursor:                Hcursor,
-	background:            Hbrush,
-	menu_name, class_name: Wstring
+	instance:              HINSTANCE,
+	icon:                  HICON,
+	cursor:                HCURSOR,
+	background:            HBRUSH,
+	menu_name, class_name: LPCWSTR
 }
+Wnd_Class_W :: WNDCLASSW;
 
-Wnd_Class_Ex_A :: struct {
+WNDCLASSEXA :: struct {
 	size, style:           u32,
-	wnd_proc:              Wnd_Proc,
+	wnd_proc:              WNDPROC,
 	cls_extra, wnd_extra:  i32,
-	instance:              Hinstance,
-	icon:                  Hicon,
-	cursor:                Hcursor,
-	background:            Hbrush,
+	instance:              HINSTANCE,
+	icon:                  HICON,
+	cursor:                HCURSOR,
+	background:            HBRUSH,
 	menu_name, class_name: cstring,
-	sm:                    Hicon,
+	sm:                    HICON,
 }
+Wnd_Class_Ex_A :: WNDCLASSEXA;
 
-Wnd_Class_Ex_W :: struct {
+WNDCLASSEXW :: struct {
 	size, style:           u32,
-	wnd_proc:              Wnd_Proc,
+	wnd_proc:              WNDPROC,
 	cls_extra, wnd_extra:  i32,
-	instance:              Hinstance,
-	icon:                  Hicon,
-	cursor:                Hcursor,
-	background:            Hbrush,
-	menu_name, class_name: Wstring,
-	sm:                    Hicon,
+	instance:              HINSTANCE,
+	icon:                  HICON,
+	cursor:                HCURSOR,
+	background:            HBRUSH,
+	menu_name, class_name: LPCWSTR,
+	sm:                    HICON,
 }
+Wnd_Class_Ex_W :: WNDCLASSEXW;
 
 
-Msg :: struct {
-	hwnd:    Hwnd,
+MSG :: struct {
+	hwnd:    HWND,
 	message: u32,
-	wparam:  Wparam,
-	lparam:  Lparam,
+	wparam:  WPARAM,
+	lparam:  LPARAM,
 	time:    u32,
-	pt:      Point,
+	pt:      POINT,
 }
+Msg :: MSG;
 
-Rect :: struct {
+RECT :: struct {
 	left:   i32,
 	top:    i32,
 	right:  i32,
 	bottom: i32,
 }
+Rect :: RECT;
 
-Filetime :: struct {
+FILETIME :: struct {
 	lo, hi: u32,
 }
+Filetime :: FILETIME;
 
-Systemtime :: struct {
+SYSTEMTIME :: struct {
 	year, month: u16,
 	day_of_week, day: u16,
 	hour, minute, second, millisecond: u16,
 }
+Systemtime :: SYSTEMTIME;
 
-By_Handle_File_Information :: struct {
+BY_HANDLE_FILE_INFORMATION :: struct {
 	file_attributes:      u32,
 	creation_time,
 	last_access_time,
-	last_write_time:      Filetime,
+	last_write_time:      FILETIME,
 	volume_serial_number,
 	file_size_high,
 	file_size_low,
@@ -120,23 +154,25 @@ By_Handle_File_Information :: struct {
 	file_index_high,
 	file_index_low:       u32,
 }
+By_Handle_File_Information :: BY_HANDLE_FILE_INFORMATION;
 
-File_Attribute_Data :: struct {
+WIN32_FILE_ATTRIBUTE_DATA :: struct {
 	file_attributes:  u32,
 	creation_time,
 	last_access_time,
-	last_write_time:  Filetime,
+	last_write_time:  FILETIME,
 	file_size_high,
 	file_size_low:    u32,
 }
+File_Attribute_Data :: WIN32_FILE_ATTRIBUTE_DATA;
 
 // NOTE(Jeroen): The widechar version might want at least the 32k MAX_PATH_WIDE
 // https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-findfirstfilew#parameters
-Find_Data_W :: struct{
+WIN32_FIND_DATAW :: struct {
     file_attributes:     u32,
-    creation_time:       Filetime,
-    last_access_time:    Filetime,
-    last_write_time:     Filetime,
+    creation_time:       FILETIME,
+    last_access_time:    FILETIME,
+    last_write_time:     FILETIME,
     file_size_high:      u32,
     file_size_low:       u32,
     reserved0:           u32,
@@ -144,12 +180,13 @@ Find_Data_W :: struct{
     file_name:           [MAX_PATH]u16,
     alternate_file_name: [14]u16,
 }
+Find_Data_W :: WIN32_FIND_DATAW;
 
-Find_Data_A :: struct{
+WIN32_FIND_DATAA :: struct {
     file_attributes:     u32,
-    creation_time:       Filetime,
-    last_access_time:    Filetime,
-    last_write_time:     Filetime,
+    creation_time:       FILETIME,
+    last_access_time:    FILETIME,
+    last_write_time:     FILETIME,
     file_size_high:      u32,
     file_size_low:       u32,
     reserved0:           u32,
@@ -157,25 +194,28 @@ Find_Data_A :: struct{
     file_name:           [MAX_PATH]byte,
     alternate_file_name: [14]byte,
 }
+Find_Data_A :: WIN32_FIND_DATAA;
 
-Security_Attributes :: struct {
+SECURITY_ATTRIBUTES :: struct {
 	length:              u32,
 	security_descriptor: rawptr,
-	inherit_handle:      Bool,
+	inherit_handle:      BOOL,
 }
+Security_Attributes :: SECURITY_ATTRIBUTES;
 
-Process_Information :: struct {
-	process:    Handle,
-	thread:     Handle,
+PROCESS_INFORMATION :: struct {
+	process:    HANDLE,
+	thread:     HANDLE,
 	process_id: u32,
 	thread_id:  u32
 }
+Process_Information :: PROCESS_INFORMATION;
 
-Startup_Info :: struct {
+STARTUPINFO :: struct {
     cb:             u32,
-    reserved:       Wstring,
-    desktop:        Wstring,
-    title:          Wstring,
+    reserved:       LPCWSTR,
+    desktop:        LPCWSTR,
+    title:          LPCWSTR,
     x:              u32,
     y:              u32,
     x_size:         u32,
@@ -187,12 +227,14 @@ Startup_Info :: struct {
     show_window:    u16,
     _:              u16,
     _:              cstring,
-    stdin:          Handle,
-    stdout:         Handle,
-    stderr:         Handle,
+    stdin:          HANDLE,
+    stdout:         HANDLE,
+    stderr:         HANDLE,
 }
+Startup_Info :: STARTUPINFO;
 
-Pixel_Format_Descriptor :: struct {
+
+PIXELFORMATDESCRIPTOR :: struct {
 	size,
 	version,
 	flags: u32,
@@ -222,53 +264,59 @@ Pixel_Format_Descriptor :: struct {
 	visible_mask,
 	damage_mask: u32,
 }
+Pixel_Format_Descriptor :: PIXELFORMATDESCRIPTOR;
 
-Critical_Section :: struct {
-	debug_info:      ^Critical_Section_Debug,
+CRITICAL_SECTION :: struct {
+	debug_info:      ^CRITICAL_SECTION_DEBUG,
 
 	lock_count:      i32,
 	recursion_count: i32,
-	owning_thread:   Handle,
-	lock_semaphore:  Handle,
+	owning_thread:   HANDLE,
+	lock_semaphore:  HANDLE,
 	spin_count:      ^u32,
 }
+Critical_Section :: CRITICAL_SECTION;
 
-Critical_Section_Debug :: struct {
+CRITICAL_SECTION_DEBUG :: struct {
 	typ:                           u16,
 	creator_back_trace_index:      u16,
-	critical_section:              ^Critical_Section,
-	process_locks_list:            ^List_Entry,
+	critical_section:              ^CRITICAL_SECTION,
+	process_locks_list:            ^LIST_ENTRY,
 	entry_count:                   u32,
 	contention_count:              u32,
 	flags:                         u32,
 	creator_back_trace_index_high: u16,
 	spare_word:                    u16,
 }
+Critical_Section_Debug :: CRITICAL_SECTION_DEBUG;
 
-List_Entry :: struct {flink, blink: ^List_Entry};
+LIST_ENTRY :: struct {flink, blink: ^LIST_ENTRY};
+List_Entry :: LIST_ENTRY;
 
-
-Raw_Input_Device :: struct {
+RAWINPUTDEVICE :: struct {
 	usage_page: u16,
 	usage:      u16,
 	flags:      u32,
-	wnd_target: Hwnd,
+	wnd_target: HWND,
 }
+Raw_Input_Device :: RAWINPUTDEVICE;
 
-Raw_Input_Header :: struct {
+RAWINPUTHEADER :: struct {
 	kind:   u32,
 	size:   u32,
-	device: Handle,
-	wparam: Wparam,
+	device: HANDLE,
+	wparam: WPARAM,
 }
+Raw_Input_Header :: RAWINPUTHEADER;
 
-Raw_HID :: struct {
+RAWHID :: struct {
 	size_hid: u32,
 	count:    u32,
 	raw_data: [1]byte,
 }
+Raw_HID :: RAWHID;
 
-Raw_Keyboard :: struct {
+RAWKEYBOARD :: struct {
 	make_code:         u16,
 	flags:             u16,
 	reserved:          u16,
@@ -276,8 +324,9 @@ Raw_Keyboard :: struct {
 	message:           u32,
 	extra_information: u32,
 }
+Raw_Keyboard :: RAWKEYBOARD;
 
-Raw_Mouse :: struct {
+RAWMOUSE :: struct {
 	flags: u16,
 	using data: struct #raw_union {
 		buttons: u32,
@@ -291,18 +340,19 @@ Raw_Mouse :: struct {
 	last_y:            i32,
 	extra_information: u32,
 }
+Raw_Mouse :: RAWMOUSE;
 
-Raw_Input :: struct {
-	using header: Raw_Input_Header,
+RAWINPUT :: struct {
+	using header: RAWINPUTHEADER,
 	data: struct #raw_union {
-		mouse:    Raw_Mouse,
-		keyboard: Raw_Keyboard,
-		hid:      Raw_HID,
+		mouse:    RAWMOUSE,
+		keyboard: RAWKEYBOARD,
+		hid:      RAWHID,
 	},
 }
+Raw_Input :: RAWINPUT;
 
-
-Overlapped :: struct {
+OVERLAPPED :: struct {
     internal:      ^u64,
     internal_high: ^u64,
     using _: struct #raw_union {
@@ -312,18 +362,20 @@ Overlapped :: struct {
         },
         pointer: rawptr,
     },
-    event: Handle,
+    event: HANDLE,
 }
+Overlapped :: OVERLAPPED;
 
-File_Notify_Information :: struct {
+FILE_NOTIFY_INFORMATION :: struct {
   next_entry_offset: u32,
   action:            u32,
   file_name_length:  u32,
   file_name:         [1]u16,
 }
+File_Notify_Information :: FILE_NOTIFY_INFORMATION;
 
 // https://docs.microsoft.com/en-gb/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info
-System_Info :: struct {
+SYSTEM_INFO :: struct {
 	using _: struct #raw_union {
 		oem_id: u32,
 		using _: struct #raw_union {
@@ -341,9 +393,10 @@ System_Info :: struct {
 	processor_level: u16,
 	processor_revision: u16,
 }
+System_Info :: SYSTEM_INFO;
 
 // https://docs.microsoft.com/en-us/windows/desktop/api/winnt/ns-winnt-_osversioninfoexa
-OS_Version_Info_Ex_A :: struct {
+OSVERSIONINFOEXA :: struct {
   os_version_info_size: u32,
   major_version:        u32,
   minor_version:        u32,
@@ -356,6 +409,7 @@ OS_Version_Info_Ex_A :: struct {
   product_type:         u8,
   reserved:             u8
 }
+OS_Version_Info_Ex_A :: OSVERSIONINFOEXA;
 
 MAPVK_VK_TO_VSC    :: 0;
 MAPVK_VSC_TO_VK    :: 1;
@@ -492,7 +546,7 @@ VK_F22            :: 0x85;
 VK_F23            :: 0x86;
 VK_F24            :: 0x87;
 
-INVALID_HANDLE :: Handle(~uintptr(0));
+INVALID_HANDLE :: HANDLE(~uintptr(0));
 
 CREATE_SUSPENDED                  :: 0x00000004;
 STACK_SIZE_PARAM_IS_A_RESERVATION :: 0x00010000;
@@ -593,7 +647,7 @@ SM_CYSCREEN :: 1;
 
 SW_SHOW :: 5;
 
-COLOR_BACKGROUND :: Hbrush(uintptr(1));
+COLOR_BACKGROUND :: HBRUSH(uintptr(1));
 
 INVALID_SET_FILE_POINTER :: ~u32(0);
 HEAP_ZERO_MEMORY         :: 0x00000008;
@@ -604,7 +658,7 @@ GWLP_ID                  :: -12;
 GWL_STYLE                :: -16;
 GWLP_USERDATA            :: -21;
 GWLP_WNDPROC             :: -4;
-Hwnd_TOP                 :: Hwnd(uintptr(0));
+Hwnd_TOP                 :: HWND(uintptr(0));
 
 BI_RGB         :: 0;
 DIB_RGB_COLORS :: 0x00;
@@ -777,14 +831,14 @@ utf8_to_utf16 :: proc(s: string, allocator := context.temp_allocator) -> []u16 {
 
 	b := transmute([]byte)s;
 	cstr := cstring(&b[0]);
-	n := multi_byte_to_wide_char(CP_UTF8, MB_ERR_INVALID_CHARS, cstr, i32(len(s)), nil, 0);
+	n := MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, cstr, i32(len(s)), nil, 0);
 	if n == 0 {
 		return nil;
 	}
 
 	text := make([]u16, n+1, allocator);
 
-	n1 := multi_byte_to_wide_char(CP_UTF8, MB_ERR_INVALID_CHARS, cstr, i32(len(s)), Wstring(&text[0]), i32(n));
+	n1 := MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, cstr, i32(len(s)), LPCWSTR(&text[0]), i32(n));
 	if n1 == 0 {
 		delete(text, allocator);
 		return nil;
@@ -796,9 +850,9 @@ utf8_to_utf16 :: proc(s: string, allocator := context.temp_allocator) -> []u16 {
 	}
 	return text[:n];
 }
-utf8_to_wstring :: proc(s: string, allocator := context.temp_allocator) -> Wstring {
+utf8_to_wstring :: proc(s: string, allocator := context.temp_allocator) -> LPCWSTR {
 	if res := utf8_to_utf16(s, allocator); res != nil {
-		return Wstring(&res[0]);
+		return LPCWSTR(&res[0]);
 	}
 	return nil;
 }
@@ -808,19 +862,19 @@ wstring_to_utf8 :: proc(s: Wstring, N: int, allocator := context.temp_allocator)
 		return "";
 	}
 
-	n := wide_char_to_multi_byte(CP_UTF8, WC_ERR_INVALID_CHARS, s, i32(N), nil, 0, nil, nil);
+	n := WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, s, i32(N), nil, 0, nil, nil);
 	if n == 0 {
 		return "";
 	}
 
 	// If N == -1 the call to wide_char_to_multi_byte assume the wide string is null terminated
-	// and will scan it to find the first null terminated character. The resulting string will 
+	// and will scan it to find the first null terminated character. The resulting string will
 	// also null terminated.
-	// If N != -1 it assumes the wide string is not null terminated and the resulting string 
+	// If N != -1 it assumes the wide string is not null terminated and the resulting string
 	// will not be null terminated, we therefore have to force it to be null terminated manually.
 	text := make([]byte, n+1 if N != -1 else n, allocator);
 
-	if n1 := wide_char_to_multi_byte(CP_UTF8, WC_ERR_INVALID_CHARS, s, i32(N), cstring(&text[0]), n, nil, nil); n1 == 0 {
+	if n1 := WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, s, i32(N), cstring(&text[0]), n, nil, nil); n1 == 0 {
 		delete(text, allocator);
 		return "";
 	}
@@ -842,14 +896,14 @@ utf16_to_utf8 :: proc(s: []u16, allocator := context.temp_allocator) -> string {
 
 get_query_performance_frequency :: proc() -> i64 {
 	r: i64;
-	query_performance_frequency(&r);
+	QueryPerformanceFrequency(&r);
 	return r;
 }
 
-HIWORD_W :: proc(wParam: Wparam) -> u16 { return u16((u32(wParam) >> 16) & 0xffff); }
-HIWORD_L :: proc(lParam: Lparam) -> u16 { return u16((u32(lParam) >> 16) & 0xffff); }
-LOWORD_W :: proc(wParam: Wparam) -> u16 { return u16(wParam); }
-LOWORD_L :: proc(lParam: Lparam) -> u16 { return u16(lParam); }
+HIWORD_W :: proc(wParam: WPARAM) -> u16 { return u16((u32(wParam) >> 16) & 0xffff); }
+HIWORD_L :: proc(lParam: LPARAM) -> u16 { return u16((u32(lParam) >> 16) & 0xffff); }
+LOWORD_W :: proc(wParam: WPARAM) -> u16 { return u16(wParam); }
+LOWORD_L :: proc(lParam: LPARAM) -> u16 { return u16(lParam); }
 
 is_key_down :: inline proc(key: Key_Code) -> bool { return get_async_key_state(i32(key)) < 0; }
 
@@ -908,23 +962,25 @@ FILE_TYPE_CHAR :: 0x0002;
 FILE_TYPE_PIPE :: 0x0003;
 
 
-Monitor_Info :: struct {
+MONITORINFO :: struct {
 	size:      u32,
-	monitor:   Rect,
-	work:      Rect,
+	monitor:   RECT,
+	work:      RECT,
 	flags:     u32,
 }
+Monitor_Info :: MONITORINFO;
 
-Window_Placement :: struct {
+WINDOWPLACEMENT :: struct {
 	length:     u32,
 	flags:      u32,
 	show_cmd:   u32,
-	min_pos:    Point,
-	max_pos:    Point,
-	normal_pos: Rect,
+	min_pos:    POINT,
+	max_pos:    POINT,
+	normal_pos: RECT,
 }
+Window_Placement :: WINDOWPLACEMENT;
 
-Bitmap_Info_Header :: struct {
+BITMAPINFOHEADER :: struct {
 	size:              u32,
 	width, height:     i32,
 	planes, bit_count: i16,
@@ -935,22 +991,27 @@ Bitmap_Info_Header :: struct {
 	clr_used:          u32,
 	clr_important:     u32,
 }
-Bitmap_Info :: struct {
-	using header: Bitmap_Info_Header,
-	colors:       [1]Rgb_Quad,
-}
+Bitmap_Info_Header :: BITMAPINFOHEADER;
 
-Paint_Struct :: struct {
-	hdc:          Hdc,
-	erase:        Bool,
-	rc_paint:     Rect,
-	restore:      Bool,
-	inc_update:   Bool,
+BITMAPINFO :: struct {
+	using header: BITMAPINFOHEADER,
+	colors:       [1]RGBQUAD,
+}
+Bitmap_Info :: BITMAPINFO;
+
+PAINTSTRUCT :: struct {
+	hdc:          HDC,
+	erase:        BOOL,
+	rc_paint:     RECT,
+	restore:      BOOL,
+	inc_update:   BOOL,
 	rgb_reserved: [32]byte
 }
+Paint_Struct :: PAINTSTRUCT;
 
 
-Rgb_Quad :: struct {blue, green, red, reserved: byte}
+RGBQUAD :: struct {blue, green, red, reserved: byte}
+Rgb_Quad :: RGBQUAD;
 
 
 Key_Code :: enum i32 {

--- a/core/sys/win32/helpers.odin
+++ b/core/sys/win32/helpers.odin
@@ -4,19 +4,19 @@ package win32
 import "core:strings";
 
 call_external_process :: proc(program, command_line: string) -> bool {
-    si := Startup_Info{ cb=size_of(Startup_Info) };
-    pi := Process_Information{};
+    si := STARTUPINFO{ cb=size_of(STARTUPINFO) };
+    pi := PROCESS_INFORMATION{};
 
-    return cast(bool)create_process_w(
+    return cast(bool)CreateProcessW(
         utf8_to_wstring(program),
         utf8_to_wstring(command_line),
-        nil, 
-        nil, 
-        Bool(false), 
-        u32(0x10), 
-        nil, 
-        nil, 
-        &si, 
+        nil,
+        nil,
+        BOOL(false),
+        u32(0x10),
+        nil,
+        nil,
+        &si,
         &pi
     );
 }

--- a/core/sys/win32/kernel32.odin
+++ b/core/sys/win32/kernel32.odin
@@ -5,187 +5,296 @@ foreign import "system:kernel32.lib"
 
 @(default_calling_convention = "std")
 foreign kernel32 {
-	@(link_name="CreateProcessA")		     create_process_a		      :: proc(application_name, command_line: cstring,
-	                                                              				 process_attributes, thread_attributes: ^Security_Attributes,
-	                                                              				 inherit_handle: Bool, creation_flags: u32, environment: rawptr,
-	                                                              				 current_direcotry: cstring, startup_info: ^Startup_Info,
-	                                                              				 process_information: ^Process_Information) -> Bool ---;
-	@(link_name="CreateProcessW")            create_process_w             :: proc(application_name, command_line: Wstring,
-	                                                                             process_attributes, thread_attributes: ^Security_Attributes,
-	                                                                             inherit_handle: Bool, creation_flags: u32, environment: rawptr,
-	                                                                             current_direcotry: cstring, startup_info: ^Startup_Info,
-	                                                                             process_information: ^Process_Information) -> Bool ---;
-	@(link_name="GetExitCodeProcess")		 get_exit_code_process        :: proc(process: Handle, exit: ^u32) -> Bool ---;
-	@(link_name="ExitProcess")               exit_process                 :: proc(exit_code: u32) ---;
-	@(link_name="GetModuleHandleA")          get_module_handle_a          :: proc(module_name: cstring) -> Hmodule ---;
-	@(link_name="GetModuleHandleW")          get_module_handle_w          :: proc(module_name: Wstring) -> Hmodule ---;
+	CreateProcessA            :: proc(application_name, command_line: cstring,
+	                                  process_attributes, thread_attributes: ^SECURITY_ATTRIBUTES,
+	                                  inherit_handle: BOOL, creation_flags: u32, environment: rawptr,
+	                                  current_direcotry: cstring, startup_info: ^STARTUPINFO,
+	                                  process_information: ^PROCESS_INFORMATION) -> BOOL ---;
 
-	@(link_name="GetModuleFileNameA")        get_module_file_name_a       :: proc(module: Hmodule, filename: cstring, size: u32) -> u32 ---;
-	@(link_name="GetModuleFileNameW")        get_module_file_name_w       :: proc(module: Hmodule, filename: Wstring, size: u32) -> u32 ---;
+	CreateProcessW            :: proc(application_name, command_line: LPCWSTR,
+	                                  process_attributes, thread_attributes: ^SECURITY_ATTRIBUTES,
+	                                  inherit_handle: BOOL, creation_flags: u32, environment: rawptr,
+	                                  current_direcotry: cstring, startup_info: ^STARTUPINFO,
+	                                  process_information: ^PROCESS_INFORMATION) -> BOOL ---;
 
-	@(link_name="Sleep")                     sleep                        :: proc(ms: u32) ---;
-	@(link_name="QueryPerformanceFrequency") query_performance_frequency  :: proc(result: ^i64) -> i32 ---;
-	@(link_name="QueryPerformanceCounter")   query_performance_counter    :: proc(result: ^i64) -> i32 ---;
-	@(link_name="OutputDebugStringA")        output_debug_string_a        :: proc(c_str: cstring) ---;
+	GetExitCodeProcess        :: proc(process: HANDLE, exit: ^u32) -> BOOL ---;
+	ExitProcess               :: proc(exit_code: u32) ---;
+	GetModuleHandleA          :: proc(module_name: cstring) -> HMODULE ---;
+	GetModuleHandleW          :: proc(module_name: LPCWSTR) -> HMODULE ---;
 
-	@(link_name="GetCommandLineA")           get_command_line_a           :: proc() -> cstring ---;
-	@(link_name="GetCommandLineW")           get_command_line_w           :: proc() -> Wstring ---;
-	@(link_name="GetSystemMetrics")          get_system_metrics           :: proc(index: i32) -> i32 ---;
-	@(link_name="GetSystemInfo")             get_system_info              :: proc(info: ^System_Info) ---;
-	@(link_name="GetVersionExA")             get_version                  :: proc(osvi: ^OS_Version_Info_Ex_A) ---;
-	@(link_name="GetCurrentThreadId")        get_current_thread_id        :: proc() -> u32 ---;
+	GetModuleFileNameA        :: proc(module: HMODULE, filename: cstring, size: u32) -> u32 ---;
+	GetModuleFileNameW        :: proc(module: HMODULE, filename: LPCWSTR, size: u32) -> u32 ---;
+
+	Sleep                     :: proc(ms: u32) ---;
+	QueryPerformanceFrequency :: proc(result: ^i64) -> i32 ---;
+	QueryPerformanceCounter   :: proc(result: ^i64) -> i32 ---;
+	OutputDebugStringA        :: proc(c_str: cstring) ---;
+
+	GetCommandLineA           :: proc() -> cstring ---;
+	GetCommandLineW           :: proc() -> LPCWSTR ---;
+	GetSystemMetrics          :: proc(index: i32) -> i32 ---;
+	GetSystemInfo             :: proc(info: ^SYSTEM_INFO) ---;
+	GetVersionExA             :: proc(osvi: ^OSVERSIONINFOEXA) ---;
+	GetCurrentThreadId        :: proc() -> u32 ---;
 
 	// NOTE(tetra): Not thread safe with SetCurrentDirectory and GetFullPathName;
 	// The current directory is stored as a global variable in the process.
-	@(link_name="GetCurrentDirectoryW")       get_current_directory_w     :: proc(len: u32, buf: Wstring) -> u32 ---;
-	@(link_name="SetCurrentDirectoryW")       set_current_directory_w     :: proc(buf: Wstring) -> u32 ---;
+	GetCurrentDirectoryW      :: proc(len: u32, buf: LPCWSTR) -> u32 ---;
+	SetCurrentDirectoryW      :: proc(buf: LPCWSTR) -> u32 ---;
 
-	@(link_name="GetSystemTimeAsFileTime")   get_system_time_as_file_time :: proc(system_time_as_file_time: ^Filetime) ---;
-	@(link_name="FileTimeToLocalFileTime")   file_time_to_local_file_time :: proc(file_time: ^Filetime, local_file_time: ^Filetime) -> Bool ---;
-	@(link_name="FileTimeToSystemTime")      file_time_to_system_time     :: proc(file_time: ^Filetime, system_time: ^Systemtime) -> Bool ---;
-	@(link_name="SystemTimeToFileTime")      system_time_to_file_time     :: proc(system_time: ^Systemtime, file_time: ^Filetime) -> Bool ---;
+	GetSystemTimeAsFileTime   :: proc(system_time_as_file_time: ^FILETIME) ---;
+	FileTimeToLocalFileTime   :: proc(file_time: ^FILETIME, local_file_time: ^FILETIME) -> BOOL ---;
+	FileTimeToSystemTime      :: proc(file_time: ^FILETIME, system_time: ^SYSTEMTIME) -> BOOL ---;
+	SystemTimeToFileTime      :: proc(system_time: ^SYSTEMTIME, file_time: ^FILETIME) -> BOOL ---;
 
-	@(link_name="GetStdHandle")              get_std_handle               :: proc(h: i32) -> Handle ---;
+	GetStdHandle :: proc(h: i32) -> HANDLE ---;
 
-	@(link_name="CreateFileA")
-	create_file_a :: proc(filename: cstring, desired_access, share_module: u32,
+	CreateFileA :: proc(filename: cstring, desired_access, share_module: u32,
 	                      security: rawptr,
-	                      creation, flags_and_attribs: u32, template_file: Handle) -> Handle ---;
+	                      creation, flags_and_attribs: u32, template_file: HANDLE) -> HANDLE ---;
 
-	@(link_name="CreateFileW")
-	create_file_w :: proc(filename: Wstring, desired_access, share_module: u32,
+	CreateFileW :: proc(filename: LPCWSTR, desired_access, share_module: u32,
 	                      security: rawptr,
-	                      creation, flags_and_attribs: u32, template_file: Handle) -> Handle ---;
+	                      creation, flags_and_attribs: u32, template_file: HANDLE) -> HANDLE ---;
 
 
-	@(link_name="ReadFile")  read_file  :: proc(h: Handle, buf: rawptr, to_read: u32, bytes_read: ^i32, overlapped: rawptr) -> Bool ---;
-	@(link_name="WriteFile") write_file :: proc(h: Handle, buf: rawptr, len: i32, written_result: ^i32, overlapped: rawptr) -> Bool ---;
+	ReadFile  :: proc(h: HANDLE, buf: rawptr, to_read: u32, bytes_read: ^i32, overlapped: rawptr) -> BOOL ---;
+	WriteFile :: proc(h: HANDLE, buf: rawptr, len: i32, written_result: ^i32, overlapped: rawptr) -> BOOL ---;
 
-	@(link_name="GetFileSizeEx")              get_file_size_ex               :: proc(file_handle: Handle, file_size: ^i64) -> Bool ---;
-	@(link_name="GetFileInformationByHandle") get_file_information_by_handle :: proc(file_handle: Handle, file_info: ^By_Handle_File_Information) -> Bool ---;
+	GetFileSizeEx              :: proc(file_handle: HANDLE, file_size: ^i64) -> BOOL ---;
+	GetFileInformationByHandle :: proc(file_handle: HANDLE, file_info: ^BY_HANDLE_FILE_INFORMATION) -> BOOL ---;
 
-	@(link_name="CreateDirectoryA") 		  create_directory_a			 :: proc(path: cstring, security_attributes: ^Security_Attributes) -> Bool ---;
-	@(link_name="CreateDirectoryW") 		  create_directory_w			 :: proc(path: Wstring, security_attributes: ^Security_Attributes) -> Bool ---;
+	CreateDirectoryA :: proc(path: cstring, security_attributes: ^SECURITY_ATTRIBUTES) -> BOOL ---;
+	CreateDirectoryW :: proc(path: LPCWSTR, security_attributes: ^SECURITY_ATTRIBUTES) -> BOOL ---;
 
-	@(link_name="GetFileType")    get_file_type    :: proc(file_handle: Handle) -> u32 ---;
-	@(link_name="SetFilePointer") set_file_pointer :: proc(file_handle: Handle, distance_to_move: i32, distance_to_move_high: ^i32, move_method: u32) -> u32 ---;
+	GetFileType    :: proc(file_handle: HANDLE) -> u32 ---;
+	SetFilePointer :: proc(file_handle: HANDLE, distance_to_move: i32, distance_to_move_high: ^i32, move_method: u32) -> u32 ---;
 
-	@(link_name="SetHandleInformation") set_handle_information :: proc(obj: Handle, mask, flags: u32) -> Bool ---;
+	SetHandleInformation :: proc(obj: HANDLE, mask, flags: u32) -> BOOL ---;
 
-	@(link_name="FindFirstFileA") find_first_file_a :: proc(file_name: cstring, data: ^Find_Data_A) -> Handle ---;
-	@(link_name="FindNextFileA")  find_next_file_a  :: proc(file: Handle, data: ^Find_Data_A) -> Bool ---;
+	FindFirstFileA :: proc(file_name: cstring, data: ^WIN32_FIND_DATAA) -> HANDLE ---;
+	FindNextFileA  :: proc(file: HANDLE, data: ^WIN32_FIND_DATAA) -> BOOL ---;
+	FindFirstFileW :: proc(file_name: LPCWSTR, data: ^WIN32_FIND_DATAW) -> HANDLE ---;
+	FindNextFileW  :: proc(file: HANDLE, data: ^WIN32_FIND_DATAW) -> BOOL ---;
+	FindClose      :: proc(file: HANDLE) -> BOOL ---;
 
-	@(link_name="FindFirstFileW") find_first_file_w :: proc(file_name: Wstring, data: ^Find_Data_W) -> Handle ---;
-	@(link_name="FindNextFileW")  find_next_file_w  :: proc(file: Handle, data: ^Find_Data_W) -> Bool ---;
+	MoveFileExA :: proc(existing, new: cstring, flags: u32) -> BOOL ---;
+	DeleteFileA :: proc(file_name: cstring) -> BOOL ---;
+	CopyFileA   :: proc(existing, new: cstring, fail_if_exists: BOOL) -> BOOL ---;
 
-	@(link_name="FindClose")      find_close        :: proc(file: Handle) -> Bool ---;
+	MoveFileExW :: proc(existing, new: LPCWSTR, flags: u32) -> BOOL ---;
+	DeleteFileW :: proc(file_name: LPCWSTR) -> BOOL ---;
+	CopyFileW   :: proc(existing, new: LPCWSTR, fail_if_exists: BOOL) -> BOOL ---;
 
-	@(link_name="MoveFileExA")    move_file_ex_a    :: proc(existing, new: cstring, flags: u32) -> Bool ---;
-	@(link_name="DeleteFileA")    delete_file_a     :: proc(file_name: cstring) -> Bool ---;
-	@(link_name="CopyFileA")      copy_file_a       :: proc(existing, new: cstring, fail_if_exists: Bool) -> Bool ---;
+	HeapAlloc      :: proc(h: HANDLE, flags: u32, bytes: int) -> rawptr ---;
+	HeapReAlloc    :: proc(h: HANDLE, flags: u32, memory: rawptr, bytes: int) -> rawptr ---;
+	HeapFree       :: proc(h: HANDLE, flags: u32, memory: rawptr) -> BOOL ---;
+	GetProcessHeap :: proc() -> HANDLE ---;
 
-	@(link_name="MoveFileExW")    move_file_ex_w    :: proc(existing, new: Wstring, flags: u32) -> Bool ---;
-	@(link_name="DeleteFileW")    delete_file_w     :: proc(file_name: Wstring) -> Bool ---;
-	@(link_name="CopyFileW")      copy_file_w       :: proc(existing, new: Wstring, fail_if_exists: Bool) -> Bool ---;
+	LocalAlloc   :: proc(flags: u32, bytes: int) -> rawptr ---;
+	LocalReAlloc :: proc(mem: rawptr, bytes: int, flags: uint) -> rawptr ---;
+	LocalFree    :: proc(mem: rawptr) -> rawptr ---;
 
-	@(link_name="HeapAlloc")      heap_alloc       :: proc(h: Handle, flags: u32, bytes: int) -> rawptr ---;
-	@(link_name="HeapReAlloc")    heap_realloc     :: proc(h: Handle, flags: u32, memory: rawptr, bytes: int) -> rawptr ---;
-	@(link_name="HeapFree")       heap_free        :: proc(h: Handle, flags: u32, memory: rawptr) -> Bool ---;
-	@(link_name="GetProcessHeap") get_process_heap :: proc() -> Handle ---;
+	FindFirstChangeNotificationA :: proc(path: cstring, watch_subtree: BOOL, filter: u32) -> HANDLE ---;
+	FindNextChangeNotification   :: proc(h: HANDLE) -> BOOL ---;
+	FindCloseChangeNotification  :: proc(h: HANDLE) -> BOOL ---;
 
-	@(link_name="LocalAlloc")     local_alloc      :: proc(flags: u32, bytes: int) -> rawptr ---;
-	@(link_name="LocalReAlloc")   local_realloc    :: proc(mem: rawptr, bytes: int, flags: uint) -> rawptr ---;
-	@(link_name="LocalFree")      local_free       :: proc(mem: rawptr) -> rawptr ---;
+	ReadDirectoryChangesW :: proc(dir: HANDLE, buf: rawptr, buf_length: u32,
+	                                                                      watch_subtree: BOOL, notify_filter: u32,
+	                                                                      bytes_returned: ^u32, overlapped: ^OVERLAPPED,
+	                                                                      completion: rawptr) -> BOOL ---;
 
-	@(link_name="FindFirstChangeNotificationA") find_first_change_notification_a :: proc(path: cstring, watch_subtree: Bool, filter: u32) -> Handle ---;
-	@(link_name="FindNextChangeNotification")   find_next_change_notification    :: proc(h: Handle) -> Bool ---;
-	@(link_name="FindCloseChangeNotification")  find_close_change_notification   :: proc(h: Handle) -> Bool ---;
+	WideCharToMultiByte :: proc(code_page: u32, flags: u32,
+	                            wchar_str: LPCWSTR, wchar: i32,
+	                            multi_str: cstring, multi: i32,
+	                            default_char: cstring, used_default_char: ^BOOL) -> i32 ---;
 
-	@(link_name="ReadDirectoryChangesW") read_directory_changes_w :: proc(dir: Handle, buf: rawptr, buf_length: u32,
-	                                                                      watch_subtree: Bool, notify_filter: u32,
-	                                                                      bytes_returned: ^u32, overlapped: ^Overlapped,
-	                                                                      completion: rawptr) -> Bool ---;
+	MultiByteToWideChar :: proc(code_page: u32, flags: u32,
+	                            mb_str: cstring, mb: i32,
+	                            wc_str: LPCWSTR, wc: i32) -> i32 ---;
 
-	@(link_name="WideCharToMultiByte") wide_char_to_multi_byte :: proc(code_page: u32, flags: u32,
-	                                                                   wchar_str: Wstring, wchar: i32,
-	                                                                   multi_str: cstring, multi: i32,
-	                                                                   default_char: cstring, used_default_char: ^Bool) -> i32 ---;
-
-	@(link_name="MultiByteToWideChar") multi_byte_to_wide_char :: proc(code_page: u32, flags: u32,
-	                                                                   mb_str: cstring, mb: i32,
-	                                                                   wc_str: Wstring, wc: i32) -> i32 ---;
-
-	@(link_name="CreateSemaphoreA")    create_semaphore_a     :: proc(attributes: ^Security_Attributes, initial_count, maximum_count: i32, name: cstring) -> Handle ---;
-	@(link_name="CreateSemaphoreW")    create_semaphore_w     :: proc(attributes: ^Security_Attributes, initial_count, maximum_count: i32, name: cstring) -> Handle ---;
-	@(link_name="ReleaseSemaphore")    release_semaphore      :: proc(semaphore: Handle, release_count: i32, previous_count: ^i32) -> Bool ---;
-	@(link_name="WaitForSingleObject") wait_for_single_object :: proc(handle: Handle, milliseconds: u32) -> u32 ---;
+	CreateSemaphoreA    :: proc(attributes: ^SECURITY_ATTRIBUTES, initial_count, maximum_count: i32, name: cstring) -> HANDLE ---;
+	CreateSemaphoreW    :: proc(attributes: ^SECURITY_ATTRIBUTES, initial_count, maximum_count: i32, name: cstring) -> HANDLE ---;
+	ReleaseSemaphore    :: proc(semaphore: HANDLE, release_count: i32, previous_count: ^i32) -> BOOL ---;
+	WaitForSingleObject :: proc(handle: HANDLE, milliseconds: u32) -> u32 ---;
 }
+
+create_process_a                  :: CreateProcessA;
+create_process_w                  :: CreateProcessW;
+get_exit_code_process             :: GetExitCodeProcess;
+exit_process                      :: ExitProcess;
+get_module_handle_a               :: GetModuleHandleA;
+get_module_handle_w               :: GetModuleHandleW;
+get_module_file_name_a            :: GetModuleFileNameA;
+get_module_file_name_w            :: GetModuleFileNameW;
+sleep                             :: Sleep;
+query_performance_frequency       :: QueryPerformanceFrequency;
+query_performance_counter         :: QueryPerformanceCounter;
+output_debug_string_a             :: OutputDebugStringA;
+get_command_line_a                :: GetCommandLineA;
+get_command_line_w                :: GetCommandLineW;
+get_system_metrics                :: GetSystemMetrics;
+get_system_info                   :: GetSystemInfo;
+get_version                       :: GetVersionExA;
+get_current_thread_id             :: GetCurrentThreadId;
+get_current_directory_w           :: GetCurrentDirectoryW;
+set_current_directory_w           :: SetCurrentDirectoryW;
+get_system_time_as_file_time      :: GetSystemTimeAsFileTime;
+file_time_to_local_file_time      :: FileTimeToLocalFileTime;
+file_time_to_system_time          :: FileTimeToSystemTime;
+system_time_to_file_time          :: SystemTimeToFileTime;
+get_std_handle                    :: GetStdHandle;
+create_file_a                     :: CreateFileA;
+create_file_w                     :: CreateFileW;
+read_file                         :: ReadFile;
+write_file                        :: WriteFile;
+get_file_size_ex                  :: GetFileSizeEx;
+get_file_information_by_handle    :: GetFileInformationByHandle;
+create_directory_a                :: CreateDirectoryA;
+create_directory_w                :: CreateDirectoryW;
+get_file_type                     :: GetFileType;
+set_file_pointer                  :: SetFilePointer;
+set_handle_information            :: SetHandleInformation;
+find_first_file_a                 :: FindFirstFileA;
+find_next_file_a                  :: FindNextFileA;
+find_first_file_w                 :: FindFirstFileW;
+find_next_file_w                  :: FindNextFileW;
+find_close                        :: FindClose;
+move_file_ex_a                    :: MoveFileExA;
+delete_file_a                     :: DeleteFileA;
+copy_file_a                       :: CopyFileA;
+move_file_ex_w                    :: MoveFileExW;
+delete_file_w                     :: DeleteFileW;
+copy_file_w                       :: CopyFileW;
+heap_alloc                        :: HeapAlloc;
+heap_realloc                      :: HeapReAlloc;
+heap_free                         :: HeapFree;
+get_process_heap                  :: GetProcessHeap;
+local_alloc                       :: LocalAlloc;
+local_realloc                     :: LocalReAlloc;
+local_free                        :: LocalFree;
+find_first_change_notification_a  :: FindFirstChangeNotificationA;
+find_next_change_notification     :: FindNextChangeNotification;
+find_close_change_notification    :: FindCloseChangeNotification;
+read_directory_changes_w          :: ReadDirectoryChangesW;
+wide_char_to_multi_byte           :: WideCharToMultiByte;
+multi_byte_to_wide_char           :: MultiByteToWideChar;
+create_semaphore_a                :: CreateSemaphoreA;
+create_semaphore_w                :: CreateSemaphoreW;
+release_semaphore                 :: ReleaseSemaphore;
+wait_for_single_object            :: WaitForSingleObject;
 
 // @(default_calling_convention = "c")
 foreign kernel32 {
-	@(link_name="GetLastError")              get_last_error               :: proc() -> i32 ---;
-	@(link_name="CloseHandle")               close_handle                 :: proc(h: Handle) -> i32 ---;
+	GetLastError :: proc() -> i32 ---;
 
-	@(link_name="GetFileAttributesA")         get_file_attributes_a          :: proc(filename: cstring) -> u32 ---;
-	@(link_name="GetFileAttributesW")         get_file_attributes_w          :: proc(filename: Wstring) -> u32 ---;
-	@(link_name="GetFileAttributesExA")       get_file_attributes_ex_a       :: proc(filename: cstring, info_level_id: GET_FILEEX_INFO_LEVELS, file_info: ^File_Attribute_Data) -> Bool ---;
-	@(link_name="GetFileAttributesExW")       get_file_attributes_ex_w       :: proc(filename: Wstring, info_level_id: GET_FILEEX_INFO_LEVELS, file_info: ^File_Attribute_Data) -> Bool ---;
-	@(link_name="CompareFileTime")            compare_file_time              :: proc(a, b: ^Filetime) -> i32 ---;
+	CloseHandle  :: proc(h: HANDLE) -> i32 ---;
+
+	GetFileAttributesA   :: proc(filename: cstring) -> u32 ---;
+	GetFileAttributesW   :: proc(filename: LPCWSTR) -> u32 ---;
+	GetFileAttributesExA :: proc(filename: cstring, info_level_id: GET_FILEEX_INFO_LEVELS, file_info: ^WIN32_FILE_ATTRIBUTE_DATA) -> BOOL ---;
+	GetFileAttributesExW :: proc(filename: LPCWSTR, info_level_id: GET_FILEEX_INFO_LEVELS, file_info: ^WIN32_FILE_ATTRIBUTE_DATA) -> BOOL ---;
+
+	CompareFileTime      :: proc(a, b: ^FILETIME) -> i32 ---;
 }
+
+get_last_error           :: GetLastError;
+close_handle             :: CloseHandle;
+get_file_attributes_a    :: GetFileAttributesA;
+get_file_attributes_w    :: GetFileAttributesW;
+get_file_attributes_ex_a :: GetFileAttributesExA;
+get_file_attributes_ex_w :: GetFileAttributesExW;
+compare_file_time        :: CompareFileTime;
 
 @(default_calling_convention = "c")
 foreign kernel32 {
-	@(link_name="InterlockedCompareExchange") interlocked_compare_exchange :: proc(dst: ^i32, exchange, comparand: i32) -> i32 ---;
-	@(link_name="InterlockedExchange")        interlocked_exchange         :: proc(dst: ^i32, desired: i32) -> i32 ---;
-	@(link_name="InterlockedExchangeAdd")     interlocked_exchange_add     :: proc(dst: ^i32, desired: i32) -> i32 ---;
-	@(link_name="InterlockedAnd")             interlocked_and              :: proc(dst: ^i32, desired: i32) -> i32 ---;
-	@(link_name="InterlockedOr")              interlocked_or               :: proc(dst: ^i32, desired: i32) -> i32 ---;
+	InterlockedCompareExchange :: proc(dst: ^i32, exchange, comparand: i32) -> i32 ---;
+	InterlockedExchange        :: proc(dst: ^i32, desired: i32) -> i32 ---;
+	InterlockedExchangeAdd     :: proc(dst: ^i32, desired: i32) -> i32 ---;
+	InterlockedAnd             :: proc(dst: ^i32, desired: i32) -> i32 ---;
+	InterlockedOr              :: proc(dst: ^i32, desired: i32) -> i32 ---;
 
-	@(link_name="InterlockedCompareExchange64") interlocked_compare_exchange64 :: proc(dst: ^i64, exchange, comparand: i64) -> i64 ---;
-	@(link_name="InterlockedExchange64")        interlocked_exchange64         :: proc(dst: ^i64, desired: i64) -> i64 ---;
-	@(link_name="InterlockedExchangeAdd64")     interlocked_exchange_add64     :: proc(dst: ^i64, desired: i64) -> i64 ---;
-	@(link_name="InterlockedAnd64")             interlocked_and64              :: proc(dst: ^i64, desired: i64) -> i64 ---;
-	@(link_name="InterlockedOr64")              interlocked_or64               :: proc(dst: ^i64, desired: i64) -> i64 ---;
+	InterlockedCompareExchange64 :: proc(dst: ^i64, exchange, comparand: i64) -> i64 ---;
+	InterlockedExchange64        :: proc(dst: ^i64, desired: i64) -> i64 ---;
+	InterlockedExchangeAdd64     :: proc(dst: ^i64, desired: i64) -> i64 ---;
+	InterlockedAnd64             :: proc(dst: ^i64, desired: i64) -> i64 ---;
+	InterlockedOr64              :: proc(dst: ^i64, desired: i64) -> i64 ---;
 }
+
+interlocked_compare_exchange   :: InterlockedCompareExchange;
+interlocked_exchange           :: InterlockedExchange;
+interlocked_exchange_add       :: InterlockedExchangeAdd;
+interlocked_and                :: InterlockedAnd;
+interlocked_or                 :: InterlockedOr;
+interlocked_compare_exchange64 :: InterlockedCompareExchange64;
+interlocked_exchange64         :: InterlockedExchange64;
+interlocked_exchange_add64     :: InterlockedExchangeAdd64;
+interlocked_and64              :: InterlockedAnd64;
+interlocked_or64               :: InterlockedOr64;
 
 @(default_calling_convention = "std")
 foreign kernel32 {
-	@(link_name="_mm_pause")        mm_pause           :: proc() ---;
-	@(link_name="ReadWriteBarrier") read_write_barrier :: proc() ---;
-	@(link_name="WriteBarrier")     write_barrier      :: proc() ---;
-	@(link_name="ReadBarrier")      read_barrier       :: proc() ---;
+	_mm_pause        :: proc() ---;
+	ReadWriteBarrier :: proc() ---;
+	WriteBarrier     :: proc() ---;
+	ReadBarrier      :: proc() ---;
 
-	@(link_name="CreateThread")
-	create_thread :: proc(thread_attributes: ^Security_Attributes, stack_size: int, start_routine: rawptr,
-	                      parameter: rawptr, creation_flags: u32, thread_id: ^u32) -> Handle ---;
-	@(link_name="ResumeThread")      resume_thread        :: proc(thread: Handle) -> u32 ---;
-	@(link_name="GetThreadPriority") get_thread_priority  :: proc(thread: Handle) -> i32 ---;
-	@(link_name="SetThreadPriority") set_thread_priority  :: proc(thread: Handle, priority: i32) -> Bool ---;
-    @(link_name="GetExitCodeThread") get_exit_code_thread :: proc(thread: Handle, exit_code: ^u32) -> Bool ---;
-	@(link_name="TerminateThread")   terminate_thread     :: proc(thread: Handle, exit_code: u32) -> Bool ---;
+	CreateThread       :: proc(thread_attributes: ^SECURITY_ATTRIBUTES, stack_size: int, start_routine: rawptr,
+	                           parameter: rawptr, creation_flags: u32, thread_id: ^u32) -> HANDLE ---;
+	ResumeThread       :: proc(thread: HANDLE) -> u32 ---;
+	GetThreadPriority  :: proc(thread: HANDLE) -> i32 ---;
+	SetThreadPriority  :: proc(thread: HANDLE, priority: i32) -> BOOL ---;
+    GetExitCodeThread  :: proc(thread: HANDLE, exit_code: ^u32) -> BOOL ---;
+	TerminateThread    :: proc(thread: HANDLE, exit_code: u32) -> BOOL ---;
 
-	@(link_name="InitializeCriticalSection")             initialize_critical_section                :: proc(critical_section: ^Critical_Section) ---;
-	@(link_name="InitializeCriticalSectionAndSpinCount") initialize_critical_section_and_spin_count :: proc(critical_section: ^Critical_Section, spin_count: u32) ---;
-	@(link_name="DeleteCriticalSection")                 delete_critical_section                    :: proc(critical_section: ^Critical_Section) ---;
-	@(link_name="SetCriticalSectionSpinCount")           set_critical_section_spin_count            :: proc(critical_section: ^Critical_Section, spin_count: u32) -> u32 ---;
-	@(link_name="TryEnterCriticalSection")               try_enter_critical_section                 :: proc(critical_section: ^Critical_Section) -> Bool ---;
-	@(link_name="EnterCriticalSection")                  enter_critical_section                     :: proc(critical_section: ^Critical_Section) ---;
-	@(link_name="LeaveCriticalSection")                  leave_critical_section                     :: proc(critical_section: ^Critical_Section) ---;
+	InitializeCriticalSection             :: proc(critical_section: ^CRITICAL_SECTION) ---;
+	InitializeCriticalSectionAndSpinCount :: proc(critical_section: ^CRITICAL_SECTION, spin_count: u32) ---;
+	DeleteCriticalSection                 :: proc(critical_section: ^CRITICAL_SECTION) ---;
+	SetCriticalSectionSpinCount           :: proc(critical_section: ^CRITICAL_SECTION, spin_count: u32) -> u32 ---;
+	TryEnterCriticalSection               :: proc(critical_section: ^CRITICAL_SECTION) -> BOOL ---;
+	EnterCriticalSection                  :: proc(critical_section: ^CRITICAL_SECTION) ---;
+	LeaveCriticalSection                  :: proc(critical_section: ^CRITICAL_SECTION) ---;
 
-	@(link_name="CreateEventA") create_event_a :: proc(event_attributes: ^Security_Attributes, manual_reset, initial_state: Bool, name: cstring) -> Handle ---;
-	@(link_name="CreateEventW") create_event_w :: proc(event_attributes: ^Security_Attributes, manual_reset, initial_state: Bool, name: Wstring) -> Handle ---;
-	@(link_name="PulseEvent")   pulse_event    :: proc(event: Handle) -> Bool ---;
-	@(link_name="SetEvent")     set_event      :: proc(event: Handle) -> Bool ---;
-	@(link_name="ResetEvent")   reset_event    :: proc(event: Handle) -> Bool ---;
+	CreateEventA :: proc(event_attributes: ^SECURITY_ATTRIBUTES, manual_reset, initial_state: BOOL, name: cstring) -> HANDLE ---;
+	CreateEventW :: proc(event_attributes: ^SECURITY_ATTRIBUTES, manual_reset, initial_state: BOOL, name: LPCWSTR) -> HANDLE ---;
+	PulseEvent   :: proc(event: HANDLE) -> BOOL ---;
+	SetEvent     :: proc(event: HANDLE) -> BOOL ---;
+	ResetEvent   :: proc(event: HANDLE) -> BOOL ---;
 
-	@(link_name="LoadLibraryA")   load_library_a   :: proc(c_str: cstring)  -> Hmodule ---;
-	@(link_name="LoadLibraryW")   load_library_w   :: proc(c_str: Wstring) -> Hmodule ---;
-	@(link_name="FreeLibrary")    free_library     :: proc(h: Hmodule) -> Bool ---;
-	@(link_name="GetProcAddress") get_proc_address :: proc(h: Hmodule, c_str: cstring) -> rawptr ---;
-
+	LoadLibraryA   :: proc(c_str: cstring)  -> HMODULE ---;
+	LoadLibraryW   :: proc(c_str: LPCWSTR) -> HMODULE ---;
+	FreeLibrary    :: proc(h: HMODULE) -> BOOL ---;
+	GetProcAddress :: proc(h: HMODULE, c_str: cstring) -> rawptr ---;
 }
 
-Memory_Basic_Information :: struct {
+mm_pause                                   :: _mm_pause;
+read_write_barrier                         :: ReadWriteBarrier;
+write_barrier                              :: WriteBarrier;
+read_barrier                               :: ReadBarrier;
+create_thread                              :: CreateThread;
+resume_thread                              :: ResumeThread;
+get_thread_priority                        :: GetThreadPriority;
+set_thread_priority                        :: SetThreadPriority;
+get_exit_code_thread                       :: GetExitCodeThread;
+terminate_thread                           :: TerminateThread;
+initialize_critical_section                :: InitializeCriticalSection;
+initialize_critical_section_and_spin_count :: InitializeCriticalSectionAndSpinCount;
+delete_critical_section                    :: DeleteCriticalSection;
+set_critical_section_spin_count            :: SetCriticalSectionSpinCount;
+try_enter_critical_section                 :: TryEnterCriticalSection;
+enter_critical_section                     :: EnterCriticalSection;
+leave_critical_section                     :: LeaveCriticalSection;
+create_event_a                             :: CreateEventA;
+create_event_w                             :: CreateEventW;
+pulse_event                                :: PulseEvent;
+set_event                                  :: SetEvent;
+reset_event                                :: ResetEvent;
+load_library_a                             :: LoadLibraryA;
+load_library_w                             :: LoadLibraryW;
+free_library                               :: FreeLibrary;
+get_proc_address                           :: GetProcAddress;
+
+MEMORY_BASIC_INFORMATION :: struct {
 	base_address:       rawptr,
 	allocation_base:    rawptr,
 	allocation_protect: u32,
@@ -197,13 +306,20 @@ Memory_Basic_Information :: struct {
 
 @(default_calling_convention = "std")
 foreign kernel32 {
-	@(link_name="VirtualAlloc")   virtual_alloc    :: proc(address: rawptr, size: uint, allocation_type: u32, protect: u32) -> rawptr ---
-	@(link_name="VirtualAllocEx") virtual_alloc_ex :: proc(process: Handle, address: rawptr, size: uint, allocation_type: u32, protect: u32) -> rawptr ---
-	@(link_name="VirtualFree")    virtual_free     :: proc(address: rawptr, size: uint, free_type: u32) -> Bool ---
-	@(link_name="VirtualLock")    virtual_lock     :: proc(address: rawptr, size: uint) -> Bool ---
-	@(link_name="VirtualProtect") virtual_protect  :: proc(address: rawptr, size: uint, new_protect: u32, old_protect: ^u32) -> Bool ---
-	@(link_name="VirtualQuery")   virtual_query    :: proc(address: rawptr, buffer: ^Memory_Basic_Information, length: uint) -> uint ---
+	VirtualAlloc   :: proc(address: rawptr, size: uint, allocation_type: u32, protect: u32) -> rawptr ---
+	VirtualAllocEx :: proc(process: HANDLE, address: rawptr, size: uint, allocation_type: u32, protect: u32) -> rawptr ---
+	VirtualFree    :: proc(address: rawptr, size: uint, free_type: u32) -> BOOL ---
+	VirtualLock    :: proc(address: rawptr, size: uint) -> BOOL ---
+	VirtualProtect :: proc(address: rawptr, size: uint, new_protect: u32, old_protect: ^u32) -> BOOL ---
+	VirtualQuery   :: proc(address: rawptr, buffer: ^MEMORY_BASIC_INFORMATION, length: uint) -> uint ---
 }
+
+virtual_alloc    :: VirtualAlloc;
+virtual_alloc_ex :: VirtualAllocEx;
+virtual_free     :: VirtualFree;
+virtual_lock     :: VirtualLock;
+virtual_protect  :: VirtualProtect;
+virtual_query    :: VirtualQuery;
 
 MEM_COMMIT      :: 0x00001000;
 MEM_RESERVE     :: 0x00002000;

--- a/core/sys/win32/ole32.odin
+++ b/core/sys/win32/ole32.odin
@@ -13,6 +13,9 @@ Com_Init :: enum {
 
 @(default_calling_convention = "std")
 foreign ole32 {
-	@(link_name ="CoInitializeEx") com_init_ex :: proc(reserved: rawptr, co_init: Com_Init) ->Hresult ---;
-	@(link_name = "CoUninitialize") com_shutdown :: proc() ---;
+    CoInitializeEx :: proc(reserved: rawptr, co_init: Com_Init) -> HRESULT ---;
+    CoUninitialize :: proc() ---;
 }
+
+co_initialize_ex :: CoInitializeEx;
+co_uninitialize  :: CoUninitialize;

--- a/core/sys/win32/shell32.odin
+++ b/core/sys/win32/shell32.odin
@@ -5,5 +5,7 @@ foreign import "system:shell32.lib"
 
 @(default_calling_convention = "std")
 foreign shell32 {
-	@(link_name="CommandLineToArgvW") command_line_to_argv_w :: proc(cmd_list: Wstring, num_args: ^i32) -> ^Wstring ---;
+	CommandLineToArgvW :: proc(cmd_list: LPCWSTR, num_args: ^i32) -> ^LPCWSTR ---;
 }
+
+command_line_to_argv_w :: CommandLineToArgvW;

--- a/core/sys/win32/user32.odin
+++ b/core/sys/win32/user32.odin
@@ -4,43 +4,46 @@ package win32
 foreign import "system:user32.lib"
 
 
-Menu_Bar_Info :: struct {
+MENUBARINFO :: struct {
 	size: u32,
-	bar: Rect,
-	menu: Hmenu,
-	wnd_menu: Hwnd,
+	bar: RECT,
+	menu: HMENU,
+	wnd_menu: HWND,
 	using fields: bit_field {
 		bar_focused: 1,
 		focuses:     1,
 	},
 }
+Menu_Bar_Info :: MENUBARINFO;
 
-Menu_Item_Info_A :: struct {
+MENUITEMINFOA :: struct {
 	size:          u32,
 	mask:          u32,
 	type:          u32,
 	state:         u32,
 	id:            u32,
-	submenu:       Hmenu,
-	bmp_checked:   Hbitmap,
-	bmp_unchecked: Hbitmap,
+	submenu:       HMENU,
+	bmp_checked:   HBITMAP,
+	bmp_unchecked: HBITMAP,
 	item_data:     u32,
 	type_data:     cstring,
 	cch:           u32,
 }
-Menu_Item_Info_W :: struct {
+Menu_Item_Info_A :: MENUITEMINFOA;
+MENUITEMINFOW :: struct {
 	size:          u32,
 	mask:          u32,
 	type:          u32,
 	state:         u32,
 	id:            u32,
-	submenu:       Hmenu,
-	bmp_checked:   Hbitmap,
-	bmp_unchecked: Hbitmap,
+	submenu:       HMENU,
+	bmp_checked:   HBITMAP,
+	bmp_unchecked: HBITMAP,
 	item_data:     u32,
-	type_data:     Wstring,
+	type_data:     LPCWSTR,
 	cch:           u32,
 }
+Menu_Item_Info_W :: MENUITEMINFOW;
 
 MF_BYCOMMAND    :: 0x00000000;
 MF_BYPOSITION   :: 0x00000400;
@@ -94,155 +97,251 @@ MB_SERVICE_NOTIFICATION :: 0x00200000;
 
 @(default_calling_convention = "std")
 foreign user32 {
-	@(link_name="GetDesktopWindow") get_desktop_window  :: proc() -> Hwnd ---;
-	@(link_name="ShowCursor")       show_cursor         :: proc(show: Bool) ---;
-	@(link_name="GetCursorPos")     get_cursor_pos      :: proc(p: ^Point) -> Bool ---;
-	@(link_name="SetCursorPos")     set_cursor_pos      :: proc(x, y: i32) -> Bool ---;
-	@(link_name="ScreenToClient")   screen_to_client    :: proc(h: Hwnd, p: ^Point) -> Bool ---;
-	@(link_name="ClientToScreen")   client_to_screen    :: proc(h: Hwnd, p: ^Point) -> Bool ---;
-	@(link_name="PostQuitMessage")  post_quit_message   :: proc(exit_code: i32) ---;
-	@(link_name="SetWindowTextA")   set_window_text_a   :: proc(hwnd: Hwnd, c_string: cstring) -> Bool ---;
-	@(link_name="SetWindowTextW")   set_window_text_w   :: proc(hwnd: Hwnd, c_string: Wstring) -> Bool ---;
-	@(link_name="RegisterClassA")   register_class_a    :: proc(wc: ^Wnd_Class_A) -> i16 ---;
-	@(link_name="RegisterClassW")   register_class_w    :: proc(wc: ^Wnd_Class_W) -> i16 ---;
-	@(link_name="RegisterClassExA") register_class_ex_a :: proc(wc: ^Wnd_Class_Ex_A) -> i16 ---;
-	@(link_name="RegisterClassExW") register_class_ex_w :: proc(wc: ^Wnd_Class_Ex_W) -> i16 ---;
+	GetDesktopWindow :: proc() -> HWND ---;
+	ShowCursor       :: proc(show: BOOL) ---;
+	GetCursorPos     :: proc(p: ^POINT) -> BOOL ---;
+	SetCursorPos     :: proc(x, y: i32) -> BOOL ---;
+	ScreenToClient   :: proc(h: HWND, p: ^POINT) -> BOOL ---;
+	ClientToScreen   :: proc(h: HWND, p: ^POINT) -> BOOL ---;
+	PostQuitMessage  :: proc(exit_code: i32) ---;
+	SetWindowTextA   :: proc(hwnd: HWND, c_string: cstring) -> BOOL ---;
+	SetWindowTextW   :: proc(hwnd: HWND, c_string: LPCWSTR) -> BOOL ---;
+	RegisterClassA   :: proc(wc: ^WNDCLASSA) -> i16 ---;
+	RegisterClassW   :: proc(wc: ^WNDCLASSW) -> i16 ---;
+	RegisterClassExA :: proc(wc: ^WNDCLASSEXA) -> i16 ---;
+	RegisterClassExW :: proc(wc: ^WNDCLASSEXW) -> i16 ---;
 
-	@(link_name="CreateWindowExA")
-	create_window_ex_a :: proc(ex_style: u32,
-	                           class_name, title: cstring,
-	                           style: u32,
-	                           x, y, w, h: i32,
-	                           parent: Hwnd, menu: Hmenu, instance: Hinstance,
-	                           param: rawptr) -> Hwnd ---;
+	CreateWindowExA :: proc(ex_style: u32,
+	                        class_name, title: cstring,
+	                        style: u32,
+	                        x, y, w, h: i32,
+	                        parent: HWND, menu: HMENU, instance: HINSTANCE,
+	                        param: rawptr) -> HWND ---;
 
-	@(link_name="CreateWindowExW")
-	create_window_ex_w :: proc(ex_style: u32,
-	                           class_name, title: Wstring,
-	                           style: u32,
-	                           x, y, w, h: i32,
-	                           parent: Hwnd, menu: Hmenu, instance: Hinstance,
-	                           param: rawptr) -> Hwnd ---;
+	CreateWindowExW :: proc(ex_style: u32,
+	                        class_name, title: LPCWSTR,
+	                        style: u32,
+	                        x, y, w, h: i32,
+	                        parent: HWND, menu: HMENU, instance: HINSTANCE,
+	                        param: rawptr) -> HWND ---;
 
-	@(link_name="ShowWindow")       show_window        :: proc(hwnd: Hwnd, cmd_show: i32) -> Bool ---;
-	@(link_name="TranslateMessage") translate_message  :: proc(msg: ^Msg) -> Bool ---;
-	@(link_name="DispatchMessageA") dispatch_message_a :: proc(msg: ^Msg) -> Lresult ---;
-	@(link_name="DispatchMessageW") dispatch_message_w :: proc(msg: ^Msg) -> Lresult ---;
-	@(link_name="UpdateWindow")     update_window      :: proc(hwnd: Hwnd) -> Bool ---;
-	@(link_name="GetMessageA")      get_message_a      :: proc(msg: ^Msg, hwnd: Hwnd, msg_filter_min, msg_filter_max: u32) -> Bool ---;
-	@(link_name="GetMessageW")      get_message_w      :: proc(msg: ^Msg, hwnd: Hwnd, msg_filter_min, msg_filter_max: u32) -> Bool ---;
+	DestroyWindow :: proc(wnd: HWND) -> BOOL ---;
 
-	@(link_name="PeekMessageA") peek_message_a :: proc(msg: ^Msg, hwnd: Hwnd, msg_filter_min, msg_filter_max, remove_msg: u32) -> Bool ---;
-	@(link_name="PeekMessageW") peek_message_w :: proc(msg: ^Msg, hwnd: Hwnd, msg_filter_min, msg_filter_max, remove_msg: u32) -> Bool ---;
+	ShowWindow       :: proc(hwnd: HWND, cmd_show: i32) -> BOOL ---;
+	TranslateMessage :: proc(msg: ^MSG) -> BOOL ---;
+	DispatchMessageA :: proc(msg: ^MSG) -> LRESULT ---;
+	DispatchMessageW :: proc(msg: ^MSG) -> LRESULT ---;
+	UpdateWindow     :: proc(hwnd: HWND) -> BOOL ---;
 
+	GetMessageA  :: proc(msg: ^MSG, hwnd: HWND, msg_filter_min, msg_filter_max: u32) -> BOOL ---;
+	GetMessageW  :: proc(msg: ^MSG, hwnd: HWND, msg_filter_min, msg_filter_max: u32) -> BOOL ---;
+	PeekMessageA :: proc(msg: ^MSG, hwnd: HWND, msg_filter_min, msg_filter_max, remove_msg: u32) -> BOOL ---;
+	PeekMessageW :: proc(msg: ^MSG, hwnd: HWND, msg_filter_min, msg_filter_max, remove_msg: u32) -> BOOL ---;
 
-	@(link_name="PostMessageA") post_message_a :: proc(hwnd: Hwnd, msg: u32, wparam: Wparam, lparam: Lparam) -> Bool ---;
-	@(link_name="PostMessageW") post_message_w :: proc(hwnd: Hwnd, msg: u32, wparam: Wparam, lparam: Lparam) -> Bool ---;
-	@(link_name="SendMessageA") send_message_a :: proc(hwnd: Hwnd, msg: u32, wparam: Wparam, lparam: Lparam) -> Bool ---;
-	@(link_name="SendMessageW") send_message_w :: proc(hwnd: Hwnd, msg: u32, wparam: Wparam, lparam: Lparam) -> Bool ---;
+	PostMessageA :: proc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam: LPARAM) -> BOOL ---;
+	PostMessageW :: proc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam: LPARAM) -> BOOL ---;
+	SendMessageA :: proc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam: LPARAM) -> BOOL ---;
+	SendMessageW :: proc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam: LPARAM) -> BOOL ---;
 
-	@(link_name="DefWindowProcA") def_window_proc_a :: proc(hwnd: Hwnd, msg: u32, wparam: Wparam, lparam: Lparam) -> Lresult ---;
-	@(link_name="DefWindowProcW") def_window_proc_w :: proc(hwnd: Hwnd, msg: u32, wparam: Wparam, lparam: Lparam) -> Lresult ---;
+	DefWindowProcA :: proc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT ---;
+	DefWindowProcW :: proc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT ---;
 
-	@(link_name="AdjustWindowRect") adjust_window_rect :: proc(rect: ^Rect, style: u32, menu: Bool) -> Bool ---;
-	@(link_name="GetActiveWindow")  get_active_window  :: proc() -> Hwnd ---;
+	AdjustWindowRect :: proc(rect: ^RECT, style: u32, menu: BOOL) -> BOOL ---;
+	GetActiveWindow  :: proc() -> HWND ---;
 
-	@(link_name="DestroyWindow")       destroy_window        :: proc(wnd: Hwnd) -> Bool ---;
-	@(link_name="DescribePixelFormat") describe_pixel_format :: proc(dc: Hdc, pixel_format: i32, bytes: u32, pfd: ^Pixel_Format_Descriptor) -> i32 ---;
+	DescribePixelFormat :: proc(dc: HDC, pixel_format: i32, bytes: u32, pfd: ^PIXELFORMATDESCRIPTOR) -> i32 ---;
 
-	@(link_name="GetMonitorInfoA")  get_monitor_info_a  :: proc(monitor: Hmonitor, mi: ^Monitor_Info) -> Bool ---;
-	@(link_name="MonitorFromWindow") monitor_from_window :: proc(wnd: Hwnd, flags: u32) -> Hmonitor ---;
+	GetMonitorInfoA   :: proc(monitor: HMONITOR, mi: ^MONITORINFO) -> BOOL ---;
+	MonitorFromWindow :: proc(wnd: HWND, flags: u32) -> HMONITOR ---;
 
-	@(link_name="SetWindowPos") set_window_pos :: proc(wnd: Hwnd, wndInsertAfter: Hwnd, x, y, width, height: i32, flags: u32) ---;
+	SetWindowPos :: proc(wnd: HWND, wndInsertAfter: HWND, x, y, width, height: i32, flags: u32) ---;
 
-	@(link_name="GetWindowPlacement") get_window_placement  :: proc(wnd: Hwnd, wndpl: ^Window_Placement) -> Bool ---;
-	@(link_name="SetWindowPlacement") set_window_placement  :: proc(wnd: Hwnd, wndpl: ^Window_Placement) -> Bool ---;
-	@(link_name="GetWindowRect")      get_window_rect       :: proc(wnd: Hwnd, rect: ^Rect) -> Bool ---;
+	GetWindowPlacement :: proc(wnd: HWND, wndpl: ^WINDOWPLACEMENT) -> BOOL ---;
+	SetWindowPlacement :: proc(wnd: HWND, wndpl: ^WINDOWPLACEMENT) -> BOOL ---;
+	GetWindowRect      :: proc(wnd: HWND, rect: ^RECT) -> BOOL ---;
 
-	@(link_name="GetWindowLongPtrA") get_window_long_ptr_a :: proc(wnd: Hwnd, index: i32) -> Long_Ptr ---;
-	@(link_name="SetWindowLongPtrA") set_window_long_ptr_a :: proc(wnd: Hwnd, index: i32, new: Long_Ptr) -> Long_Ptr ---;
-	@(link_name="GetWindowLongPtrW") get_window_long_ptr_w :: proc(wnd: Hwnd, index: i32) -> Long_Ptr ---;
-	@(link_name="SetWindowLongPtrW") set_window_long_ptr_w :: proc(wnd: Hwnd, index: i32, new: Long_Ptr) -> Long_Ptr ---;
+	GetWindowLongPtrA :: proc(wnd: HWND, index: i32) -> Long_Ptr ---;
+	SetWindowLongPtrA :: proc(wnd: HWND, index: i32, new: Long_Ptr) -> Long_Ptr ---;
+	GetWindowLongPtrW :: proc(wnd: HWND, index: i32) -> Long_Ptr ---;
+	SetWindowLongPtrW :: proc(wnd: HWND, index: i32, new: Long_Ptr) -> Long_Ptr ---;
 
-	@(link_name="GetWindowText") get_window_text :: proc(wnd: Hwnd, str: cstring, maxCount: i32) -> i32 ---;
+	GetWindowText :: proc(wnd: HWND, str: cstring, maxCount: i32) -> i32 ---;
 
-	@(link_name="GetClientRect") get_client_rect :: proc(hwnd: Hwnd, rect: ^Rect) -> Bool ---;
+	GetClientRect :: proc(hwnd: HWND, rect: ^RECT) -> BOOL ---;
 
-	@(link_name="GetDC")     get_dc     :: proc(h: Hwnd) -> Hdc ---;
-	@(link_name="ReleaseDC") release_dc :: proc(wnd: Hwnd, hdc: Hdc) -> i32 ---;
+	GetDC     :: proc(h: HWND) -> HDC ---;
+	ReleaseDC :: proc(wnd: HWND, hdc: HDC) -> i32 ---;
 
-	@(link_name="MapVirtualKeyA") map_virtual_key_a :: proc(scancode: u32, map_type: u32) -> u32 ---;
-	@(link_name="MapVirtualKeyW") map_virtual_key_w :: proc(scancode: u32, map_type: u32) -> u32 ---;
+	MapVirtualKeyA :: proc(scancode: u32, map_type: u32) -> u32 ---;
+	MapVirtualKeyW :: proc(scancode: u32, map_type: u32) -> u32 ---;
 
-	@(link_name="GetKeyState")      get_key_state       :: proc(v_key: i32) -> i16 ---;
-	@(link_name="GetAsyncKeyState") get_async_key_state :: proc(v_key: i32) -> i16 ---;
+	GetKeyState      :: proc(v_key: i32) -> i16 ---;
+	GetAsyncKeyState :: proc(v_key: i32) -> i16 ---;
 
-	@(link_name="SetForegroundWindow") set_foreground_window :: proc(h: Hwnd) -> Bool ---;
-	@(link_name="SetFocus")            set_focus             :: proc(h: Hwnd) -> Hwnd ---;
+	SetForegroundWindow :: proc(h: HWND) -> BOOL ---;
+	SetFocus            :: proc(h: HWND) -> HWND ---;
 
 
-    @(link_name="LoadImageA")       load_image_a        :: proc(instance: Hinstance, name: cstring, type_: u32, x_desired, y_desired : i32, load : u32) -> Handle ---;
-    @(link_name="LoadIconA")        load_icon_a         :: proc(instance: Hinstance, icon_name: cstring) -> Hicon ---;
-    @(link_name="DestroyIcon")      destroy_icon        :: proc(icon: Hicon) -> Bool ---;
+    LoadImageA  :: proc(instance: HINSTANCE, name: cstring, type_: u32, x_desired, y_desired : i32, load : u32) -> HANDLE ---;
+    LoadIconA   :: proc(instance: HINSTANCE, icon_name: cstring) -> HICON ---;
+    DestroyIcon :: proc(icon: HICON) -> BOOL ---;
 
-    @(link_name="LoadCursorA")      load_cursor_a       :: proc(instance: Hinstance, cursor_name: cstring) -> Hcursor ---;
-    @(link_name="LoadCursorW")      load_cursor_w       :: proc(instance: Hinstance, cursor_name: Wstring) -> Hcursor ---;
-	@(link_name="GetCursor")        get_cursor          :: proc() -> Hcursor ---;
-	@(link_name="SetCursor")        set_cursor          :: proc(cursor: Hcursor) -> Hcursor ---;
+    LoadCursorA :: proc(instance: HINSTANCE, cursor_name: cstring) -> HCURSOR ---;
+    LoadCursorW :: proc(instance: HINSTANCE, cursor_name: LPCWSTR) -> HCURSOR ---;
+	GetCursor   :: proc() -> HCURSOR ---;
+	SetCursor   :: proc(cursor: HCURSOR) -> HCURSOR ---;
 
-	@(link_name="RegisterRawInputDevices") register_raw_input_devices :: proc(raw_input_device: ^Raw_Input_Device, num_devices, size: u32) -> Bool ---;
+	RegisterRawInputDevices :: proc(raw_input_device: ^RAWINPUTDEVICE, num_devices, size: u32) -> BOOL ---;
 
-	@(link_name="GetRawInputData") get_raw_input_data :: proc(raw_input: Hrawinput, command: u32, data: rawptr, size: ^u32, size_header: u32) -> u32 ---;
+	GetRawInputData :: proc(raw_input: HRAWINPUT, command: u32, data: rawptr, size: ^u32, size_header: u32) -> u32 ---;
 
-	@(link_name="MapVirtualKeyExW") map_virtual_key_ex_w :: proc(code, map_type: u32, hkl: HKL) ---;
-	@(link_name="MapVirtualKeyExA") map_virtual_key_ex_a :: proc(code, map_type: u32, hkl: HKL) ---;
+	MapVirtualKeyExW :: proc(code, map_type: u32, hkl: HKL) ---;
+	MapVirtualKeyExA :: proc(code, map_type: u32, hkl: HKL) ---;
 
-	@(link_name="EnumDisplayMonitors") enum_display_monitors :: proc(hdc: Hdc,  rect: ^Rect, enum_proc: Monitor_Enum_Proc, lparam: Lparam) -> bool ---;
+	EnumDisplayMonitors :: proc(hdc: HDC, rect: ^RECT, enum_proc: MONITORENUMPROC, lparam: LPARAM) -> bool ---;
 }
+
+get_desktop_window         :: GetDesktopWindow;
+show_cursor                :: ShowCursor;
+get_cursor_pos             :: GetCursorPos;
+set_cursor_pos             :: SetCursorPos;
+screen_to_client           :: ScreenToClient;
+client_to_screen           :: ClientToScreen;
+post_quit_message          :: PostQuitMessage;
+set_window_text_a          :: SetWindowTextA;
+set_window_text_w          :: SetWindowTextW;
+register_class_a           :: RegisterClassA;
+register_class_w           :: RegisterClassW;
+register_class_ex_a        :: RegisterClassExA;
+register_class_ex_w        :: RegisterClassExW;
+create_window_ex_a         :: CreateWindowExA;
+create_window_ex_w         :: CreateWindowExW;
+destroy_window             :: DestroyWindow;
+show_window                :: ShowWindow;
+translate_message          :: TranslateMessage;
+dispatch_message_a         :: DispatchMessageA;
+dispatch_message_w         :: DispatchMessageW;
+update_window              :: UpdateWindow;
+get_message_a              :: GetMessageA;
+get_message_w              :: GetMessageW;
+peek_message_a             :: PeekMessageA;
+peek_message_w             :: PeekMessageW;
+post_message_a             :: PostMessageA;
+post_message_w             :: PostMessageW;
+send_message_a             :: SendMessageA;
+send_message_w             :: SendMessageW;
+def_window_proc_a          :: DefWindowProcA;
+def_window_proc_w          :: DefWindowProcW;
+adjust_window_rect         :: AdjustWindowRect;
+get_active_window          :: GetActiveWindow;
+describe_pixel_format      :: DescribePixelFormat;
+get_monitor_info_a         :: GetMonitorInfoA;
+monitor_from_window        :: MonitorFromWindow;
+set_window_pos             :: SetWindowPos;
+get_window_placement       :: GetWindowPlacement;
+set_window_placement       :: SetWindowPlacement;
+get_window_rect            :: GetWindowRect;
+get_window_long_ptr_a      :: GetWindowLongPtrA;
+set_window_long_ptr_a      :: SetWindowLongPtrA;
+get_window_long_ptr_w      :: GetWindowLongPtrW;
+set_window_long_ptr_w      :: SetWindowLongPtrW;
+get_window_text            :: GetWindowText;
+get_client_rect            :: GetClientRect;
+get_dc                     :: GetDC;
+release_dc                 :: ReleaseDC;
+map_virtual_key_a          :: MapVirtualKeyA;
+map_virtual_key_w          :: MapVirtualKeyW;
+get_key_state              :: GetKeyState;
+get_async_key_state        :: GetAsyncKeyState;
+set_foreground_window      :: SetForegroundWindow;
+set_focus                  :: SetFocus;
+load_image_a               :: LoadImageA;
+load_icon_a                :: LoadIconA;
+destroy_icon               :: DestroyIcon;
+load_cursor_a              :: LoadCursorA;
+load_cursor_w              :: LoadCursorW;
+get_cursor                 :: GetCursor;
+set_cursor                 :: SetCursor;
+register_raw_input_devices :: RegisterRawInputDevices;
+get_raw_input_data         :: GetRawInputData;
+map_virtual_key_ex_w       :: MapVirtualKeyExW;
+map_virtual_key_ex_a       :: MapVirtualKeyExA;
+enum_display_monitors      :: EnumDisplayMonitors;
 
 @(default_calling_convention = "c")
 foreign user32 {
-	@(link_name="CreateMenu")      create_menu   :: proc() -> Hmenu ---
-	@(link_name="CreatePopupMenu") create_popup_menu :: proc() -> Hmenu ---
-	@(link_name="DestroyMenu")     destroy_menu :: proc(menu: Hmenu) -> Bool ---
-	@(link_name="DeleteMenu")      delete_menu :: proc(menu: Hmenu, position: u32, flags: u32) -> Bool ---
+	CreateMenu      :: proc() -> HMENU ---
+	CreatePopupMenu :: proc() -> HMENU ---
+	DestroyMenu     :: proc(menu: HMENU) -> BOOL ---
+	DeleteMenu      :: proc(menu: HMENU, position: u32, flags: u32) -> BOOL ---
 
-	@(link_name="EnableMenuItem")  enable_menu_item :: proc(menu: Hmenu, id_enable_itme: i32, enable: u32) -> Bool ---
-	@(link_name="EndMenu")         end_menu :: proc() -> Bool ---
-	@(link_name="GetMenu")         get_menu :: proc(wnd: Hwnd) -> Hmenu ---
-	@(link_name="GetMenuBarInfo")  get_menu_bar_info :: proc(wnd: Hwnd, id_object, id_item: u32, mbi: ^Menu_Bar_Info) -> Hmenu ---
-	@(link_name="GetMenuStringA")  get_menu_string_a :: proc(menu: Hmenu, id_item: u32, s: string,  cch_max: i32, flags: u32) -> i32 ---
-	@(link_name="GetMenuStringW")  get_menu_string_w :: proc(menu: Hmenu, id_item: u32, s: Wstring, cch_max: i32, flags: u32) -> i32 ---
-	@(link_name="GetMenuState")    get_menu_state :: proc(menu: Hmenu, id: u32, flags: u32) -> u32 ---
-	@(link_name="GetMenuItemRect") get_menu_item_rect :: proc(wnd: Hwnd, menu: Hmenu, id_item: u32, item: ^Rect) -> Bool ---
+	EnableMenuItem  :: proc(menu: HMENU, id_enable_itme: i32, enable: u32) -> BOOL ---
+	EndMenu         :: proc() -> BOOL ---
+	GetMenu         :: proc(wnd: HWND) -> HMENU ---
+	GetMenuBarInfo  :: proc(wnd: HWND, id_object, id_item: u32, mbi: ^MENUBARINFO) -> HMENU ---
+	GetMenuStringA  :: proc(menu: HMENU, id_item: u32, s: string,  cch_max: i32, flags: u32) -> i32 ---
+	GetMenuStringW  :: proc(menu: HMENU, id_item: u32, s: LPCWSTR, cch_max: i32, flags: u32) -> i32 ---
+	GetMenuState    :: proc(menu: HMENU, id: u32, flags: u32) -> u32 ---
+	GetMenuItemRect :: proc(wnd: HWND, menu: HMENU, id_item: u32, item: ^RECT) -> BOOL ---
 
-	@(link_name="SetMenu")         set_menu :: proc(wnd: Hwnd, menu: Hmenu) -> Hmenu ---
+	SetMenu :: proc(wnd: HWND, menu: HMENU) -> HMENU ---
 
-	@(link_name="DrawMenuBar")     draw_menu_bar :: proc(wnd: Hwnd) -> Bool ---
-	@(link_name="InsertMenuA")     insert_menu_a :: proc(menu: Hmenu, position: u32, flags: u32, id_new_item: Uint_Ptr, new_item: cstring) -> Bool ---
-	@(link_name="InsertMenuW")     insert_menu_w :: proc(menu: Hmenu, position: u32, flags: u32, id_new_item: Uint_Ptr, new_item: Wstring) -> Bool ---
+	DrawMenuBar :: proc(wnd: HWND) -> BOOL ---
+	InsertMenuA :: proc(menu: HMENU, position: u32, flags: u32, id_new_item: Uint_Ptr, new_item: cstring) -> BOOL ---
+	InsertMenuW :: proc(menu: HMENU, position: u32, flags: u32, id_new_item: Uint_Ptr, new_item: LPCWSTR) -> BOOL ---
 
-	@(link_name="InsertMenuItemA") insert_menu_item_a :: proc(menu: Hmenu, item: u32, by_position: bool, mi: ^Menu_Item_Info_A) -> Bool ---
-	@(link_name="InsertMenuItemW") insert_menu_item_w :: proc(menu: Hmenu, item: u32, by_position: bool, mi: ^Menu_Item_Info_W) -> Bool ---
+	InsertMenuItemA :: proc(menu: HMENU, item: u32, by_position: bool, mi: ^MENUITEMINFOA) -> BOOL ---
+	InsertMenuItemW :: proc(menu: HMENU, item: u32, by_position: bool, mi: ^MENUITEMINFOW) -> BOOL ---
 
-	@(link_name="AppendMenuA") append_menu_a :: proc(menu: Hmenu, flags: u32, id_new_item: Uint_Ptr, new_item: cstring) -> Bool ---
-	@(link_name="AppendMenuW") append_menu_w :: proc(menu: Hmenu, flags: u32, id_new_item: Uint_Ptr, new_item: Wstring) -> Bool ---
+	AppendMenuA :: proc(menu: HMENU, flags: u32, id_new_item: Uint_Ptr, new_item: cstring) -> BOOL ---
+	AppendMenuW :: proc(menu: HMENU, flags: u32, id_new_item: Uint_Ptr, new_item: LPCWSTR) -> BOOL ---
 
-	@(link_name="CheckMenuItem") check_menu_item :: proc(menu: Hmenu, id_check_item: u32, check: u32) -> u32 ---
-	@(link_name="CheckMenuRadioItem") check_menu_radio_item :: proc(menu: Hmenu, first, last: u32, check: u32, flags: u32) -> Bool ---
+	CheckMenuItem      :: proc(menu: HMENU, id_check_item: u32, check: u32) -> u32 ---
+	CheckMenuRadioItem :: proc(menu: HMENU, first, last: u32, check: u32, flags: u32) -> BOOL ---
 
-	@(link_name="GetPropA") get_prop_a :: proc(wnd: Hwnd, s: cstring) -> Handle ---
-	@(link_name="GetPropW") get_prop_w :: proc(wnd: Hwnd, s: Wstring) -> Handle ---
+	GetPropA :: proc(wnd: HWND, s: cstring) -> HANDLE ---
+	GetPropW :: proc(wnd: HWND, s: LPCWSTR) -> HANDLE ---
 
-	@(link_name="MessageBoxA") message_box_a :: proc(wnd: Hwnd, text, caption: cstring, type: u32) -> i32 ---
-	@(link_name="MessageBoxW") message_box_w :: proc(wnd: Hwnd, text, caption: Wstring, type: u32) -> i32 ---
+	MessageBoxA :: proc(wnd: HWND, text, caption: cstring, type: u32) -> i32 ---
+	MessageBoxW :: proc(wnd: HWND, text, caption: LPCWSTR, type: u32) -> i32 ---
 
-	@(link_name="MessageBoxExA") message_box_ex_a :: proc(wnd: Hwnd, text, caption: cstring, type: u32, language_id: u16) -> i32 ---
-	@(link_name="MessageBoxExW") message_box_ex_w :: proc(wnd: Hwnd, text, caption: Wstring, type: u32, language_id: u16) -> i32 ---
+	MessageBoxExA :: proc(wnd: HWND, text, caption: cstring, type: u32, language_id: u16) -> i32 ---
+	MessageBoxExW :: proc(wnd: HWND, text, caption: LPCWSTR, type: u32, language_id: u16) -> i32 ---
 
-	@(link_name="BeginPaint") begin_paint :: proc(wnd: Hwnd, paint: ^Paint_Struct) -> Hdc ---
-	@(link_name="EndPaint")   end_paint :: proc(wnd: Hwnd, paint: ^Paint_Struct) -> Bool ---
+	BeginPaint :: proc(wnd: HWND, paint: ^PAINTSTRUCT) -> HDC ---
+	EndPaint   :: proc(wnd: HWND, paint: ^PAINTSTRUCT) -> BOOL ---
 }
+
+create_menu           :: CreateMenu;
+create_popup_menu     :: CreatePopupMenu;
+destroy_menu          :: DestroyMenu;
+delete_menu           :: DeleteMenu;
+enable_menu_item      :: EnableMenuItem;
+end_menu              :: EndMenu;
+get_menu              :: GetMenu;
+get_menu_bar_info     :: GetMenuBarInfo;
+get_menu_string_a     :: GetMenuStringA;
+get_menu_string_w     :: GetMenuStringW;
+get_menu_state        :: GetMenuState;
+get_menu_item_rect    :: GetMenuItemRect;
+set_menu              :: SetMenu;
+draw_menu_bar         :: DrawMenuBar;
+insert_menu_a         :: InsertMenuA;
+insert_menu_w         :: InsertMenuW;
+insert_menu_item_a    :: InsertMenuItemA;
+insert_menu_item_w    :: InsertMenuItemW;
+append_menu_a         :: AppendMenuA;
+append_menu_w         :: AppendMenuW;
+check_menu_item       :: CheckMenuItem;
+check_menu_radio_item :: CheckMenuRadioItem;
+get_prop_a            :: GetPropA;
+get_prop_w            :: GetPropW;
+message_box_a         :: MessageBoxA;
+message_box_w         :: MessageBoxW;
+message_box_ex_a      :: MessageBoxExA;
+message_box_ex_w      :: MessageBoxExW;
+begin_paint           :: BeginPaint;
+end_paint             :: EndPaint;
 
 
 _IDC_APPSTARTING := rawptr(uintptr(32650));

--- a/core/sys/win32/wgl.odin
+++ b/core/sys/win32/wgl.odin
@@ -11,10 +11,13 @@ CONTEXT_FORWARD_COMPATIBLE_BIT_ARB    :: 0x0002;
 CONTEXT_CORE_PROFILE_BIT_ARB          :: 0x00000001;
 CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB :: 0x00000002;
 
-Hglrc     :: distinct Handle;
-Color_Ref :: distinct u32;
+HGLRC :: distinct HANDLE;
+Hglrc :: HGLRC;
 
-Layer_Plane_Descriptor :: struct {
+COLORREF  :: distinct u32;
+Color_Ref :: COLORREF;
+
+LAYERPLANEDESCRIPTOR :: struct {
 	size:             u16,
 	version:          u16,
 	flags:            u32,
@@ -40,21 +43,26 @@ Layer_Plane_Descriptor :: struct {
 	reserved:         u8,
 	transparent:      Color_Ref,
 }
+Layer_Plane_Descriptor :: LAYERPLANEDESCRIPTOR;
 
-Point_Float :: struct {x, y: f32};
 
-Glyph_Metrics_Float :: struct {
+POINTFLOAT  :: struct {x, y: f32};
+Point_Float :: POINTFLOAT;
+
+GLYPHMETRICSFLOAT :: struct {
 	black_box_x:  f32,
 	black_box_y:  f32,
 	glyph_origin: Point_Float,
 	cell_inc_x:   f32,
 	cell_inc_y:   f32,
 }
+Glyph_Metrics_Float :: GLYPHMETRICSFLOAT;
 
-Create_Context_Attribs_ARB_Type :: #type proc "c" (hdc: Hdc, h_share_context: rawptr, attribList: ^i32) -> Hglrc;
-Choose_Pixel_Format_ARB_Type    :: #type proc "c" (hdc: Hdc, attrib_i_list: ^i32, attrib_f_list: ^f32, max_formats: u32, formats: ^i32, num_formats : ^u32) -> Bool;
+
+Create_Context_Attribs_ARB_Type :: #type proc "c" (hdc: HDC, h_share_context: rawptr, attribList: ^i32) -> HGLRC;
+Choose_Pixel_Format_ARB_Type    :: #type proc "c" (hdc: HDC, attrib_i_list: ^i32, attrib_f_list: ^f32, max_formats: u32, formats: ^i32, num_formats : ^u32) -> BOOL;
 Swap_Interval_EXT_Type          :: #type proc "c" (interval: i32) -> bool;
-Get_Extensions_String_ARB_Type  :: #type proc "c" (Hdc) -> cstring;
+Get_Extensions_String_ARB_Type  :: #type proc "c" (HDC) -> cstring;
 
 // Procedures
 	create_context_attribs_arb: Create_Context_Attribs_ARB_Type;
@@ -64,51 +72,41 @@ Get_Extensions_String_ARB_Type  :: #type proc "c" (Hdc) -> cstring;
 
 
 foreign opengl32 {
-	@(link_name="wglCreateContext")
-	create_context :: proc(hdc: Hdc) -> Hglrc ---;
+	wglCreateContext     :: proc(hdc: HDC) -> HGLRC ---;
+	wglDeleteContext     :: proc(hglrc: HGLRC) -> BOOL ---;
+	wglMakeCurrent       :: proc(hdc: HDC, hglrc: HGLRC) -> BOOL ---;
+	wglCopyContext       :: proc(src, dst: HGLRC, mask: u32) -> BOOL ---;
+	wglGetCurrentContext :: proc() -> HGLRC ---;
+	wglGetProcAddress    :: proc(c_str: cstring) -> rawptr ---;
 
-	@(link_name="wglMakeCurrent")
-	make_current :: proc(hdc: Hdc, hglrc: Hglrc) -> Bool ---;
+	wglCreateLayerContext :: proc(hdc: HDC, layer_plane: i32) -> HGLRC ---;
 
-	@(link_name="wglGetProcAddress")
-	get_gl_proc_address :: proc(c_str: cstring) -> rawptr ---;
+	wglSwapLayerBuffers :: proc(hdc: HDC, planes: u32) -> BOOL ---;
+	wglGetCurrentDC     :: proc() -> HDC ---;
 
-	@(link_name="wglDeleteContext")
-	delete_context :: proc(hglrc: Hglrc) -> Bool ---;
+	wglDescribeLayerPlane     :: proc(hdc: HDC, pixel_format, layer_plane: i32, bytes: u32, pd: ^Layer_Plane_Descriptor) -> BOOL ---;
+	wglGetLayerPaletteEntries :: proc(hdc: HDC, layer_plane, start, entries: i32, cr: ^Color_Ref) -> i32 ---;
+	wglRealizeLayerPalette    :: proc(hdc: HDC, layer_plane: i32, realize: BOOL) -> BOOL ---;
+	wglSetLayerPaletteEntries :: proc(hdc: HDC, layer_plane, start, entries: i32, cr: ^Color_Ref) -> i32 ---;
+	wglShareLists             :: proc(hglrc1, hglrc2: HGLRC) -> BOOL ---;
 
-	@(link_name="wglCopyContext")
-	copy_context :: proc(src, dst: Hglrc, mask: u32) -> Bool ---;
-
-	@(link_name="wglCreateLayerContext")
-	create_layer_context :: proc(hdc: Hdc, layer_plane: i32) -> Hglrc ---;
-
-	@(link_name="wglDescribeLayerPlane")
-	describe_layer_plane :: proc(hdc: Hdc, pixel_format, layer_plane: i32, bytes: u32, pd: ^Layer_Plane_Descriptor) -> Bool ---;
-
-	@(link_name="wglGetCurrentContext")
-	get_current_context :: proc() -> Hglrc ---;
-
-	@(link_name="wglGetCurrentDC")
-	get_current_dc :: proc() -> Hdc ---;
-
-	@(link_name="wglGetLayerPaletteEntries")
-	get_layer_palette_entries :: proc(hdc: Hdc, layer_plane, start, entries: i32, cr: ^Color_Ref) -> i32 ---;
-
-	@(link_name="wglRealizeLayerPalette")
-	realize_layer_palette :: proc(hdc: Hdc, layer_plane: i32, realize: Bool) -> Bool ---;
-
-	@(link_name="wglSetLayerPaletteEntries")
-	set_layer_palette_entries :: proc(hdc: Hdc, layer_plane, start, entries: i32, cr: ^Color_Ref) -> i32 ---;
-
-	@(link_name="wglShareLists")
-	share_lists :: proc(hglrc1, hglrc2: Hglrc) -> Bool ---;
-
-	@(link_name="wglSwapLayerBuffers")
-	swap_layer_buffers :: proc(hdc: Hdc, planes: u32) -> Bool ---;
-
-	@(link_name="wglUseFontBitmaps")
-	use_font_bitmaps :: proc(hdc: Hdc, first, count, list_base: u32) -> Bool ---;
-
-	@(link_name="wglUseFontOutlines")
-	use_font_outlines :: proc(hdc: Hdc, first, count, list_base: u32, deviation, extrusion: f32, format: i32, gmf: ^Glyph_Metrics_Float) -> Bool ---;
+	wglUseFontBitmaps  :: proc(hdc: HDC, first, count, list_base: u32) -> BOOL ---;
+	wglUseFontOutlines :: proc(hdc: HDC, first, count, list_base: u32, deviation, extrusion: f32, format: i32, gmf: ^Glyph_Metrics_Float) -> BOOL ---;
 }
+
+create_context            :: wglCreateContext;
+delete_context            :: wglDeleteContext;
+make_current              :: wglMakeCurrent;
+copy_context              :: wglCopyContext;
+get_current_context       :: wglGetCurrentContext;
+get_gl_proc_address       :: wglGetProcAddress;
+create_layer_context      :: wglCreateLayerContext;
+swap_layer_buffers        :: wglSwapLayerBuffers;
+get_current_dc            :: wglGetCurrentDC;
+describe_layer_plane      :: wglDescribeLayerPlane;
+get_layer_palette_entries :: wglGetLayerPaletteEntries;
+realize_layer_palette     :: wglRealizeLayerPalette;
+set_layer_palette_entries :: wglSetLayerPaletteEntries;
+share_lists               :: wglShareLists;
+use_font_bitmaps          :: wglUseFontBitmaps;
+use_Font_outlines         :: wglUseFontOutlines;

--- a/core/sys/win32/winmm.odin
+++ b/core/sys/win32/winmm.odin
@@ -6,5 +6,7 @@ foreign import "system:winmm.lib"
 
 @(default_calling_convention = "std")
 foreign winmm {
-	@(link_name="timeGetTime") time_get_time :: proc() -> u32 ---;
+	timeGetTime :: proc() -> u32 ---;
 }
+
+time_get_time :: timeGetTime;

--- a/core/thread/thread_windows.odin
+++ b/core/thread/thread_windows.odin
@@ -5,7 +5,7 @@ import "core:sync"
 import "core:sys/win32"
 
 Thread_Os_Specific :: struct {
-	win32_thread:    win32.Handle,
+	win32_thread:    win32.HANDLE,
 	win32_thread_id: u32,
 	done: bool, // see note in `is_done`
 }
@@ -50,7 +50,7 @@ create :: proc(procedure: Thread_Proc, priority := Thread_Priority.Normal) -> ^T
 	win32_thread_proc := rawptr(__windows_thread_entry_proc);
 	thread := new(Thread);
 
-	win32_thread := win32.create_thread(nil, 0, win32_thread_proc, thread, win32.CREATE_SUSPENDED, &win32_thread_id);
+	win32_thread := win32.CreateThread(nil, 0, win32_thread_proc, thread, win32.CREATE_SUSPENDED, &win32_thread_id);
 	if win32_thread == nil {
 		free(thread);
 		return nil;
@@ -60,14 +60,14 @@ create :: proc(procedure: Thread_Proc, priority := Thread_Priority.Normal) -> ^T
 	thread.win32_thread_id = win32_thread_id;
 	thread.init_context = context;
 
-	ok := win32.set_thread_priority(win32_thread, _thread_priority_map[priority]);
+	ok := win32.SetThreadPriority(win32_thread, _thread_priority_map[priority]);
 	assert(ok == true);
 
 	return thread;
 }
 
 start :: proc(using thread: ^Thread) {
-	win32.resume_thread(win32_thread);
+	win32.ResumeThread(win32_thread);
 }
 
 is_done :: proc(using thread: ^Thread) -> bool {
@@ -79,8 +79,8 @@ is_done :: proc(using thread: ^Thread) -> bool {
 
 join :: proc(using thread: ^Thread) {
 	if win32_thread != win32.INVALID_HANDLE {
-		win32.wait_for_single_object(win32_thread, win32.INFINITE);
-		win32.close_handle(win32_thread);
+		win32.WaitForSingleObject(win32_thread, win32.INFINITE);
+		win32.CloseHandle(win32_thread);
 		win32_thread = win32.INVALID_HANDLE;
 	}
 }
@@ -91,9 +91,9 @@ destroy :: proc(thread: ^Thread) {
 }
 
 terminate :: proc(using thread : ^Thread, exit_code : u32) {
-	win32.terminate_thread(win32_thread, exit_code);
+	win32.TerminateThread(win32_thread, exit_code);
 }
 
 yield :: proc() {
-	win32.sleep(0);
+	win32.Sleep(0);
 }

--- a/core/time/time_windows.odin
+++ b/core/time/time_windows.odin
@@ -5,9 +5,9 @@ import "core:sys/win32"
 IS_SUPPORTED :: true;
 
 now :: proc() -> Time {
-	file_time: win32.Filetime;
+	file_time: win32.FILETIME;
 
-	win32.get_system_time_as_file_time(&file_time);
+	win32.GetSystemTimeAsFileTime(&file_time);
 
 	ft := i64(u64(file_time.lo) | u64(file_time.hi) << 32);
 
@@ -16,5 +16,5 @@ now :: proc() -> Time {
 }
 
 sleep :: proc(d: Duration) {
-	win32.sleep(u32(d/Millisecond));
+	win32.Sleep(u32(d/Millisecond));
 }


### PR DESCRIPTION
Change the style back to that of the Windows API to aid with porting Win32 code.
I've also added aliases so that code using the Odin-style procedure names will continue to work, and can be used in the future if the person prefers to.

It was changed to snake case originally to better fit the Odin style.
Turns out, that was a bad idea.

Note: I think all the aliases are correct - I checked pretty meticulously - but would appreciate it if others verified I did them all right. 😄 