### PR TITLE
[math/big] Fix int_set and int_get.

### DIFF
--- a/core/math/big/common.odin
+++ b/core/math/big/common.odin
@@ -158,13 +158,14 @@ Error :: enum int {
 	Invalid_Pointer         = 2,
 	Invalid_Argument        = 3,
 
-	Assignment_To_Immutable = 4,
-	Max_Iterations_Reached  = 5,
-	Buffer_Overflow         = 6,
-	Integer_Overflow        = 7,
+	Assignment_To_Immutable = 10,
+	Max_Iterations_Reached  = 11,
+	Buffer_Overflow         = 12,
+	Integer_Overflow        = 13,
+	Integer_Underflow       = 14,
 
-	Division_by_Zero        = 8,
-	Math_Domain_Error       = 9,
+	Division_by_Zero        = 30,
+	Math_Domain_Error       = 31,
 
 	Cannot_Open_File        = 50,
 	Cannot_Read_File        = 51,

--- a/tests/core/math/big/test.py
+++ b/tests/core/math/big/test.py
@@ -127,17 +127,22 @@ def we_iterate():
 # Error enum values
 #
 class Error(Enum):
-	Okay                   = 0
-	Out_Of_Memory          = 1
-	Invalid_Pointer        = 2
-	Invalid_Argument       = 3
-	Unknown_Error          = 4
-	Max_Iterations_Reached = 5
-	Buffer_Overflow        = 6
-	Integer_Overflow       = 7
-	Division_by_Zero       = 8
-	Math_Domain_Error      = 9
-	Unimplemented          = 127
+	Okay                    = 0
+	Out_Of_Memory           = 1
+	Invalid_Pointer         = 2
+	Invalid_Argument        = 3
+	Unknown_Error           = 4
+	Assignment_To_Immutable = 10
+	Max_Iterations_Reached  = 11
+	Buffer_Overflow         = 12
+	Integer_Overflow        = 13
+	Integer_Underflow       = 14
+	Division_by_Zero        = 30
+	Math_Domain_Error       = 31
+	Cannot_Open_File        = 50
+	Cannot_Read_File        = 51
+	Cannot_Write_File       = 52
+	Unimplemented           = 127
 
 #
 # Disable garbage collection


### PR DESCRIPTION
`int_get` now returns `.Integer_Underflow` or `.Integer_Overflow` if the big int doesn't fit in the target.
```
Target: -170141183460469231731687303715884105728 170141183460469231731687303715884105727 -9223372036854775808 9223372036854775807 

a -170141183460469231731687303715884105728 (base: 10, bits: 128, digits: 3)
b 170141183460469231731687303715884105727 (base: 10, bits: 127, digits: 3)
c -9223372036854775808 (base: 10, bits: 64, digits: 2)
d 9223372036854775807 (base: 10, bits: 63, digits: 2)

AA: -9223372036854775808 (Integer_Underflow)
BB: 9223372036854775807 (Integer_Overflow)
CC: -9223372036854775808 (Okay)
DD: 9223372036854775807 (Okay)
```