### PR TITLE
Linux: Fix missing file error reported by #load

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -782,15 +782,17 @@ String path_to_fullpath(gbAllocator a, String s) {
 
 
 String get_fullpath_relative(gbAllocator a, String base_dir, String path) {
-	u8 *str = gb_alloc_array(heap_allocator(), u8, base_dir.len+1+path.len+1);
+	u8 *str = gb_alloc_array(heap_allocator(), u8, base_dir.len+path.len+1);
 	defer (gb_free(heap_allocator(), str));
 
 	isize i = 0;
 	gb_memmove(str+i, base_dir.text, base_dir.len); i += base_dir.len;
-	gb_memmove(str+i, "/", 1);                      i += 1;
+	// avoid having a double / in the path
+	if ((base_dir.len > 0 && str[base_dir.len-1] != '/') || (base_dir.len == 0)) {
+		gb_memmove(str+i, "/", 1);											i += 1;
+	}
 	gb_memmove(str+i, path.text,     path.len);     i += path.len;
 	str[i] = 0;
-
 
 	String res = make_string(str, i);
 	res = string_trim_whitespace(res);

--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -283,7 +283,6 @@ bool check_builtin_procedure(CheckerContext *c, Operand *operand, Ast *call, i32
 			char *c_str = alloc_cstring(a, path);
 			defer (gb_free(a, c_str));
 
-
 			gbFile f = {};
 			gbFileError file_err = gb_file_open(&f, c_str);
 			defer (gb_file_close(&f));
@@ -291,10 +290,10 @@ bool check_builtin_procedure(CheckerContext *c, Operand *operand, Ast *call, i32
 			switch (file_err) {
 			default:
 			case gbFileError_Invalid:
-				error(ce->proc, "Failed to `#load` file: %s; invalid file or cannot be found", c_str);
+				error(ce->proc, "Failed to `#load` file: %.*s; invalid file or cannot be found", LIT(original_string));
 				return false;
 			case gbFileError_NotExists:
-				error(ce->proc, "Failed to `#load` file: %s; file cannot be found", c_str);
+				error(ce->proc, "Failed to `#load` file: %.s; file cannot be found", LIT(original_string));
 				return false;
 			case gbFileError_Permission:
 				error(ce->proc, "Failed to `#load` file: %s; file permissions problem", c_str);


### PR DESCRIPTION
Under Linux (and other *nix) `realpath` will return NULL when resolving
a given path if the file or path does not exist.  When this happens the
error message returned by #load during compile time will display an
error with a missing file name or path.

Given the following program:

```odin
package main

import "core:fmt"

main :: proc() {
  stuffs := #load("test.file")
  fmt.printf("stuffs %v\n", stuffs)
}
```

If the file `test.file` is missing or the path is invalid you would get
the following error:

```
Failed to `#load` file: ; invalid file or cannot be found
```

However, the correct behavior should be:

```
Failed to `#load` file: test.file; invalid file or cannot be found
```

This PR corrects this