### PR TITLE
Add ProcOverload_ParamNames; overload on param names

### DIFF
--- a/examples/demo/demo.odin
+++ b/examples/demo/demo.odin
@@ -480,6 +480,36 @@ explicit_procedure_overloading :: proc() {
 	// Ambiguous answers
 	// add(1.0, 2);
 	// add(1, 2.0);
+
+	fmt.println("\n# explicit procedure overloading using unique parameter names");
+
+	resize_frame :: proc{resize_frame_xyxy, resize_frame_xywh, resize_frame_ltrb};
+
+	resize_frame_xyxy :: proc(x0, y0, x1, y1 : int) {
+		fmt.printf(" frame resized to p0=(%d,%d) p1=(%d,%d)\n", x0, y0, x1, y1);
+	}
+
+	resize_frame_xywh :: proc(x, y, width, height : int) {
+		fmt.print("(xywh)");
+		// Allowed to use procedure group name inside specific members
+		resize_frame(x0=x, y0=y, x1=x+width, y1=y+height);
+	}
+
+	resize_frame_ltrb :: proc(left, top, right, bottom : int) {
+		fmt.print("(ltrb)");
+		// Allowed to reorder named arguments
+		resize_frame(x0=left, y1=top, x1=right, y0=bottom);
+	}
+
+	// These are equivalent
+	resize_frame(x=1, y=2, width=5, height=6);
+	resize_frame(left=1, top=8, bottom=2, right=6);
+
+	// Not allowed to mix named and unnamed arguments
+	// resize_frame(1, 1, x1=5, y1=10);
+
+	// Ambiguous
+	// resize_frame(1, 1, 5, 10);
 }
 
 struct_type :: proc() {

--- a/src/check_decl.cpp
+++ b/src/check_decl.cpp
@@ -1079,6 +1079,7 @@ void check_proc_group_decl(CheckerContext *ctx, Entity *pg_entity, DeclInfo *d) 
 				break;
 			case ProcOverload_ParamCount:
 			case ProcOverload_ParamTypes:
+			case ProcOverload_ParamNames:
 				// This is okay :)
 				break;
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -2229,6 +2229,8 @@ enum ProcTypeOverloadKind {
 	ProcOverload_ParamCount,
 	ProcOverload_ParamVariadic,
 	ProcOverload_ParamTypes,
+	ProcOverload_ParamNames,
+
 	ProcOverload_ResultCount,
 	ProcOverload_ResultTypes,
 	ProcOverload_Polymorphic,
@@ -2294,6 +2296,9 @@ ProcTypeOverloadKind are_proc_types_overload_safe(Type *x, Type *y) {
 		Entity *ey = py.params->Tuple.variables[0];
 		bool ok = are_types_identical(ex->type, ey->type);
 		if (ok) {
+			if (ex->token.string != ey->token.string) {
+				return ProcOverload_ParamNames;
+			}
 		}
 	}
 


### PR DESCRIPTION
Allows to resolve a specific procedure of a procedure group when
the types are identical and the parameter names are unique.  The
change introduces a new ProcOverload kind that relaxes the check
of the procedure group only when types are identical.  Omitting
the parameter names at the call site will continue to complain
about an ambiguitiy with a reasonable message.  As before, mixed
positional and named parameters are not allowed.