### PR TITLE
Fix pthread_t on Macos.

### DIFF
--- a/core/sys/unix/pthread_darwin.odin
+++ b/core/sys/unix/pthread_darwin.odin
@@ -14,11 +14,7 @@ PTHREAD_ONCE_SIZE      :: 8;
 PTHREAD_RWLOCK_SIZE    :: 192;
 PTHREAD_RWLOCKATTR_SIZE :: 16;
 
-pthread_t :: opaque struct #align 16 {
-	sig: c.long,
-	cleanup_stack: rawptr,
-	_: [PTHREAD_SIZE] c.char,
-};
+pthread_t :: opaque u64;
 
 pthread_attr_t :: opaque struct #align 16 {
 	sig: c.long,


### PR DESCRIPTION
From some testing with directly using C code, pthread_t on macos is 8 bytes.
This is my test code:

```
#include <assert.h>
#include <stdio.h>

#include <pthread.h>



void* PosixThreadMainRoutine(void* data)

{

	// Do some work here.
	for (int i = 0; i < 2000000000; i++) {

	}



	return NULL;

}



pthread_t LaunchThread()

{

	// Create the thread using POSIX routines.

	pthread_attr_t  attr;

	pthread_t       posixThreadID;

	int             returnVal;



	returnVal = pthread_attr_init(&attr);

	assert(!returnVal);

	returnVal = pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);

	assert(!returnVal);



	int     threadError = pthread_create(&posixThreadID, &attr, &PosixThreadMainRoutine, NULL);



	returnVal = pthread_attr_destroy(&attr);

	assert(!returnVal);

	if (threadError != 0)

	{

		// Report an error.

	}

	return posixThreadID;

}

int main() {
	pthread_t t = LaunchThread();

	void ** ret;


	printf("%d, %d\n", sizeof(t), sizeof(pthread_t));

	int val = pthread_join(t, ret);


	printf("%d", val);
	return 0;
}
```
running this on macos reports `8, 8`. 
Then I made the proposed changes and errors I was having with threads completely went away.