### PR TITLE
add zeroing to new region from realloc

### DIFF
--- a/core/os/os.odin
+++ b/core/os/os.odin
@@ -206,11 +206,20 @@ heap_allocator_proc :: proc(allocator_data: rawptr, mode: mem.Allocator_Mode,
 		}
 	}
 
-	aligned_resize :: proc(p: rawptr, old_size: int, new_size: int, new_alignment: int) -> ([]byte, mem.Allocator_Error) {
+	aligned_resize :: proc(p: rawptr, old_size: int, new_size: int, new_alignment: int) -> (new_memory: []byte, err: mem.Allocator_Error) {
 		if p == nil {
 			return nil, nil
 		}
-		return aligned_alloc(new_size, new_alignment, p)
+
+		new_memory = aligned_alloc(new_size, new_alignment, p) or_return
+		when ODIN_OS != "windows" {
+			// NOTE: realloc does not zero the new memory, so we do it
+			if new_size > old_size {
+				new_region := mem.raw_data(new_memory[old_size:])
+				mem.zero(new_region, new_size - old_size)
+			}
+		}
+		return
 	}
 
 	switch mode {


### PR DESCRIPTION
On Linux, `calloc` (`heap_resize` in os_linux.odin) is used for the default allocator's `aligned_alloc` procedure which has the benefit of providing zero'd memory.  However, `aligned_resize`, utilizes `realloc` which does not provide zero'd memory.  As far as I know, there really isn't a built in way to do this.  This change manually takes care of it for non-windows environments.