### PR TITLE
Allow seeding CRC32, CRC64 & Adler32 with previous partial hash.

### DIFF
--- a/core/hash/crc.odin
+++ b/core/hash/crc.odin
@@ -1,14 +1,14 @@
 package hash
 
-crc32 :: proc(data: []byte) -> u32 #no_bounds_check {
-	result := ~u32(0);
+crc32 :: proc(data: []byte, seed := u32(0)) -> u32 #no_bounds_check {
+	result := ~u32(seed);
 	for b in data {
 		result = result>>8 ~ _crc32_table[(result ~ u32(b)) & 0xff];
 	}
 	return ~result;
 }
-crc64 :: proc(data: []byte) -> u64 #no_bounds_check {
-	result := ~u64(0);
+crc64 :: proc(data: []byte, seed := u32(0)) -> u64 #no_bounds_check {
+	result := ~u64(seed);
 	for b in data {
 		result = result>>8 ~ _crc64_table[(result ~ u64(b)) & 0xff];
 	}

--- a/core/hash/hash.odin
+++ b/core/hash/hash.odin
@@ -2,9 +2,9 @@ package hash
 
 import "core:mem"
 
-adler32 :: proc(data: []byte) -> u32 {
+adler32 :: proc(data: []byte, seed := u32(1)) -> u32 {
 	ADLER_CONST :: 65521;
-	a, b: u32 = 1, 0;
+	a, b: u32 = seed & 0xFFFF, seed >> 16;
 	for x in data {
 		a = (a + u32(x)) % ADLER_CONST;
 		b = (b + a) % ADLER_CONST;


### PR DESCRIPTION
When writing chunked formats like PNG, sometimes you just want to calculate a hash on a length field's bytes, then extend the hash with the actual contents, without first having to concatenate the two into a new buffer before passing them to a hash function.

It may also at times be cheaper to compute a rolling hash as you output. Computing a hash over the entirety of contents is not always feasible either, think large files you don't necessarily want to load completely.

```odin
Foo     := []u8{'F', 'o','o', '3', 'F', 'o', 'o', '4'};
crc     := hash.crc32(Foo[0:4]);
crc      = hash.crc32(Foo[4:], crc);
crc_all := hash.crc32(Foo);

fmt.printf("%8x %8x\n", crc, crc_all);
```
d6285ff7 d6285ff7

```odin
a32     := hash.adler32(Foo[0:4]);
a32      = hash.adler32(Foo[4:], a32);
a32_all := hash.adler32(Foo);
fmt.printf("%8x %8x\n", a32, a32_all);
```
0c5102b0 0c5102b0