### PR TITLE
LLVM Struct Types with Explicit Padding

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -1989,7 +1989,7 @@ bool check_builtin_procedure(CheckerContext *c, Operand *operand, Ast *call, i32
 				Entity *old_field = old_struct->Struct.fields[i];
 				if (old_field->kind == Entity_Variable) {
 					Type *array_type = alloc_type_array(old_field->type, count);
-					Entity *new_field = alloc_entity_field(scope, old_field->token, array_type, false, old_field->Variable.field_src_index);
+					Entity *new_field = alloc_entity_field(scope, old_field->token, array_type, false, old_field->Variable.field_index);
 					soa_struct->Struct.fields[i] = new_field;
 					add_entity(c, scope, nullptr, new_field);
 				} else {

--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -2317,7 +2317,7 @@ Type *make_soa_struct_internal(CheckerContext *ctx, Ast *array_typ_expr, Ast *el
 				} else {
 					field_type = alloc_type_pointer(old_field->type);
 				}
-				Entity *new_field = alloc_entity_field(scope, old_field->token, field_type, false, old_field->Variable.field_src_index);
+				Entity *new_field = alloc_entity_field(scope, old_field->token, field_type, false, old_field->Variable.field_index);
 				soa_struct->Struct.fields[i] = new_field;
 				add_entity(ctx, scope, nullptr, new_field);
 				add_entity_use(ctx, nullptr, new_field);

--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -215,13 +215,7 @@ bool check_custom_align(CheckerContext *ctx, Ast *node, i64 *align_) {
 				error(node, "#align must be a power of 2, got %lld", align);
 				return false;
 			}
-
-			// NOTE(bill): Success!!!
-			i64 custom_align = gb_clamp(align, 1, build_context.max_align);
-			if (custom_align < align) {
-				warning(node, "Custom alignment has been clamped to %lld from %lld", align, custom_align);
-			}
-			*align_ = custom_align;
+			*align_ = align;
 			return true;
 		}
 	}

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -155,8 +155,7 @@ struct Entity {
 		} Constant;
 		struct {
 			Ast *init_expr; // only used for some variables within procedure bodies
-			i32        field_index;
-			i32        field_src_index;
+			i32  field_index;
 
 			ParameterValue param_value;
 			Ast *          param_expr;
@@ -319,20 +318,18 @@ Entity *alloc_entity_const_param(Scope *scope, Token token, Type *type, ExactVal
 }
 
 
-Entity *alloc_entity_field(Scope *scope, Token token, Type *type, bool is_using, i32 field_src_index, EntityState state = EntityState_Unresolved) {
+Entity *alloc_entity_field(Scope *scope, Token token, Type *type, bool is_using, i32 field_index, EntityState state = EntityState_Unresolved) {
 	Entity *entity = alloc_entity_variable(scope, token, type);
-	entity->Variable.field_src_index = field_src_index;
-	entity->Variable.field_index = field_src_index;
+	entity->Variable.field_index = field_index;
 	if (is_using) entity->flags |= EntityFlag_Using;
 	entity->flags |= EntityFlag_Field;
 	entity->state = state;
 	return entity;
 }
 
-Entity *alloc_entity_array_elem(Scope *scope, Token token, Type *type, i32 field_src_index) {
+Entity *alloc_entity_array_elem(Scope *scope, Token token, Type *type, i32 field_index) {
 	Entity *entity = alloc_entity_variable(scope, token, type);
-	entity->Variable.field_src_index = field_src_index;
-	entity->Variable.field_index = field_src_index;
+	entity->Variable.field_index = field_index;
 	entity->flags |= EntityFlag_Field;
 	entity->flags |= EntityFlag_ArrayElem;
 	entity->state = EntityState_Resolved;

--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -806,8 +806,6 @@ lbProcedure *lb_create_main_procedure(lbModule *m, lbProcedure *startup_runtime)
 		lbAddr all_tests_array_addr = lb_add_global_generated(p->module, array_type, {});
 		lbValue all_tests_array = lb_addr_get_ptr(p, all_tests_array_addr);
 
-		LLVMTypeRef lbt_Internal_Test = lb_type(m, t_Internal_Test);
-
 		LLVMValueRef indices[2] = {};
 		indices[0] = LLVMConstInt(lb_type(m, t_i32), 0, false);
 
@@ -834,7 +832,7 @@ lbProcedure *lb_create_main_procedure(lbModule *m, lbProcedure *startup_runtime)
 			GB_ASSERT(LLVMIsConstant(vals[2]));
 
 			LLVMValueRef dst = LLVMConstInBoundsGEP(all_tests_array.value, indices, gb_count_of(indices));
-			LLVMValueRef src = llvm_const_named_struct(lbt_Internal_Test, vals, gb_count_of(vals));
+			LLVMValueRef src = llvm_const_named_struct(m, t_Internal_Test, vals, gb_count_of(vals));
 
 			LLVMBuildStore(p->builder, src, dst);
 		}

--- a/src/llvm_backend.hpp
+++ b/src/llvm_backend.hpp
@@ -432,6 +432,7 @@ void lb_build_nested_proc(lbProcedure *p, AstProcLit *pd, Entity *e);
 lbValue lb_emit_logical_binary_expr(lbProcedure *p, TokenKind op, Ast *left, Ast *right, Type *type);
 lbValue lb_build_cond(lbProcedure *p, Ast *cond, lbBlock *true_block, lbBlock *false_block);
 
+LLVMValueRef llvm_const_named_struct(lbModule *m, Type *t, LLVMValueRef *values, isize value_count_);
 LLVMValueRef llvm_const_named_struct(LLVMTypeRef t, LLVMValueRef *values, isize value_count_);
 void lb_set_entity_from_other_modules_linkage_correctly(lbModule *other_module, Entity *e, String const &name);
 
@@ -445,6 +446,8 @@ void lb_emit_init_context(lbProcedure *p, lbAddr addr);
 lbCopyElisionHint lb_set_copy_elision_hint(lbProcedure *p, lbAddr const &addr, Ast *ast);
 void lb_reset_copy_elision_hint(lbProcedure *p, lbCopyElisionHint prev_hint);
 lbValue lb_consume_copy_elision_hint(lbProcedure *p);
+
+bool lb_struct_has_padding_prefix(Type *t);
 
 #define LB_STARTUP_RUNTIME_PROC_NAME   "__$startup_runtime"
 #define LB_STARTUP_TYPE_INFO_PROC_NAME "__$startup_type_info"

--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -3259,7 +3259,7 @@ lbAddr lb_build_addr(lbProcedure *p, Ast *expr) {
 						TypeAndValue tav = type_and_value_of_expr(elem);
 					} else {
 						TypeAndValue tav = type_and_value_of_expr(elem);
-						Selection sel = lookup_field_from_index(bt, st->fields[field_index]->Variable.field_src_index);
+						Selection sel = lookup_field_from_index(bt, st->fields[field_index]->Variable.field_index);
 						index = sel.index[0];
 					}
 

--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -1923,9 +1923,9 @@ lbValue lb_emit_comp_against_nil(lbProcedure *p, TokenKind op_kind, lbValue x) {
 			lbValue map_ptr = lb_address_from_load_or_generate_local(p, x);
 
 			unsigned indices[2] = {0, 0};
-			LLVMValueRef hashes_data = LLVMBuildStructGEP(p->builder, map_ptr.value, 0, "");
-			LLVMValueRef hashes_data_ptr_ptr = LLVMBuildStructGEP(p->builder, hashes_data, 0, "");
-			LLVMValueRef hashes_data_ptr = LLVMBuildLoad(p->builder, hashes_data_ptr_ptr, "");
+			lbValue hashes_data = lb_emit_struct_ep(p, map_ptr, 0);
+			lbValue hashes_data_ptr_ptr = lb_emit_struct_ep(p, hashes_data, 0);
+			LLVMValueRef hashes_data_ptr = LLVMBuildLoad(p->builder, hashes_data_ptr_ptr.value, "");
 
 			if (op_kind == Token_CmpEq) {
 				res.value = LLVMBuildIsNull(p->builder, hashes_data_ptr, "");
@@ -2786,7 +2786,7 @@ lbAddr lb_build_addr(lbProcedure *p, Ast *expr) {
 
 		bool deref = is_type_pointer(t);
 		t = base_type(type_deref(t));
-		if (is_type_soa_struct(t)) {
+		if (is_type_soa_struct(t)) {			
 			// SOA STRUCTURES!!!!
 			lbValue val = lb_build_addr_ptr(p, ie->expr);
 			if (deref) {
@@ -2821,7 +2821,6 @@ lbAddr lb_build_addr(lbProcedure *p, Ast *expr) {
 				// lbValue len = ir_soa_struct_len(p, base_struct);
 				// lb_emit_bounds_check(p, ast_token(ie->index), index, len);
 			}
-
 			lbValue val = lb_emit_ptr_offset(p, field, index);
 			return lb_addr(val);
 		}

--- a/src/llvm_backend_stmt.cpp
+++ b/src/llvm_backend_stmt.cpp
@@ -357,8 +357,7 @@ void lb_build_range_indexed(lbProcedure *p, lbValue expr, Type *val_type, lbValu
 		lbValue entries = lb_map_entries_ptr(p, expr);
 		lbValue elem = lb_emit_struct_ep(p, entries, 0);
 		elem = lb_emit_load(p, elem);
-
-		lbValue entry = lb_emit_ptr_offset(p, elem, idx);
+		lbValue entry = lb_emit_ptr_offset(p, elem, idx);		
 		idx = lb_emit_load(p, lb_emit_struct_ep(p, entry, 2));
 		val = lb_emit_load(p, lb_emit_struct_ep(p, entry, 3));
 

--- a/src/llvm_backend_type.cpp
+++ b/src/llvm_backend_type.cpp
@@ -157,12 +157,14 @@ lbValue lb_type_info_member_tags_offset(lbProcedure *p, isize count) {
 void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info data
 	lbModule *m = p->module;
 	CheckerInfo *info = m->info;
-
+	
+	i64 global_type_info_data_entity_count = 0;
 	{
 		// NOTE(bill): Set the type_table slice with the global backing array
 		lbValue global_type_table = lb_find_runtime_value(m, str_lit("type_table"));
 		Type *type = base_type(lb_global_type_info_data_entity->type);
 		GB_ASSERT(is_type_array(type));
+		global_type_info_data_entity_count = type->Array.count;
 
 		LLVMValueRef indices[2] = {llvm_zero(m), llvm_zero(m)};
 		LLVMValueRef values[2] = {
@@ -179,6 +181,11 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 	Entity *type_info_flags_entity = find_core_entity(info->checker, str_lit("Type_Info_Flags"));
 	Type *t_type_info_flags = type_info_flags_entity->type;
 
+	
+	auto entries_handled = slice_make<bool>(heap_allocator(), cast(isize)global_type_info_data_entity_count);
+	defer (gb_free(heap_allocator(), entries_handled.data));
+	entries_handled[0] = true;
+	
 	for_array(type_info_type_index, info->type_info_types) {
 		Type *t = info->type_info_types[type_info_type_index];
 		if (t == nullptr || t == t_invalid) {
@@ -189,18 +196,35 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 		if (entry_index <= 0) {
 			continue;
 		}
+		
+		if (entries_handled[entry_index]) {
+			continue;
+		}
+		entries_handled[entry_index] = true;
 
+		lbValue global_data_ptr = lb_global_type_info_data_ptr(m);
 		lbValue tag = {};
-		lbValue ti_ptr = lb_emit_array_epi(p, lb_global_type_info_data_ptr(m), cast(i32)entry_index);
+		lbValue ti_ptr = lb_emit_array_epi(p, global_data_ptr, cast(i32)entry_index);
+		
+		i64 size = type_size_of(t);
+		i64 align = type_align_of(t);
+		u32 flags = type_info_flags_of_type(t);
+		lbValue id = lb_typeid(m, t);
+		GB_ASSERT_MSG(align != 0, "%lld %s", align, type_to_string(t));
+		
+		lbValue type_info_flags = lb_const_int(p->module, t_type_info_flags, flags);
+		
+		lbValue size_ptr  = lb_emit_struct_ep(p, ti_ptr, 0);
+		lbValue align_ptr = lb_emit_struct_ep(p, ti_ptr, 1);
+		lbValue flags_ptr = lb_emit_struct_ep(p, ti_ptr, 2);
+		lbValue id_ptr    = lb_emit_struct_ep(p, ti_ptr, 3);
+				
+		lb_emit_store(p, size_ptr,  lb_const_int(m, t_int, size));
+		lb_emit_store(p, align_ptr, lb_const_int(m, t_int, align));
+		lb_emit_store(p, flags_ptr, type_info_flags);
+		lb_emit_store(p, id_ptr,    id);
+		
 		lbValue variant_ptr = lb_emit_struct_ep(p, ti_ptr, 4);
-
-		lbValue type_info_flags = lb_const_int(p->module, t_type_info_flags, type_info_flags_of_type(t));
-
-		lb_emit_store(p, lb_emit_struct_ep(p, ti_ptr, 0), lb_const_int(m, t_int, type_size_of(t)));
-		lb_emit_store(p, lb_emit_struct_ep(p, ti_ptr, 1), lb_const_int(m, t_int, type_align_of(t)));
-		lb_emit_store(p, lb_emit_struct_ep(p, ti_ptr, 2), type_info_flags);
-		lb_emit_store(p, lb_emit_struct_ep(p, ti_ptr, 3), lb_typeid(m, t));
-
 
 		switch (t->kind) {
 		case Type_Named: {
@@ -233,7 +257,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 
 			lbValue res = {};
 			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 			lb_emit_store(p, tag, res);
 			break;
 		}
@@ -298,7 +322,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 
 				lbValue res = {};
 				res.type = type_deref(tag.type);
-				res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+				res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 				lb_emit_store(p, tag, res);
 				break;
 			}
@@ -334,7 +358,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 
 					lbValue res = {};
 					res.type = type_deref(tag.type);
-					res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+					res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 					lb_emit_store(p, tag, res);
 				}
 				break;
@@ -368,7 +392,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 
 					lbValue res = {};
 					res.type = type_deref(tag.type);
-					res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+					res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 					lb_emit_store(p, tag, res);
 				}
 				break;
@@ -393,7 +417,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 
 			lbValue res = {};
 			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 			lb_emit_store(p, tag, res);
 			break;
 		}
@@ -407,7 +431,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 
 			lbValue res = {};
 			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 			lb_emit_store(p, tag, res);
 			break;
 		}
@@ -423,7 +447,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 
 			lbValue res = {};
 			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 			lb_emit_store(p, tag, res);
 			break;
 		}
@@ -443,7 +467,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 
 			lbValue res = {};
 			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 			lb_emit_store(p, tag, res);
 
 			// NOTE(bill): Union assignment
@@ -467,7 +491,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 
 			lbValue res = {};
 			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 			lb_emit_store(p, tag, res);
 			break;
 		}
@@ -481,7 +505,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 
 			lbValue res = {};
 			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 			lb_emit_store(p, tag, res);
 			break;
 		}
@@ -506,7 +530,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 
 			lbValue res = {};
 			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 			lb_emit_store(p, tag, res);
 			break;
 		}
@@ -545,7 +569,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 
 			lbValue res = {};
 			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 			lb_emit_store(p, tag, res);
 
 			break;
@@ -596,7 +620,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 
 				lbValue res = {};
 				res.type = type_deref(tag.type);
-				res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+				res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 				lb_emit_store(p, tag, res);
 			}
 			break;
@@ -650,7 +674,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 
 				lbValue res = {};
 				res.type = type_deref(tag.type);
-				res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+				res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 				lb_emit_store(p, tag, res);
 			}
 
@@ -688,7 +712,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 					vals[11] = soa_len.value;
 				}
 			}
-
+			
 			isize count = t->Struct.fields.count;
 			if (count > 0) {
 				lbValue memory_types   = lb_type_info_member_types_offset  (p, count);
@@ -743,11 +767,10 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 					vals[i]  = LLVMConstNull(lb_type(m, get_struct_field_type(tag.type, i)));
 				}
 			}
-
-
+			
 			lbValue res = {};
 			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 			lb_emit_store(p, tag, res);
 
 			break;
@@ -767,7 +790,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 
 			lbValue res = {};
 			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 			lb_emit_store(p, tag, res);
 			break;
 		}
