### PR TITLE
Fix misplaced line number in log (was wrongly formatted and before procedure)

### DIFF
--- a/core/log/file_console_logger.odin
+++ b/core/log/file_console_logger.odin
@@ -127,12 +127,6 @@ do_location_header :: proc(opts: Options, buf: ^strings.Builder, location := #ca
 	if Location_File_Opts & opts != nil {
 		fmt.sbprint(buf, file);
 	}
-	if .Line in opts {
-		if (Location_File_Opts | {.Procedure}) & opts != nil {
-			fmt.sbprint(buf, ":");
-		}
-		fmt.sbprint(buf, location.line);
-	}
 
 	if .Procedure in opts {
 		if Location_File_Opts & opts != nil {
@@ -141,6 +135,12 @@ do_location_header :: proc(opts: Options, buf: ^strings.Builder, location := #ca
 		fmt.sbprintf(buf, "%s()", location.procedure);
 	}
 
+	if .Line in opts {
+		if (Location_File_Opts | {.Procedure}) & opts != nil {
+			fmt.sbprint(buf, ":");
+		}
+		fmt.sbprint(buf, location.line);
+	}
 
 	fmt.sbprint(buf, "] ");
 }

--- a/core/log/file_console_logger.odin
+++ b/core/log/file_console_logger.odin
@@ -135,7 +135,7 @@ do_location_header :: proc(opts: Options, buf: ^strings.Builder, location := #ca
 	}
 
 	if .Procedure in opts {
-		if (Location_File_Opts | {.Procedure}) & opts != nil {
+		if (Location_File_Opts | {.Line}) & opts != nil {
 			fmt.sbprint(buf, ":");
 		}
 		fmt.sbprintf(buf, "%s()", location.procedure);

--- a/core/log/file_console_logger.odin
+++ b/core/log/file_console_logger.odin
@@ -127,19 +127,18 @@ do_location_header :: proc(opts: Options, buf: ^strings.Builder, location := #ca
 	if Location_File_Opts & opts != nil {
 		fmt.sbprint(buf, file);
 	}
-
-	if .Procedure in opts {
+	if .Line in opts {
 		if Location_File_Opts & opts != nil {
 			fmt.sbprint(buf, ":");
 		}
-		fmt.sbprintf(buf, "%s()", location.procedure);
+		fmt.sbprint(buf, location.line);
 	}
 
-	if .Line in opts {
+	if .Procedure in opts {
 		if (Location_File_Opts | {.Procedure}) & opts != nil {
 			fmt.sbprint(buf, ":");
 		}
-		fmt.sbprint(buf, location.line);
+		fmt.sbprintf(buf, "%s()", location.procedure);
 	}
 
 	fmt.sbprint(buf, "] ");


### PR DESCRIPTION
Before: `[DEBUG] --- [:176clean_field_key()]  ImGuiWindowFlags_Popup`
After: `[DEBUG] --- [clean_field_key():176]  ImGuiNavLayer_Menu`