### PR TITLE
Mark mem.slice_ptr_to_bytes as deprecated.

### DIFF
--- a/core/mem/mem.odin
+++ b/core/mem/mem.odin
@@ -142,6 +142,7 @@ slice_ptr :: proc(ptr: ^$T, len: int) -> []T {
 byte_slice :: #force_inline proc "contextless" (data: rawptr, len: int) -> []byte {
 	return transmute([]u8)Raw_Slice{data=data, len=max(len, 0)};
 }
+@(deprecated="use byte_slice")
 slice_ptr_to_bytes :: proc(data: rawptr, len: int) -> []byte {
 	return transmute([]u8)Raw_Slice{data=data, len=max(len, 0)};
 }


### PR DESCRIPTION
Use byte_slice instead.

We can't make it an alias *and* mark it as deprecated, regrettably:

```odin
byte_slice :: #force_inline proc "contextless" (data: rawptr, len: int) -> []byte {
    return transmute([]u8)Raw_Slice{data=data, len=max(len, 0)};
}
@(deprecated="use byte_slice")
slice_ptr_to_bytes :: byte_slice;

"mem.odin(145:1) Constant alias declarations cannot have attributes"
```