### PR TITLE
Convert `core:compress` and `core:image` error checks to new union co…

### DIFF
--- a/core/compress/common.odin
+++ b/core/compress/common.odin
@@ -3,12 +3,6 @@ package compress
 import "core:io"
 import "core:image"
 
-// Error helper, e.g. is_kind(err, General_Error.OK);
-is_kind :: proc(u: $U, x: $V) -> bool {
-    v, ok := u.(V);
-    return ok && v == x;
-}
-
 Error :: union {
 	General_Error,
 	Deflate_Error,

--- a/core/compress/gzip/example.odin
+++ b/core/compress/gzip/example.odin
@@ -35,7 +35,7 @@ main :: proc() {
 	if len(args) < 2 {
 		stderr("No input file specified.\n");
 		err := gzip.load(TEST, &buf);
-		if gzip.is_kind(err, gzip.E_General.OK) {
+		if err != E_General.OK {
 			stdout("Displaying test vector: ");
 			stdout(bytes.buffer_to_string(&buf));
 			stdout("\n");
@@ -54,8 +54,8 @@ main :: proc() {
 		} else {
 			err = gzip.load(file, &buf);
 		}
-		if !gzip.is_kind(err, gzip.E_General.OK) {
-			if gzip.is_kind(err, gzip.E_General.File_Not_Found) {
+		if err != gzip.E_General.OK {
+			if err != E_General.File_Not_Found {
 				stderr("File not found: ");
 				stderr(file);
 				stderr("\n");

--- a/core/compress/gzip/gzip.odin
+++ b/core/compress/gzip/gzip.odin
@@ -94,7 +94,6 @@ E_General :: compress.General_Error;
 E_GZIP    :: compress.GZIP_Error;
 E_ZLIB    :: compress.ZLIB_Error;
 E_Deflate :: compress.Deflate_Error;
-is_kind   :: compress.is_kind;
 
 load_from_slice :: proc(slice: []u8, buf: ^bytes.Buffer, allocator := context.allocator) -> (err: Error) {
 
@@ -278,7 +277,7 @@ load_from_stream :: proc(stream: io.Stream, buf: ^bytes.Buffer, allocator := con
 
 	// fmt.printf("ZLIB returned: %v\n", zlib_error);
 
-	if !is_kind(zlib_error, E_General.OK) || zlib_error == nil {
+	if zlib_error != E_General.OK || zlib_error == nil {
 		return zlib_error;
 	}
 

--- a/core/compress/zlib/example.odin
+++ b/core/compress/zlib/example.odin
@@ -33,7 +33,7 @@ main :: proc() {
 	err := zlib.inflate(ODIN_DEMO, &buf);
 	defer bytes.buffer_destroy(&buf);
 
-	if !zlib.is_kind(err, zlib.E_General.OK) {
+	if err != zlib.E_General.OK {
 		fmt.printf("\nError: %v\n", err);
 	}
 	s := bytes.buffer_to_string(&buf);

--- a/core/compress/zlib/zlib.odin
+++ b/core/compress/zlib/zlib.odin
@@ -8,7 +8,7 @@ import "core:bytes"
 import "core:hash"
 /*
 	zlib.inflate decompresses a ZLIB stream passed in as a []u8 or io.Stream.
-	Returns: Error. You can use zlib.is_kind or compress.is_kind to easily test for OK.
+	Returns: Error.
 */
 
 Context :: compress.Context;
@@ -34,7 +34,6 @@ Error     :: compress.Error;
 E_General :: compress.General_Error;
 E_ZLIB    :: compress.ZLIB_Error;
 E_Deflate :: compress.Deflate_Error;
-is_kind   :: compress.is_kind;
 
 DEFLATE_MAX_CHUNK_SIZE   :: 65535;
 DEFLATE_MAX_LITERAL_SIZE :: 65535;
@@ -256,7 +255,7 @@ decode_huffman :: proc(z: ^Context, t: ^Huffman_Table) -> (r: u16, err: Error) #
 parse_huffman_block :: proc(z: ^Context, z_repeat, z_offset: ^Huffman_Table) -> (err: Error) #no_bounds_check {
 	#no_bounds_check for {
 		value, e := decode_huffman(z, z_repeat);
-		if !is_kind(e, E_General.OK) {
+		if e != E_General.OK {
 			return err;
 		}
 		if value < 256 {
@@ -277,7 +276,7 @@ parse_huffman_block :: proc(z: ^Context, z_repeat, z_offset: ^Huffman_Table) -> 
 			}
 
 			value, e = decode_huffman(z, z_offset);
-			if !is_kind(e, E_General.OK) {
+			if e != E_General.OK {
 				return E_Deflate.Bad_Huffman_Code;
 			}
 
@@ -390,7 +389,7 @@ inflate_from_stream :: proc(using ctx: ^Context, raw := false, allocator := cont
 
  	// Parse ZLIB stream without header.
 	err = inflate_raw(ctx);
-	if !is_kind(err, E_General.OK) {
+	if err != E_General.OK {
 		return err;
 	}
 
@@ -418,15 +417,15 @@ inflate_from_stream_raw :: proc(z: ^Context, allocator := context.allocator) -> 
 	codelength_ht: ^Huffman_Table;
 
 	z_repeat, err = allocate_huffman_table(allocator=context.allocator);
-	if !is_kind(err, E_General.OK) {
+	if err != E_General.OK {
 		return err;
 	}
 	z_offset, err = allocate_huffman_table(allocator=context.allocator);
-	if !is_kind(err, E_General.OK) {
+	if err != E_General.OK {
 		return err;
 	}
 	codelength_ht, err = allocate_huffman_table(allocator=context.allocator);
-	if !is_kind(err, E_General.OK) {
+	if err != E_General.OK {
 		return err;
 	}
 	defer free(z_repeat);
@@ -482,11 +481,11 @@ inflate_from_stream_raw :: proc(z: ^Context, allocator := context.allocator) -> 
 			if type == 1 {
 				// Use fixed code lengths.
 				err = build_huffman(z_repeat, Z_FIXED_LENGTH[:]);
-				if !is_kind(err, E_General.OK) {
+				if err != E_General.OK {
 					return err;
 				}
 				err = build_huffman(z_offset, Z_FIXED_DIST[:]);
-				if !is_kind(err, E_General.OK) {
+				if err != E_General.OK {
 					return err;
 				}
 			} else {
@@ -507,7 +506,7 @@ inflate_from_stream_raw :: proc(z: ^Context, allocator := context.allocator) -> 
 					codelength_sizes[Z_LENGTH_DEZIGZAG[i]] = u8(s);
 				}
 				err = build_huffman(codelength_ht, codelength_sizes[:]);
-				if !is_kind(err, E_General.OK) {
+				if err != E_General.OK {
 					return err;
 				}
 
@@ -516,7 +515,7 @@ inflate_from_stream_raw :: proc(z: ^Context, allocator := context.allocator) -> 
 
 				for n < ntot {
 					c, err = decode_huffman(z, codelength_ht);
-					if !is_kind(err, E_General.OK) {
+					if err != E_General.OK {
 						return err;
 					}
 
@@ -560,18 +559,18 @@ inflate_from_stream_raw :: proc(z: ^Context, allocator := context.allocator) -> 
 				}
 
 				err = build_huffman(z_repeat, lencodes[:hlit]);
-				if !is_kind(err, E_General.OK) {
+				if err != E_General.OK {
 					return err;
 				}
 
 				err = build_huffman(z_offset, lencodes[hlit:ntot]);
-				if !is_kind(err, E_General.OK) {
+				if err != E_General.OK {
 					return err;
 				}
 			}
 			err = parse_huffman_block(z, z_repeat, z_offset);
 			// log.debugf("Err: %v | Final: %v | Type: %v\n", err, final, type);
-			if !is_kind(err, E_General.OK) {
+			if err != E_General.OK {
 				return err;
 			}
 		}

--- a/core/image/png/example.odin
+++ b/core/image/png/example.odin
@@ -23,7 +23,7 @@ main :: proc() {
 	img, err = png.load(file, options);
 	defer png.destroy(img);
 
-	if !png.is_kind(err, png.E_General.OK) {
+	if err != png.E_General.OK {
 		fmt.printf("Trying to read PNG file %v returned %v\n", file, err);
 	} else {
 		v:  png.Info;
@@ -120,7 +120,7 @@ main :: proc() {
 		}
 	}
 
-	if is_kind(err, E_General.OK) && .do_not_decompress_image not_in options && .info not_in options {
+	if err == E_General.OK && .do_not_decompress_image not_in options && .info not_in options {
 		if ok := write_image_as_ppm("out.ppm", img); ok {
 			fmt.println("Saved decoded image.");
 		} else {

--- a/core/image/png/helpers.odin
+++ b/core/image/png/helpers.odin
@@ -107,7 +107,7 @@ text :: proc(c: Chunk) -> (res: Text, ok: bool) {
 		buf: bytes.Buffer;
 		zlib_error := zlib.inflate_from_byte_array(fields[2], &buf);
 		defer bytes.buffer_destroy(&buf);
-		if !is_kind(zlib_error, E_General.OK) {
+		if zlib_error != E_General.OK {
 			ok = false; return;
 		}
 
@@ -161,7 +161,7 @@ text :: proc(c: Chunk) -> (res: Text, ok: bool) {
 			buf: bytes.Buffer;
 			zlib_error := zlib.inflate_from_byte_array(rest, &buf);
 			defer bytes.buffer_destroy(&buf);
-			if !is_kind(zlib_error, E_General.OK) {
+			if zlib_error != E_General.OK {
 
 				ok = false; return;
 			}
@@ -200,7 +200,7 @@ iccp :: proc(c: Chunk) -> (res: iCCP, ok: bool) {
 	// Set up ZLIB context and decompress iCCP payload
 	buf: bytes.Buffer;
 	zlib_error := zlib.inflate_from_byte_array(fields[2], &buf);
-	if !is_kind(zlib_error, E_General.OK) {
+	if zlib_error != E_General.OK {
 		bytes.buffer_destroy(&buf);
 		ok = false; return;
 	}
@@ -498,7 +498,7 @@ when false {
 		err = zlib.write_zlib_stream_from_memory(&ctx);
 
 		b: []u8;
-		if is_kind(err, E_General, E_General.OK) {
+		if err == E_General.OK {
 			b = ctx.out_buf[:];
 		} else {
 			return err;

--- a/core/image/png/png.odin
+++ b/core/image/png/png.odin
@@ -16,7 +16,6 @@ Error     :: compress.Error;
 E_General :: compress.General_Error;
 E_PNG     :: image.Error;
 E_Deflate :: compress.Deflate_Error;
-is_kind   :: compress.is_kind;
 
 Image     :: image.Image;
 Options   :: image.Options;
@@ -274,7 +273,7 @@ read_chunk :: proc(ctx: ^compress.Context) -> (Chunk, Error) {
 read_header :: proc(ctx: ^compress.Context) -> (IHDR, Error) {
 
 	c, e := read_chunk(ctx);
-	if !is_kind(e, E_General.OK) {
+	if e != E_General.OK {
 		return {}, e;
 	}
 
@@ -454,7 +453,7 @@ load_from_stream :: proc(stream: io.Stream, options := Options{}, allocator := c
 				seen_ihdr = true;
 
 				header, err = read_header(&ctx);
-				if !is_kind(err, E_General.OK) {
+				if err != E_General.OK {
 					return img, err;
 				}
 
@@ -507,7 +506,7 @@ load_from_stream :: proc(stream: io.Stream, options := Options{}, allocator := c
 				}
 
 				c, err = read_chunk(&ctx);
-				if !is_kind(err, E_General.OK) {
+				if err != E_General.OK {
 					return img, err;
 				}
 
@@ -542,7 +541,7 @@ load_from_stream :: proc(stream: io.Stream, options := Options{}, allocator := c
 				next := ch.type;
 				for next == .IDAT {
 					c, err = read_chunk(&ctx);
-					if !is_kind(err, E_General.OK) {
+					if err != E_General.OK {
 						return img, err;
 					}
 
@@ -562,7 +561,7 @@ load_from_stream :: proc(stream: io.Stream, options := Options{}, allocator := c
 				seen_idat = true;
 			case .IEND:
 				c, err = read_chunk(&ctx);
-				if !is_kind(err, E_General.OK) {
+				if err != E_General.OK {
 					return img, err;
 				}
 				seen_iend = true;
@@ -571,7 +570,7 @@ load_from_stream :: proc(stream: io.Stream, options := Options{}, allocator := c
 				// TODO: Make sure that 16-bit bKGD + tRNS chunks return u16 instead of u16be
 
 				c, err = read_chunk(&ctx);
-				if !is_kind(err, E_General.OK) {
+				if err != E_General.OK {
 					return img, err;
 				}
 				seen_bkgd = true;
@@ -606,7 +605,7 @@ load_from_stream :: proc(stream: io.Stream, options := Options{}, allocator := c
 				}
 			case .tRNS:
 				c, err = read_chunk(&ctx);
-				if !is_kind(err, E_General.OK) {
+				if err != E_General.OK {
 					return img, err;
 				}
 
@@ -648,7 +647,7 @@ load_from_stream :: proc(stream: io.Stream, options := Options{}, allocator := c
 			case:
 				// Unhandled type
 				c, err = read_chunk(&ctx);
-				if !is_kind(err, E_General.OK) {
+				if err != E_General.OK {
 					return img, err;
 				}
 				if .return_metadata in options {
@@ -676,7 +675,7 @@ load_from_stream :: proc(stream: io.Stream, options := Options{}, allocator := c
 	zlib_error := zlib.inflate(idat, &buf);
 	defer bytes.buffer_destroy(&buf);
 
-	if !is_kind(zlib_error, E_General.OK) {
+	if zlib_error != E_General.OK {
 		return {}, zlib_error;
 	} else {
 		/*
@@ -713,7 +712,7 @@ load_from_stream :: proc(stream: io.Stream, options := Options{}, allocator := c
 		as metadata, and set it instead to the raw number of channels.
 	*/
 	defilter_error := defilter(img, &buf, &header, options);
-	if !is_kind(defilter_error, E_General.OK) {
+	if defilter_error != E_General.OK {
 		bytes.buffer_destroy(&img.pixels);
 		return {}, defilter_error;
 	}


### PR DESCRIPTION
…mparison.

No more need for `is_kind(err, Error_Value)`, just test err == Error_Value.