### PR TITLE
WIP: Linux signal support

### DIFF
--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -697,10 +697,14 @@ _alloc_command_line_arguments :: proc() -> []string {
 
 
 Signal_Handler :: proc(i32);
-Signal_Set     :: distinct rawptr;
+
+// NOTE(rytc): platform dependent
+Signal_Set     :: struct {
+    val : [16]u64,
+}
 
 Signal_Action :: struct {
-    handler   : proc(i32),
+    handler   : Signal_Handler,
     sigaction : proc(i32, ^Signal_Info, rawptr),
     mask      : Signal_Set,
     flags     : i32,

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -347,12 +347,16 @@ foreign libc {
 
 	@(link_name="exit")             _unix_exit          :: proc(status: c.int) -> ! ---;
 
+    @(link_name="getpid")           _unix_getpid        :: proc() -> i32 ---;
+    
+    @(link_name="kill")             _unix_kill          :: proc(pid, signal: i32) -> i32 ---;
+    @(link_name="killpg")           _unix_killpg        :: proc(pgrp, signal: i32) -> i32 ---;
+    @(link_name="raise")            _unix_raise         :: proc(signal: i32) -> i32 ---;
+
     @(link_name="signal")           _unix_signal        :: proc(signal: i32, handler: rawptr) -> Signal_Handler ---;
     @(link_name="sigaction")        _unix_sigaction     :: proc(signum: i32, action: ^Signal_Action, oldact: ^Signal_Action) -> i32 ---;
     @(link_name="sigemptyset")      _unix_sigemptyset   :: proc(mask: ^Signal_Set) ---;
     @(link_name="sigaddset")        _unix_sigaddset     :: proc(mask: ^Signal_Set, signal: i32) ---;
-
-
 }
 foreign dl {
 	@(link_name="dlopen")           _unix_dlopen        :: proc(filename: cstring, flags: c.int) -> rawptr ---;
@@ -773,5 +777,30 @@ sigemptyset :: proc(mask: ^Signal_Set) {
 sigaddset :: proc(mask: ^Signal_Set, signal: i32) {
     _unix_sigaddset(mask, signal);
 }
+
+getpid :: proc() -> i32 {
+    return _unix_getpid();
+}
+
+kill :: proc(pid, signal: i32) -> i32 {
+    return _unix_kill(pid, signal);
+}
+
+killpg :: proc(pgrp, signal: i32) -> i32 {
+    return _unix_killpg(pgrp, signal);
+}
+
+raise :: proc(signal: i32) -> i32 {
+    return _unix_raise(signal);
+}
+
+
+
+
+
+
+
+
+
 
 


### PR DESCRIPTION
Adding support to os_linux for POSIX signal handling: https://linux.die.net/man/7/signal

I used this in one of my projects, but had it implemented separately and decided it may be useful for others.  This could also be done for Drawin and FreeBSD, though I have no way of testing on those platforms. I assume that since it's POSIX standard, it should be the same for those platforms.

This is my first time contributing to something on Github and to Odin, so feedback is appreciated.

Sample usage:


```odin
package main

import "core:fmt"
import "core:os"
import "core:time"

running := true;

test_callback :: proc(signal: i32)  {
    running = false; 
}

main :: proc() {
  
    fmt.print("Running linux signal test, press CTRL-C to close.\n");

    // os.signal is available, however it is not recommended to be used due to portability issues
    // see: https://linux.die.net/man/2/signal
    //os.signal(os.SIGINT, test_callback);
    
    // Recommended usage is sigaction()
    new_action : os.Signal_Action;
    new_action.handler = test_callback;
    os.sigemptyset(&new_action.mask);
    os.sigaddset(&new_action.mask, os.SIGINT);
    new_action.flags = 0;


    old_action : os.Signal_Action;
    
    os.sigaction(os.SIGINT, nil, &old_action);

    os.sigaction(os.SIGINT, &new_action, nil);

    for running {
        time.sleep(5*time.Second);
    }

    fmt.print("\nSuccess, SIGINT received\n");

}
```

