### PR TITLE
fix custom alignment clamping warning

### DIFF
--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -223,7 +223,7 @@ bool check_custom_align(CheckerContext *ctx, Ast *node, i64 *align_) {
 			// NOTE(bill): Success!!!
 			i64 custom_align = gb_clamp(align, 1, build_context.max_align);
 			if (custom_align < align) {
-				warning(node, "Custom alignment has been clamped to %lld from %lld", align, custom_align);
+				warning(node, "Custom alignment has been clamped from %lld to %lld", align, custom_align);
 			}
 			*align_ = custom_align;
 			return true;


### PR DESCRIPTION
I was following some conversation on discord about this message, and that it was incorrect. here a fix.