### PR TITLE
Issue #1116 Newline bug in field list

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1228,6 +1228,9 @@ void comsume_comment_groups(AstFile *f, Token prev) {
 }
 
 bool ignore_newlines(AstFile *f) {
+	if (f->ignoring_newlines) {
+		return true;
+	}
 	if (f->allow_newline) {
 		return f->expr_level > 0;
 	}
@@ -3585,6 +3588,8 @@ Ast *parse_field_list(AstFile *f, isize *name_count_, u32 allowed_flags, TokenKi
 	bool seen_ellipsis = false;
 	bool is_signature = (allowed_flags & FieldFlag_Signature) == FieldFlag_Signature;
 
+	f->ignoring_newlines = true;
+
 	while (f->curr_token.kind != follow &&
 	       f->curr_token.kind != Token_Colon &&
 	       f->curr_token.kind != Token_EOF) {
@@ -3739,6 +3744,7 @@ Ast *parse_field_list(AstFile *f, isize *name_count_, u32 allowed_flags, TokenKi
 			}
 		}
 
+		f->ignoring_newlines = false;
 		if (name_count_) *name_count_ = total_name_count;
 		return ast_field_list(f, start_token, params);
 	}
@@ -3760,6 +3766,7 @@ Ast *parse_field_list(AstFile *f, isize *name_count_, u32 allowed_flags, TokenKi
 		array_add(&params, param);
 	}
 
+	f->ignoring_newlines = false;
 	if (name_count_) *name_count_ = total_name_count;
 	return ast_field_list(f, start_token, params);
 }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -112,9 +112,10 @@ struct AstFile {
 	// <  0: In Control Clause
 	// NOTE(bill): Used to prevent type literals in control clauses
 	isize        expr_level;
-	bool         allow_newline; // Only valid for expr_level == 0
-	bool         allow_range;   // NOTE(bill): Ranges are only allowed in certain cases
-	bool         allow_in_expr; // NOTE(bill): in expression are only allowed in certain cases
+	bool         allow_newline;     // Only valid for expr_level == 0
+	bool         ignoring_newlines; // In a field list. (Ignore all new lines)
+	bool         allow_range;       // NOTE(bill): Ranges are only allowed in certain cases
+	bool         allow_in_expr;     // NOTE(bill): in expression are only allowed in certain cases
 	bool         in_foreign_block;
 	bool         allow_type;
 


### PR DESCRIPTION
Unfortunately, needed to add a field to the `struct AstFile` to accomplish this.