### PR TITLE
glfw.WindowShouldClose should return a bool

### DIFF
--- a/vendor/glfw/bindings/bindings.odin
+++ b/vendor/glfw/bindings/bindings.odin
@@ -46,7 +46,7 @@ foreign glfw {
 	WindowHint         :: proc(hint, value: c.int) ---
 	DefaultWindowHints :: proc() ---
 	WindowHintString   :: proc(hint: c.int, value: cstring) ---
-	WindowShouldClose  :: proc(window: WindowHandle) -> c.int ---
+	WindowShouldClose  :: proc(window: WindowHandle) -> b32 ---
 
 	SwapInterval :: proc(interval: c.int) ---
 	SwapBuffers  :: proc(window: WindowHandle) ---

--- a/vendor/glfw/wrapper.odin
+++ b/vendor/glfw/wrapper.odin
@@ -52,9 +52,7 @@ DestroyWindow :: glfw.DestroyWindow
 WindowHint         :: glfw.WindowHint
 DefaultWindowHints :: glfw.DefaultWindowHints
 WindowHintString   :: glfw.WindowHintString
-WindowShouldClose :: proc "c" (window: WindowHandle) -> bool {
-    return glfw.WindowShouldClose(window) != 0
-}
+WindowShouldClose  :: glfw.WindowShouldClose
 
 SwapInterval :: glfw.SwapInterval
 SwapBuffers  :: glfw.SwapBuffers


### PR DESCRIPTION
[WindowShouldClose](https://www.glfw.org/docs/latest/group__window.html#ga24e02fbfefbb81fc45320989f8140ab5) returns the value of the close flag which is always `0` or `1`

https://www.glfw.org/docs/latest/window_guide.html#window_close