### PR TITLE
Do not filter test procedures when filter is empty

### DIFF
--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -4773,6 +4773,10 @@ void check_unchecked_bodies(Checker *c) {
 }
 
 void check_test_procedures(Checker *c) {
+	if (build_context.test_names.entries.count == 0) {
+		return;
+	}
+
 	AstPackage *pkg = c->info.init_package;
 	Scope *s = pkg->scope;
 


### PR DESCRIPTION
When #1293 got merged, a bug surfaced where it would unconditionally filter test cases no matter what. This have the side effect of filtering out all test cases unless you explicitly name them.

If `build_context.test_names` is empty, we do not need to perform any filtering.