### PR TITLE
Fix unused imports.

### DIFF
--- a/core/sort/map.odin
+++ b/core/sort/map.odin
@@ -4,6 +4,9 @@ import "core:intrinsics"
 import "core:runtime"
 import "core:slice"
 
+_ :: runtime
+_ :: slice
+
 map_entries_by_key :: proc(m: ^$M/map[$K]$V, loc := #caller_location) where intrinsics.type_is_ordered(K) {
 	Entry :: struct {
 		hash:  uintptr,


### PR DESCRIPTION
Prevent the following:
```
W:/Odin/core/sort/map.odin(4:8) 'runtime' declared but not used
W:/Odin/core/sort/map.odin(5:8) 'slice' declared but not used
```