### PR TITLE
Fix layout of Stat for linux and make usage consistent

### DIFF
--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -186,7 +186,7 @@ RTLD_FIRST    :: 0x100;
 // "Argv" arguments converted to Odin strings
 args := _alloc_command_line_arguments();
 
-_File_Time :: struct {
+Unix_File_Time :: struct {
 	seconds: i64,
 	nanoseconds: i64,
 }
@@ -200,10 +200,10 @@ Stat :: struct {
 	gid:           u32, // Group ID of the file's group
 	rdev:          i32, // Device ID, if device
 
-	last_access:   _File_Time, // Time of last access
-	modified:      _File_Time, // Time of last modification
-	status_change: _File_Time, // Time of last status change
-	created:       _File_Time, // Time of creation
+	last_access:   Unix_File_Time, // Time of last access
+	modified:      Unix_File_Time, // Time of last modification
+	status_change: Unix_File_Time, // Time of last status change
+	created:       Unix_File_Time, // Time of creation
 
 	size:          i64,  // Size of the file, in bytes
 	blocks:        i64,  // Number of blocks allocated for the file

--- a/core/os/os_freebsd.odin
+++ b/core/os/os_freebsd.odin
@@ -144,7 +144,7 @@ RTLD_NOLOAD       :: 0x02000;
 
 args := _alloc_command_line_arguments();
 
-_File_Time :: struct {
+Unix_File_Time :: struct {
 	seconds: i64,
 	nanoseconds: c.long,
 }
@@ -162,10 +162,10 @@ Stat :: struct {
 	_padding1: i32,
 	rdev: u64,
 
-	last_access: File_Time,
-	modified: File_Time,
-	status_change: File_Time,
-	birthtime: File_Time,
+	last_access: Unix_File_Time,
+	modified: Unix_File_Time,
+	status_change: Unix_File_Time,
+	birthtime: Unix_File_Time,
 
 	size: i64,
 	blocks: i64,
@@ -328,7 +328,8 @@ last_write_time :: proc(fd: Handle) -> (File_Time, Errno) {
 	if err != ERROR_NONE {
 		return 0, err;
 	}
-	return File_Time(s.modified), ERROR_NONE;
+	modified := s.modified.seconds * 1_000_000_000 + s.modified.nanoseconds;
+	return File_Time(modified), ERROR_NONE;
 }
 
 last_write_time_by_name :: proc(name: string) -> (File_Time, Errno) {
@@ -336,7 +337,8 @@ last_write_time_by_name :: proc(name: string) -> (File_Time, Errno) {
 	if err != ERROR_NONE {
 		return 0, err;
 	}
-	return File_Time(s.modified), ERROR_NONE;
+	modified := s.modified.seconds * 1_000_000_000 + s.modified.nanoseconds;
+	return File_Time(modified), ERROR_NONE;
 }
 
 stat :: inline proc(path: string) -> (Stat, Errno) {

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -179,7 +179,7 @@ RTLD_GLOBAL       :: 0x100;
 // "Argv" arguments converted to Odin strings
 args := _alloc_command_line_arguments();
 
-_File_Time :: struct {
+Unix_File_Time :: struct {
 	seconds:     i64,
 	nanoseconds: i64,
 }
@@ -197,9 +197,9 @@ Stat :: struct {
 	block_size:    i64, // Optimal bllocksize for I/O
 	blocks:        i64, // Number of 512-byte blocks allocated
 
-	last_access:   File_Time, // Time of last access
-	status_change: File_Time, // Time of last status change
-	modified:      File_Time, // Time of last modification
+	last_access:   Unix_File_Time, // Time of last access
+	modified:      Unix_File_Time, // Time of last modification
+	status_change: Unix_File_Time, // Time of last status change
 
 	_reserve1,
 	_reserve2,
@@ -364,7 +364,8 @@ last_write_time :: proc(fd: Handle) -> (File_Time, Errno) {
 	if err != ERROR_NONE {
 		return 0, err;
 	}
-	return File_Time(s.modified), ERROR_NONE;
+	modified := s.modified.seconds * 1_000_000_000 + s.modified.nanoseconds;
+	return File_Time(modified), ERROR_NONE;
 }
 
 last_write_time_by_name :: proc(name: string) -> (File_Time, Errno) {
@@ -372,7 +373,8 @@ last_write_time_by_name :: proc(name: string) -> (File_Time, Errno) {
 	if err != ERROR_NONE {
 		return 0, err;
 	}
-	return File_Time(s.modified), ERROR_NONE;
+	modified := s.modified.seconds * 1_000_000_000 + s.modified.nanoseconds;
+	return File_Time(modified), ERROR_NONE;
 }
 
 stat :: inline proc(path: string) -> (Stat, Errno) {


### PR DESCRIPTION
The Stat structure has the wrong size in linux, which was causing stack corruption in opt:2 and higher. This corrects the structure and renames the type to prevent future confusion.

I've made similar changes to Darwin and BSD, but am unable to test them myself.