### PR TITLE
Fix macOS linking for user/local/libs and object files

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -341,13 +341,10 @@ i32 linker_stage(lbGenerator *gen) {
 					String lib_name = lib;
 					lib_name = remove_extension_from_path(lib_name);
 					lib_str = gb_string_append_fmt(lib_str, " -framework %.*s ", LIT(lib_name));
-				} else if (string_ends_with(lib, str_lit(".a")) || 
-                     string_ends_with(lib, str_lit(".o")) || 
-                     string_ends_with(lib, str_lit(".dylib"))) 
-        {
-          // For:
-          // object 
-          // dynamic lib
+				} else if (string_ends_with(lib, str_lit(".a")) || string_ends_with(lib, str_lit(".o")) || string_ends_with(lib, str_lit(".dylib"))) {
+          				// For:
+          				// object 
+          				// dynamic lib
 					// static libs, absolute full path relative to the file in which the lib was imported from
 					lib_str = gb_string_append_fmt(lib_str, " %.*s ", LIT(lib));
 				} else {
@@ -434,12 +431,12 @@ i32 linker_stage(lbGenerator *gen) {
 				" -e _main "
 			#endif
 			, linker, object_files, LIT(output_base), LIT(output_ext),
-      #if defined(GB_SYSTEM_OSX)
-        "-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib",
-      #else
-        "-lc -lm",
-      #endif
-      lib_str,
+      			#if defined(GB_SYSTEM_OSX)
+        			"-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib",
+      			#else
+        			"-lc -lm",
+      			#endif
+      			lib_str,
 			LIT(build_context.link_flags),
 			LIT(build_context.extra_linker_flags),
 			link_settings);
@@ -2139,13 +2136,11 @@ int main(int arg_count, char const **arg_ptr) {
 						String lib_name = lib;
 						lib_name = remove_extension_from_path(lib_name);
 						lib_str = gb_string_append_fmt(lib_str, " -framework %.*s ", LIT(lib_name));
-					} else if (string_ends_with(lib, str_lit(".a")) || 
-                     string_ends_with(lib, str_lit(".o")) || 
-                     string_ends_with(lib, str_lit(".dylib"))) 
-        {
-          // For:
-          // object 
-          // dynamic lib
+						
+				} else if (string_ends_with(lib, str_lit(".a")) || string_ends_with(lib, str_lit(".o")) || string_ends_with(lib, str_lit(".dylib"))) {
+          				// For:
+          				// object 
+          				// dynamic lib
 					// static libs, absolute full path relative to the file in which the lib was imported from
 					lib_str = gb_string_append_fmt(lib_str, " %.*s ", LIT(lib));
 				} else {
@@ -2226,11 +2221,11 @@ int main(int arg_count, char const **arg_ptr) {
 				#endif
 				, linker, LIT(output_base), LIT(output_base), LIT(output_ext),
 				lib_str,
-        #if defined(GB_SYSTEM_OSX)
-          "-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib",
-        #else
-          "-lc -lm",
-        #endif
+        			#if defined(GB_SYSTEM_OSX)
+          				"-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib",
+        			#else
+          				"-lc -lm",
+        			#endif
 				LIT(build_context.link_flags),
 				LIT(build_context.extra_linker_flags),
 				link_settings);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -341,11 +341,14 @@ i32 linker_stage(lbGenerator *gen) {
 					String lib_name = lib;
 					lib_name = remove_extension_from_path(lib_name);
 					lib_str = gb_string_append_fmt(lib_str, " -framework %.*s ", LIT(lib_name));
-				} else if (string_ends_with(lib, str_lit(".a"))) {
+				} else if (string_ends_with(lib, str_lit(".a")) || 
+                     string_ends_with(lib, str_lit(".o")) || 
+                     string_ends_with(lib, str_lit(".dylib"))) 
+        {
+          // For:
+          // object 
+          // dynamic lib
 					// static libs, absolute full path relative to the file in which the lib was imported from
-					lib_str = gb_string_append_fmt(lib_str, " %.*s ", LIT(lib));
-				} else if (string_ends_with(lib, str_lit(".dylib"))) {
-					// dynamic lib
 					lib_str = gb_string_append_fmt(lib_str, " %.*s ", LIT(lib));
 				} else {
 					// dynamic or static system lib, just link regularly searching system library paths
@@ -2136,13 +2139,16 @@ int main(int arg_count, char const **arg_ptr) {
 						String lib_name = lib;
 						lib_name = remove_extension_from_path(lib_name);
 						lib_str = gb_string_append_fmt(lib_str, " -framework %.*s ", LIT(lib_name));
-					} else if (string_ends_with(lib, str_lit(".a"))) {
-						// static libs, absolute full path relative to the file in which the lib was imported from
-						lib_str = gb_string_append_fmt(lib_str, " %.*s ", LIT(lib));
-					} else if (string_ends_with(lib, str_lit(".dylib"))) {
-						// dynamic lib
-						lib_str = gb_string_append_fmt(lib_str, " %.*s ", LIT(lib));
-					} else {
+					} else if (string_ends_with(lib, str_lit(".a")) || 
+                     string_ends_with(lib, str_lit(".o")) || 
+                     string_ends_with(lib, str_lit(".dylib"))) 
+        {
+          // For:
+          // object 
+          // dynamic lib
+					// static libs, absolute full path relative to the file in which the lib was imported from
+					lib_str = gb_string_append_fmt(lib_str, " %.*s ", LIT(lib));
+				} else {
 						// dynamic or static system lib, just link regularly searching system library paths
 						lib_str = gb_string_append_fmt(lib_str, " -l%.*s ", LIT(lib));
 					}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -431,19 +431,19 @@ i32 linker_stage(lbGenerator *gen) {
 				" -e _main "
 			#endif
 			, linker, object_files, LIT(output_base), LIT(output_ext),
-			lib_str,
       #if defined(GB_SYSTEM_OSX)
-        "-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
+        "-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -L/usr/local/lib",
       #else
         "-lc -lm",
       #endif
+      lib_str,
 			LIT(build_context.link_flags),
 			LIT(build_context.extra_linker_flags),
 			link_settings);
 		if (exit_code != 0) {
 			return exit_code;
 		}
-
+    
 	#if defined(GB_SYSTEM_OSX)
 		if (build_context.ODIN_DEBUG) {
 			// NOTE: macOS links DWARF symbols dynamically. Dsymutil will map the stubs in the exe
@@ -2221,7 +2221,7 @@ int main(int arg_count, char const **arg_ptr) {
 				, linker, LIT(output_base), LIT(output_base), LIT(output_ext),
 				lib_str,
         #if defined(GB_SYSTEM_OSX)
-          "-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
+          "-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib",
         #else
           "-lc -lm",
         #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -341,13 +341,16 @@ i32 linker_stage(lbGenerator *gen) {
 					String lib_name = lib;
 					lib_name = remove_extension_from_path(lib_name);
 					lib_str = gb_string_append_fmt(lib_str, " -framework %.*s ", LIT(lib_name));
-				} else if (string_ends_with(lib, str_lit(".a")) || string_ends_with(lib, str_lit(".o")) || string_ends_with(lib, str_lit(".dylib"))) {
-                        // For:
-                        // object 
-                        // dynamic lib
-                        // static libs, absolute full path relative to the file in which the lib was imported from
-    					lib_str = gb_string_append_fmt(lib_str, " %.*s ", LIT(lib));
-    			} else {
+				} else if (string_ends_with(lib, str_lit(".a")) || 
+                     string_ends_with(lib, str_lit(".o")) || 
+                     string_ends_with(lib, str_lit(".dylib"))) 
+        {
+          // For:
+          // object 
+          // dynamic lib
+					// static libs, absolute full path relative to the file in which the lib was imported from
+					lib_str = gb_string_append_fmt(lib_str, " %.*s ", LIT(lib));
+				} else {
 					// dynamic or static system lib, just link regularly searching system library paths
 					lib_str = gb_string_append_fmt(lib_str, " -l%.*s ", LIT(lib));
 				}
@@ -431,12 +434,12 @@ i32 linker_stage(lbGenerator *gen) {
 				" -e _main "
 			#endif
 			, linker, object_files, LIT(output_base), LIT(output_ext),
-            #if defined(GB_SYSTEM_OSX)
-                "-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib",
-            #else
-                "-lc -lm",
-            #endif
-            lib_str,
+      #if defined(GB_SYSTEM_OSX)
+        "-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib",
+      #else
+        "-lc -lm",
+      #endif
+      lib_str,
 			LIT(build_context.link_flags),
 			LIT(build_context.extra_linker_flags),
 			link_settings);
@@ -2136,13 +2139,16 @@ int main(int arg_count, char const **arg_ptr) {
 						String lib_name = lib;
 						lib_name = remove_extension_from_path(lib_name);
 						lib_str = gb_string_append_fmt(lib_str, " -framework %.*s ", LIT(lib_name));
-					} else if (string_ends_with(lib, str_lit(".a")) || string_ends_with(lib, str_lit(".o")) || string_ends_with(lib, str_lit(".dylib"))) {
-                        // For:
-                        // object 
-                        // dynamic lib
-                        // static libs, absolute full path relative to the file in which the lib was imported from
-    					lib_str = gb_string_append_fmt(lib_str, " %.*s ", LIT(lib));
-    				} else {
+					} else if (string_ends_with(lib, str_lit(".a")) || 
+                     string_ends_with(lib, str_lit(".o")) || 
+                     string_ends_with(lib, str_lit(".dylib"))) 
+        {
+          // For:
+          // object 
+          // dynamic lib
+					// static libs, absolute full path relative to the file in which the lib was imported from
+					lib_str = gb_string_append_fmt(lib_str, " %.*s ", LIT(lib));
+				} else {
 						// dynamic or static system lib, just link regularly searching system library paths
 						lib_str = gb_string_append_fmt(lib_str, " -l%.*s ", LIT(lib));
 					}
@@ -2220,11 +2226,11 @@ int main(int arg_count, char const **arg_ptr) {
 				#endif
 				, linker, LIT(output_base), LIT(output_base), LIT(output_ext),
 				lib_str,
-                #if defined(GB_SYSTEM_OSX)
-                    "-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib",
-                #else
-                    "-lc -lm",
-                #endif
+        #if defined(GB_SYSTEM_OSX)
+          "-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib",
+        #else
+          "-lc -lm",
+        #endif
 				LIT(build_context.link_flags),
 				LIT(build_context.extra_linker_flags),
 				link_settings);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -435,7 +435,7 @@ i32 linker_stage(lbGenerator *gen) {
 			#endif
 			, linker, object_files, LIT(output_base), LIT(output_ext),
       #if defined(GB_SYSTEM_OSX)
-        "-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -L/usr/local/lib",
+        "-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib",
       #else
         "-lc -lm",
       #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -341,16 +341,13 @@ i32 linker_stage(lbGenerator *gen) {
 					String lib_name = lib;
 					lib_name = remove_extension_from_path(lib_name);
 					lib_str = gb_string_append_fmt(lib_str, " -framework %.*s ", LIT(lib_name));
-				} else if (string_ends_with(lib, str_lit(".a")) || 
-                     string_ends_with(lib, str_lit(".o")) || 
-                     string_ends_with(lib, str_lit(".dylib"))) 
-        {
-          // For:
-          // object 
-          // dynamic lib
-					// static libs, absolute full path relative to the file in which the lib was imported from
-					lib_str = gb_string_append_fmt(lib_str, " %.*s ", LIT(lib));
-				} else {
+				} else if (string_ends_with(lib, str_lit(".a")) || string_ends_with(lib, str_lit(".o")) || string_ends_with(lib, str_lit(".dylib"))) {
+                        // For:
+                        // object 
+                        // dynamic lib
+                        // static libs, absolute full path relative to the file in which the lib was imported from
+    					lib_str = gb_string_append_fmt(lib_str, " %.*s ", LIT(lib));
+    			} else {
 					// dynamic or static system lib, just link regularly searching system library paths
 					lib_str = gb_string_append_fmt(lib_str, " -l%.*s ", LIT(lib));
 				}
@@ -434,12 +431,12 @@ i32 linker_stage(lbGenerator *gen) {
 				" -e _main "
 			#endif
 			, linker, object_files, LIT(output_base), LIT(output_ext),
-      #if defined(GB_SYSTEM_OSX)
-        "-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib",
-      #else
-        "-lc -lm",
-      #endif
-      lib_str,
+            #if defined(GB_SYSTEM_OSX)
+                "-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib",
+            #else
+                "-lc -lm",
+            #endif
+            lib_str,
 			LIT(build_context.link_flags),
 			LIT(build_context.extra_linker_flags),
 			link_settings);
@@ -2139,16 +2136,13 @@ int main(int arg_count, char const **arg_ptr) {
 						String lib_name = lib;
 						lib_name = remove_extension_from_path(lib_name);
 						lib_str = gb_string_append_fmt(lib_str, " -framework %.*s ", LIT(lib_name));
-					} else if (string_ends_with(lib, str_lit(".a")) || 
-                     string_ends_with(lib, str_lit(".o")) || 
-                     string_ends_with(lib, str_lit(".dylib"))) 
-        {
-          // For:
-          // object 
-          // dynamic lib
-					// static libs, absolute full path relative to the file in which the lib was imported from
-					lib_str = gb_string_append_fmt(lib_str, " %.*s ", LIT(lib));
-				} else {
+					} else if (string_ends_with(lib, str_lit(".a")) || string_ends_with(lib, str_lit(".o")) || string_ends_with(lib, str_lit(".dylib"))) {
+                        // For:
+                        // object 
+                        // dynamic lib
+                        // static libs, absolute full path relative to the file in which the lib was imported from
+    					lib_str = gb_string_append_fmt(lib_str, " %.*s ", LIT(lib));
+    				} else {
 						// dynamic or static system lib, just link regularly searching system library paths
 						lib_str = gb_string_append_fmt(lib_str, " -l%.*s ", LIT(lib));
 					}
@@ -2226,11 +2220,11 @@ int main(int arg_count, char const **arg_ptr) {
 				#endif
 				, linker, LIT(output_base), LIT(output_base), LIT(output_ext),
 				lib_str,
-        #if defined(GB_SYSTEM_OSX)
-          "-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib",
-        #else
-          "-lc -lm",
-        #endif
+                #if defined(GB_SYSTEM_OSX)
+                    "-lSystem -lm -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib",
+                #else
+                    "-lc -lm",
+                #endif
 				LIT(build_context.link_flags),
 				LIT(build_context.extra_linker_flags),
 				link_settings);


### PR DESCRIPTION
Last time I fixed the linking for odin on macOS11, it seems like the tests I did at that time where not extensive enough so this is now a fixup for the linking part. I also added the fix for .o linking and combine all of these cases to a single branch as it doesn't do anything different really for the linking side.