### PR TITLE
Added option to parse number as integer, disabled by default

### DIFF
--- a/core/encoding/json/parser.odin
+++ b/core/encoding/json/parser.odin
@@ -11,11 +11,12 @@ Parser :: struct {
 	spec:           Specification,
 	allocator:      mem.Allocator,
 	unmarshal_data: any,
+	parse_integers: bool,
 }
 
-make_parser :: proc(data: []byte, spec := Specification.JSON, allocator := context.allocator) -> Parser {
+make_parser :: proc(data: []byte, spec := Specification.JSON, parse_integers := false, allocator := context.allocator) -> Parser {
 	p: Parser;
-	p.tok = make_tokenizer(data, spec);
+	p.tok = make_tokenizer(data, spec, parse_integers);
 	p.spec = spec;
 	p.allocator = allocator;
 	assert(p.allocator.procedure != nil);
@@ -23,9 +24,9 @@ make_parser :: proc(data: []byte, spec := Specification.JSON, allocator := conte
 	return p;
 }
 
-parse :: proc(data: []byte, spec := Specification.JSON, allocator := context.allocator) -> (Value, Error) {
+parse :: proc(data: []byte, spec := Specification.JSON, parse_integers := false, allocator := context.allocator) -> (Value, Error) {
 	context.allocator = allocator;
-	p := make_parser(data, spec, allocator);
+	p := make_parser(data, spec, parse_integers, allocator);
 
 	if p.spec == Specification.JSON5 {
 		return parse_value(&p);

--- a/core/encoding/json/tokenizer.odin
+++ b/core/encoding/json/tokenizer.odin
@@ -42,12 +42,13 @@ Tokenizer :: struct {
 	w:                int,  // current rune width in bytes
 	curr_line_offset: int,
 	spec:             Specification,
+	parse_integers:   bool,
 }
 
 
 
-make_tokenizer :: proc(data: []byte, spec := Specification.JSON) -> Tokenizer {
-	t := Tokenizer{pos = {line=1}, data = data, spec = spec};
+make_tokenizer :: proc(data: []byte, spec := Specification.JSON, parse_integers := false) -> Tokenizer {
+	t := Tokenizer{pos = {line=1}, data = data, spec = spec, parse_integers = parse_integers};
 	next_rune(&t);
 	if t.r == utf8.RUNE_BOM {
 		next_rune(&t);
@@ -217,7 +218,7 @@ get_token :: proc(t: ^Tokenizer) -> (token: Token, err: Error) {
 		fallthrough;
 
 	case '0'..'9':
-		token.kind = .Integer;
+		token.kind = t.parse_integers ? .Integer : .Float;
 		if t.spec == .JSON5 { // Hexadecimal Numbers
 			if curr_rune == '0' && (t.r == 'x' || t.r == 'X') {
 				next_rune(t);

--- a/core/encoding/json/validator.odin
+++ b/core/encoding/json/validator.odin
@@ -3,8 +3,8 @@ package json
 import "core:mem"
 
 // NOTE(bill): is_valid will not check for duplicate keys
-is_valid :: proc(data: []byte, spec := Specification.JSON) -> bool {
-	p := make_parser(data, spec, false, mem.nil_allocator());
+is_valid :: proc(data: []byte, spec := Specification.JSON, parse_integers := false) -> bool {
+	p := make_parser(data, spec, parse_integers, mem.nil_allocator());
 	if p.spec == Specification.JSON5 {
 		return validate_value(&p);
 	}

--- a/core/encoding/json/validator.odin
+++ b/core/encoding/json/validator.odin
@@ -4,7 +4,7 @@ import "core:mem"
 
 // NOTE(bill): is_valid will not check for duplicate keys
 is_valid :: proc(data: []byte, spec := Specification.JSON) -> bool {
-	p := make_parser(data, spec, mem.nil_allocator());
+	p := make_parser(data, spec, false, mem.nil_allocator());
 	if p.spec == Specification.JSON5 {
 		return validate_value(&p);
 	}


### PR DESCRIPTION
New optional paramter "parse_integers" turns on the old behaviour:

```odin
package main;

import "core:fmt"
import "core:mem"
import "core:encoding/json"

main :: proc() {
	json_string := cstring(`
		{
			"array" : [0.5, 0]
		}
	`);
	parse_integers := true;
	parser := json.make_parser(data = mem.slice_ptr(cast(^u8) json_string, len(json_string)), parse_integers = parse_integers);
	root, ok := json.parse_value(&parser);
	array : json.Array = root.value.(json.Object)["array"].value.?;
	for value in &array {
		fmt.println(value.value.(json.Float));
	}
}

```