@@ -791,7 +814,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 
 				lbValue res = {};
 				res.type = type_deref(tag.type);
-				res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+				res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 				lb_emit_store(p, tag, res);
 			}
 			break;
@@ -808,7 +831,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 
 				lbValue res = {};
 				res.type = type_deref(tag.type);
-				res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+				res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 				lb_emit_store(p, tag, res);
 			}
 			break;
@@ -823,7 +846,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 
 				lbValue res = {};
 				res.type = type_deref(tag.type);
-				res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+				res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 				lb_emit_store(p, tag, res);
 			}
 			break;
@@ -837,7 +860,7 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 
 				lbValue res = {};
 				res.type = type_deref(tag.type);
-				res.value = llvm_const_named_struct(lb_type(m, res.type), vals, gb_count_of(vals));
+				res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
 				lb_emit_store(p, tag, res);
 			}
 			break;
@@ -854,6 +877,12 @@ void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup type_info da
 			if (t != t_llvm_bool) {
 				GB_PANIC("Unhandled Type_Info variant: %s", type_to_string(t));
 			}
+		}
+	}
+	
+	for_array(i, entries_handled) {
+		if (!entries_handled[i]) {
+			GB_PANIC("UNHANDLED ENTRY %td (%td)", i, entries_handled.count);
 		}
 	}
 }

