### PR TITLE
Riscv64 Support

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -826,7 +826,7 @@ void init_build_context(TargetMetrics *cross_target) {
 			gb_exit(1);
 			break;
 		case TargetOs_linux:
-			bc->link_flags = str_lit("-arch rv64imafdc ");
+			bc->link_flags = str_lit("-arch rv64imafdc -mfloat-abi=hard ");
 			break;
 		case TargetOs_freebsd:
 			bc->link_flags = str_lit("-arch riscv64 ");

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -1551,7 +1551,11 @@ void ir_print_instr(irFileBuffer *f, irModule *m, irValue *value) {
 				break;
 
 			case BuiltinProc_cpu_relax:
+#if defined(GB_CPU_RISCV)
+				ir_write_str_lit(f, "call void asm sideeffect \"nop\", \"\"()");
+#else
 				ir_write_str_lit(f, "call void asm sideeffect \"pause\", \"\"()");
+#endif
 				break;
 			default: GB_PANIC("Unknown inline code %d", instr->InlineCode.id); break;
 			}


### PR DESCRIPTION
Ok, so I did a ton of work to get both the compiler running on RiscV as well as compiling *for* RiscV64.
Odin successfully runs, however, it does not successfully compile a program yet due to soft-float vs. double-float linking errors. I've tried various options in src/build_settings.cpp to try to get it to link with the correct floating point options, but I have not been able to find the correct options yet.

However, I believe everything should be done where, once the correct options are given to llc and the linker, it should compile.
Of course, we still need to make sure the compiled binary runs correctly, as well as deal with runtime issues and handle different RiscV extensions. We also might need to look at the call convention stuff, too.
We can start working on that once we have the correct llc and linker options being passed.