### PR TITLE
fix hsl math.mod to usual hsl conversion

### DIFF
--- a/core/math/linalg/specific.odin
+++ b/core/math/linalg/specific.odin
@@ -120,7 +120,9 @@ vector4_linear_to_srgb :: proc(col: Vector4) -> Vector4 {
 
 vector4_hsl_to_rgb :: proc(h, s, l: Float, a: Float = 1) -> Vector4 {
 	hue_to_rgb :: proc(p, q, t0: Float) -> Float {
-		t := math.mod(t0, 1.0);
+		t := t;
+		if t < 0 do t += 1;
+		if t > 1 do t -= 1;
 		switch {
 		case t < 1.0/6.0: return p + (q - p) * 6.0 * t;
 		case t < 1.0/2.0: return q;


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/22886746/91645019-d5440500-ea41-11ea-8cf2-d340e01456e5.png)
left before | right after

not quite sure what was wrong with the modulo approach but the one i submitted is the code you usually see online and works as expected!