### PR TITLE
don't try to use __cpuid() on arm64

### DIFF
--- a/src/bug_report.cpp
+++ b/src/bug_report.cpp
@@ -146,10 +146,17 @@ void report_windows_product_type(DWORD ProductType) {
 #endif
 
 void odin_cpuid(int leaf, int result[]) {
-	#if defined(GB_COMPILER_MSVC)
-		__cpuid(result, leaf);
-	#else
-		__get_cpuid(leaf, (unsigned int*)&result[0], (unsigned int*)&result[1], (unsigned int*)&result[2], (unsigned int*)&result[3]);
+	#if defined(GB_CPU_ARM)
+		return;
+
+	#elif defined(GB_CPU_X86)
+	
+		#if defined(GB_COMPILER_MSVC)
+			__cpuid(result, leaf);
+		#else
+			__get_cpuid(leaf, (unsigned int*)&result[0], (unsigned int*)&result[1], (unsigned int*)&result[2], (unsigned int*)&result[3]);
+		#endif
+
 	#endif
 }
 


### PR DESCRIPTION
__cpuid() isn't available on arm architecture. we might be able to recreate this functionality using sysctl, but it looks like we're already bailing on calling cpuid on arm anyway.