### PR TITLE
Reuse container.Queue capacity when calling pop_front()

### DIFF
--- a/core/container/queue.odin
+++ b/core/container/queue.odin
@@ -115,6 +115,9 @@ queue_pop_front :: proc(q: ^$Q/Queue($T)) -> T {
 	item := queue_get(q^, 0);
 	q.offset = (q.offset + 1) % array_len(q.data);
 	q.len -= 1;
+	if q.len == 0 {
+		q.offset = 0;
+	}
 	return item;
 }
 


### PR DESCRIPTION
Currently, the Queue will never reuse it's full capacity if you call `pop_front`, even if you empty it before pushing more items.

With this change, if you empty the Queue with `pop_front`, then the offset will be set back to the start of the underlying array when you pop the last item.

Future pushes will then reuse the already-allocated--but now empty--space.