### PR TITLE
Recover from closing brace not found in field list

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -416,7 +416,16 @@ expect_closing_brace_of_field_list :: proc(p: ^Parser) -> tokenizer.Token {
 		str := tokenizer.token_to_string(token)
 		error(p, end_of_line_pos(p, p.prev_tok), "expected a comma, got %s", str)
 	}
-	return expect_token(p, .Close_Brace)
+	expect_brace := expect_token(p, .Close_Brace)
+
+	if expect_brace.kind != .Close_Brace {
+		for p.curr_tok.kind != .Close_Brace && p.curr_tok.kind != .EOF {
+			advance_token(p)
+		}
+		return p.curr_tok
+	} 
+
+	return expect_brace
 }
 
 

--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -419,7 +419,7 @@ expect_closing_brace_of_field_list :: proc(p: ^Parser) -> tokenizer.Token {
 	expect_brace := expect_token(p, .Close_Brace)
 
 	if expect_brace.kind != .Close_Brace {
-		for p.curr_tok.kind != .Close_Brace && p.curr_tok.kind != .EOF {
+		for p.curr_tok.kind != .Close_Brace && p.curr_tok.kind != .EOF && !is_non_inserted_semicolon(p.curr_tok) {
 			advance_token(p)
 		}
 		return p.curr_tok
@@ -428,6 +428,9 @@ expect_closing_brace_of_field_list :: proc(p: ^Parser) -> tokenizer.Token {
 	return expect_brace
 }
 
+is_non_inserted_semicolon :: proc(tok: tokenizer.Token) -> bool {
+	return tok.kind == .Semicolon && tok.text != "\n"
+}
 
 is_blank_ident :: proc{
 	is_blank_ident_string,


### PR DESCRIPTION
The current parser breaks completely after incorrect field lists:
```
My_Struct :: struct {
	type: int,
	wrong
	indent: int,
	width: int,
}
```
The fix is to keep looking for a closing brace or EOF. 

This change is really necessary to prevent OLS from giving wrong information or crashing.