### PR TITLE
Fix issue #515

### DIFF
--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -1253,7 +1253,13 @@ bool check_type_specialization_to(CheckerContext *ctx, Type *specialization, Typ
 						e->type = t_e->type;
 					}
 				} else {
-					bool ok = is_polymorphic_type_assignable(ctx, st, tt, true, modify_type);
+					if (st->kind == Type_Basic && tt->kind == Type_Basic &&
+						s_e->kind == Entity_Constant && t_e->kind == Entity_Constant) {
+						if (!compare_exact_values(Token_CmpEq, s_e->Constant.value, t_e->Constant.value))
+							return false;
+					} else {
+						bool ok = is_polymorphic_type_assignable(ctx, st, tt, true, modify_type);
+					}
 				}
 			}
 


### PR DESCRIPTION
Modify `check_type_specialization_to` to require exact values
to be equal when called with constant basic types. This also
now allows procedure group members to differ only by constant
value specializations.  See the further example in the issue.