### PR TITLE
Make optional semicolons the default on odin/parser, and add parser test on demo.odin

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -116,7 +116,7 @@ end_pos :: proc(tok: tokenizer.Token) -> tokenizer.Pos {
 	return pos
 }
 
-default_parser :: proc(flags := Flags{}) -> Parser {
+default_parser :: proc(flags := Flags{.Optional_Semicolons}) -> Parser {
 	return Parser {
 		flags = flags,
 		err  = default_error_handler,

--- a/tests/core/build.bat
+++ b/tests/core/build.bat
@@ -21,3 +21,8 @@ echo ---
 echo Running core:hash tests
 echo ---
 %PATH_TO_ODIN% run hash %COMMON% -o:size
+
+echo ---
+echo Running core:odin tests
+echo ---
+%PATH_TO_ODIN% run odin %COMMON% -o:size

--- a/tests/core/odin/test_parse.odin
+++ b/tests/core/odin/test_parse.odin
@@ -1,0 +1,50 @@
+package test_core_odin_parse
+
+import "core:testing"
+import "core:fmt"
+
+import "core:odin/parser"
+
+
+TEST_count := 0
+TEST_fail  := 0
+
+when ODIN_TEST {
+    expect  :: testing.expect
+    log     :: testing.log
+} else {
+    expect  :: proc(t: ^testing.T, condition: bool, message: string, loc := #caller_location) {
+        fmt.printf("[%v] ", loc)
+        TEST_count += 1
+        if !condition {
+            TEST_fail += 1
+            fmt.println(message)
+            return
+        }
+        fmt.println(" PASS")
+    }
+    log     :: proc(t: ^testing.T, v: any, loc := #caller_location) {
+        fmt.printf("[%v] ", loc)
+        fmt.printf("log: %v\n", v)
+    }
+}
+
+
+main :: proc() {
+    t := testing.T{}
+    test_parse_demo(&t)
+
+    fmt.printf("%v/%v tests successful.\n", TEST_count - TEST_fail, TEST_count)
+}
+
+
+@test
+test_parse_demo :: proc(t: ^testing.T) {
+	pkg, ok := parser.parse_package_from_path("examples/demo")
+	
+	expect(t, ok == true, "parser.parse_package_from_path failed")
+
+	for key, value in pkg.files {
+		expect(t, value.syntax_error_count == 0, fmt.tprintf("%v should contain zero errors", key))
+	}
+}

--- a/tests/core/odin/test_parser.odin
+++ b/tests/core/odin/test_parser.odin
@@ -1,4 +1,4 @@
-package test_core_odin_parse
+package test_core_odin_parser
 
 import "core:testing"
 import "core:fmt"


### PR DESCRIPTION
Closes #1152

There is no longer any errors when parsing demo.odin.