### PR TITLE
Feature/fix odin fmt

### DIFF
--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -290,10 +290,15 @@ foreign libc {
 	@(link_name="fstat64")          _unix_fstat         :: proc(fd: Handle, stat: ^OS_Stat) -> c.int ---
 	@(link_name="readlink")         _unix_readlink      :: proc(path: cstring, buf: ^byte, bufsiz: c.size_t) -> c.ssize_t ---
 	@(link_name="access")           _unix_access        :: proc(path: cstring, mask: int) -> int ---
-	@(link_name="fdopendir$INODE64") _unix_fdopendir    :: proc(fd: Handle) -> Dir ---
+
+	@(link_name="fdopendir$INODE64") _unix_fdopendir_amd64 :: proc(fd: Handle) -> Dir ---
+	@(link_name="readdir_r$INODE64") _unix_readdir_r_amd64 :: proc(dirp: Dir, entry: ^Dirent, result: ^^Dirent) -> c.int ---
+	@(link_name="fdopendir")         _unix_fdopendir_arm64 :: proc(fd: Handle) -> Dir ---
+	@(link_name="readdir_r")         _unix_readdir_r_arm64 :: proc(dirp: Dir, entry: ^Dirent, result: ^^Dirent) -> c.int ---
+
 	@(link_name="closedir")         _unix_closedir      :: proc(dirp: Dir) -> c.int ---
 	@(link_name="rewinddir")        _unix_rewinddir     :: proc(dirp: Dir) ---
-	@(link_name="readdir_r$INODE64") _unix_readdir_r    :: proc(dirp: Dir, entry: ^Dirent, result: ^^Dirent) -> c.int ---
+	
 	@(link_name="fcntl")            _unix_fcntl         :: proc(fd: Handle, cmd: c.int, buf: ^byte) -> c.int ---
 
 	@(link_name="rename") _unix_rename :: proc(old: cstring, new: cstring) -> c.int ---
@@ -313,6 +318,14 @@ foreign libc {
 	@(link_name="strerror") _darwin_string_error :: proc(num : c.int) -> cstring ---
 
 	@(link_name="exit")    _unix_exit :: proc(status: c.int) -> ! ---
+}
+
+when ODIN_ARCH != "arm64" {
+	_unix_fdopendir :: proc {_unix_fdopendir_amd64}
+	_unix_readdir_r :: proc {_unix_readdir_r_amd64}
+} else {
+	_unix_fdopendir :: proc {_unix_fdopendir_arm64}
+	_unix_readdir_r :: proc {_unix_readdir_r_arm64}
 }
 
 foreign dl {

--- a/core/path/filepath/walk.odin
+++ b/core/path/filepath/walk.odin
@@ -71,7 +71,7 @@ _walk :: proc(info: os.File_Info, walk_proc: Walk_Proc) -> (err: os.Errno, skip_
 
 @(private)
 read_dir :: proc(dir_name: string, allocator := context.temp_allocator) -> ([]os.File_Info, os.Errno) {
-	f, err := os.open(dir_name)
+	f, err := os.open(dir_name, os.O_RDONLY)
 	if err != 0 {
 		return nil, err
 	}

--- a/tools/odinfmt/main.odin
+++ b/tools/odinfmt/main.odin
@@ -114,7 +114,6 @@ main :: proc() {
 		filepath.walk(path, walk_files);
 
 		for file in files {
-			fmt.println(file);
 
 			backup_path := strings.concatenate({file, "_bk"});
 			defer delete(backup_path);


### PR DESCRIPTION
This finally fixes odinfmt also on macOS was just a simple default value which wasn't the correct one. 
And that $INODE64 calls don't exist on arm macOS there you use the default calls