### PR TITLE
Add test command to CLI usage output

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -540,6 +540,7 @@ void usage(String argv0) {
 	print_usage_line(1, "          one must contain the program's entry point, all must be in the same package.");
 	print_usage_line(1, "run       same as 'build', but also then runs the newly compiled executable.");
 	print_usage_line(1, "check     parse and type check .odin file");
+	print_usage_line(1, "test      build and runs procedures with the attribute @(test) in the initial package.");
 	print_usage_line(1, "query     parse, type check, and output a .json file containing information about the program");
 	print_usage_line(1, "doc       generate documentation .odin file, or directory of .odin files");
 	print_usage_line(1, "version   print version");


### PR DESCRIPTION
It was not obvious to me that there existed a `test` command since it was not documented. I reused the same documentation as you get when you run `odin test -help`. If you want me to adjust the documentation, I'd be happy to do so. 🙂 