### PR TITLE
ZLIB: Optimize

### DIFF
--- a/core/compress/common.odin
+++ b/core/compress/common.odin
@@ -69,6 +69,13 @@ General_Error :: enum {
 	Checksum_Failed,
 	Incompatible_Options,
 	Unimplemented,
+
+
+	/*
+		Memory errors
+	*/
+	Allocation_Failed,
+	Resize_Failed,
 }
 
 GZIP_Error :: enum {

--- a/core/compress/common.odin
+++ b/core/compress/common.odin
@@ -182,6 +182,16 @@ Context_Stream_Input :: struct #packed {
 
 // TODO: Make these return compress.Error errors.
 
+input_size_from_memory :: proc(z: ^Context_Memory_Input) -> (res: i64, err: Error) {
+	return i64(len(z.input_data)), nil;
+}
+
+input_size_from_stream :: proc(z: ^Context_Stream_Input) -> (res: i64, err: Error) {
+	return io.size(z.input), nil;
+}
+
+input_size :: proc{input_size_from_memory, input_size_from_stream};
+
 @(optimization_mode="speed")
 read_slice_from_memory :: #force_inline proc(z: ^Context_Memory_Input, size: int) -> (res: []u8, err: io.Error) {
 	#no_bounds_check {
@@ -257,12 +267,10 @@ peek_data_from_memory :: #force_inline proc(z: ^Context_Memory_Input, $T: typeid
 		}
 	}
 
-	if z.input_fully_in_memory {
-		if len(z.input_data) < size {
-			return T{}, .EOF;
-		} else {
-			return T{}, .Short_Buffer;
-		}
+	if len(z.input_data) == 0 {
+		return T{}, .EOF;
+	} else {
+		return T{}, .Short_Buffer;
 	}
 }
 