--- a/src/llvm_backend_utility.cpp
+++ b/src/llvm_backend_utility.cpp
@@ -807,6 +807,13 @@ lbValue lb_address_from_load(lbProcedure *p, lbValue value) {
 	return {};
 }
 
+i32 lb_convert_struct_index(Type *t, i32 index) {
+	if (t->kind == Type_Struct && t->Struct.custom_align != 0) {
+		index += 1;
+	}
+	return index;
+}
+
 lbValue lb_emit_struct_ep(lbProcedure *p, lbValue s, i32 index) {
 	GB_ASSERT(is_type_pointer(s.type));
 	Type *t = base_type(type_deref(s.type));
@@ -883,10 +890,9 @@ lbValue lb_emit_struct_ep(lbProcedure *p, lbValue s, i32 index) {
 	}
 
 	GB_ASSERT_MSG(result_type != nullptr, "%s %d", type_to_string(t), index);
-
-	if (t->kind == Type_Struct && t->Struct.custom_align != 0) {
-		index += 1;
-	}
+	
+	index = lb_convert_struct_index(t, index);
+	
 	if (lb_is_const(s)) {
 		lbModule *m = p->module;
 		lbValue res = {};
@@ -1006,10 +1012,8 @@ lbValue lb_emit_struct_ev(lbProcedure *p, lbValue s, i32 index) {
 	}
 
 	GB_ASSERT_MSG(result_type != nullptr, "%s, %d", type_to_string(s.type), index);
-
-	if (t->kind == Type_Struct && t->Struct.custom_align != 0) {
-		index += 1;
-	}
+	
+	index = lb_convert_struct_index(t, index);
 
 	lbValue res = {};
 	res.value = LLVMBuildExtractValue(p->builder, s.value, cast(unsigned)index, "");

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -2432,7 +2432,7 @@ Selection lookup_field_from_index(Type *type, i64 index) {
 		for (isize i = 0; i < max_count; i++) {
 			Entity *f = type->Struct.fields[i];
 			if (f->kind == Entity_Variable) {
-				if (f->Variable.field_src_index == index) {
+				if (f->Variable.field_index == index) {
 					auto sel_array = array_make<i32>(a, 1);
 					sel_array[0] = cast(i32)i;
 					return make_selection(f, sel_array, false);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -2972,7 +2972,7 @@ i64 type_align_of_internal(Type *t, TypePath *path) {
 			return 1;
 		}
 		if (t->Union.custom_align > 0) {
-			return gb_clamp(t->Union.custom_align, 1, build_context.max_align);
+			return gb_max(t->Union.custom_align, 1);
 		}
 
 		i64 max = 1;
@@ -2993,7 +2993,7 @@ i64 type_align_of_internal(Type *t, TypePath *path) {
 
 	case Type_Struct: {
 		if (t->Struct.custom_align > 0) {
-			return gb_clamp(t->Struct.custom_align, 1, build_context.max_align);
+			return gb_max(t->Struct.custom_align, 1);
 		}
 		if (t->Struct.is_raw_union) {
 			i64 max = 1;


### PR DESCRIPTION
Instead of relying on LLVM doing the padding and alignment correctly, I have added explicit padding between struct fields. 