### PR TITLE
src: Add preliminary support for Linux AArch64

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -300,6 +300,14 @@ gb_global TargetMetrics target_linux_amd64 = {
 	str_lit("x86_64-pc-linux-gnu"),
 	str_lit("e-m:w-i64:64-f80:128-n8:16:32:64-S128"),
 };
+gb_global TargetMetrics target_linux_arm64 = {
+	TargetOs_linux,
+	TargetArch_arm64,
+	8,
+	16,
+	str_lit("aarch64-linux-elf"),
+	str_lit("e-m:e-i8:8:32-i16:32-i64:64-i128:128-n32:64-S128"),
+};
 
 gb_global TargetMetrics target_darwin_amd64 = {
 	TargetOs_darwin,
@@ -394,6 +402,7 @@ gb_global NamedTargetMetrics named_targets[] = {
 	{ str_lit("essence_amd64"),       &target_essence_amd64  },
 	{ str_lit("linux_386"),           &target_linux_386      },
 	{ str_lit("linux_amd64"),         &target_linux_amd64    },
+	{ str_lit("linux_arm64"),         &target_linux_arm64    },
 	{ str_lit("windows_386"),         &target_windows_386    },
 	{ str_lit("windows_amd64"),       &target_windows_amd64  },
 	{ str_lit("freebsd_386"),         &target_freebsd_386    },
@@ -880,6 +889,8 @@ void init_build_context(TargetMetrics *cross_target) {
 			#endif
 		#elif defined(GB_SYSTEM_FREEBSD)
 			metrics = &target_freebsd_amd64;
+		#elif defined(GB_CPU_ARM)
+			metrics = &target_linux_arm64;
 		#else
 			metrics = &target_linux_amd64;
 		#endif
@@ -958,6 +969,9 @@ void init_build_context(TargetMetrics *cross_target) {
 		switch (bc->metrics.os) {
 		case TargetOs_darwin:
 			bc->link_flags = str_lit("-arch arm64 ");
+			break;
+		case TargetOs_linux:
+			bc->link_flags = str_lit("-arch aarch64 ");
 			break;
 		}
 	} else if (is_arch_wasm()) {

--- a/src/gb/gb.h
+++ b/src/gb/gb.h
@@ -3355,6 +3355,8 @@ gb_inline u32 gb_thread_current_id(void) {
 	__asm__("mov %%gs:0x08,%0" : "=r"(thread_id));
 #elif defined(GB_ARCH_64_BIT) && defined(GB_CPU_X86)
 	__asm__("mov %%fs:0x10,%0" : "=r"(thread_id));
+#elif defined(GB_SYSTEM_LINUX)
+	thread_id = gettid();
 #else
 	#error Unsupported architecture for gb_thread_current_id()
 #endif

--- a/src/threading.cpp
+++ b/src/threading.cpp
@@ -296,6 +296,8 @@ u32 thread_current_id(void) {
 	__asm__("mov %%gs:0x08,%0" : "=r"(thread_id));
 #elif defined(GB_ARCH_64_BIT) && defined(GB_CPU_X86)
 	__asm__("mov %%fs:0x10,%0" : "=r"(thread_id));
+#elif defined(GB_SYSTEM_LINUX)
+	thread_id = gettid();
 #else
 	#error Unsupported architecture for thread_current_id()
 #endif
@@ -315,6 +317,8 @@ gb_inline void yield_thread(void) {
 	#endif
 #elif defined(GB_CPU_X86)
 	_mm_pause();
+#elif defined(GB_CPU_ARM)
+	__asm__ volatile ("yield" : : : "memory");
 #else
 #error Unknown architecture
 #endif


### PR DESCRIPTION
Tested via `tests/core`, on a Raspberry Pi 4 running the latest
64-bit Raspberry Pi OS image (LLVM 11).