### PR TITLE
Fixes for MacOS 11 / Big Sur

### DIFF
--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -1,8 +1,8 @@
 package os
 
 foreign import dl   "system:dl"
-foreign import libc "system:c"
-foreign import pthread "system:pthread"
+foreign import libc "System.framework"
+foreign import pthread "System.framework"
 
 import "core:runtime"
 import "core:strings"

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -1,6 +1,6 @@
 package darwin;
 
-foreign import "system:pthread"
+foreign import pthread "System.framework"
 
 import "core:c"
 

--- a/core/time/time_unix.odin
+++ b/core/time/time_unix.odin
@@ -3,7 +3,14 @@ package time
 
 IS_SUPPORTED :: true; // NOTE: Times on Darwin are UTC.
 
-foreign import libc "system:c"
+when ODIN_OS == "darwin" {
+  foreign import libc "System.framework"
+}
+
+when ODIN_OS != "darwin" {
+  foreign import libc "system:c"
+}
+
 
 @(default_calling_convention="c")
 foreign libc {

--- a/core/time/time_unix.odin
+++ b/core/time/time_unix.odin
@@ -5,9 +5,7 @@ IS_SUPPORTED :: true; // NOTE: Times on Darwin are UTC.
 
 when ODIN_OS == "darwin" {
   foreign import libc "System.framework"
-}
-
-when ODIN_OS != "darwin" {
+} else  {
   foreign import libc "system:c"
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -432,7 +432,11 @@ i32 linker_stage(lbGenerator *gen) {
 			#endif
 			, linker, object_files, LIT(output_base), LIT(output_ext),
 			lib_str,
-			"-lc -lm",
+      #if defined(GB_SYSTEM_OSX)
+        "-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
+      #else
+        "-lc -lm",
+      #endif
 			LIT(build_context.link_flags),
 			LIT(build_context.extra_linker_flags),
 			link_settings);
@@ -2195,7 +2199,11 @@ int main(int arg_count, char const **arg_ptr) {
 				#endif
 				, linker, LIT(output_base), LIT(output_base), LIT(output_ext),
 				lib_str,
-				"-lc -lm",
+        #if defined(GB_SYSTEM_OSX)
+          "-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
+        #else
+          "-lc -lm",
+        #endif
 				LIT(build_context.link_flags),
 				LIT(build_context.extra_linker_flags),
 				link_settings);


### PR DESCRIPTION
Hello here some fixes for macOS so that odin compiles code correctly under Big Sur, i didn’t test this on older macOS versions but demo seems to compile fine on github actions.

This basically only changes the linker flags and removes the linking of libc as this is now inside the `System.framework`

On thing that seemed to be quite important is the addition of `-syslibroot` else it doesn’t find the libraries the path there is to a symlink that automatically is linked to the current sdk. 