### PR TITLE
Add package declaration specific error message

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -5219,11 +5219,15 @@ bool parse_file(Parser *p, AstFile *f) {
 	}
 
 	CommentGroup *docs = f->lead_comment;
+	
+	f->package_token = f->curr_token;
+	advance_token(f);
 
-	f->package_token = expect_token(f, Token_package);
 	if (f->package_token.kind != Token_package) {
+		syntax_error(f->package_token, "Expected package declaration on first line.");
 		return false;
 	}
+
 	Token package_name = expect_token_after(f, Token_Ident, "package");
 	if (package_name.kind == Token_Ident) {
 		if (package_name.string == "_") {


### PR DESCRIPTION
If the first token is not `package` a specific error message is emitted, instead of the default `expect_token` message. This should be a little more user-friendly. 

For example:
```
//test.odin
//package main

main :: proc() {
}
```

Now outputs the error message: `test.odin(3:1) Syntax Error: Expected package declaration on first line.`
Instead of the previous generic message: `test.odin(3:1) Syntax Error: Expected 'package', got 'identifier'`

Side note: is package declaration a correct definition or should this be called something else?