### PR TITLE
New Windows types and APIs for future `os.start_process` call.

### DIFF
--- a/core/sys/windows/advapi32.odin
+++ b/core/sys/windows/advapi32.odin
@@ -10,3 +10,30 @@ foreign advapi32 {
 	                         DesiredAccess: DWORD,
 	                         TokenHandle: ^HANDLE) -> BOOL ---
 }
+// Necessary to create a token to impersonate a user with for CreateProcessAsUser
+@(default_calling_convention="stdcall")
+foreign advapi32 {
+	LogonUserW :: proc(
+		lpszUsername: LPCWSTR,
+		lpszDomain: LPCWSTR,
+		lpszPassword: LPCWSTR,
+		dwLogonType: Logon32_Type,
+		dwLogonProvider: Logon32_Provider,
+		phToken: PHANDLE,
+	) -> BOOL ---
+
+	/*
+	LogonUserExW :: proc(
+		lpszUsername: LPCWSTR,
+		lpszDomain:   LPCWSTR,
+		lpszPassword: LPCWSTR,
+		dwLogonType:  DWORD,
+		dwLogonProvider: DWORD,
+		phToken: PHANDLE,
+		ppLogonSid: PSID,
+		ppProfileBuffer: PVOID,
+		pdwProfileLength: LPDWORD,
+		pQuotaLimits: PQUOTA_LIMITS,
+	) -> BOOL ---
+	*/
+}

--- a/core/sys/windows/kernel32.odin
+++ b/core/sys/windows/kernel32.odin
@@ -132,6 +132,19 @@ foreign kernel32 {
 		lpStartupInfo: LPSTARTUPINFO,
 		lpProcessInformation: LPPROCESS_INFORMATION,
 	) -> BOOL ---
+	CreateProcessAsUserW :: proc(
+		hToken: HANDLE,
+		lpApplicationName: LPCWSTR,
+		lpCommandLine: LPWSTR,
+		lpProcessAttributes: LPSECURITY_ATTRIBUTES,
+		lpThreadAttributes: LPSECURITY_ATTRIBUTES,
+		bInheritHandles: BOOL,
+		dwCreationFlags: DWORD,
+		lpEnvironment: LPVOID,
+		lpCurrentDirectory: LPCWSTR,
+		lpStartupInfo: LPSTARTUPINFO,
+		lpProcessInformation: LPPROCESS_INFORMATION,
+	) -> BOOL ---
 	GetEnvironmentVariableW :: proc(n: LPCWSTR, v: LPWSTR, nsize: DWORD) -> DWORD ---
 	SetEnvironmentVariableW :: proc(n: LPCWSTR, v: LPCWSTR) -> BOOL ---
 	GetEnvironmentStringsW :: proc() -> LPWCH ---

--- a/core/sys/windows/types.odin
+++ b/core/sys/windows/types.odin
@@ -75,6 +75,7 @@ PCSTR :: cstring;
 PCWSTR :: wstring;
 PDWORD :: ^DWORD;
 LPHANDLE :: ^HANDLE;
+PHANDLE :: ^HANDLE;
 LPOVERLAPPED :: ^OVERLAPPED;
 LPPROCESS_INFORMATION :: ^PROCESS_INFORMATION;
 PSECURITY_ATTRIBUTES :: ^SECURITY_ATTRIBUTES;
