### PR TITLE
allow build to support all x64 cpus

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ if [ "$release_mode" -eq "0" ]; then
 	other_args="${other_args} -g"
 fi
 if [ "$release_mode" -eq "1" ]; then
-	other_args="${other_args} -O3 -march=native"
+	other_args="${other_args} -O3"
 fi
 
 if [[ "$(uname)" == "Darwin" ]]; then


### PR DESCRIPTION
-march=native is a build machine specific option that the nightly builds are compiled with. this does not support all x64 processors as it will use instructions that are not universal. this has crashed my machine (Illegal instruction) before and i had though that this had been removed, must have been in error in communication. if so, sorry about that.