### PR TITLE
avoid segfault in llvm_backend_general.cpp on map resize

### DIFF
--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -1602,8 +1602,9 @@ LLVMTypeRef lb_type_internal(lbModule *m, Type *type) {
 						return llvm_type;
 					}
 					llvm_type = LLVMStructCreateNamed(ctx, name);
+					LLVMTypeRef found_val = *found;
 					map_set(&m->types, type, llvm_type);
-					lb_clone_struct_type(llvm_type, *found);
+					lb_clone_struct_type(llvm_type, found_val);
 					return llvm_type;
 				}
 			}


### PR DESCRIPTION
@ llvm_backend_general.cpp:1595 (comments are mine)
```cpp
LLVMTypeRef *found = map_get(&m->types, base);  // found pointing into map
if (found) {
        LLVMTypeKind kind = LLVMGetTypeKind(*found);
        if (kind == LLVMStructTypeKind) {
                char const *name = alloc_cstring(permanent_allocator(), lb_get_entity_name(m, type->Named.type_name));
                LLVMTypeRef llvm_type = LLVMGetTypeByName(m->mod, name);
                if (llvm_type != nullptr) {
                        return llvm_type;
                }
                llvm_type = LLVMStructCreateNamed(ctx, name);
                map_set(&m->types, type, llvm_type);  // found can be invalidated here if the map resizes
                lb_clone_struct_type(llvm_type, *found);  // found may now be garbage
                return llvm_type;
        }
}
```