### PR TITLE
Remove assert from `mem.ptr_to_bytes`. Fixes #1206

### DIFF
--- a/core/mem/mem.odin
+++ b/core/mem/mem.odin
@@ -179,7 +179,6 @@ buffer_from_slice :: proc "contextless" (backing: $T/[]$E) -> [dynamic]E {
 }
 
 ptr_to_bytes :: proc "contextless" (ptr: ^$T, len := 1) -> []byte {
-	assert(len >= 0)
 	return transmute([]byte)Raw_Slice{ptr, len*size_of(T)}
 }
 


### PR DESCRIPTION
`assert` doesn't work in "contextless" environments.