### PR TITLE
fix bug with fields_proc discarding last byte

### DIFF
--- a/core/bytes/bytes.odin
+++ b/core/bytes/bytes.odin
@@ -1143,7 +1143,7 @@ fields_proc :: proc(s: []byte, f: proc(rune) -> bool, allocator := context.alloc
 	}
 
 	if start >= 0 {
-		append(&subslices, s[start : end])
+		append(&subslices, s[start : end + 1])
 	}
 
 	return subslices[:]

--- a/core/strings/strings.odin
+++ b/core/strings/strings.odin
@@ -1288,7 +1288,7 @@ fields_proc :: proc(s: string, f: proc(rune) -> bool, allocator := context.alloc
 	}
 
 	if start >= 0 {
-		append(&substrings, s[start : end])
+		append(&substrings, s[start : end + 1])
 	}
 
 	return substrings[:]


### PR DESCRIPTION
```odin
package main

import "core:bytes"
import "core:fmt"
import "core:strings"
import "core:unicode"

main :: proc() {
	str := "Odin Programming Language"
	s := transmute([]u8)str

	fmt.println(strings.fields_proc(str, unicode.is_space))
	// [Odin, Programming, Languag]

	fmt.println(bytes.fields_proc(s, unicode.is_space))
	// [[79, 100, 105, 110], [80, 114, 111, 103, 114, 97, 109, 109, 105, 110, 103], [76, 97, 110, 103, 117, 97, 103]]
}
```