### PR TITLE
Allow custom LLVM_CONFIG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ OS=$(shell uname)
 ifeq ($(OS), Darwin)
     
     ARCH=$(shell uname -m)
-    LLVM_CONFIG=
+    LLVM_CONFIG=llvm-config
 
     # allow for arm only llvm's with version 13
     ifeq ($(ARCH), arm64)
@@ -27,9 +27,7 @@ ifeq ($(OS), Darwin)
     LLMV_VERSION_PATTERN_REMOVE_SINGLE_STR = $(subst ",,$(LLVM_VERSION_PATTERN_REMOVE_ELEMENTS))
     LLVM_VERSION_PATTERN = "^(($(LLMV_VERSION_PATTERN_REMOVE_SINGLE_STR)))"
 
-    ifneq ($(shell llvm-config --version | grep -E $(LLVM_VERSION_PATTERN)),)
-        LLVM_CONFIG=llvm-config
-    else
+    ifeq ($(shell $(LLVM_CONFIG) --version | grep -E $(LLVM_VERSION_PATTERN)),)
         ifeq ($(ARCH), arm64)
             $(error "Requirement: llvm-config must be base version 13 for arm64")
         else 
@@ -48,9 +46,7 @@ ifeq ($(OS), Linux)
     else ifneq ($(shell which llvm-config-11-64 2>/dev/null),)
         LLVM_CONFIG=llvm-config-11-64
     else
-        ifneq ($(shell llvm-config --version | grep '^11\.'),)
-            LLVM_CONFIG=llvm-config
-        else
+        ifeq ($(shell $(LLVM_CONFIG) --version | grep '^11\.'),)
             $(error "Requirement: llvm-config must be version 11")
         endif
     endif


### PR DESCRIPTION
This patch was required to package odin for MacPorts (now available via `sudo port install odin`).