### PR TITLE
Fix nullref access violation when building with no entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ bld/
 ![Cc]ore/[Ll]og/
 # Visual Studio 2015 cache/options directory
 .vs/
+# Visual Studio Code options directory
+.vscode/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 demo

--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -1907,7 +1907,7 @@ void generate_minimum_dependency_set(Checker *c, Entity *start) {
 				array_add(&c->info.testing_procedures, e);
 			}
 		}
-	} else {
+	} else if (start != nullptr) {
 		start->flags |= EntityFlag_Used;
 		add_dependency_to_set(c, start);
 	}


### PR DESCRIPTION
The compilation of any dll would fail silently due to an access violation on a null start pointer.