### PR TITLE
Run an early memcpy pass regardless of the opt flag and return large structs by pointer on linux

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -873,7 +873,7 @@ void init_build_context(TargetMetrics *cross_target) {
 		//   -memcpyopt: MemCpy optimization
 	}
 	if (bc->ODIN_DEBUG == false) {
-		opt_flags = gb_string_appendc(opt_flags, "-mem2reg -memcpyopt -die ");
+		opt_flags = gb_string_appendc(opt_flags, "-mem2reg -die ");
 	}
 
 

--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -2423,7 +2423,7 @@ bool abi_compat_return_by_pointer(gbAllocator a, ProcCallingConvention cc, Type 
 		}
 	}
 
-	if (build_context.ODIN_OS == "windows") {
+	if (build_context.ODIN_OS == "windows" || build_context.ODIN_OS == "linux" ) {
 		i64 size = 8*type_size_of(abi_return_type);
 		switch (size) {
 		case 0:

--- a/src/ir_print.cpp
+++ b/src/ir_print.cpp
@@ -339,8 +339,7 @@ void ir_print_proc_type_without_pointer(irFileBuffer *f, irModule *m, Type *t) {
 		// ir_fprintf(f, "* sret noalias ");
 		// ir_write_string(f, str_lit("* noalias "));
 		ir_write_string(f, str_lit("*"));
-		if (build_context.ODIN_OS == "darwin" ||
-		    build_context.ODIN_OS == "linux") {
+		if (build_context.ODIN_OS == "darwin") {
 			ir_fprintf(f, " byval");
 		}
 		if (param_count > 0 || t->Proc.calling_convention == ProcCC_Odin)  {
@@ -2456,8 +2455,7 @@ void ir_print_proc(irFileBuffer *f, irModule *m, irProcedure *proc) {
 	if (proc_type->return_by_pointer) {
 		ir_print_type(f, m, reduce_tuple_to_single_type(proc_type->results));
 		ir_write_str_lit(f, "* sret noalias ");
-		if (build_context.ODIN_OS == "darwin" ||
-		    build_context.ODIN_OS == "linux") {
+		if (build_context.ODIN_OS == "darwin") {
 			ir_fprintf(f, "byval ");
 		}
 		ir_write_str_lit(f, "%agg.result");


### PR DESCRIPTION
This should reduce the long compile times due to llc/opt by a significant amount.