--- a/core/compress/gzip/example.odin
+++ b/core/compress/gzip/example.odin
@@ -45,7 +45,7 @@ main :: proc() {
 
 	if len(args) < 2 {
 		stderr("No input file specified.\n");
-		err := load(TEST, &buf);
+		err := load(slice=TEST, buf=&buf, known_gzip_size=len(TEST));
 		if err == nil {
 			stdout("Displaying test vector: ");
 			stdout(bytes.buffer_to_string(&buf));

--- a/core/compress/gzip/example.odin
+++ b/core/compress/gzip/example.odin
@@ -65,7 +65,7 @@ main :: proc() {
 		if file == "-" {
 			// Read from stdin
 			s := os.stream_from_handle(os.stdin);
-			ctx := &compress.Context{
+			ctx := &compress.Context_Stream_Input{
 				input = s,
 			};
 			err = load(ctx, &buf);

--- a/core/compress/gzip/gzip.odin
+++ b/core/compress/gzip/gzip.odin
@@ -103,7 +103,7 @@ E_Deflate :: compress.Deflate_Error;
 
 GZIP_MAX_PAYLOAD_SIZE :: int(max(u32le));
 
-load :: proc{load_from_slice, load_from_stream, load_from_file};
+load :: proc{load_from_slice, load_from_file, load_from_context};
 
 load_from_file :: proc(filename: string, buf: ^bytes.Buffer, expected_output_size := -1, allocator := context.allocator) -> (err: Error) {
 	data, ok := os.read_entire_file(filename, allocator);
@@ -123,9 +123,15 @@ load_from_slice :: proc(slice: []u8, buf: ^bytes.Buffer, known_gzip_size := -1, 
 		input_data = slice,
 		output = buf,
 	};
+	return load_from_context(z, buf, known_gzip_size, expected_output_size, allocator);
+}
 
+load_from_context :: proc(z: ^$C, buf: ^bytes.Buffer, known_gzip_size := -1, expected_output_size := -1, allocator := context.allocator) -> (err: Error) {
+	buf := buf;
 	expected_output_size := expected_output_size;
+
 	input_data_consumed := 0;
+
 	z.output = buf;
 
 	if expected_output_size > GZIP_MAX_PAYLOAD_SIZE {
@@ -310,252 +316,9 @@ load_from_slice :: proc(slice: []u8, buf: ^bytes.Buffer, known_gzip_size := -1, 
 
 		*/
 		if known_gzip_size > -1 {
-			offset := known_gzip_size - input_data_consumed - 4;
-			if len(z.input_data) >= offset + 4 {
-				length_bytes         := z.input_data[offset:][:4];
-				payload_u32le         = (^u32le)(&length_bytes[0])^;
-				expected_output_size = int(payload_u32le);
-			}
-		} else {
-			/*
-				TODO(Jeroen): When reading a GZIP from a stream, check if impl_seek is present.
-				If so, we can seek to the end, grab the size from the footer, and seek back to payload start.
-			*/
-		}
-	}
-
-	// fmt.printf("GZIP: Expected Payload Size: %v\n", expected_output_size);
-
-	zlib_error := zlib.inflate_raw(z=z, expected_output_size=expected_output_size);
-	if zlib_error != nil {
-		return zlib_error;
-	}
-	/*
-		Read CRC32 using the ctx bit reader because zlib may leave bytes in there.
-	*/
-	compress.discard_to_next_byte_lsb(z);
-
-	footer_error: io.Error;
-
-	payload_crc_b: [4]u8;
-	for _, i in payload_crc_b {
-		if z.num_bits >= 8 {
-			payload_crc_b[i] = u8(compress.read_bits_lsb(z, 8));
-		} else {
-			payload_crc_b[i], footer_error = compress.read_u8(z);
-		}
-	}
-	payload_crc := transmute(u32le)payload_crc_b;
-	payload_u32le, footer_error = compress.read_data(z, u32le);
-
-	payload := bytes.buffer_to_bytes(buf);
-
-	// fmt.printf("GZIP payload: %v\n", string(payload));
-
-	crc32 := u32le(hash.crc32(payload));
-
-	if crc32 != payload_crc {
-		return E_GZIP.Payload_CRC_Invalid;
-	}
-
-	if len(payload) != int(payload_u32le) {
-		return E_GZIP.Payload_Length_Invalid;
-	}
-	return nil;
-}
-
-load_from_stream :: proc(z: ^compress.Context_Stream_Input, buf: ^bytes.Buffer, known_gzip_size := -1, expected_output_size := -1, allocator := context.allocator) -> (err: Error) {
-	buf := buf;
-	expected_output_size := expected_output_size;
-
-	input_data_consumed := 0;
-
-	z.output = buf;
-
-	if expected_output_size > GZIP_MAX_PAYLOAD_SIZE {
-		return E_GZIP.Payload_Size_Exceeds_Max_Payload;
-	}
-
-	if expected_output_size > compress.COMPRESS_OUTPUT_ALLOCATE_MAX {
-		return E_GZIP.Output_Exceeds_COMPRESS_OUTPUT_ALLOCATE_MAX;
-	}
-
-	b: []u8;
-
-	header, e := compress.read_data(z, Header);
-	if e != .None {
-		return E_General.File_Too_Short;
-	}
-	input_data_consumed += size_of(Header);
-
-	if header.magic != .GZIP {
-		return E_GZIP.Invalid_GZIP_Signature;
-	}
-	if header.compression_method != .DEFLATE {
-		return E_General.Unknown_Compression_Method;
-	}
-
-	if header.os >= ._Unknown {
-		header.os = .Unknown;
-	}
-
-	if .reserved_1 in header.flags || .reserved_2 in header.flags || .reserved_3 in header.flags {
-		return E_GZIP.Reserved_Flag_Set;
-	}
-
-	// printf("signature: %v\n", header.magic);
-	// printf("compression: %v\n", header.compression_method);
-	// printf("flags: %v\n", header.flags);
-	// printf("modification time: %v\n", time.unix(i64(header.modification_time), 0));
-	// printf("xfl: %v (%v)\n", header.xfl, int(header.xfl));
-	// printf("os: %v\n", OS_Name[header.os]);
-
-	if .extra in header.flags {
-		xlen, e_extra := compress.read_data(z, u16le);
-		input_data_consumed += 2;
-
-		if e_extra != .None {
-			return E_General.Stream_Too_Short;
-		}
-		// printf("Extra data present (%v bytes)\n", xlen);
-		if xlen < 4 {
-			// Minimum length is 2 for ID + 2 for a field length, if set to zero.
-			return E_GZIP.Invalid_Extra_Data;
-		}
-
-		field_id:     [2]u8;
-		field_length: u16le;
-		field_error: io.Error;
-
-		for xlen >= 4 {
-			// println("Parsing Extra field(s).");
-			field_id, field_error = compress.read_data(z, [2]u8);
-			if field_error != .None {
-				// printf("Parsing Extra returned: %v\n", field_error);
-				return E_General.Stream_Too_Short;
-			}
-			xlen -= 2;
-			input_data_consumed += 2;
-
-			field_length, field_error = compress.read_data(z, u16le);
-			if field_error != .None {
-				// printf("Parsing Extra returned: %v\n", field_error);
-				return E_General.Stream_Too_Short;
-			}
-			xlen -= 2;
-			input_data_consumed += 2;
-
-			if xlen <= 0 {
-				// We're not going to try and recover by scanning for a ZLIB header.
-				// Who knows what else is wrong with this file.
-				return E_GZIP.Invalid_Extra_Data;
-			}
-
-			// printf("    Field \"%v\" of length %v found: ", string(field_id[:]), field_length);
-			if field_length > 0 {
-				b, field_error = compress.read_slice(z, int(field_length));
-				if field_error != .None {
-					// printf("Parsing Extra returned: %v\n", field_error);
-					return E_General.Stream_Too_Short;
-				}
-				xlen -= field_length;
-				input_data_consumed += int(field_length);
-
-				// printf("%v\n", string(field_data));
-			}
-
-			if xlen != 0 {
-				return E_GZIP.Invalid_Extra_Data;
-			}
-		}
-	}
-
-	if .name in header.flags {
-		// Should be enough.
-		name: [1024]u8;
-		i := 0;
-		name_error: io.Error;
-
-		for i < len(name) {
-			b, name_error = compress.read_slice(z, 1);
-			if name_error != .None {
-				return E_General.Stream_Too_Short;
-			}
-			input_data_consumed += 1;
-			if b[0] == 0 {
-				break;
-			}
-			name[i] = b[0];
-			i += 1;
-			if i >= len(name) {
-				return E_GZIP.Original_Name_Too_Long;
-			}
-		}
-		// printf("Original filename: %v\n", string(name[:i]));
-	}
-
-	if .comment in header.flags {
-		// Should be enough.
-		comment: [1024]u8;
-		i := 0;
-		comment_error: io.Error;
-
-		for i < len(comment) {
-			b, comment_error = compress.read_slice(z, 1);
-			if comment_error != .None {
-				return E_General.Stream_Too_Short;
-			}
-			input_data_consumed += 1;
-			if b[0] == 0 {
-				break;
-			}
-			comment[i] = b[0];
-			i += 1;
-			if i >= len(comment) {
-				return E_GZIP.Comment_Too_Long;
-			}
-		}
-		// printf("Comment: %v\n", string(comment[:i]));
-	}
-
-	if .header_crc in header.flags {
-		crc_error: io.Error;
-		_, crc_error = compress.read_slice(z, 2);
-		input_data_consumed += 2;
-		if crc_error != .None {
-			return E_General.Stream_Too_Short;
-		}
-		/*
-			We don't actually check the CRC16 (lower 2 bytes of CRC32 of header data until the CRC field).
-			If we find a gzip file in the wild that sets this field, we can add proper support for it.
-		*/
-	}
-
-	/*
-		We should have arrived at the ZLIB payload.
-	*/
-	payload_u32le: u32le;
-
-	// fmt.printf("known_gzip_size: %v | expected_output_size: %v\n", known_gzip_size, expected_output_size);
-
-	if expected_output_size > -1 {
-		/*
-			We already checked that it's not larger than the output buffer max,
-			or GZIP length field's max.
-
-			We'll just pass it on to `zlib.inflate_raw`;
-		*/
-	} else {
-		/*
-			If we know the size of the GZIP file *and* it is fully in memory,
-			then we can peek at the unpacked size at the end.
-
-			We'll still want to ensure there's capacity left in the output buffer when we write, of course.
-
-		*/
-		if z.input_fully_in_memory && known_gzip_size > -1 {
-			offset := known_gzip_size - input_data_consumed - 4;
-			if len(z.input_data) >= offset + 4 {
+			offset := i64(known_gzip_size - input_data_consumed - 4);
+			size, _ := compress.input_size(z);
+			if size >= offset + 4 {
 				length_bytes         := z.input_data[offset:][:4];
 				payload_u32le         = (^u32le)(&length_bytes[0])^;
 				expected_output_size = int(payload_u32le);

--- a/core/compress/gzip/gzip.odin
+++ b/core/compress/gzip/gzip.odin
@@ -21,6 +21,8 @@ import "core:io"
 import "core:bytes"
 import "core:hash"
 
+// import "core:fmt"
+
 Magic :: enum u16le {
 	GZIP = 0x8b << 8 | 0x1f,
 }
@@ -99,7 +101,9 @@ E_GZIP    :: compress.GZIP_Error;
 E_ZLIB    :: compress.ZLIB_Error;
 E_Deflate :: compress.Deflate_Error;
 
-load_from_slice :: proc(slice: []u8, buf: ^bytes.Buffer, allocator := context.allocator) -> (err: Error) {
+GZIP_MAX_PAYLOAD_SIZE :: int(max(u32le));
+
+load_from_slice :: proc(slice: []u8, buf: ^bytes.Buffer, known_gzip_size := -1, expected_output_size := -1, allocator := context.allocator) -> (err: Error) {
 
 	r := bytes.Reader{};
 	bytes.reader_init(&r, slice);
@@ -111,26 +115,39 @@ load_from_slice :: proc(slice: []u8, buf: ^bytes.Buffer, allocator := context.al
 		input_fully_in_memory = true,
 		input_refills_from_stream = true,
 	};
-	err = load_from_stream(ctx, buf, allocator);
+
+	err = load_from_stream(ctx, buf, known_gzip_size, expected_output_size, allocator);
 
 	return err;
 }
 
-load_from_file :: proc(filename: string, buf: ^bytes.Buffer, allocator := context.allocator) -> (err: Error) {
+load_from_file :: proc(filename: string, buf: ^bytes.Buffer, expected_output_size := -1, allocator := context.allocator) -> (err: Error) {
 	data, ok := os.read_entire_file(filename, allocator);
 	defer delete(data);
 
 	err = E_General.File_Not_Found;
 	if ok {
-		err = load_from_slice(data, buf, allocator);
+		err = load_from_slice(data, buf, len(data), expected_output_size, allocator);
 	}
 	return;
 }
 
-load_from_stream :: proc(ctx: ^compress.Context, buf: ^bytes.Buffer, allocator := context.allocator) -> (err: Error) {
+load_from_stream :: proc(ctx: ^compress.Context, buf: ^bytes.Buffer, known_gzip_size := -1, expected_output_size := -1, allocator := context.allocator) -> (err: Error) {
 	buf := buf;
+	expected_output_size := expected_output_size;
+
+	input_data_consumed := 0;
+
 	ws := bytes.buffer_to_stream(buf);
 	ctx.output = ws;
+
+	if expected_output_size > GZIP_MAX_PAYLOAD_SIZE {
+		return E_GZIP.Payload_Size_Exceeds_Max_Payload;
+	}
+
+	if expected_output_size > compress.COMPRESS_OUTPUT_ALLOCATE_MAX {
+		return E_GZIP.Output_Exceeds_COMPRESS_OUTPUT_ALLOCATE_MAX;
+	}
 
 	b: []u8;
 
@@ -138,6 +155,7 @@ load_from_stream :: proc(ctx: ^compress.Context, buf: ^bytes.Buffer, allocator :
 	if e != .None {
 		return E_General.File_Too_Short;
 	}
+	input_data_consumed += size_of(Header);
 
 	if header.magic != .GZIP {
 		return E_GZIP.Invalid_GZIP_Signature;
@@ -163,6 +181,8 @@ load_from_stream :: proc(ctx: ^compress.Context, buf: ^bytes.Buffer, allocator :
 
 	if .extra in header.flags {
 		xlen, e_extra := compress.read_data(ctx, u16le);
+		input_data_consumed += 2;
+
 		if e_extra != .None {
 			return E_General.Stream_Too_Short;
 		}
@@ -184,6 +204,7 @@ load_from_stream :: proc(ctx: ^compress.Context, buf: ^bytes.Buffer, allocator :
 				return E_General.Stream_Too_Short;
 			}
 			xlen -= 2;
+			input_data_consumed += 2;
 
 			field_length, field_error = compress.read_data(ctx, u16le);
 			if field_error != .None {
@@ -191,6 +212,7 @@ load_from_stream :: proc(ctx: ^compress.Context, buf: ^bytes.Buffer, allocator :
 				return E_General.Stream_Too_Short;
 			}
 			xlen -= 2;
+			input_data_consumed += 2;
 
 			if xlen <= 0 {
 				// We're not going to try and recover by scanning for a ZLIB header.
@@ -206,6 +228,7 @@ load_from_stream :: proc(ctx: ^compress.Context, buf: ^bytes.Buffer, allocator :
 					return E_General.Stream_Too_Short;
 				}
 				xlen -= field_length;
+				input_data_consumed += int(field_length);
 
 				// printf("%v\n", string(field_data));
 			}
@@ -227,6 +250,7 @@ load_from_stream :: proc(ctx: ^compress.Context, buf: ^bytes.Buffer, allocator :
 			if name_error != .None {
 				return E_General.Stream_Too_Short;
 			}
+			input_data_consumed += 1;
 			if b[0] == 0 {
 				break;
 			}
@@ -250,6 +274,7 @@ load_from_stream :: proc(ctx: ^compress.Context, buf: ^bytes.Buffer, allocator :
 			if comment_error != .None {
 				return E_General.Stream_Too_Short;
 			}
+			input_data_consumed += 1;
 			if b[0] == 0 {
 				break;
 			}
@@ -265,6 +290,7 @@ load_from_stream :: proc(ctx: ^compress.Context, buf: ^bytes.Buffer, allocator :
 	if .header_crc in header.flags {
 		crc_error: io.Error;
 		_, crc_error = compress.read_slice(ctx, 2);
+		input_data_consumed += 2;
 		if crc_error != .None {
 			return E_General.Stream_Too_Short;
 		}
@@ -280,7 +306,43 @@ load_from_stream :: proc(ctx: ^compress.Context, buf: ^bytes.Buffer, allocator :
 	code_buffer := compress.Code_Buffer{};
 	cb := &code_buffer;
 
-	zlib_error := zlib.inflate_raw(ctx, &code_buffer);
+	payload_u32le: u32le;
+
+	// fmt.printf("known_gzip_size: %v | expected_output_size: %v\n", known_gzip_size, expected_output_size);
+
+	if expected_output_size > -1 {
+		/*
+			We already checked that it's not larger than the output buffer max,
+			or GZIP length field's max.
+
+			We'll just pass it on to `zlib.inflate_raw`;
+		*/
+	} else {
+		/*
+			If we know the size of the GZIP file *and* it is fully in memory,
+			then we can peek at the unpacked size at the end.
+
+			We'll still want to ensure there's capacity left in the output buffer when we write, of course.
+
+		*/
+		if ctx.input_fully_in_memory && known_gzip_size > -1 {
+			offset := known_gzip_size - input_data_consumed - 4;
+			if len(ctx.input_data) >= offset + 4 {
+				length_bytes         := ctx.input_data[offset:][:4];
+				payload_u32le         = (^u32le)(&length_bytes[0])^;
+				expected_output_size = int(payload_u32le);
+			}
+		} else {
+			/*
+				TODO(Jeroen): When reading a GZIP from a stream, check if impl_seek is present.
+				If so, we can seek to the end, grab the size from the footer, and seek back to payload start.
+			*/
+		}
+	}
+
+	// fmt.printf("GZIP: Expected Payload Size: %v\n", expected_output_size);
+
+	zlib_error := zlib.inflate_raw(z=ctx, cb=&code_buffer, expected_output_size=expected_output_size);
 	if zlib_error != nil {
 		return zlib_error;
 	}
@@ -300,9 +362,7 @@ load_from_stream :: proc(ctx: ^compress.Context, buf: ^bytes.Buffer, allocator :
 		}
 	}
 	payload_crc := transmute(u32le)payload_crc_b;
-
-	payload_len: u32le;
-	payload_len, footer_error = compress.read_data(ctx, u32le);
+	payload_u32le, footer_error = compress.read_data(ctx, u32le);
 
 	payload := bytes.buffer_to_bytes(buf);
 	crc32 := u32le(hash.crc32(payload));
@@ -311,7 +371,7 @@ load_from_stream :: proc(ctx: ^compress.Context, buf: ^bytes.Buffer, allocator :
 		return E_GZIP.Payload_CRC_Invalid;
 	}
 
-	if len(payload) != int(payload_len) {
+	if len(payload) != int(payload_u32le) {
 		return E_GZIP.Payload_Length_Invalid;
 	}
 	return nil;

--- a/core/compress/gzip/gzip.odin
+++ b/core/compress/gzip/gzip.odin
@@ -113,7 +113,6 @@ load_from_slice :: proc(slice: []u8, buf: ^bytes.Buffer, known_gzip_size := -1, 
 		input = stream,
 		input_data = slice,
 		input_fully_in_memory = true,
-		input_refills_from_stream = true,
 		output = buf,
 	};
 

--- a/core/compress/zlib/example.odin
+++ b/core/compress/zlib/example.odin
@@ -13,7 +13,6 @@ package zlib
 
 import "core:bytes"
 import "core:fmt"
-import "core:compress"
 
 main :: proc() {
 
@@ -37,8 +36,6 @@ main :: proc() {
 		 63, 234, 138, 133, 204,
 	};
 	OUTPUT_SIZE :: 438;
-
-	fmt.printf("size_of(Context): %v\n", size_of(compress.Context_Memory_Input));
 
 	buf: bytes.Buffer;
 

--- a/core/compress/zlib/example.odin
+++ b/core/compress/zlib/example.odin
@@ -38,7 +38,7 @@ main :: proc() {
 	};
 	OUTPUT_SIZE :: 438;
 
-	fmt.printf("size_of(Context): %v\n", size_of(compress.Context));
+	fmt.printf("size_of(Context): %v\n", size_of(compress.Context_Memory_Input));
 
 	buf: bytes.Buffer;
 

--- a/core/compress/zlib/example.odin
+++ b/core/compress/zlib/example.odin
@@ -13,6 +13,7 @@ package zlib
 
 import "core:bytes"
 import "core:fmt"
+import "core:compress"
 
 main :: proc() {
 
@@ -37,6 +38,7 @@ main :: proc() {
 	};
 	OUTPUT_SIZE :: 438;
 
+	fmt.printf("size_of(Context): %v\n", size_of(compress.Context));
 
 	buf: bytes.Buffer;
 

--- a/core/compress/zlib/example.odin
+++ b/core/compress/zlib/example.odin
@@ -35,11 +35,13 @@ main :: proc() {
 		171,  15,  18,  59, 138, 112,  63,  23, 205, 110, 254, 136, 109,  78, 231,
 		 63, 234, 138, 133, 204,
 	};
+	OUTPUT_SIZE :: 438;
+
 
 	buf: bytes.Buffer;
 
 	// We can pass ", true" to inflate a raw DEFLATE stream instead of a ZLIB wrapped one.
-	err := inflate(ODIN_DEMO, &buf);
+	err := inflate(input=ODIN_DEMO, buf=&buf, expected_output_size=OUTPUT_SIZE);
 	defer bytes.buffer_destroy(&buf);
 
 	if err != nil {
@@ -47,5 +49,5 @@ main :: proc() {
 	}
 	s := bytes.buffer_to_string(&buf);
 	fmt.printf("Input: %v bytes, output (%v bytes):\n%v\n", len(ODIN_DEMO), len(s), s);
-	assert(len(s) == 438);
+	assert(len(s) == OUTPUT_SIZE);
 }

--- a/core/compress/zlib/zlib.odin
+++ b/core/compress/zlib/zlib.odin
@@ -430,8 +430,7 @@ inflate_from_stream :: proc(using ctx: ^Context, raw := false, expected_output_s
 		- read
 		- size
 
-		ctx.output must be an io.Stream backed by an implementation that supports:
-		- write
+		ctx.output must be a bytes.Buffer for now. We'll add a separate implementation that writes to a stream.
 
 		raw determines whether the ZLIB header is processed, or we're inflating a raw
 		DEFLATE stream.
@@ -498,6 +497,8 @@ inflate_from_stream :: proc(using ctx: ^Context, raw := false, expected_output_s
 	}
 	return nil;
 }
+
+// TODO: Check alignment of reserve/resize.
 
 @(optimization_mode="speed")
 inflate_from_stream_raw :: proc(z: ^Context, expected_output_size := -1, allocator := context.allocator) -> (err: Error) #no_bounds_check {

--- a/core/image/png/example.odin
+++ b/core/image/png/example.odin
@@ -41,7 +41,7 @@ main :: proc() {
 demo :: proc() {
 	file: string;
 
-	options := image.Options{.return_metadata};
+	options := image.Options{}; // {.return_metadata};
 	err:       compress.Error;
 	img:      ^image.Image;
 
@@ -56,9 +56,9 @@ demo :: proc() {
 		v: ^Info;
 
 		fmt.printf("Image: %vx%vx%v, %v-bit.\n", img.width, img.height, img.channels, img.depth);
-
 		if img.metadata_ptr != nil && img.metadata_type == Info {
 			v = (^Info)(img.metadata_ptr);
+
 			// Handle ancillary chunks as you wish.
 			// We provide helper functions for a few types.
 			for c in v.chunks {

--- a/core/image/png/png.odin
+++ b/core/image/png/png.odin
@@ -245,7 +245,7 @@ ADAM7_Y_SPACING := []int{ 8,8,8,4,4,2,2 };
 
 // Implementation starts here
 
-read_chunk :: proc(ctx: ^compress.Context) -> (chunk: Chunk, err: Error) {
+read_chunk :: proc(ctx: ^$C) -> (chunk: Chunk, err: Error) {
 	ch, e := compress.read_data(ctx, Chunk_Header);
 	if e != .None {
 		return {}, E_General.Stream_Too_Short;
@@ -274,7 +274,7 @@ read_chunk :: proc(ctx: ^compress.Context) -> (chunk: Chunk, err: Error) {
 	return chunk, nil;
 }
 
-read_header :: proc(ctx: ^compress.Context) -> (IHDR, Error) {
+read_header :: proc(ctx: ^$C) -> (IHDR, Error) {
 	c, e := read_chunk(ctx);
 	if e != nil {
 		return {}, e;
@@ -353,14 +353,8 @@ chunk_type_to_name :: proc(type: ^Chunk_Type) -> string {
 }
 
 load_from_slice :: proc(slice: []u8, options := Options{}, allocator := context.allocator) -> (img: ^Image, err: Error) {
-	r := bytes.Reader{};
-	bytes.reader_init(&r, slice);
-	stream := bytes.reader_to_stream(&r);
-
-	ctx := &compress.Context{
-		input = stream,
+	ctx := &compress.Context_Memory_Input{
 		input_data = slice,
-		input_fully_in_memory = true,
 	};
 
 	/*
@@ -368,7 +362,7 @@ load_from_slice :: proc(slice: []u8, options := Options{}, allocator := context.
 		This way the stream reader could avoid the copy into the temp memory returned by it,
 		and instead return a slice into the original memory that's already owned by the caller.
 	*/
-	img, err = load_from_stream(ctx, options, allocator);
+	img, err = load_from_context(ctx, options, allocator);
 
 	return img, err;
 }
@@ -386,7 +380,7 @@ load_from_file :: proc(filename: string, options := Options{}, allocator := cont
 	}
 }
 
-load_from_stream :: proc(ctx: ^compress.Context, options := Options{}, allocator := context.allocator) -> (img: ^Image, err: Error) {
+load_from_context :: proc(ctx: ^$C, options := Options{}, allocator := context.allocator) -> (img: ^Image, err: Error) {
 	options := options;
 	if .info in options {
 		options |= {.return_metadata, .do_not_decompress_image};
@@ -1657,4 +1651,4 @@ defilter :: proc(img: ^Image, filter_bytes: ^bytes.Buffer, header: ^IHDR, option
 	return nil;
 }
 
-load :: proc{load_from_file, load_from_slice, load_from_stream};
+load :: proc{load_from_file, load_from_slice, load_from_context};


### PR DESCRIPTION
`zlib.inflate` is now 3.5x faster than it used to be, competitive with some of the faster implementations.