### PR TITLE
Add's Handling for Return Values for Linker-Stage

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2523,7 +2523,6 @@ int main(int arg_count, char const **arg_ptr) {
 				}
 			}
 
-      gb_printf("Started Linking!");
 			i32 result = system_exec_command_line_app("ld-link",
 				"%s \"%.*s.o\" -o \"%.*s%.*s\" %s "
 				" %s "


### PR DESCRIPTION
I added return values so that if the linker fails it also gets reflected in the return value of the program. 
Tried to use gb_exit and exit but zsh behaved weird with both of them. 

This is related to #895 