### PR TITLE
Fix the windows binding for getaddrinfo

### DIFF
--- a/core/sys/windows/ws2_32.odin
+++ b/core/sys/windows/ws2_32.odin
@@ -76,10 +76,10 @@ foreign ws2_32 {
 	listen :: proc(socket: SOCKET, backlog: c_int) -> c_int ---
 	connect :: proc(socket: SOCKET, address: ^SOCKADDR, len: c_int) -> c_int ---
 	getaddrinfo :: proc(
-		node: ^c_char,
-		service: ^c_char,
+		node: cstring,
+		service: cstring,
 		hints: ^ADDRINFOA,
-		res: ^ADDRINFOA,
+		res: ^^ADDRINFOA,
 	) -> c_int ---
 	freeaddrinfo :: proc(res: ^ADDRINFOA) ---
 	select :: proc(


### PR DESCRIPTION
getaddrinfo should take a double pointer to ADDRINFOA instead of a single pointer. If you call the binding in its current state you will not get back a valid ADDRINFOA struct.

I have also changed the `node` and `service` params to be cstring to avoid having to do `transmute(u8) value`.

> This PR was created in the web UI for github, if that causes issues let me know and I'll clone down the repo and sort out any git commit/history stuff.