### PR TITLE
Fix _queue_increase_capacity to copy correct slice

### DIFF
--- a/core/container/queue.odin
+++ b/core/container/queue.odin
@@ -163,10 +163,8 @@ _queue_increase_capacity :: proc(q: ^$Q/Queue($T), new_capacity: int) {
 	end := array_len(q.data);
 	array_resize(&q.data, new_capacity);
 	if q.offset + q.len > end {
-		end_items := q.len + end;
 		data := array_slice(q.data);
-		copy(data[new_capacity-end_items:][:end_items], data[q.offset:][:end_items]);
-		q.offset += new_capacity - end;
+		copy(data[end:][:q.offset], data[0:][:q.offset]);
 	}
 }
 _queue_grow :: proc(q: ^$Q/Queue($T), min_capacity: int = 0) {

--- a/core/container/queue.odin
+++ b/core/container/queue.odin
@@ -163,8 +163,11 @@ _queue_increase_capacity :: proc(q: ^$Q/Queue($T), new_capacity: int) {
 	end := array_len(q.data);
 	array_resize(&q.data, new_capacity);
 	if q.offset + q.len > end {
+		end_items := end - q.offset;
+		new_offset := new_capacity - end_items;
 		data := array_slice(q.data);
-		copy(data[end:][:q.offset], data[0:][:q.offset]);
+		copy(data[new_offset:], data[q.offset:][:end_items]);
+		q.offset = new_offset;
 	}
 }
 _queue_grow :: proc(q: ^$Q/Queue($T), min_capacity: int = 0) {


### PR DESCRIPTION
This function was previously copying a large, overlapping
range of data when the queue resized. The function caused
program to fail on out of bounds slices if the queue was
pop_front-ed from (offset > 0) and resized on full.

New code copies the range [0:offset] to [end:end+offset] where
end is the previous size of the queue buffer

Additional note: this fix made a failing Day 7 Advent of Code program produce the correct result 😄 