### PR TITLE
Fix issue #486

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -852,6 +852,10 @@ bool is_polymorphic_type_assignable(CheckerContext *c, Type *poly, Type *source,
 		return false;
 	case Type_Pointer:
 		if (source->kind == Type_Pointer) {
+			isize level = check_is_assignable_to_using_subtype(source->Pointer.elem, poly->Pointer.elem);
+			if (level > 0) {
+				return true;
+			}
 			return is_polymorphic_type_assignable(c, poly->Pointer.elem, source->Pointer.elem, true, modify_type);
 		}
 		return false;


### PR DESCRIPTION
Use `check_is_assignable_to_using_subtype` in `is_polymorphic_type_assignable`.

The polymorphic procedure in #486 can now also be written without the
cast:
```odin
print_entity :: proc(e : ^$E, p : proc(^$T) = print_base) { p(e); }
```