### PR TITLE
Add Nix derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,27 @@
+{ pkgs ? import <nixpkgs> { } }:
+let
+  odin-unwrapped = pkgs.llvmPackages_11.stdenv.mkDerivation (rec {
+    name = "odin-unwrapped";
+    src = ./.;
+    dontConfigure = true;
+    nativeBuildInputs = [ pkgs.git ];
+    buildPhase = ''
+      make debug SHELL=${pkgs.llvmPackages_11.stdenv.shell}
+    '';
+    installPhase = ''
+      mkdir -p $out/bin
+      cp odin $out/bin/odin
+      cp -r core $out/bin/core
+    '';
+  });
+  path = builtins.map (path: path + "/bin") (with pkgs.llvmPackages_11; [
+    bintools
+    llvm
+    clang
+    lld
+  ]);
+in
+pkgs.writeScriptBin "odin" ''
+  #!${pkgs.llvmPackages_11.stdenv.shell} 
+  PATH="${(builtins.concatStringsSep ":" path)}" exec ${odin-unwrapped}/bin/odin $@
+''


### PR DESCRIPTION
This pull request adds a Nix derivation to help with building and development to anyone using the Nix/NixOS ecosystem.
The derivation builds successfully Odin (using a wrapper to bring the LLVM tools and Clang to it's PATH) and the compiled result manages to run the demo `examples/demo/demo.odin` successfully as well (although it can't be done during the build phase due to the need to make a wrapper script for it, so the test was made after the Nix build succeeded.)