### PR TITLE
"odin doc <dir> -web" command for windows

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -157,6 +157,7 @@ enum CmdDocFlag : u32 {
 	CmdDocFlag_Short       = 1<<0,
 	CmdDocFlag_AllPackages = 1<<1,
 	CmdDocFlag_DocFormat   = 1<<2,
+	CmdDocFlag_Web         = 1<<3,
 };
 
 enum TimingsExportFormat : i32 {

--- a/src/docs.cpp
+++ b/src/docs.cpp
@@ -357,6 +357,23 @@ void generate_documentation(Checker *c) {
 		defer (gb_string_free(output_file_path));
 
 		odin_doc_write(info, output_file_path);
+	} else if (build_context.cmd_doc_flags & CmdDocFlag_Web){
+		#if defined(GB_SYSTEM_WINDOWS)
+		String init_fullpath = c->parser->init_fullpath;
+		String web_ext = {};
+		isize core_index = string_index_of(init_fullpath, str_lit("core"));
+		if (core_index >= 0) {
+			web_ext = substring(init_fullpath, core_index, init_fullpath.len);
+		}
+		isize vendor_index = string_index_of(init_fullpath, str_lit("vendor"));
+		if (vendor_index >= 0) {
+			web_ext = substring(init_fullpath, core_index, init_fullpath.len);
+		}
+		system_exec_command_line_app("doc webpage",
+			"cmd.exe /C start https://pkg.odin-lang.org/%.*s", LIT(web_ext));
+		#else
+		gb_printf("odin doc <dir> -web is currently unsupported for this OS");
+		#endif
 	} else {
 		auto pkgs = array_make<AstPackage *>(permanent_allocator(), 0, info->packages.entries.count);
 		for_array(i, info->packages.entries) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,7 +44,6 @@ gb_global Timings global_timings = {0};
 
 #include "parser.cpp"
 #include "checker.cpp"
-#include "docs.cpp"
 
 
 #include "llvm_backend.cpp"
@@ -126,8 +125,7 @@ i32 system_exec_command_line_app(char const *name, char const *fmt, ...) {
 	return exit_code;
 }
 
-
-
+#include "docs.cpp"
 
 i32 linker_stage(lbGenerator *gen) {
 	i32 result = 0;
@@ -671,6 +669,7 @@ enum BuildFlagKind {
 	BuildFlag_Short,
 	BuildFlag_AllPackages,
 	BuildFlag_DocFormat,
+	BuildFlag_Web,
 
 	BuildFlag_IgnoreWarnings,
 	BuildFlag_WarningsAsErrors,
@@ -823,6 +822,7 @@ bool parse_build_flags(Array<String> args) {
 	add_flag(&build_flags, BuildFlag_Short,         str_lit("short"),        BuildFlagParam_None, Command_doc);
 	add_flag(&build_flags, BuildFlag_AllPackages,   str_lit("all-packages"), BuildFlagParam_None, Command_doc);
 	add_flag(&build_flags, BuildFlag_DocFormat,     str_lit("doc-format"),   BuildFlagParam_None, Command_doc);
+	add_flag(&build_flags, BuildFlag_Web,     str_lit("web"),   BuildFlagParam_None, Command_doc);
 
 	add_flag(&build_flags, BuildFlag_IgnoreWarnings,   str_lit("ignore-warnings"),    BuildFlagParam_None, Command_all);
 	add_flag(&build_flags, BuildFlag_WarningsAsErrors, str_lit("warnings-as-errors"), BuildFlagParam_None, Command_all);
@@ -1447,6 +1447,9 @@ bool parse_build_flags(Array<String> args) {
 							break;
 						case BuildFlag_DocFormat:
 							build_context.cmd_doc_flags |= CmdDocFlag_DocFormat;
+							break;
+						case BuildFlag_Web:
+							build_context.cmd_doc_flags |= CmdDocFlag_Web;
 							break;
 						case BuildFlag_IgnoreWarnings: {
 							if (build_context.warnings_as_errors) {

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -89,7 +89,6 @@ String substring(String const &s, isize lo, isize hi) {
 	return make_string(s.text+lo, hi-lo);
 }
 
-
 char *alloc_cstring(gbAllocator a, String s) {
 	char *c_str = gb_alloc_array(a, char, s.len+1);
 	gb_memmove(c_str, s.text, s.len);
@@ -228,6 +227,34 @@ gb_inline bool string_ends_with(String const &s, u8 suffix) {
 	}
 
 	return s[s.len-1] == suffix;
+}
+
+bool string_contains(String const &s, String sub) {
+	if (sub.len > s.len) {
+		return false;
+	}
+
+	for (isize i = 0; i <= s.len - sub.len; i++) {
+		String curr = substring(s, i, i+sub.len);
+		if (str_eq(sub,curr)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+isize string_index_of(String const &s, String sub) {
+	if (sub.len > s.len) {
+		return -1;
+	}
+
+	for (isize i = 0; i <= s.len - sub.len; i++) {
+		String curr = substring(s, i, i+sub.len);
+		if (str_eq(sub,curr)) {
+			return i;
+		}
+	}
+	return -1;
 }
 
 gb_inline isize string_extension_position(String const &str) {


### PR DESCRIPTION
This will launch the default browser to the odin package documentation site if the <dir> argument contains "core" or "vendor".

Feedback on how to improve the parsing to figure out if it's a valid page would be appreciated.
Or feedback for any other improvements / alterations.