### PR TITLE
Removes unneeded lookups / Adds sret to call site which fixes the mac…

### DIFF
--- a/src/llvm_abi.cpp
+++ b/src/llvm_abi.cpp
@@ -981,16 +981,16 @@ namespace lbAbiArm64 {
 			if (size <= 16) {
 				LLVMTypeRef cast_type = nullptr;
 				if (size <= 1) {
-					cast_type = LLVMIntTypeInContext(c, 8);
+					cast_type = LLVMInt8TypeInContext(c);
 				} else if (size <= 2) {
-					cast_type = LLVMIntTypeInContext(c, 16);
+					cast_type = LLVMInt16TypeInContext(c);
 				} else if (size <= 4) {
-					cast_type = LLVMIntTypeInContext(c, 32);
+					cast_type = LLVMInt32TypeInContext(c);
 				} else if (size <= 8) {
-					cast_type = LLVMIntTypeInContext(c, 64);
+					cast_type = LLVMInt64TypeInContext(c);
 				} else {
 					unsigned count = cast(unsigned)((size+7)/8);
-					cast_type = LLVMArrayType(LLVMIntTypeInContext(c, 64), count);
+					cast_type = LLVMArrayType(LLVMInt64TypeInContext(c), count);
 				}
 				return lb_arg_type_direct(type, cast_type, nullptr, nullptr);
 			} else {
@@ -999,7 +999,7 @@ namespace lbAbiArm64 {
 			}
 		}
 	}
-
+    
 	Array<lbArgType> compute_arg_types(LLVMContextRef c, LLVMTypeRef *arg_types, unsigned arg_count) {
 		auto args = array_make<lbArgType>(heap_allocator(), arg_count);
 

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -736,6 +736,10 @@ lbValue lb_emit_call_internal(lbProcedure *p, lbValue value, lbValue return_ptr,
 
 		LLVMValueRef ret = LLVMBuildCall2(p->builder, fnp, fn, args, arg_count, "");
 
+		if (return_ptr.value != nullptr) {
+			LLVMAddCallSiteAttribute(ret, 1, lb_create_enum_attribute_with_type(p->module->ctx, "sret", LLVMTypeOf(args[0])));
+		}
+
 		switch (inlining) {
 		case ProcInlining_none:
 			break;


### PR DESCRIPTION
Fixes the arm64 Abi bug that happened on macOS mainly because someone didn't want to add the right attribute to the call site which makes problems when you call through a pointer. And also removes the needless lookups that we had for the ABI types on arm side.