### PR TITLE
Fix #1268.

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -3660,8 +3660,11 @@ bool check_index_value(CheckerContext *c, Type *main_type, bool open_range, Ast 
 				String lo_str = {};
 				String hi_str = {};
 				if (bt->Enum.fields.count > 0) {
-					lo_str = bt->Enum.fields[bt->Enum.min_value_index]->token.string;
-					hi_str = bt->Enum.fields[bt->Enum.max_value_index]->token.string;
+					isize lo_idx = gb_clamp(bt->Enum.min_value_index, 0, bt->Enum.fields.count - 1);
+					isize hi_idx = gb_clamp(bt->Enum.max_value_index, 0, bt->Enum.fields.count - 1);
+
+					lo_str = bt->Enum.fields[lo_idx]->token.string;
+					hi_str = bt->Enum.fields[hi_idx]->token.string;
 				}
 
 				bool out_of_bounds = false;


### PR DESCRIPTION
Error message for enumerated arrays going out of bounds was not yet updated for the Enum change.