### PR TITLE
Multi Pointers `[^]T`

### DIFF
--- a/core/encoding/json/marshal.odin
+++ b/core/encoding/json/marshal.odin
@@ -139,6 +139,9 @@ marshal_arg :: proc(b: ^strings.Builder, v: any) -> Marshal_Error {
 	case runtime.Type_Info_Pointer:
 		return .Unsupported_Type;
 
+	case runtime.Type_Info_Multi_Pointer:
+		return .Unsupported_Type;
+
 	case runtime.Type_Info_Procedure:
 		return .Unsupported_Type;
 

--- a/core/odin/ast/ast.odin
+++ b/core/odin/ast/ast.odin
@@ -656,6 +656,14 @@ Pointer_Type :: struct {
 	elem:    ^Expr,
 }
 
+Multi_Pointer_Type :: struct {
+	using node: Expr,
+	open:    tokenizer.Pos,
+	pointer: tokenizer.Pos,
+	close:   tokenizer.Pos,
+	elem:    ^Expr,
+}
+
 Array_Type :: struct {
 	using node: Expr,
 	open:  tokenizer.Pos,

--- a/core/odin/ast/clone.odin
+++ b/core/odin/ast/clone.odin
@@ -251,6 +251,8 @@ clone_node :: proc(node: ^Node) -> ^Node {
 		r.results = auto_cast clone(r.results);
 	case Pointer_Type:
 		r.elem = clone(r.elem);
+	case Multi_Pointer_Type:
+		r.elem = clone(r.elem);
 	case Array_Type:
 		r.len  = clone(r.len);
 		r.elem = clone(r.elem);

--- a/core/odin/ast/walk.odin
+++ b/core/odin/ast/walk.odin
@@ -349,6 +349,8 @@ walk :: proc(v: ^Visitor, node: ^Node) {
 		walk(v, n.results);
 	case Pointer_Type:
 		walk(v, n.elem);
+	case Multi_Pointer_Type:
+		walk(v, n.elem);
 	case Array_Type:
 		if n.tag != nil {
 			walk(v, n.tag);

--- a/core/odin/doc-format/doc_format.odin
+++ b/core/odin/doc-format/doc_format.odin
@@ -166,6 +166,7 @@ Type_Kind :: enum u32le {
 	SOA_Struct_Dynamic = 19,
 	Relative_Pointer   = 20,
 	Relative_Slice     = 21,
+	Multi_Pointer      = 22,
 }
 
 Type_Elems_Cap :: 4;
@@ -222,6 +223,7 @@ Type :: struct {
 	// .Simd_Vector        - 1 type:    0=element
 	// .Relative_Pointer   - 2 types:   0=pointer type, 1=base integer
 	// .Relative_Slice     - 2 types:   0=slice type, 1=base integer
+	// .Multi_Pointer      - 1 type:    0=element
 	types: Array(Type_Index),
 
 	// Used by:

--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -2440,18 +2440,26 @@ parse_operand :: proc(p: ^Parser, lhs: bool) -> ^ast.Expr {
 		tok := expect_token(p, .Pointer);
 		elem := parse_type(p);
 		ptr := ast.new(ast.Pointer_Type, tok.pos, elem.end);
+		ptr.pointer = tok.pos;
 		ptr.elem = elem;
 		return ptr;
+
 
 	case .Open_Bracket:
 		open := expect_token(p, .Open_Bracket);
 		count: ^ast.Expr;
-		if p.curr_tok.kind == .Question {
-			tok := expect_token(p, .Question);
-			q := ast.new(ast.Unary_Expr, tok.pos, end_pos(tok));
-			q.op = tok;
-			count = q;
-		} else if p.curr_tok.kind == .Dynamic {
+		switch p.curr_tok.kind {
+		case .Pointer:
+			tok := expect_token(p, .Pointer);
+			close := expect_token(p, .Close_Bracket);
+			elem := parse_type(p);
+			t := ast.new(ast.Multi_Pointer_Type, open.pos, elem.end_pos);
+			t.open = open.pos;
+			t.pointer = tok.pos;
+			t.close = close.pos;
+			t.elem = elem;
+			return t;
+		case .Dynamic:
 			tok := expect_token(p, .Dynamic);
 			close := expect_token(p, .Close_Bracket);
 			elem := parse_type(p);
@@ -2460,12 +2468,18 @@ parse_operand :: proc(p: ^Parser, lhs: bool) -> ^ast.Expr {
 			da.dynamic_pos = tok.pos;
 			da.close = close.pos;
 			da.elem = elem;
-
 			return da;
-		} else if p.curr_tok.kind != .Close_Bracket {
+		case .Question:
+			tok := expect_token(p, .Question);
+			q := ast.new(ast.Unary_Expr, tok.pos, end_pos(tok));
+			q.op = tok;
+			count = q;
+		case:
 			p.expr_level += 1;
 			count = parse_expr(p, false);
 			p.expr_level -= 1;
+		case .Close_Bracket:
+			// handle below
 		}
 		close := expect_token(p, .Close_Bracket);
 		elem := parse_type(p);

--- a/core/reflect/reflect.odin
+++ b/core/reflect/reflect.odin
@@ -18,6 +18,7 @@ Type_Info_Boolean          :: runtime.Type_Info_Boolean;
 Type_Info_Any              :: runtime.Type_Info_Any;
 Type_Info_Type_Id          :: runtime.Type_Info_Type_Id;
 Type_Info_Pointer          :: runtime.Type_Info_Pointer;
+Type_Info_Multi_Pointer    :: runtime.Type_Info_Multi_Pointer;
 Type_Info_Procedure        :: runtime.Type_Info_Procedure;
 Type_Info_Array            :: runtime.Type_Info_Array;
 Type_Info_Enumerated_Array :: runtime.Type_Info_Enumerated_Array;
@@ -50,6 +51,7 @@ Type_Kind :: enum {
 	Any,
 	Type_Id,
 	Pointer,
+	Multi_Pointer,
 	Procedure,
 	Array,
 	Enumerated_Array,
@@ -82,6 +84,7 @@ type_kind :: proc(T: typeid) -> Type_Kind {
 		case Type_Info_Any:              return .Any;
 		case Type_Info_Type_Id:          return .Type_Id;
 		case Type_Info_Pointer:          return .Pointer;
+		case Type_Info_Multi_Pointer:    return .Multi_Pointer;
 		case Type_Info_Procedure:        return .Procedure;
 		case Type_Info_Array:            return .Array;
 		case Type_Info_Enumerated_Array: return .Enumerated_Array;
@@ -172,6 +175,7 @@ typeid_elem :: proc(id: typeid) -> typeid {
 		case 256: return f64;
 		}
 	case Type_Info_Pointer:          return v.elem.id;
+	case Type_Info_Multi_Pointer:    return v.elem.id;
 	case Type_Info_Array:            return v.elem.id;
 	case Type_Info_Enumerated_Array: return v.elem.id;
 	case Type_Info_Slice:            return v.elem.id;
@@ -292,6 +296,13 @@ index :: proc(val: any, i: int, loc := #caller_location) -> any {
 		return index({val.data, a.base.id}, i, loc);
 
 	case Type_Info_Pointer:
+		ptr := (^rawptr)(val.data)^;
+		if ptr == nil {
+			return nil;
+		}
+		return index({ptr, a.elem.id}, i, loc);
+
+	case Type_Info_Multi_Pointer:
 		ptr := (^rawptr)(val.data)^;
 		if ptr == nil {
 			return nil;

--- a/core/runtime/core.odin
+++ b/core/runtime/core.odin
@@ -74,6 +74,9 @@ Type_Info_Type_Id    :: struct {};
 Type_Info_Pointer :: struct {
 	elem: ^Type_Info, // nil -> rawptr
 };
+Type_Info_Multi_Pointer :: struct {
+	elem: ^Type_Info,
+};
 Type_Info_Procedure :: struct {
 	params:     ^Type_Info, // Type_Info_Tuple
 	results:    ^Type_Info, // Type_Info_Tuple
@@ -184,6 +187,7 @@ Type_Info :: struct {
 		Type_Info_Any,
 		Type_Info_Type_Id,
 		Type_Info_Pointer,
+		Type_Info_Multi_Pointer,
 		Type_Info_Procedure,
 		Type_Info_Array,
 		Type_Info_Enumerated_Array,
@@ -214,6 +218,7 @@ Typeid_Kind :: enum u8 {
 	Any,
 	Type_Id,
 	Pointer,
+	Multi_Pointer,
 	Procedure,
 	Array,
 	Enumerated_Array,
@@ -340,7 +345,7 @@ Context :: struct {
 
 
 Raw_String :: struct {
-	data: ^byte,
+	data: [^]byte,
 	len:  int,
 }
 

--- a/core/runtime/error_checks.odin
+++ b/core/runtime/error_checks.odin
@@ -45,6 +45,24 @@ slice_handle_error :: proc "contextless" (file: string, line, column: i32, lo, h
 	bounds_trap();
 }
 
+multi_pointer_slice_handle_error :: proc "contextless" (file: string, line, column: i32, lo, hi: int) -> ! {
+	print_caller_location(Source_Code_Location{file, line, column, ""});
+	print_string(" Invalid slice indices: ");
+	print_i64(i64(lo));
+	print_string(":");
+	print_i64(i64(hi));
+	print_byte('\n');
+	bounds_trap();
+}
+
+
+multi_pointer_slice_expr_error :: proc "contextless" (file: string, line, column: i32, lo, hi: int) {
+	if lo <= hi {
+		return;
+	}
+	multi_pointer_slice_handle_error(file, line, column, lo, hi);
+}
+
 slice_expr_error_hi :: proc "contextless" (file: string, line, column: i32, hi: int, len: int) {
 	if 0 <= hi && hi <= len {
 		return;

--- a/core/runtime/print.odin
+++ b/core/runtime/print.odin
@@ -203,6 +203,9 @@ print_type :: proc "contextless" (ti: ^Type_Info) {
 			print_string("^");
 			print_type(info.elem);
 		}
+	case Type_Info_Multi_Pointer:
+		print_string("[^]");
+		print_type(info.elem);
 	case Type_Info_Procedure:
 		print_string("proc");
 		if info.params == nil {

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -601,13 +601,13 @@ i64 check_distance_between_types(CheckerContext *c, Operand *operand, Type *type
 		return 5;
 	}
 	// ^T <- [^]T
-	if (is_type_pointer(dst) && is_type_multi_pointer(src)) {
+	if (dst->kind == Type_Pointer && src->kind == Type_MultiPointer) {
 		if (are_types_identical(dst->Pointer.elem, src->MultiPointer.elem)) {
 			return 4;
 		}
 	}
 	// [^]T <- ^T
-	if (is_type_multi_pointer(dst) && is_type_pointer(src)) {
+	if (dst->kind == Type_MultiPointer && src->kind == Type_Pointer) {
 		if (are_types_identical(dst->MultiPointer.elem, src->Pointer.elem)) {
 			return 4;
 		}
@@ -943,6 +943,16 @@ bool is_polymorphic_type_assignable(CheckerContext *c, Type *poly, Type *source,
 				return true;
 			}
 			return is_polymorphic_type_assignable(c, poly->Pointer.elem, source->Pointer.elem, true, modify_type);
+		}
+		return false;
+
+	case Type_MultiPointer:
+		if (source->kind == Type_MultiPointer) {
+			isize level = check_is_assignable_to_using_subtype(source->MultiPointer.elem, poly->MultiPointer.elem);
+			if (level > 0) {
+				return true;
+			}
+			return is_polymorphic_type_assignable(c, poly->MultiPointer.elem, source->MultiPointer.elem, true, modify_type);
 		}
 		return false;
 	case Type_Array:

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -8486,6 +8486,7 @@ ExprKind check_expr_base_internal(CheckerContext *c, Operand *o, Ast *node, Type
 	case Ast_PolyType:
 	case Ast_ProcType:
 	case Ast_PointerType:
+	case Ast_MultiPointerType:
 	case Ast_ArrayType:
 	case Ast_DynamicArrayType:
 	case Ast_StructType:
@@ -8928,6 +8929,11 @@ gbString write_expr_to_string(gbString str, Ast *node, bool shorthand) {
 
 	case_ast_node(pt, PointerType, node);
 		str = gb_string_append_rune(str, '^');
+		str = write_expr_to_string(str, pt->type, shorthand);
+	case_end;
+
+	case_ast_node(pt, MultiPointerType, node);
+		str = gb_string_appendc(str, "[^]");
 		str = write_expr_to_string(str, pt->type, shorthand);
 	case_end;
 

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -592,10 +592,25 @@ i64 check_distance_between_types(CheckerContext *c, Operand *operand, Type *type
 #if 1
 
 
-	// TODO(bill): Should I allow this implicit conversion at all?!
 	// rawptr <- ^T
 	if (are_types_identical(type, t_rawptr) && is_type_pointer(src)) {
-	    return 5;
+		return 5;
+	}
+	// rawptr <- [^]T
+	if (are_types_identical(type, t_rawptr) && is_type_multi_pointer(src)) {
+		return 5;
+	}
+	// ^T <- [^]T
+	if (is_type_pointer(dst) && is_type_multi_pointer(src)) {
+		if (are_types_identical(dst->Pointer.elem, src->MultiPointer.elem)) {
+			return 4;
+		}
+	}
+	// [^]T <- ^T
+	if (is_type_multi_pointer(dst) && is_type_pointer(src)) {
+		if (are_types_identical(dst->MultiPointer.elem, src->Pointer.elem)) {
+			return 4;
+		}
 	}
 #endif
 
@@ -2392,6 +2407,15 @@ bool check_is_castable_to(CheckerContext *c, Operand *operand, Type *y) {
 	if (is_type_pointer(src) && is_type_pointer(dst)) {
 		return true;
 	}
+	if (is_type_multi_pointer(src) && is_type_multi_pointer(dst)) {
+		return true;
+	}
+	if (is_type_multi_pointer(src) && is_type_pointer(dst)) {
+		return true;
+	}
+	if (is_type_pointer(src) && is_type_multi_pointer(dst)) {
+		return true;
+	}
 
 	// uintptr <-> pointer
 	if (is_type_uintptr(src) && is_type_pointer(dst)) {
@@ -2400,16 +2424,18 @@ bool check_is_castable_to(CheckerContext *c, Operand *operand, Type *y) {
 	if (is_type_pointer(src) && is_type_uintptr(dst)) {
 		return true;
 	}
+	if (is_type_uintptr(src) && is_type_multi_pointer(dst)) {
+		return true;
+	}
+	if (is_type_multi_pointer(src) && is_type_uintptr(dst)) {
+		return true;
+	}
 
 	// []byte/[]u8 <-> string (not cstring)
 	if (is_type_u8_slice(src) && (is_type_string(dst) && !is_type_cstring(dst))) {
 		return true;
 	}
-	if ((is_type_string(src) && !is_type_cstring(src)) && is_type_u8_slice(dst)) {
-		// if (is_type_typed(src)) {
-			// return true;
-		// }
-	}
+
 	// cstring -> string
 	if (are_types_identical(src, t_cstring) && are_types_identical(dst, t_string)) {
 		if (operand->mode != Addressing_Constant) {
@@ -2421,6 +2447,10 @@ bool check_is_castable_to(CheckerContext *c, Operand *operand, Type *y) {
 	if (are_types_identical(src, t_cstring) && is_type_u8_ptr(dst)) {
 		return !is_constant;
 	}
+	// cstring -> [^]u8
+	if (are_types_identical(src, t_cstring) && is_type_u8_multi_ptr(dst)) {
+		return !is_constant;
+	}
 	// cstring -> rawptr
 	if (are_types_identical(src, t_cstring) && is_type_rawptr(dst)) {
 		return !is_constant;
@@ -2428,6 +2458,10 @@ bool check_is_castable_to(CheckerContext *c, Operand *operand, Type *y) {
 
 	// ^u8 -> cstring
 	if (is_type_u8_ptr(src) && are_types_identical(dst, t_cstring)) {
+		return !is_constant;
+	}
+	// [^]u8 -> cstring
+	if (is_type_u8_multi_ptr(src) && are_types_identical(dst, t_cstring)) {
 		return !is_constant;
 	}
 	// rawptr -> cstring
@@ -3328,7 +3362,7 @@ void convert_to_typed(CheckerContext *c, Operand *operand, Type *target_type) {
 	operand->type = target_type;
 }
 
-bool check_index_value(CheckerContext *c, bool open_range, Ast *index_value, i64 max_count, i64 *value, Type *type_hint=nullptr) {
+bool check_index_value(CheckerContext *c, Type *main_type, bool open_range, Ast *index_value, i64 max_count, i64 *value, Type *type_hint=nullptr) {
 	Operand operand = {Addressing_Invalid};
 	check_expr_with_type_hint(c, &operand, index_value, type_hint);
 	if (operand.mode == Addressing_Invalid) {
@@ -3367,7 +3401,7 @@ bool check_index_value(CheckerContext *c, bool open_range, Ast *index_value, i64
 	if (operand.mode == Addressing_Constant &&
 	    (c->state_flags & StateFlag_no_bounds_check) == 0) {
 		BigInt i = exact_value_to_integer(operand.value).value_integer;
-		if (i.sign && !is_type_enum(index_type)) {
+		if (i.sign && !is_type_enum(index_type) && !is_type_multi_pointer(main_type)) {
 			gbString expr_str = expr_to_string(operand.expr);
 			error(operand.expr, "Index '%s' cannot be a negative value", expr_str);
 			gb_string_free(expr_str);
@@ -6102,6 +6136,13 @@ bool check_set_index_data(Operand *o, Type *t, bool indirection, i64 *max_count,
 		}
 		break;
 
+	case Type_MultiPointer:
+		o->type = t->MultiPointer.elem;
+		if (o->mode != Addressing_Constant) {
+			o->mode = Addressing_Variable;
+		}
+		return true;
+
 	case Type_Array:
 		*max_count = t->Array.count;
 		if (indirection) {
@@ -8133,13 +8174,9 @@ ExprKind check_expr_base_internal(CheckerContext *c, Operand *o, Ast *node, Type
 		}
 
 		i64 index = 0;
-		bool ok = check_index_value(c, false, ie->index, max_count, &index, index_type_hint);
+		bool ok = check_index_value(c, t, false, ie->index, max_count, &index, index_type_hint);
 		if (is_const) {
 			if (index < 0) {
-				if (max_count < 0) {
-
-				}
-
 				gbString str = expr_to_string(o->expr);
 				error(o->expr, "Cannot index a constant '%s'", str);
 				error_line("\tSuggestion: store the constant into a variable in order to index it with a variable index\n");
@@ -8206,6 +8243,11 @@ ExprKind check_expr_base_internal(CheckerContext *c, Operand *o, Ast *node, Type
 			o->type = alloc_type_slice(t->Array.elem);
 			break;
 
+		case Type_MultiPointer:
+			valid = true;
+			o->type = type_deref(o->type);
+			break;
+
 		case Type_Slice:
 			valid = true;
 			o->type = type_deref(o->type);
@@ -8262,7 +8304,7 @@ ExprKind check_expr_base_internal(CheckerContext *c, Operand *o, Ast *node, Type
 					capacity = max_count;
 				}
 				i64 j = 0;
-				if (check_index_value(c, true, nodes[i], capacity, &j)) {
+				if (check_index_value(c, t, true, nodes[i], capacity, &j)) {
 					index = j;
 				}
 
@@ -8289,6 +8331,16 @@ ExprKind check_expr_base_internal(CheckerContext *c, Operand *o, Ast *node, Type
 				error(se->expr, "Cannot slice constant value '%s'", s);
 				gb_string_free(s);
 			}
+		}
+
+		if (t->kind == Type_MultiPointer && se->high != nullptr) {
+			/*
+				x[:]   -> [^]T
+				x[i:]  -> [^]T
+				x[:n]  -> []T
+				x[i:n] -> []T
+			*/
+			o->type = alloc_type_slice(t->MultiPointer.elem);
 		}
 
 		o->mode = Addressing_Value;

--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -2525,6 +2525,12 @@ bool check_type_internal(CheckerContext *ctx, Ast *e, Type **type, Type *named_t
 		return true;
 	case_end;
 
+	case_ast_node(pt, MultiPointerType, e);
+		*type = alloc_type_multi_pointer(check_type(ctx, pt->type));
+		set_base_type(named_type, *type);
+		return true;
+	case_end;
+
 	case_ast_node(rt, RelativeType, e);
 		GB_ASSERT(rt->tag->kind == Ast_CallExpr);
 		ast_node(ce, CallExpr, rt->tag);

--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -1545,6 +1545,10 @@ void add_type_info_type_internal(CheckerContext *c, Type *t) {
 		add_type_info_type_internal(c, bt->Pointer.elem);
 		break;
 
+	case Type_MultiPointer:
+		add_type_info_type_internal(c, bt->MultiPointer.elem);
+		break;
+
 	case Type_Array:
 		add_type_info_type_internal(c, bt->Array.elem);
 		add_type_info_type_internal(c, alloc_type_pointer(bt->Array.elem));
@@ -1752,6 +1756,10 @@ void add_min_dep_type_info(Checker *c, Type *t) {
 
 	case Type_Pointer:
 		add_min_dep_type_info(c, bt->Pointer.elem);
+		break;
+
+	case Type_MultiPointer:
+		add_min_dep_type_info(c, bt->MultiPointer.elem);
 		break;
 
 	case Type_Array:
@@ -1993,6 +2001,7 @@ void generate_minimum_dependency_set(Checker *c, Entity *start) {
 			str_lit("bounds_check_error"),
 			str_lit("slice_expr_error_hi"),
 			str_lit("slice_expr_error_lo_hi"),
+			str_lit("multi_pointer_slice_expr_error"),
 		};
 		for (isize i = 0; i < gb_count_of(bounds_check_entities); i++) {
 			force_add_dependency_entity(c, c->info.runtime_package->scope, bounds_check_entities[i]);
@@ -2400,6 +2409,7 @@ void init_core_type_info(Checker *c) {
 	t_type_info_any              = find_core_type(c, str_lit("Type_Info_Any"));
 	t_type_info_typeid           = find_core_type(c, str_lit("Type_Info_Type_Id"));
 	t_type_info_pointer          = find_core_type(c, str_lit("Type_Info_Pointer"));
+	t_type_info_multi_pointer    = find_core_type(c, str_lit("Type_Info_Multi_Pointer"));
 	t_type_info_procedure        = find_core_type(c, str_lit("Type_Info_Procedure"));
 	t_type_info_array            = find_core_type(c, str_lit("Type_Info_Array"));
 	t_type_info_enumerated_array = find_core_type(c, str_lit("Type_Info_Enumerated_Array"));
@@ -2426,6 +2436,7 @@ void init_core_type_info(Checker *c) {
 	t_type_info_any_ptr              = alloc_type_pointer(t_type_info_any);
 	t_type_info_typeid_ptr           = alloc_type_pointer(t_type_info_typeid);
 	t_type_info_pointer_ptr          = alloc_type_pointer(t_type_info_pointer);
+	t_type_info_multi_pointer_ptr    = alloc_type_pointer(t_type_info_multi_pointer);
 	t_type_info_procedure_ptr        = alloc_type_pointer(t_type_info_procedure);
 	t_type_info_array_ptr            = alloc_type_pointer(t_type_info_array);
 	t_type_info_enumerated_array_ptr = alloc_type_pointer(t_type_info_enumerated_array);

--- a/src/docs_format.cpp
+++ b/src/docs_format.cpp
@@ -81,6 +81,7 @@ enum OdinDocTypeKind : u32 {
 	OdinDocType_SOAStructDynamic = 19,
 	OdinDocType_RelativePointer  = 20,
 	OdinDocType_RelativeSlice    = 21,
+	OdinDocType_MultiPointer     = 22,
 };
 
 enum OdinDocTypeFlag_Basic : u32 {

--- a/src/docs_writer.cpp
+++ b/src/docs_writer.cpp
@@ -530,6 +530,10 @@ OdinDocTypeIndex odin_doc_type(OdinDocWriter *w, Type *type) {
 		doc_type.kind = OdinDocType_Pointer;
 		doc_type.types = odin_doc_type_as_slice(w, type->Pointer.elem);
 		break;
+	case Type_MultiPointer:
+		doc_type.kind = OdinDocType_MultiPointer;
+		doc_type.types = odin_doc_type_as_slice(w, type->MultiPointer.elem);
+		break;
 	case Type_Array:
 		doc_type.kind = OdinDocType_Array;
 		doc_type.elem_count_len = 1;

--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -1274,6 +1274,25 @@ lbValue lb_emit_conv(lbProcedure *p, lbValue value, Type *t) {
 		res.value = LLVMBuildPointerCast(p->builder, value.value, lb_type(m, t), "");
 		return res;
 	}
+	if (is_type_multi_pointer(src) && is_type_pointer(dst)) {
+		lbValue res = {};
+		res.type = t;
+		res.value = LLVMBuildPointerCast(p->builder, value.value, lb_type(m, t), "");
+		return res;
+	}
+	if (is_type_pointer(src) && is_type_multi_pointer(dst)) {
+		lbValue res = {};
+		res.type = t;
+		res.value = LLVMBuildPointerCast(p->builder, value.value, lb_type(m, t), "");
+		return res;
+	}
+	if (is_type_multi_pointer(src) && is_type_multi_pointer(dst)) {
+		lbValue res = {};
+		res.type = t;
+		res.value = LLVMBuildPointerCast(p->builder, value.value, lb_type(m, t), "");
+		return res;
+	}
+
 
 
 
@@ -2838,6 +2857,21 @@ lbAddr lb_build_addr(lbProcedure *p, Ast *expr) {
 			return lb_addr(v);
 		}
 
+		case Type_MultiPointer: {
+			lbValue multi_ptr = {};
+			multi_ptr = lb_build_expr(p, ie->expr);
+			if (deref) {
+				multi_ptr = lb_emit_load(p, multi_ptr);
+			}
+			lbValue index = lb_build_expr(p, ie->index);
+			lbValue v = {};
+
+			LLVMValueRef indices[1] = {index.value};
+			v.value = LLVMBuildGEP(p->builder, multi_ptr.value, indices, 1, "");
+			v.type = t;
+			return lb_addr(v);
+		}
+
 		case Type_RelativeSlice: {
 			lbAddr slice_addr = {};
 			if (deref) {
@@ -2952,6 +2986,27 @@ lbAddr lb_build_addr(lbProcedure *p, Ast *expr) {
 			return slice;
 		}
 
+		case Type_MultiPointer: {
+			lbAddr res = lb_add_local_generated(p, type_of_expr(expr), false);
+			if (se->high == nullptr) {
+				lbValue offset = base;
+				LLVMValueRef indices[1] = {low.value};
+				offset.value = LLVMBuildGEP(p->builder, offset.value, indices, 1, "");
+				lb_addr_store(p, res, offset);
+			} else {
+				lb_emit_multi_pointer_slice_bounds_check(p, se->open, low, high);
+
+				LLVMValueRef indices[1] = {low.value};
+				LLVMValueRef ptr = LLVMBuildGEP(p->builder, base.value, indices, 1, "");
+				LLVMValueRef len = LLVMBuildSub(p->builder, high.value, low.value, "");
+				// TODO(bill): bounds_check for negative length
+				LLVMValueRef gep0 = lb_emit_struct_ep(p, res.addr, 0).value;
+				LLVMValueRef gep1 = lb_emit_struct_ep(p, res.addr, 1).value;
+				LLVMBuildStore(p->builder, ptr, gep0);
+				LLVMBuildStore(p->builder, len, gep1);
+			}
+			return res;
+		}
 
 		case Type_Array: {
 			Type *slice_type = alloc_type_slice(type->Array.elem);

--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -1727,6 +1727,7 @@ lbValue lb_emit_comp(lbProcedure *p, TokenKind op_kind, lbValue left, lbValue ri
 	if (is_type_integer(a) ||
 	    is_type_boolean(a) ||
 	    is_type_pointer(a) ||
+	    is_type_multi_pointer(a) ||
 	    is_type_proc(a) ||
 	    is_type_enum(a)) {
 		LLVMIntPredicate pred = {};

--- a/src/llvm_backend_type.cpp
+++ b/src/llvm_backend_type.cpp
@@ -40,6 +40,7 @@ lbValue lb_typeid(lbModule *m, Type *type) {
 		if (flags & BasicFlag_Rune)     kind = Typeid_Rune;
 	} break;
 	case Type_Pointer:         kind = Typeid_Pointer;          break;
+	case Type_MultiPointer:    kind = Typeid_Multi_Pointer;    break;
 	case Type_Array:           kind = Typeid_Array;            break;
 	case Type_EnumeratedArray: kind = Typeid_Enumerated_Array; break;
 	case Type_Slice:           kind = Typeid_Slice;            break;
@@ -385,6 +386,20 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 		case Type_Pointer: {
 			tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_pointer_ptr);
 			lbValue gep = lb_get_type_info_ptr(m, t->Pointer.elem);
+
+			LLVMValueRef vals[1] = {
+				gep.value,
+			};
+
+			lbValue res = {};
+			res.type = type_deref(tag.type);
+			res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+			lb_emit_store(p, tag, res);
+			break;
+		}
+		case Type_MultiPointer: {
+			tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_multi_pointer_ptr);
+			lbValue gep = lb_get_type_info_ptr(m, t->MultiPointer.elem);
 
 			LLVMValueRef vals[1] = {
 				gep.value,

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -337,6 +337,9 @@ Ast *clone_ast(Ast *node) {
 	case Ast_PointerType:
 		n->PointerType.type = clone_ast(n->PointerType.type);
 		break;
+	case Ast_MultiPointerType:
+		n->MultiPointerType.type = clone_ast(n->MultiPointerType.type);
+		break;
 	case Ast_ArrayType:
 		n->ArrayType.count = clone_ast(n->ArrayType.count);
 		n->ArrayType.elem  = clone_ast(n->ArrayType.elem);
@@ -985,7 +988,12 @@ Ast *ast_pointer_type(AstFile *f, Token token, Ast *type) {
 	result->PointerType.type = type;
 	return result;
 }
-
+Ast *ast_multi_pointer_type(AstFile *f, Token token, Ast *type) {
+	Ast *result = alloc_ast_node(f, Ast_MultiPointerType);
+	result->MultiPointerType.token = token;
+	result->MultiPointerType.type = type;
+	return result;
+}
 Ast *ast_array_type(AstFile *f, Token token, Ast *count, Ast *elem) {
 	Ast *result = alloc_ast_node(f, Ast_ArrayType);
 	result->ArrayType.token = token;
@@ -2317,7 +2325,11 @@ Ast *parse_operand(AstFile *f, bool lhs) {
 	case Token_OpenBracket: {
 		Token token = expect_token(f, Token_OpenBracket);
 		Ast *count_expr = nullptr;
-		if (f->curr_token.kind == Token_Question) {
+		if (f->curr_token.kind == Token_Pointer) {
+			expect_token(f, Token_Pointer);
+			expect_token(f, Token_CloseBracket);
+			return ast_multi_pointer_type(f, token, parse_type(f));
+		} else if (f->curr_token.kind == Token_Question) {
 			count_expr = ast_unary_expr(f, expect_token(f, Token_Question), nullptr);
 		} else if (allow_token(f, Token_dynamic)) {
 			expect_token(f, Token_CloseBracket);

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -604,6 +604,10 @@ AST_KIND(_TypeBegin, "", bool) \
 		Ast *tag; \
 		Ast *type; \
 	}) \
+	AST_KIND(MultiPointerType, "multi pointer type", struct { \
+		Token token; \
+		Ast *type; \
+	}) \
 	AST_KIND(ArrayType, "array type", struct { \
 		Token token; \
 		Ast *count; \

--- a/src/parser_pos.cpp
+++ b/src/parser_pos.cpp
@@ -95,6 +95,7 @@ Token ast_token(Ast *node) {
 	case Ast_ProcType:         return node->ProcType.token;
 	case Ast_RelativeType:     return ast_token(node->RelativeType.tag);
 	case Ast_PointerType:      return node->PointerType.token;
+	case Ast_MultiPointerType: return node->MultiPointerType.token;
 	case Ast_ArrayType:        return node->ArrayType.token;
 	case Ast_DynamicArrayType: return node->DynamicArrayType.token;
 	case Ast_StructType:       return node->StructType.token;
@@ -312,6 +313,7 @@ Token ast_end_token(Ast *node) {
 	case Ast_RelativeType:
 		return ast_end_token(node->RelativeType.type);
 	case Ast_PointerType:      return ast_end_token(node->PointerType.type);
+	case Ast_MultiPointerType: return ast_end_token(node->MultiPointerType.type);
 	case Ast_ArrayType:        return ast_end_token(node->ArrayType.elem);
 	case Ast_DynamicArrayType: return ast_end_token(node->DynamicArrayType.elem);
 	case Ast_StructType:


### PR DESCRIPTION
Multi-Pointers in Odin are a way to describe `foreign` (C-like) pointers which act like arrays (pointers that map to multiple items).

The name of Multi-Pointers may subject to change.

What Multi-Pointers support:
* Indexing (without any bounds checking)
* Slicing (bound checking on if both the low and high operands are given).
* Implicit conversions between `^T` and `[^]T`
* Implicit conversion to `rawptr` (like all pointers)

What Multi-Pointers DO NOT SUPPORT:
* Dereferencing (which makes it closer to a slim-slice than a pointer)

The main purpose of this type is to aid with `foreign` code and act as a way to auto-document functionality and allow for easier transition to Odin code, especially converting pointers into slices.

The following are the rules for indexing and slicing for multi-pointers, and what type they produce depending the operands given:

```odin
x: [^]T = ...;

x[i]   -> T
x[:]   -> [^]T
x[i:]  -> [^]T
x[:n]  -> []T
x[i:n] -> []T
```