### PR TITLE
rename sdl2 KeyCode to Keycode

### DIFF
--- a/vendor/sdl2/sdl_keyboard.odin
+++ b/vendor/sdl2/sdl_keyboard.odin
@@ -9,7 +9,7 @@ when ODIN_OS == "freebsd" { foreign import lib "system:SDL2" }
 
 Keysym :: struct {
 	scancode: Scancode, /**< SDL physical key code - see ::SDL_Scancode for details */
-	sym:      KeyCode,  /**< SDL virtual key code - see ::SDL_KeyCode for details */
+	sym:      Keycode,  /**< SDL virtual key code - see ::SDL_Keycode for details */
 	mod:      Keymod,   /**< current key modifiers */
 	unused:   u32,
 }
@@ -19,12 +19,12 @@ Keysym :: struct {
 foreign lib {
 	GetKeyboardFocus        :: proc() -> ^Window ---
 	GetKeyboardState        :: proc(numkeys: ^c.int) -> [^]u8 ---
-	GetKeyFromScancode      :: proc(scancode: Scancode) -> KeyCode ---
-	GetScancodeFromKey      :: proc(key: KeyCode) -> Scancode ---
+	GetKeyFromScancode      :: proc(scancode: Scancode) -> Keycode ---
+	GetScancodeFromKey      :: proc(key: Keycode) -> Scancode ---
 	GetScancodeName         :: proc(scancode: Scancode) -> cstring ---
 	GetScancodeFromName     :: proc(name: cstring) -> Scancode ---
-	GetKeyName              :: proc(key: KeyCode) -> cstring ---
-	GetKeyFromName          :: proc(name: cstring) -> KeyCode ---
+	GetKeyName              :: proc(key: Keycode) -> cstring ---
+	GetKeyFromName          :: proc(name: cstring) -> Keycode ---
 	StartTextInput          :: proc() ---
 	IsTextInputActive       :: proc() -> bool ---
 	StopTextInput           :: proc() ---

--- a/vendor/sdl2/sdl_keycode.odin
+++ b/vendor/sdl2/sdl_keycode.odin
@@ -2,11 +2,11 @@ package sdl2
 
 
 SCANCODE_MASK :: 1<<30
-SCANCODE_TO_KEYCODE :: #force_inline proc "c" (X: Scancode) -> KeyCode {
-	return KeyCode(i32(X) | SCANCODE_MASK)
+SCANCODE_TO_KEYCODE :: #force_inline proc "c" (X: Scancode) -> Keycode {
+	return Keycode(i32(X) | SCANCODE_MASK)
 }
 
-KeyCode :: enum i32 {
+Keycode :: enum i32 {
 	UNKNOWN = 0,
 
 	RETURN = '\r',


### PR DESCRIPTION
request to change sdl2 `KeyCode` to `Keycode` (from uppercase C to lowercase c)

1) to be consistent with the original SDL naming convention
<https://wiki.libsdl.org/SDL_Keycode>
2) to be consistent with Odin's `sdl2.Scancode`