### PR TITLE
Control %s width in fmt.print* functions

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -898,6 +898,11 @@ fmt_string :: proc(fi: ^Info, s: string, verb: rune) {
 	switch verb {
 	case 's', 'v':
 		strings.write_string(fi.buf, s);
+		if fi.width_set && len(s) < fi.width {
+			for i in 0..<fi.width - len(s) {
+				strings.write_byte(fi.buf, ' ');
+			}
+		}
 
 	case 'q': // quoted string
 		strings.write_quoted_string(fi.buf, s, '"');


### PR DESCRIPTION
Use width in when printing formatted string to control padding added after the string.

For instance

```fmt.printf("%10s", s)```

will add spaces after the string if len(s) is less than specified width in the format string