### PR TITLE
Fixed wrong function name in vendor/OpenGL/README.md

### DIFF
--- a/vendor/OpenGL/README.md
+++ b/vendor/OpenGL/README.md
@@ -9,7 +9,7 @@ gl.load_up_to(4, 5, proc(p: rawptr, name: cstring) do (cast(^rawptr)p)^ = glfw.G
 ```
 [odin-glfw](https://github.com/vassvik/odin-glfw) also provides a useful helper you can pass straight to `gl.load_up_to`:
 ```go
-gl.load_up_to(4, 5, glfw.set_proc_address);
+gl.load_up_to(4, 5, glfw.gl_set_proc_address);
 ```
 
 #### NOTE: It is recommended to put this into the shared collection:


### PR DESCRIPTION
The function in glfw package is named gl_set_proc_address not set_proc_address