### PR TITLE
allow absolute filepaths on windows

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -4724,7 +4724,7 @@ gb_global Rune illegal_import_runes[] = {
 	'\\', // NOTE(bill): Disallow windows style filepaths
 	'!', '$', '%', '^', '&', '*', '(', ')', '=', '+',
 	'[', ']', '{', '}',
-	';', ':', '#',
+	';', '#',
 	'|', ',',  '<', '>', '?',
 };
 


### PR DESCRIPTION
this removes the colon from "illegal_import_runes" so absolute filepaths are allowed on windows (*nix stuff doesn't have C: etc).