### PR TITLE
Add LLVM boolean compatibility to result types

### DIFF
--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -2388,6 +2388,18 @@ Type *type_to_abi_compat_result_type(gbAllocator a, Type *original_type, ProcCal
 		new_type = tuple;
 	}
 
+	if (cc == ProcCC_None) {
+	  for_array(i, new_type->Tuple.variables) {
+	    Type *result_type = new_type->Tuple.variables[i]->type;
+	    if (is_type_boolean(result_type)) {
+	      Type *t = core_type(base_type(result_type));
+	      if (t == t_bool) {
+	        new_type->Tuple.variables[i]->type = t_llvm_bool;
+	      }
+	    }
+	  }
+	}
+
 	new_type->cached_size = -1;
 	new_type->cached_align = -1;
 	return new_type;


### PR DESCRIPTION
This converts `bool` result types to `llvm_bool` when using the "none" calling convention, in a similar fashion to how we [convert param types](https://github.com/odin-lang/Odin/blob/84bb3499005e89184a46dc34dc575fd879cb6f26/src/check_type.cpp#L2181-L2187). This allows us to bind and use LLVM intrinsics that return an `i1` "one bit" boolean, such as these [overflow intrinsics](https://github.com/odin-lang/Odin/blob/84bb3499005e89184a46dc34dc575fd879cb6f26/core/math/bits/bits.odin#L179-L189).