### PR TITLE
Adds version check for Apple Silicon for LLVM Version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,21 @@ CC=clang
 OS=$(shell uname)
 
 ifeq ($(OS), Darwin)
+    ARCH=$(shell uname -m)
     LLVM_CONFIG=llvm-config
-    ifneq ($(shell llvm-config --version | grep '^11\.'),)
+
+    # LLVM Version Setting  
+    LLVM_VERSION_PATTERN="^11\."
+    LLVM_VERSION="11"
+    ifeq ($(ARCH), arm64)
+	LLVM_VERSION="13"
+        LLVM_VERSION_PATTERN="^13"
+    endif 
+
+    ifneq ($(shell llvm-config --version | grep $(LLVM_VERSION_PATTERN)),)
         LLVM_CONFIG=llvm-config
     else
-        $(error "Requirement: llvm-config must be version 11")
+        $(error "Requirement: llvm-config must be version $(LLVM_VERSION)")
     endif
 
     LDFLAGS:=$(LDFLAGS) -liconv


### PR DESCRIPTION
This pr changes the llvm version required for users of odin on apple silicon it doesn't change the version for anyone else. 
The main reason why this is required is that the current macOS version seems to have changed a bunch off stuff how they handle debug info. I can't say if this doesn't happen on versions prior to 12.1/12.0 but it shouldn't make a difference for these people. 