### PR TITLE
Remove `intrinsics` import

### DIFF
--- a/core/math/linalg/specific.odin
+++ b/core/math/linalg/specific.odin
@@ -1,7 +1,6 @@
 package linalg
 
 import "core:math"
-import "intrinsics"
 
 
 // Specific


### PR DESCRIPTION
When using `linalg` with the `-vet` compiler switch, you get the warning/error:

`odin/core/math/linalg/specific.odin(4:8) 'intrinsics' declared but not used`