### PR TITLE
fix strip-semicolon using original file handle size

### DIFF
--- a/src/gb/gb.h
+++ b/src/gb/gb.h
@@ -6030,8 +6030,11 @@ gb_inline b32 gb_file_copy(char const *existing_filename, char const *new_filena
 
 	struct stat stat_existing;
 	fstat(existing_fd, &stat_existing);
-
 	size = sendfile(new_fd, existing_fd, 0, stat_existing.st_size);
+	
+	// set new handle to wanted size for safety
+	int i = ftruncate(new_fd, size);
+	GB_ASSERT(i == 0);
 
 	close(new_fd);
 	close(existing_fd);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2141,8 +2141,8 @@ int strip_semicolons(Parser *parser) {
 		generated_count += 1;
 		
 		i64 written = 0;
-		defer (gb_file_truncate(&f, written));
-		
+		defer (err = gb_file_truncate(&f, written));
+
 		debugf("Write file with stripped tokens: %s\n", filename);
 		err = write_file_with_stripped_tokens(&f, file->file, &written);
 		if (err) {
@@ -2178,6 +2178,7 @@ int strip_semicolons(Parser *parser) {
 		}
 		
 		debugf("Copy '%s' to '%s'\n", new_fullpath, old_fullpath);
+
 		if (!gb_file_copy(new_fullpath, old_fullpath, false)) {
 			gb_printf_err("failed to copy '%s' to '%s'\n", old_fullpath, new_fullpath);
 			debugf("Copy '%s' to '%s'\n", old_fullpath_backup, old_fullpath);
@@ -2187,7 +2188,7 @@ int strip_semicolons(Parser *parser) {
 			failed = true;
 			break;
 		}
-		
+
 		debugf("Remove '%s'\n", old_fullpath_backup);
 		if (!gb_file_remove(old_fullpath_backup)) {
 			gb_printf_err("failed to remove '%s'\n", old_fullpath_backup);


### PR DESCRIPTION
After copying from a temp file (115B) to the original file (119B), the original file kept its size but got all semicolons removed with the rest 4B being garbage. This happens on linux, so I assume Windows copy call does more than the linux one.

Truncating the file for safety in the `gb_file_copy` makes sense in my opinion. There should probably be better error handling then the assertion I posted. :sweat_smile: 