### PR TITLE
Fix slice into_dynamic zeroing len of input slice

### DIFF
--- a/core/slice/slice.odin
+++ b/core/slice/slice.odin
@@ -23,7 +23,7 @@ swap_between :: proc(a, b: $T/[]$E) {
 	n := builtin.min(len(a), len(b))
 	if n >= 0 {
 		ptr_swap_overlapping(&a[0], &b[0], size_of(E)*n)
-	}	
+	}
 }
 
 
@@ -206,7 +206,7 @@ into_dynamic :: proc(a: $T/[]$E) -> [dynamic]E {
 	s := transmute(mem.Raw_Slice)a
 	d := mem.Raw_Dynamic_Array{
 		data = s.data,
-		len  = 0,
+		len  = s.len,
 		cap  = s.len,
 		allocator = mem.nil_allocator(),
 	}


### PR DESCRIPTION
I'm assuming this is the intended behavior? When converting a slice to a dynamic array the length was zeroed out returning something with an equal capacity but no elements.