### PR TITLE
Allow .a or .o files to be linked on macos.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -341,7 +341,7 @@ i32 linker_stage(lbGenerator *gen) {
 					String lib_name = lib;
 					lib_name = remove_extension_from_path(lib_name);
 					lib_str = gb_string_append_fmt(lib_str, " -framework %.*s ", LIT(lib_name));
-				} else if (string_ends_with(lib, str_lit(".a"))) {
+				} else if (string_ends_with(lib, str_lit(".a")) || string_ends_with(lib, str_lit(".o"))) {
 					// static libs, absolute full path relative to the file in which the lib was imported from
 					lib_str = gb_string_append_fmt(lib_str, " %.*s ", LIT(lib));
 				} else if (string_ends_with(lib, str_lit(".dylib"))) {


### PR DESCRIPTION
In my projects I usually make a lot of .o files from C libs. This should allow to link them without having to change file extensions to get around the compiler.