### PR TITLE
Minimal passes for opt:0 and -debug to preserve debug information reporting

### DIFF
--- a/src/llvm_backend_opt.cpp
+++ b/src/llvm_backend_opt.cpp
@@ -39,19 +39,31 @@ void lb_populate_function_pass_manager(lbModule *m, LLVMPassManagerRef fpm, bool
 	optimization_level = gb_clamp(optimization_level, 0, 2);
 
 	lb_add_must_preserve_predicate_pass(m, fpm, optimization_level);
-	if (optimization_level == 0) {
-		if (!ignore_memcpy_pass) {
-			LLVMAddMemCpyOptPass(fpm);
+
+	if (build_context.ODIN_DEBUG) {
+		if (optimization_level == 0) {
+			if (!ignore_memcpy_pass) {
+				LLVMAddMemCpyOptPass(fpm);
+			}
+
+			return;
 		}
 
-		return;
+		if (ignore_memcpy_pass) {
+			lb_basic_populate_function_pass_manager(fpm);
+			
+			return;
+		} 
+	} else {
+		if (ignore_memcpy_pass) {
+			lb_basic_populate_function_pass_manager(fpm);
+			return;
+		} else if (optimization_level == 0) {
+			LLVMAddMemCpyOptPass(fpm);
+			lb_basic_populate_function_pass_manager(fpm);
+			return;
+		}
 	}
-
-	if (ignore_memcpy_pass) {
-		lb_basic_populate_function_pass_manager(fpm);
-		
-		return;
-	} 
 
 #if 0
 	LLVMPassManagerBuilderRef pmb = LLVMPassManagerBuilderCreate();
@@ -87,8 +99,15 @@ void lb_populate_function_pass_manager_specific(lbModule *m, LLVMPassManagerRef 
 	optimization_level = gb_clamp(optimization_level, 0, 2);
 
 	lb_add_must_preserve_predicate_pass(m, fpm, optimization_level);
+
 	if (optimization_level == 0) { //NOTE(Jesse): This is the only path taken for opt:[1,2]
-		return;
+		if (build_context.ODIN_DEBUG) {
+			return;
+		} else {
+			LLVMAddMemCpyOptPass(fpm);
+			lb_basic_populate_function_pass_manager(fpm);
+			return;
+		}
 	}
 
 #if 1
@@ -120,8 +139,10 @@ void lb_populate_function_pass_manager_specific(lbModule *m, LLVMPassManagerRef 
 }
 
 void lb_add_function_simplifcation_passes(LLVMPassManagerRef mpm, i32 optimization_level) {
-	if (optimization_level == 0) { //NOTE(Jesse): Compiling demo.odin or my program under opt:0 never calls this.
-		return;
+	if (build_context.ODIN_DEBUG) {
+		if (optimization_level == 0) { //NOTE(Jesse): Compiling demo.odin or my program under opt:0 never calls this.
+			return;
+		}
 	}
 
 	LLVMAddEarlyCSEMemSSAPass(mpm);
@@ -180,14 +201,20 @@ void lb_populate_module_pass_manager(LLVMTargetMachineRef target_machine, LLVMPa
 	// NOTE(bill): Treat -opt:3 as if it was -opt:2
 	// TODO(bill): Determine which opt definitions should exist in the first place
 	optimization_level = gb_clamp(optimization_level, 0, 2);
-	if (optimization_level == 0) {
-		return;
+	if (build_context.ODIN_DEBUG) {
+		if (optimization_level == 0) {
+			return;
+		}
 	}
 
 	LLVMAddAlwaysInlinerPass(mpm);
 	LLVMAddStripDeadPrototypesPass(mpm);
 	LLVMAddAnalysisPasses(target_machine, mpm);
 	LLVMAddPruneEHPass(mpm);
+
+	if (optimization_level == 0) {
+		return;
+	}
 
 	LLVMAddGlobalDCEPass(mpm);
 

--- a/src/llvm_backend_opt.cpp
+++ b/src/llvm_backend_opt.cpp
@@ -40,11 +40,16 @@ void lb_populate_function_pass_manager(lbModule *m, LLVMPassManagerRef fpm, bool
 
 	lb_add_must_preserve_predicate_pass(m, fpm, optimization_level);
 	if (optimization_level == 0) {
-		LLVMAddMemCpyOptPass(fpm);
+		if (!ignore_memcpy_pass) {
+			LLVMAddMemCpyOptPass(fpm);
+		}
+
 		return;
 	}
-	else if (ignore_memcpy_pass) {
+
+	if (ignore_memcpy_pass) {
 		lb_basic_populate_function_pass_manager(fpm);
+		
 		return;
 	} 
 


### PR DESCRIPTION
Early out as soon as possible while maintaining the minimum LLVM optimization passes for opt:0 to preserve debug variable reporting.

This was tested with the official demo.odin and my own odin program on opt:0, 1, and 2, with and without -debug.  But I would consider this PR only minimally tested.