@@ -787,4 +788,76 @@ OSVERSIONINFOEXW :: struct {
     wSuiteMask:          USHORT,
     wProductType:        UCHAR,
     wReserved:           UCHAR,
+};
+
+// https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-quota_limits
+// Used in LogonUserExW
+PQUOTA_LIMITS :: struct {
+	PagedPoolLimit: SIZE_T,
+	NonPagedPoolLimit: SIZE_T,
+	MinimumWorkingSetSize: SIZE_T,
+	MaximumWorkingSetSize: SIZE_T,
+	PagefileLimit: SIZE_T,
+	TimeLimit: LARGE_INTEGER,
+};
+
+Logon32_Type :: enum DWORD {
+	INTERACTIVE       = 2,
+	NETWORK           = 3,
+	BATCH             = 4,
+	SERVICE           = 5,
+	UNLOCK            = 7,
+	NETWORK_CLEARTEXT = 8,
+	NEW_CREDENTIALS   = 9,
+}
+
+Logon32_Provider :: enum DWORD {
+	DEFAULT = 0,
+	WINNT35 = 1,
+	WINNT40 = 2,
+	WINNT50 = 3,
+	VIRTUAL = 4,
+}
+
+// https://docs.microsoft.com/en-us/windows/win32/api/profinfo/ns-profinfo-profileinfow
+// Used in LoadUserProfileW
+
+PROFILEINFOW :: struct {
+	dwSize: DWORD,
+	dwFlags: DWORD,
+	lpUserName: LPWSTR,
+	lpProfilePath: LPWSTR,
+	lpDefaultPath: LPWSTR,
+	lpServerName: LPWSTR,
+	lpPolicyPath: LPWSTR,
+  	hProfile: HANDLE,
+};
+
+// Used in LookupAccountNameW
+SID_NAME_USE :: distinct DWORD;
+
+SID_TYPE :: enum SID_NAME_USE {
+  SidTypeUser = 1,
+  SidTypeGroup,
+  SidTypeDomain,
+  SidTypeAlias,
+  SidTypeWellKnownGroup,
+  SidTypeDeletedAccount,
+  SidTypeInvalid,
+  SidTypeUnknown,
+  SidTypeComputer,
+  SidTypeLabel,
+  SidTypeLogonSession
+}
+
+// https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-sid
+SID :: struct {
+	Revision: byte,
+	SubAuthorityCount: byte,
+	IdentifierAuthority: SID_IDENTIFIER_AUTHORITY,
+	SubAuthority: ^[]DWORD,
+};
+
+SID_IDENTIFIER_AUTHORITY :: struct {
+    Value: [6]u8,
 };

--- a/core/sys/windows/userenv.odin
+++ b/core/sys/windows/userenv.odin
@@ -7,4 +7,44 @@ foreign userenv {
 	GetUserProfileDirectoryW :: proc(hToken: HANDLE,
 	                                 lpProfileDir: LPWSTR,
 	                                 lpcchSize: ^DWORD) -> BOOL ---
+	LoadUserProfileW :: proc(
+		hToken: HANDLE,
+		lpProfileInfo: ^PROFILEINFOW,
+	) -> BOOL ---
+
+	// https://docs.microsoft.com/en-us/windows/win32/api/userenv/nf-userenv-createprofile
+	// The caller must have administrator privileges to call this function.
+	CreateProfile :: proc(
+		pszUserSid: LPCWSTR,
+		pszUserName: LPCWSTR,
+		pszProfilePath: LPWSTR,
+		cchProfilePath: DWORD,
+	) -> HRESULT ---
+
+	// https://docs.microsoft.com/en-us/windows/win32/api/userenv/nf-userenv-deleteprofilew
+	// The caller must have administrative privileges to delete a user's profile.
+	DeleteProfileW :: proc(
+		lpSidString: LPCWSTR,
+		lpProfilePath: LPCWSTR,
+		lpComputerName: LPCWSTR,
+	) -> BOOL ---
+
+	// https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-lookupaccountnamew
+	// To look up the SID to use with DeleteProfileW.
+	LookupAccountNameW :: proc(
+		lpSystemName: LPCWSTR,
+		lpAccountName: LPCWSTR,
+		Sid: ^SID,
+		cbSid: LPDWORD,
+		ReferencedDomainName: LPWSTR,
+		cchReferencedDomainName: LPDWORD,
+		peUse: ^SID_TYPE,
+	) -> BOOL ---
+
+	// https://docs.microsoft.com/en-us/windows/win32/api/sddl/nf-sddl-convertsidtostringsida
+	// To turn a SID into a string SID to use with DeleteProfileW.
+	ConvertSidToStringSidW :: proc(
+		Sid: ^SID,
+	  	StringSid: LPWSTR,
+	) -> BOOL ---
 }


### PR DESCRIPTION
Groundwork for `os.start_process` on Windows, adding additional types and APIs to allow starting a child process, creating and deleting a user profile and handling security tokens.