### PR TITLE
Fix issue #697

### DIFF
--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -110,6 +110,8 @@ bool does_field_type_allow_using(Type *t) {
 		return true;
 	} else if (is_type_array(t)) {
 		return t->Array.count <= 4;
+	} else if (is_type_typeid(t)) {
+		return true;
 	}
 	return false;
 }


### PR DESCRIPTION
Add `is_type_typeid` check to `does_field_type_allow_using`; allows `using` on `typeid` struct members.
