### PR TITLE
fix logic in bswap_128

### DIFF
--- a/core/runtime/internal.odin
+++ b/core/runtime/internal.odin
@@ -37,10 +37,8 @@ bswap_64 :: proc "contextless" (x: u64) -> u64 {
 
 bswap_128 :: proc "contextless" (x: u128) -> u128 {
 	z := transmute([4]u32)x
-	z[0] = bswap_32(z[3])
-	z[1] = bswap_32(z[2])
-	z[2] = bswap_32(z[1])
-	z[3] = bswap_32(z[0])
+	z[0], z[3] = bswap_32(z[3]), bswap_32(z[0])
+	z[1], z[2] = bswap_32(z[2]), bswap_32(z[1])
 	return transmute(u128)z
 }
 


### PR DESCRIPTION
previously the last two words of the output were lost.
see output of:
```odin
  a : u128 : 0x00112233_44556677_8899aabb_ccddeeff
  fmt.printf("{:32x}\n", runtime.bswap_128(a))
  fmt.printf("{:32x}\n", a)
```