### PR TITLE
Fix return stmt when it's one lined(check for close brace).

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -1312,7 +1312,7 @@ parse_stmt :: proc(p: ^Parser) -> ^ast.Stmt {
 		}
 
 		results: [dynamic]^ast.Expr
-		for p.curr_tok.kind != .Semicolon {
+		for p.curr_tok.kind != .Semicolon && p.curr_tok.kind != .Close_Brace {
 			result := parse_expr(p, false)
 			append(&results, result)
 			if p.curr_tok.kind != .Comma ||


### PR DESCRIPTION
This fixes the error on `core:odin/parser`.
```
f :: proc() {
  if a == 2 { return }
}
```

The code lacked a check on closing brace, which is present on the cpp version.


