### PR TITLE
Add functionality to export build timings.

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -157,7 +157,11 @@ enum CmdDocFlag : u32 {
 	CmdDocFlag_DocFormat   = 1<<2,
 };
 
-
+enum TimingsExportFormat : i32 {
+	TimingsExportUnspecified = 0,
+	TimingsExportJson        = 1,
+	TimingsExportCSV         = 2,
+};
 
 // This stores the information for the specify architecture of this build
 struct BuildContext {
@@ -197,6 +201,8 @@ struct BuildContext {
 	bool   generate_docs;
 	i32    optimization_level;
 	bool   show_timings;
+	TimingsExportFormat export_timings_format;
+	String export_timings_file;
 	bool   show_unused;
 	bool   show_unused_with_location;
 	bool   show_more_timings;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1256,87 +1256,88 @@ bool parse_build_flags(Array<String> args) {
 							break;
 						}
 
-						case BuildFlag_Debug:
+						case BuildFlag_Debug: {
 							build_context.ODIN_DEBUG = true;
 							break;
-
-						case BuildFlag_DisableAssert:
+						}
+						case BuildFlag_DisableAssert: {
 							build_context.ODIN_DISABLE_ASSERT = true;
 							break;
-
-						case BuildFlag_NoBoundsCheck:
+						}
+						case BuildFlag_NoBoundsCheck: {
 							build_context.no_bounds_check = true;
 							break;
-
-						case BuildFlag_NoDynamicLiterals:
+						}
+						case BuildFlag_NoDynamicLiterals: {
 							build_context.no_dynamic_literals = true;
 							break;
-
-						case BuildFlag_NoCRT:
+						}
+						case BuildFlag_NoCRT: {
 							build_context.no_crt = true;
 							break;
-
-						case BuildFlag_NoEntryPoint:
+						}
+						case BuildFlag_NoEntryPoint: {
 							build_context.no_entry_point = true;
 							break;
-
-						case BuildFlag_UseLLD:
+						}
+						case BuildFlag_UseLLD: {
 							build_context.use_lld = true;
 							break;
-
-						case BuildFlag_UseSeparateModules:
+						}
+						case BuildFlag_UseSeparateModules: {
 							build_context.use_separate_modules = true;
 							break;
-
-						case BuildFlag_ThreadedChecker:
+						}
+						case BuildFlag_ThreadedChecker: {
 							#if defined(DEFAULT_TO_THREADED_CHECKER)
 							gb_printf_err("-threaded-checker is the default on this platform\n");
 							bad_flags = true;
 							#endif
 							build_context.threaded_checker = true;
 							break;
-
-						case BuildFlag_NoThreadedChecker:
+						}
+						case BuildFlag_NoThreadedChecker: {
 							#if !defined(DEFAULT_TO_THREADED_CHECKER)
 							gb_printf_err("-no-threaded-checker is the default on this platform\n");
 							bad_flags = true;
 							#endif
 							build_context.threaded_checker = false;
 							break;
-
-						case BuildFlag_ShowDebugMessages:
+						}
+						case BuildFlag_ShowDebugMessages: {
 							build_context.show_debug_messages = true;
 							break;
-
-						case BuildFlag_Vet:
+						}
+						case BuildFlag_Vet: {
 							build_context.vet = true;
 							break;
-						case BuildFlag_VetExtra:
+						}
+						case BuildFlag_VetExtra: {
 							build_context.vet = true;
 							build_context.vet_extra = true;
 							break;
-
-						case BuildFlag_UseLLVMApi:
+						}
+						case BuildFlag_UseLLVMApi: {
 							gb_printf_err("-llvm-api flag is not required any more\n");
 							bad_flags = true;
 							break;
-
-						case BuildFlag_IgnoreUnknownAttributes:
+						}
+						case BuildFlag_IgnoreUnknownAttributes: {
 							build_context.ignore_unknown_attributes = true;
 							break;
-
-						case BuildFlag_ExtraLinkerFlags:
+						}
+						case BuildFlag_ExtraLinkerFlags: {
 							GB_ASSERT(value.kind == ExactValue_String);
 							build_context.extra_linker_flags = value.value_string;
 							break;
-
-						case BuildFlag_Microarch:
+						}
+						case BuildFlag_Microarch: {
 							GB_ASSERT(value.kind == ExactValue_String);
 							build_context.microarch = value.value_string;
 							string_to_lower(&build_context.microarch);
 							break;
-
-						case BuildFlag_TestName:
+						}
+						case BuildFlag_TestName: {
 							GB_ASSERT(value.kind == ExactValue_String);
 							{
 								String name = value.value_string;
@@ -1350,35 +1351,35 @@ bool parse_build_flags(Array<String> args) {
 								// NOTE(bill): Allow for multiple -test-name
 								continue;
 							}
-
-						case BuildFlag_DisallowDo:
+						}
+						case BuildFlag_DisallowDo: {
 							build_context.disallow_do = true;
 							break;
-
-						case BuildFlag_DefaultToNilAllocator:
+						}
+						case BuildFlag_DefaultToNilAllocator: {
 							build_context.ODIN_DEFAULT_TO_NIL_ALLOCATOR = true;
 							break;
-
-						case BuildFlag_InsertSemicolon:
+						}
+						case BuildFlag_InsertSemicolon: {
 							gb_printf_err("-insert-semicolon flag is not required any more\n");
 							bad_flags = true;
 							break;
-
-						case BuildFlag_StrictStyle:
+						}
+						case BuildFlag_StrictStyle: {
 							if (build_context.strict_style_init_only) {
 								gb_printf_err("-strict-style and -strict-style-init-only cannot be used together\n");
 							}
 							build_context.strict_style = true;
 							break;
-						case BuildFlag_StrictStyleInitOnly:
+						}
+						case BuildFlag_StrictStyleInitOnly: {
 							if (build_context.strict_style) {
 								gb_printf_err("-strict-style and -strict-style-init-only cannot be used together\n");
 							}
 							build_context.strict_style_init_only = true;
 							break;
-
-
-						case BuildFlag_Compact:
+						}
+						case BuildFlag_Compact: {
 							if (!build_context.query_data_set_settings.ok) {
 								gb_printf_err("Invalid use of -compact flag, only allowed with 'odin query'\n");
 								bad_flags = true;
@@ -1386,8 +1387,8 @@ bool parse_build_flags(Array<String> args) {
 								build_context.query_data_set_settings.compact = true;
 							}
 							break;
-
-						case BuildFlag_GlobalDefinitions:
+						}
+						case BuildFlag_GlobalDefinitions: {
 							if (!build_context.query_data_set_settings.ok) {
 								gb_printf_err("Invalid use of -global-definitions flag, only allowed with 'odin query'\n");
 								bad_flags = true;
@@ -1398,7 +1399,8 @@ bool parse_build_flags(Array<String> args) {
 								build_context.query_data_set_settings.kind = QueryDataSet_GlobalDefinitions;
 							}
 							break;
-						case BuildFlag_GoToDefinitions:
+						}
+						case BuildFlag_GoToDefinitions: {
 							if (!build_context.query_data_set_settings.ok) {
 								gb_printf_err("Invalid use of -go-to-definitions flag, only allowed with 'odin query'\n");
 								bad_flags = true;
@@ -1409,17 +1411,20 @@ bool parse_build_flags(Array<String> args) {
 								build_context.query_data_set_settings.kind = QueryDataSet_GoToDefinitions;
 							}
 							break;
-
-						case BuildFlag_Short:
+						}
+						case BuildFlag_Short: {
 							build_context.cmd_doc_flags |= CmdDocFlag_Short;
 							break;
-						case BuildFlag_AllPackages:
+						}
+						case BuildFlag_AllPackages: {
 							build_context.cmd_doc_flags |= CmdDocFlag_AllPackages;
 							break;
-						case BuildFlag_DocFormat:
+						}
+						case BuildFlag_DocFormat: {
 							build_context.cmd_doc_flags |= CmdDocFlag_DocFormat;
 							break;
-						case BuildFlag_IgnoreWarnings:
+						}
+						case BuildFlag_IgnoreWarnings: {
 							if (build_context.warnings_as_errors) {
 								gb_printf_err("-ignore-warnings cannot be used with -warnings-as-errors\n");
 								bad_flags = true;
@@ -1427,7 +1432,8 @@ bool parse_build_flags(Array<String> args) {
 								build_context.ignore_warnings = true;
 							}
 							break;
-						case BuildFlag_WarningsAsErrors:
+						}
+						case BuildFlag_WarningsAsErrors: {
 							if (build_context.ignore_warnings) {
 								gb_printf_err("-warnings-as-errors cannot be used with -ignore-warnings\n");
 								bad_flags = true;
@@ -1435,21 +1441,21 @@ bool parse_build_flags(Array<String> args) {
 								build_context.warnings_as_errors = true;
 							}
 							break;
-
-						case BuildFlag_VerboseErrors:
+						}
+						case BuildFlag_VerboseErrors: {
 							build_context.show_error_line = true;
 							break;
-
-						case BuildFlag_InternalIgnoreLazy:
+						}
+						case BuildFlag_InternalIgnoreLazy: {
 							build_context.ignore_lazy = true;
 							break;
-
+						}
 					#if defined(GB_SYSTEM_WINDOWS)
-						case BuildFlag_IgnoreVsSearch:
+						case BuildFlag_IgnoreVsSearch: {
 							GB_ASSERT(value.kind == ExactValue_Invalid);
 							build_context.ignore_microsoft_magic = true;
 							break;
-
+						}
 						case BuildFlag_ResourceFile: {
 							GB_ASSERT(value.kind == ExactValue_String);
 							String path = value.value_string;
@@ -1537,15 +1543,15 @@ bool parse_build_flags(Array<String> args) {
 	}
 
 	if ((!(build_context.export_timings_format == TimingsExportUnspecified)) && (build_context.export_timings_file.len == 0)) {
-		gb_printf_err("`-export-timings:format` requires `-export-timings-file:filename` to be specified as well\n");
+		gb_printf_err("`-export-timings:<format>` requires `-export-timings-file:<filename>` to be specified as well\n");
 		bad_flags = true;
 	} else if ((build_context.export_timings_format == TimingsExportUnspecified) && (build_context.export_timings_file.len > 0)) {
-		gb_printf_err("`-export-timings-file:filename` requires `-export-timings:format` to be specified as well\n");
+		gb_printf_err("`-export-timings-file:<filename>` requires `-export-timings:<format>` to be specified as well\n");
 		bad_flags = true;
 	}
 
 	if (build_context.export_timings_format && !(build_context.show_timings || build_context.show_more_timings)) {
-		gb_printf_err("`-export-timings:format` requires `-show-timings` or `-show-more-timings` to be present\n");
+		gb_printf_err("`-export-timings:<format>` requires `-show-timings` or `-show-more-timings` to be present\n");
 		bad_flags = true;
 	}
 
@@ -1898,13 +1904,16 @@ void print_show_help(String const arg0, String const &command) {
 		print_usage_line(2, "Shows an advanced overview of the timings of different stages within the compiler in milliseconds");
 		print_usage_line(0, "");
 
-		print_usage_line(1, "-export-timings");
+		print_usage_line(1, "-export-timings:<format>");
 		print_usage_line(2, "Export timings to one of a few formats. Requires `-show-timings` or `-show-more-timings`");
-		print_usage_line(2, "Accepted values: json, csv");
+		print_usage_line(2, "Available options:");
+		print_usage_line(3, "-export-timings:json        Export compile time stats to JSON");
+		print_usage_line(3, "-export-timings:csv         Export compile time stats to CSV");
 		print_usage_line(0, "");
 
-		print_usage_line(1, "-export-timings-file:filename");
-		print_usage_line(2, "Specify the filename for `-export-timings`.");
+		print_usage_line(1, "-export-timings-file:<filename>");
+		print_usage_line(2, "Specify the filename for `-export-timings`");
+		print_usage_line(2, "Example: -export-timings-file:timings.json");
 		print_usage_line(0, "");
 
 		print_usage_line(1, "-thread-count:<integer>");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -933,10 +933,9 @@ bool parse_build_flags(Array<String> args) {
 						}
 
 						if (ok) switch (bf.kind) {
-						case BuildFlag_Help: {
+						case BuildFlag_Help:
 							build_context.show_help = true;
 							break;
-						}
 						case BuildFlag_OutFile: {
 							GB_ASSERT(value.kind == ExactValue_String);
 							String path = value.value_string;
@@ -1256,38 +1255,30 @@ bool parse_build_flags(Array<String> args) {
 							break;
 						}
 
-						case BuildFlag_Debug: {
+						case BuildFlag_Debug:
 							build_context.ODIN_DEBUG = true;
 							break;
-						}
-						case BuildFlag_DisableAssert: {
+						case BuildFlag_DisableAssert:
 							build_context.ODIN_DISABLE_ASSERT = true;
 							break;
-						}
-						case BuildFlag_NoBoundsCheck: {
+						case BuildFlag_NoBoundsCheck:
 							build_context.no_bounds_check = true;
 							break;
-						}
-						case BuildFlag_NoDynamicLiterals: {
+						case BuildFlag_NoDynamicLiterals:
 							build_context.no_dynamic_literals = true;
 							break;
-						}
-						case BuildFlag_NoCRT: {
+						case BuildFlag_NoCRT:
 							build_context.no_crt = true;
 							break;
-						}
-						case BuildFlag_NoEntryPoint: {
+						case BuildFlag_NoEntryPoint:
 							build_context.no_entry_point = true;
 							break;
-						}
-						case BuildFlag_UseLLD: {
+						case BuildFlag_UseLLD:
 							build_context.use_lld = true;
 							break;
-						}
-						case BuildFlag_UseSeparateModules: {
+						case BuildFlag_UseSeparateModules:
 							build_context.use_separate_modules = true;
 							break;
-						}
 						case BuildFlag_ThreadedChecker: {
 							#if defined(DEFAULT_TO_THREADED_CHECKER)
 							gb_printf_err("-threaded-checker is the default on this platform\n");
@@ -1304,14 +1295,12 @@ bool parse_build_flags(Array<String> args) {
 							build_context.threaded_checker = false;
 							break;
 						}
-						case BuildFlag_ShowDebugMessages: {
+						case BuildFlag_ShowDebugMessages:
 							build_context.show_debug_messages = true;
 							break;
-						}
-						case BuildFlag_Vet: {
+						case BuildFlag_Vet:
 							build_context.vet = true;
 							break;
-						}
 						case BuildFlag_VetExtra: {
 							build_context.vet = true;
 							build_context.vet_extra = true;
@@ -1322,10 +1311,9 @@ bool parse_build_flags(Array<String> args) {
 							bad_flags = true;
 							break;
 						}
-						case BuildFlag_IgnoreUnknownAttributes: {
+						case BuildFlag_IgnoreUnknownAttributes:
 							build_context.ignore_unknown_attributes = true;
 							break;
-						}
 						case BuildFlag_ExtraLinkerFlags: {
 							GB_ASSERT(value.kind == ExactValue_String);
 							build_context.extra_linker_flags = value.value_string;
@@ -1352,14 +1340,12 @@ bool parse_build_flags(Array<String> args) {
 								continue;
 							}
 						}
-						case BuildFlag_DisallowDo: {
+						case BuildFlag_DisallowDo:
 							build_context.disallow_do = true;
 							break;
-						}
-						case BuildFlag_DefaultToNilAllocator: {
+						case BuildFlag_DefaultToNilAllocator:
 							build_context.ODIN_DEFAULT_TO_NIL_ALLOCATOR = true;
 							break;
-						}
 						case BuildFlag_InsertSemicolon: {
 							gb_printf_err("-insert-semicolon flag is not required any more\n");
 							bad_flags = true;
@@ -1412,18 +1398,15 @@ bool parse_build_flags(Array<String> args) {
 							}
 							break;
 						}
-						case BuildFlag_Short: {
+						case BuildFlag_Short:
 							build_context.cmd_doc_flags |= CmdDocFlag_Short;
 							break;
-						}
-						case BuildFlag_AllPackages: {
+						case BuildFlag_AllPackages:
 							build_context.cmd_doc_flags |= CmdDocFlag_AllPackages;
 							break;
-						}
-						case BuildFlag_DocFormat: {
+						case BuildFlag_DocFormat:
 							build_context.cmd_doc_flags |= CmdDocFlag_DocFormat;
 							break;
-						}
 						case BuildFlag_IgnoreWarnings: {
 							if (build_context.warnings_as_errors) {
 								gb_printf_err("-ignore-warnings cannot be used with -warnings-as-errors\n");
@@ -1442,14 +1425,12 @@ bool parse_build_flags(Array<String> args) {
 							}
 							break;
 						}
-						case BuildFlag_VerboseErrors: {
+						case BuildFlag_VerboseErrors:
 							build_context.show_error_line = true;
 							break;
-						}
-						case BuildFlag_InternalIgnoreLazy: {
+						case BuildFlag_InternalIgnoreLazy:
 							build_context.ignore_lazy = true;
 							break;
-						}
 					#if defined(GB_SYSTEM_WINDOWS)
 						case BuildFlag_IgnoreVsSearch: {
 							GB_ASSERT(value.kind == ExactValue_Invalid);
@@ -1596,10 +1577,10 @@ void timings_export_all(Timings *t, Checker *c, bool timings_are_finalized = fal
 	}
 	defer (gb_file_close(&f));
 
-	/*
-		JSON export
-	*/
 	if (build_context.export_timings_format == TimingsExportJson) {
+		/*
+			JSON export
+		*/
 		Parser *p             = c->parser;
 		isize lines           = p->total_line_count;
 		isize tokens          = p->total_token_count;
@@ -1643,13 +1624,10 @@ void timings_export_all(Timings *t, Checker *c, bool timings_are_finalized = fal
 		gb_fprintf(&f, "\t],\n");
 
 		gb_fprintf(&f, "}\n");
-	}
-
-	/*
-		CSV export
-	*/
-	else if (build_context.export_timings_format == TimingsExportCSV) {
-
+	} else if (build_context.export_timings_format == TimingsExportCSV) {
+		/*
+			CSV export
+		*/
 		t->total_time_seconds = time_stamp_as_s(t->total, t->freq);
 		f64 total_time = time_stamp(t->total, t->freq, unit);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -859,9 +859,9 @@ bool parse_build_flags(Array<String> args) {
 					} else {
 						ok = true;
 						switch (bf.param_kind) {
-						default:
+						default: {
 							ok = false;
-							break;
+						} break;
 						case BuildFlagParam_Boolean: {
 							if (str_eq_ignore_case(param, str_lit("t")) ||
 								str_eq_ignore_case(param, str_lit("true")) ||
@@ -875,12 +875,12 @@ bool parse_build_flags(Array<String> args) {
 								gb_printf_err("Invalid flag parameter for '%.*s' : '%.*s'\n", LIT(name), LIT(param));
 							}
 						} break;
-						case BuildFlagParam_Integer:
+						case BuildFlagParam_Integer: {
 							value = exact_value_integer_from_string(param);
-							break;
-						case BuildFlagParam_Float:
+						} break;
+						case BuildFlagParam_Float: {
 							value = exact_value_float_from_string(param);
-							break;
+						} break;
 						case BuildFlagParam_String: {
 							value = exact_value_string(param);
 							if (value.kind == ExactValue_String) {
@@ -933,10 +933,10 @@ bool parse_build_flags(Array<String> args) {
 						}
 
 						if (ok) switch (bf.kind) {
-						case BuildFlag_Help:
+						case BuildFlag_Help: {
 							build_context.show_help = true;
 							break;
-
+						}
 						case BuildFlag_OutFile: {
 							GB_ASSERT(value.kind == ExactValue_String);
 							String path = value.value_string;
@@ -949,7 +949,7 @@ bool parse_build_flags(Array<String> args) {
 							}
 							break;
 						}
-						case BuildFlag_OptimizationLevel:
+						case BuildFlag_OptimizationLevel: {
 							GB_ASSERT(value.kind == ExactValue_Integer);
 							if (set_flags[BuildFlag_OptimizationMode]) {
 								gb_printf_err("Mixture of -opt and -o is not allowed\n");
@@ -958,7 +958,8 @@ bool parse_build_flags(Array<String> args) {
 							}
 							build_context.optimization_level = cast(i32)big_int_to_i64(&value.value_integer);
 							break;
-						case BuildFlag_OptimizationMode:
+						}
+						case BuildFlag_OptimizationMode: {
 							GB_ASSERT(value.kind == ExactValue_String);
 							if (set_flags[BuildFlag_OptimizationLevel]) {
 								gb_printf_err("Mixture of -opt and -o is not allowed\n");
@@ -981,25 +982,29 @@ bool parse_build_flags(Array<String> args) {
 								bad_flags = true;
 							}
 							break;
-						case BuildFlag_ShowTimings:
+						}
+						case BuildFlag_ShowTimings: {
 							GB_ASSERT(value.kind == ExactValue_Invalid);
 							build_context.show_timings = true;
 							break;
-						case BuildFlag_ShowUnused:
+						}
+						case BuildFlag_ShowUnused: {
 							GB_ASSERT(value.kind == ExactValue_Invalid);
 							build_context.show_unused = true;
 							break;
-						case BuildFlag_ShowUnusedWithLocation:
+						}
+						case BuildFlag_ShowUnusedWithLocation: {
 							GB_ASSERT(value.kind == ExactValue_Invalid);
 							build_context.show_unused = true;
 							build_context.show_unused_with_location = true;
 							break;
+						}
 						case BuildFlag_ShowMoreTimings:
 							GB_ASSERT(value.kind == ExactValue_Invalid);
 							build_context.show_timings = true;
 							build_context.show_more_timings = true;
 							break;
-						case BuildFlag_ExportTimings:
+						case BuildFlag_ExportTimings: {
 							GB_ASSERT(value.kind == ExactValue_String);
 							/*
 								NOTE(Jeroen): `build_context.export_timings_format == 0` means the option wasn't used.
@@ -1017,7 +1022,8 @@ bool parse_build_flags(Array<String> args) {
 							}
 
 							break;
-						case BuildFlag_ExportTimingsFile:
+						}
+						case BuildFlag_ExportTimingsFile: {
 							GB_ASSERT(value.kind == ExactValue_String);
 
 							String export_path = string_trim_whitespace(value.value_string);
@@ -1029,10 +1035,12 @@ bool parse_build_flags(Array<String> args) {
 							}
 
 							break;
-						case BuildFlag_ShowSystemCalls:
+						}
+						case BuildFlag_ShowSystemCalls: {
 							GB_ASSERT(value.kind == ExactValue_Invalid);
 							build_context.show_system_calls = true;
 							break;
+						}
 						case BuildFlag_ThreadCount: {
 							GB_ASSERT(value.kind == ExactValue_Integer);
 							isize count = cast(isize)big_int_to_i64(&value.value_integer);
@@ -1044,11 +1052,11 @@ bool parse_build_flags(Array<String> args) {
 							}
 							break;
 						}
-						case BuildFlag_KeepTempFiles:
+						case BuildFlag_KeepTempFiles: {
 							GB_ASSERT(value.kind == ExactValue_Invalid);
 							build_context.keep_temp_files = true;
 							break;
-
+						}
 						case BuildFlag_Collection: {
 							GB_ASSERT(value.kind == ExactValue_String);
 							String str = value.value_string;
@@ -1112,8 +1120,6 @@ bool parse_build_flags(Array<String> args) {
 							// NOTE(bill): Allow for multiple library collections
 							continue;
 						}
-
-
 						case BuildFlag_Define: {
 							GB_ASSERT(value.kind == ExactValue_String);
 							String str = value.value_string;
@@ -1530,10 +1536,10 @@ bool parse_build_flags(Array<String> args) {
 		}
 	}
 
-	if (!build_context.export_timings_format == TimingsExportUnspecified && build_context.export_timings_file.len == 0) {
+	if ((!(build_context.export_timings_format == TimingsExportUnspecified)) && (build_context.export_timings_file.len == 0)) {
 		gb_printf_err("`-export-timings:format` requires `-export-timings-file:filename` to be specified as well\n");
 		bad_flags = true;
-	} else if (build_context.export_timings_format == TimingsExportUnspecified && build_context.export_timings_file.len > 0) {
+	} else if ((build_context.export_timings_format == TimingsExportUnspecified) && (build_context.export_timings_file.len > 0)) {
 		gb_printf_err("`-export-timings-file:filename` requires `-export-timings:format` to be specified as well\n");
 		bad_flags = true;
 	}
@@ -1556,7 +1562,7 @@ bool parse_build_flags(Array<String> args) {
 }
 
 void timings_export_all(Timings *t, Checker *c, bool timings_are_finalized = false) {
-	GB_ASSERT(!build_context.export_timings_format == TimingsExportUnspecified && build_context.export_timings_file.len > 0);
+	GB_ASSERT((!(build_context.export_timings_format == TimingsExportUnspecified) && build_context.export_timings_file.len > 0));
 
 	/*
 		NOTE(Jeroen): Whether we call `timings_print_all()`, then `timings_export_all()`, the other way around,
@@ -1605,11 +1611,11 @@ void timings_export_all(Timings *t, Checker *c, bool timings_are_finalized = fal
 		gb_fprintf(&f, "{\n");
 		gb_fprintf(&f, "\t\"totals\": [\n");
 
-		gb_fprintf(&f, "\t\t{\"name\": \"total_packages\",  \"count\": %d},\n", packages);
-		gb_fprintf(&f, "\t\t{\"name\": \"total_files\",     \"count\": %d},\n", files);
-		gb_fprintf(&f, "\t\t{\"name\": \"total_lines\",     \"count\": %d},\n", lines);
-		gb_fprintf(&f, "\t\t{\"name\": \"total_tokens\",    \"count\": %d},\n", tokens);
-		gb_fprintf(&f, "\t\t{\"name\": \"total_file_size\", \"count\": %d},\n", total_file_size);
+		gb_fprintf(&f, "\t\t{\"name\": \"total_packages\",  \"count\": %td},\n", packages);
+		gb_fprintf(&f, "\t\t{\"name\": \"total_files\",     \"count\": %td},\n", files);
+		gb_fprintf(&f, "\t\t{\"name\": \"total_lines\",     \"count\": %td},\n", lines);
+		gb_fprintf(&f, "\t\t{\"name\": \"total_tokens\",    \"count\": %td},\n", tokens);
+		gb_fprintf(&f, "\t\t{\"name\": \"total_file_size\", \"count\": %td},\n", total_file_size);
 
 		gb_fprintf(&f, "\t],\n");
 
@@ -1677,7 +1683,7 @@ void show_timings(Checker *c, Timings *t) {
 
 	timings_print_all(t);
 
-	if (!build_context.export_timings_format == TimingsExportUnspecified) {
+	if (!(build_context.export_timings_format == TimingsExportUnspecified)) {
 		timings_export_all(t, c, true);
 	}
 

--- a/src/timings.cpp
+++ b/src/timings.cpp
@@ -169,14 +169,19 @@ f64 time_stamp(TimeStamp const &ts, u64 freq, TimingUnit unit) {
 	}
 }
 
-void timings_print_all(Timings *t, TimingUnit unit = TimingUnit_Millisecond) {
+void timings_print_all(Timings *t, TimingUnit unit = TimingUnit_Millisecond, bool timings_are_finalized = false) {
 	isize const SPACES_LEN = 256;
 	char SPACES[SPACES_LEN+1] = {0};
 	gb_memset(SPACES, ' ', SPACES_LEN);
 
-
-	timings__stop_current_section(t);
-	t->total.finish = time_stamp_time_now();
+	/*
+		NOTE(Jeroen): Whether we call `timings_print_all()`, then `timings_export_all()`, the other way around,
+		or just one of them, we only need to stop the clock once.
+	*/
+	if (!timings_are_finalized) {
+		timings__stop_current_section(t);
+		t->total.finish = time_stamp_time_now();
+	}
 
 	isize max_len = gb_min(36, t->total.label.len);
 	for_array(i, t->sections) {


### PR DESCRIPTION
Usage:
`odin build examples/demo -show-extra-timings -export-timings:json -export-timings-file:timings.json`
`odin build examples/demo -show-timings -export-timings:csv -export-timings-file:timings.csv`

Example output:
```json
{
        "totals": [
                {"name": "total_packages",  "count": 23},
                {"name": "total_files",     "count": 114},
                {"name": "total_lines",     "count": 44413},
                {"name": "total_tokens",    "count": 257884},
                {"name": "total_file_size", "count": 1134058},
        ],
        "timings": [
                {"name": "Total Time", "millis": 1720.383},
                {"name": "initialization", "millis": 2.019},
                {"name": "parse files", "millis": 57.618},
                {"name": "type check", "millis": 316.631},
                {"name": "LLVM API Code Gen", "millis": 1239.287},
                {"name": "msvc-link", "millis": 104.822},
        ],
}
```