### PR TITLE
Add socket() function to windows ws32 bindings

### DIFF
--- a/core/sys/windows/ws2_32.odin
+++ b/core/sys/windows/ws2_32.odin
@@ -39,6 +39,11 @@ foreign ws2_32 {
 		g: GROUP,
 		dwFlags: DWORD,
 	) -> SOCKET ---
+	socket :: proc(
+		af: c_int,
+		type: c_int,
+		protocol: c_int,
+	) -> SOCKET ---
 
 	ioctlsocket :: proc(s: SOCKET, cmd: c_long, argp: ^c_ulong) -> c_int ---
 	closesocket :: proc(socket: SOCKET) -> c_int ---


### PR DESCRIPTION
It looks like this was missing from the winsock bindings. Odin contains
WSASocketW which I assume would also work for obtaining a socket, but
socket() is distinct and is what I was using, so I assume others will
want it too.