### PR TITLE
core:odin/parser: Fix parsing of Allman style braces in for loops

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -888,6 +888,7 @@ parse_for_stmt :: proc(p: ^Parser) -> ^ast.Stmt {
 			error(p, body.pos, "the body of a 'do' must be on the same line as the 'for' token")
 		}
 	} else {
+		allow_token(p, .Semicolon)
 		body = parse_body(p)
 	}
 


### PR DESCRIPTION
```odin
for i := 0
    i < n
    i += 1
{
    // ...
}