### PR TITLE
Fix path to static GLFW lib on Windows

### DIFF
--- a/vendor/glfw/bindings/bindings.odin
+++ b/vendor/glfw/bindings/bindings.odin
@@ -6,7 +6,7 @@ import vk "vendor:vulkan"
 when ODIN_OS == "linux"   { foreign import glfw "system:glfw" } // TODO: Add the billion-or-so static libs to link to in linux
 when ODIN_OS == "windows" { 
 	foreign import glfw { 
-		"lib/glfw3.lib", 
+		"../lib/glfw3_mt.lib",
 		"system:user32.lib", 
 		"system:gdi32.lib", 
 		"system:shell32.lib",


### PR DESCRIPTION
The static library provided by GLFW for Windows is named `glfw3_mt.lib` (because it's compiled with `/MT`). Also the library path needed correcting (`vendor/glfw/lib` rather than `vendor/glfw/bindings/lib`).