### PR TITLE
Added zeroing to new memory regions from _unix_realloc

### DIFF
--- a/core/os/os.odin
+++ b/core/os/os.odin
@@ -212,12 +212,11 @@ heap_allocator_proc :: proc(allocator_data: rawptr, mode: mem.Allocator_Mode,
 		}
 
 		new_memory = aligned_alloc(new_size, new_alignment, p) or_return
-		when ODIN_OS != "windows" {
-			// NOTE: realloc does not zero the new memory, so we do it
-			if new_size > old_size {
-				new_region := mem.raw_data(new_memory[old_size:])
-				mem.zero(new_region, new_size - old_size)
-			}
+		
+		// NOTE: heap_resize does not zero the new memory, so we do it
+		if new_size > old_size {
+			new_region := mem.raw_data(new_memory[old_size:])
+			mem.zero(new_region, new_size - old_size)
 		}
 		return
 	}

--- a/core/os/os.odin
+++ b/core/os/os.odin
@@ -206,11 +206,20 @@ heap_allocator_proc :: proc(allocator_data: rawptr, mode: mem.Allocator_Mode,
 		}
 	}
 
-	aligned_resize :: proc(p: rawptr, old_size: int, new_size: int, new_alignment: int) -> ([]byte, mem.Allocator_Error) {
+	aligned_resize :: proc(p: rawptr, old_size: int, new_size: int, new_alignment: int) -> (new_memory: []byte, err: mem.Allocator_Error) {
 		if p == nil {
 			return nil, nil
 		}
-		return aligned_alloc(new_size, new_alignment, p)
+
+		new_memory = aligned_alloc(new_size, new_alignment, p) or_return
+		when ODIN_OS != "windows" {
+			// NOTE: realloc does not zero the new memory, so we do it
+			if new_size > old_size {
+				new_region := mem.raw_data(new_memory[old_size:])
+				mem.zero(new_region, new_size - old_size)
+			}
+		}
+		return
 	}
 
 	switch mode {

--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -530,6 +530,8 @@ heap_alloc :: proc(size: int) -> rawptr {
 	return _unix_calloc(1, size)
 }
 heap_resize :: proc(ptr: rawptr, new_size: int) -> rawptr {
+	// NOTE: _unix_realloc doesn't guarantee new memory will be zeroed on
+	// POSIX platforms. Ensure your caller takes this into account.
 	return _unix_realloc(ptr, new_size)
 }
 heap_free :: proc(ptr: rawptr) {

--- a/core/os/os_freebsd.odin
+++ b/core/os/os_freebsd.odin
@@ -378,6 +378,8 @@ heap_alloc :: proc(size: int) -> rawptr {
 }
 
 heap_resize :: proc(ptr: rawptr, new_size: int) -> rawptr {
+	// NOTE: _unix_realloc doesn't guarantee new memory will be zeroed on
+	// POSIX platforms. Ensure your caller takes this into account.
 	return _unix_realloc(ptr, c.size_t(new_size));
 }
 

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -543,6 +543,8 @@ heap_alloc :: proc(size: int) -> rawptr {
 }
 
 heap_resize :: proc(ptr: rawptr, new_size: int) -> rawptr {
+	// NOTE: _unix_realloc doesn't guarantee new memory will be zeroed on
+	// POSIX platforms. Ensure your caller takes this into account.
 	return _unix_realloc(ptr, c.size_t(new_size))
 }
 


### PR DESCRIPTION
Added manual zeroing to `aligned_resize` in `core/os/os.odin` for non-windows environments.  Also added notes to some of the OS-specific files in `core/os/` warning that the new memory region returned by `_unix_realloc` is undefined. 