### PR TITLE
Implement os.current_thread_id() for Darwin (assumes OSX 10.6 / iOS 3…

### DIFF
--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -2,6 +2,7 @@ package os
 
 foreign import dl   "system:dl"
 foreign import libc "system:c"
+foreign import pthread "system:pthread"
 
 import "core:runtime"
 import "core:strings"
@@ -428,8 +429,13 @@ exit :: inline proc(code: int) -> ! {
 }
 
 current_thread_id :: proc "contextless" () -> int {
-	// return int(_unix_gettid());
-	return 0;
+	tid: u64;
+	// NOTE(Oskar): available from OSX 10.6 and iOS 3.2.
+	// For older versions there is `syscall(SYS_thread_selfid)`, but not really
+	// the same thing apparently.
+	foreign pthread { pthread_threadid_np :: proc "c" (rawptr, ^u64) -> c.int ---; }
+	pthread_threadid_np(nil, &tid);
+	return int(tid);
 }
 
 dlopen :: inline proc(filename: string, flags: int) -> rawptr {


### PR DESCRIPTION
….2 and later)