### PR TITLE
Remove double removal of extension when using the -out option.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -875,12 +875,6 @@ bool parse_build_flags(Array<String> args) {
 							String path = value.value_string;
 							path = string_trim_whitespace(path);
 							if (is_build_flag_path_valid(path)) {
-								#if defined(GB_SYSTEM_WINDOWS)
-									String ext = path_extension(path);
-									if (ext == ".exe") {
-										path = substring(path, 0, string_extension_position(path));
-									}
-								#endif
 								build_context.out_filepath = path_to_full_path(heap_allocator(), path);
 							} else {
 								gb_printf_err("Invalid -out path, got %.*s\n", LIT(path));


### PR DESCRIPTION
When specifying the out parameter, the extension was stripped twice.
If your path contains a ".", this caused issues.

e.g.
cd "C:\Repro\Path With a . In The Name\"
odin run repro.odin -keep-temp-files -out repro.exe

This would cause the files to end up as:
"C:\Repro\Path With a.exe", "C:\Repro\Path With a.ll", "C:\Repro\Path With a.bc" and "C:\Repro\Path With a.obj"

With this patch it works as expected, with or without a . in the file path.