### PR TITLE
fix memory leak in path.join

### DIFF
--- a/core/path/path.odin
+++ b/core/path/path.odin
@@ -150,7 +150,7 @@ join :: proc(elems: ..string, allocator := context.allocator) -> string {
 	context.allocator = allocator
 	for elem, i in elems {
 		if elem != "" {
-			s := strings.join(elems[i:], "/")
+			s := strings.join(elems[i:], "/", context.temp_allocator)
 			return clean(s)
 		}
 	}


### PR DESCRIPTION
The `clean` call always allocates a fresh string, while `strings.join` does too. Paths are relatively short, so just use the temporary allocator here for the join.