### PR TITLE
Parser fixes

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -1564,10 +1564,6 @@ check_field_flag_prefixes :: proc(p: ^Parser, name_count: int, allowed_flags, se
 		}
 	}
 
-	if .Using in allowed_flags && .Using in flags {
-		flags &~= {.Using};
-	}
-
 	return flags;
 }
 

--- a/core/odin/tokenizer/tokenizer.odin
+++ b/core/odin/tokenizer/tokenizer.odin
@@ -236,7 +236,7 @@ scan_raw_string :: proc(t: ^Tokenizer) -> string {
 	for {
 		ch := t.ch;
 		if ch == utf8.RUNE_EOF {
-			error(t, offset, "string literal was not terminated");
+			error(t, offset, "raw string literal was not terminated");
 			break;
 		}
 		advance_rune(t);

--- a/core/odin/tokenizer/tokenizer.odin
+++ b/core/odin/tokenizer/tokenizer.odin
@@ -235,8 +235,8 @@ scan_raw_string :: proc(t: ^Tokenizer) -> string {
 
 	for {
 		ch := t.ch;
-		if ch == '\n' || ch < 0 {
-			error(t, offset, "raw string literal was not terminated");
+		if ch == utf8.RUNE_EOF {
+			error(t, offset, "string literal was not terminated");
 			break;
 		}
 		advance_rune(t);


### PR DESCRIPTION
Fixes: 
Give error when raw string literals hit EOF instead of newline. 
Don't remove .Using flag when it exists in flags and allowed flags.