### PR TITLE
[core:net] Cleanup UDP send/recv procedures on Linux

### DIFF
--- a/core/net/socket_linux.odin
+++ b/core/net/socket_linux.odin
@@ -287,8 +287,8 @@ Udp_Recv_Error :: enum c.int {
 	// A signal occurred before any data was transmitted.
 	// See signal(7).
 	Interrupted = c.int(os.EINTR),
-	// The send timeout duration passed before all data was sent.
-	// See Socket_Option.Send_Timeout.
+	// The send timeout duration passed before all data was received.
+	// See Socket_Option.Receive_Timeout.
 	Timeout = c.int(os.EWOULDBLOCK), // NOTE: No, really. Presumably this means something different for nonblocking sockets...
 	// The socket must be bound for this operation, but isn't.
 	Socket_Not_Bound = c.int(os.EINVAL),

--- a/core/net/socket_linux.odin
+++ b/core/net/socket_linux.odin
@@ -385,18 +385,18 @@ Udp_Send_Error :: enum c.int {
 	No_Memory_Available = c.int(os.ENOMEM),
 }
 
+// Sends a single UDP datagram packet.
+//
+// Datagrams are limited in size; attempting to send more than this limit at once will result in a Message_Too_Long error.
+// UDP packets are not guarenteed to be received in order.
 send_udp :: proc(skt: Udp_Socket, buf: []byte, to: Endpoint) -> (bytes_written: int, err: Network_Error) {
 	toaddr := endpoint_to_sockaddr(to)
-	for bytes_written < len(buf) {
-		limit := min(1<<31, len(buf) - bytes_written)
-		remaining := buf[bytes_written:][:limit]
-		res, ok := os.sendto(os.Socket(skt), remaining, 0, cast(^os.SOCKADDR) &toaddr, size_of(toaddr))
-		if ok != os.ERROR_NONE {
-			err = Udp_Send_Error(ok)
-			return
-		}
-		bytes_written += int(res)
+	res, os_err := os.sendto(os.Socket(skt), buf, 0, cast(^os.SOCKADDR) &toaddr, size_of(toaddr))
+	if os_err != os.ERROR_NONE {
+		err = Udp_Send_Error(os_err)
+		return
 	}
+	bytes_written = int(res)
 	return
 }
 

--- a/core/net/socket_linux.odin
+++ b/core/net/socket_linux.odin
@@ -358,7 +358,7 @@ send_tcp :: proc(skt: Tcp_Socket, buf: []byte) -> (bytes_written: int, err: Netw
 // TODO
 Udp_Send_Error :: enum c.int {
 	// The message is too big. No data was sent.
-	Truncated = c.int(os.EMSGSIZE),
+	Message_Too_Long = c.int(os.EMSGSIZE),
 	// TODO: not sure what the exact circumstances for this is yet
 	Network_Unreachable = c.int(os.ENETUNREACH),
 	// There are no more emphemeral outbound ports available to bind the socket to, in order to send.

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -70,6 +70,10 @@ SO_SNDTIMEO_NEW: int : 67
 TCP_NODELAY: int : 1
 TCP_CORK:    int : 3
 
+MSG_PEEK  : int : 0x02
+MSG_TRUNC : int : 0x20
+
+
 
 ERROR_NONE:     Errno : 0
 EPERM:          Errno : 1


### PR DESCRIPTION
- Cleanup send_udp() by removing the unnecessary loop
- Rename Udp_Send_Error.Truncated to .Message_Too_Long to match Windows.
- Fix recv_udp() error handling when receive buffer is too small.
- Rename Udp_Recv_Error.Truncated to .Buffer_Too_Small.
- Also fix a doc-comment typo.