### PR TITLE
Change PNG's img.sidecar to ^Info, make img.depth an int.

### DIFF
--- a/core/image/common.odin
+++ b/core/image/common.odin
@@ -7,7 +7,7 @@ Image :: struct {
 	width:      int,
 	height:     int,
 	channels:   int,
-	depth:      u8,
+	depth:      int,
 	pixels:     bytes.Buffer,
 	/*
 		Some image loaders/writers can return/take an optional background color.

--- a/core/image/png/example.odin
+++ b/core/image/png/example.odin
@@ -26,12 +26,12 @@ main :: proc() {
 	if err != nil {
 		fmt.printf("Trying to read PNG file %v returned %v\n", file, err);
 	} else {
-		v:  png.Info;
+		v: ^png.Info;
 		ok: bool;
 
 		fmt.printf("Image: %vx%vx%v, %v-bit.\n", img.width, img.height, img.channels, img.depth);
 
-		if v, ok = img.sidecar.(png.Info); ok {
+		if v, ok = img.sidecar.(^png.Info); ok {
 			// Handle ancillary chunks as you wish.
 			// We provide helper functions for a few types.
 			for c in v.chunks {
@@ -195,7 +195,7 @@ write_image_as_ppm :: proc(filename: string, image: ^image.Image) -> (success: b
 	defer close(fd);
 
 	write_string(fd,
-		fmt.tprintf("P6\n%v %v\n%v\n", width, height, (1 << depth -1)),
+		fmt.tprintf("P6\n%v %v\n%v\n", width, height, (1 << uint(depth) - 1)),
 	);
 
 	if channels == 3 {


### PR DESCRIPTION
For compatibility with the upcoming OpenEXR code, img.depth is now an int.
Like OpenEXR's code, it will now also return metadata as ^Info instead of Info.

The example was updated to retrieve the metadata this way.

It regrettably does not fix: #1018. That seems to be a codegen issue in the test runner or elsewhere.