### PR TITLE
[core:net] Cleanup and fixes for SRV records + a couple of DNS fixes

### DIFF
--- a/core/net/common.odin
+++ b/core/net/common.odin
@@ -205,7 +205,7 @@ DNS_Record_MX :: struct {
 //
 // The host may be "." to indicate that it is "decidedly not available" on this domain.
 DNS_Record_SRV :: struct {
-	entire_name_buffer: string, // NOTE(tetra): service_name, protocol_name, and host_name are all substrings of this string.
+	_entire_name_buffer: string, // NOTE(tetra): service_name, protocol_name, and host_name are all substrings of this string.
 	service_name, protocol_name, host_name: string,
 	port: int,
 	priority: int, // lower is higher priority

--- a/core/net/common.odin
+++ b/core/net/common.odin
@@ -205,6 +205,7 @@ DNS_Record_MX :: struct {
 //
 // The host may be "." to indicate that it is "decidedly not available" on this domain.
 DNS_Record_SRV :: struct {
+	entire_name_buffer: string, // NOTE(tetra): service_name, protocol, and host are all substrings of this string.
 	service_name, protocol, host: string,
 	port: int,
 	priority: int, // lower is higher priority

--- a/core/net/common.odin
+++ b/core/net/common.odin
@@ -115,11 +115,6 @@ IPv4_Address :: distinct [4]u8
 IPv6_Address :: distinct [8]u16be
 Address :: union {IPv4_Address, IPv6_Address}
 
-Addr_Type :: enum {
-	IPv4,
-	IPv6,
-}
-
 IPv4_Loopback := IPv4_Address{127, 0, 0, 1}
 IPv6_Loopback := IPv6_Address{0, 0, 0, 0, 0, 0, 0, 1}
 

--- a/core/net/common.odin
+++ b/core/net/common.odin
@@ -191,7 +191,7 @@ DNS_Record_NS :: distinct string
 // Domain names for email servers that are associated with the domain name.
 // These records also have values which ranks them in the order they should be preferred. Lower is more-preferred.
 DNS_Record_MX :: struct {
-	host: string,
+	host_name: string,
 	preference: int,
 }
 
@@ -205,8 +205,8 @@ DNS_Record_MX :: struct {
 //
 // The host may be "." to indicate that it is "decidedly not available" on this domain.
 DNS_Record_SRV :: struct {
-	entire_name_buffer: string, // NOTE(tetra): service_name, protocol, and host are all substrings of this string.
-	service_name, protocol, host: string,
+	entire_name_buffer: string, // NOTE(tetra): service_name, protocol_name, and host_name are all substrings of this string.
+	service_name, protocol_name, host_name: string,
 	port: int,
 	priority: int, // lower is higher priority
 	weight: int, // relative weight of this host compared to other of same priority; the chance of using this host should be proporitional to this weight.

--- a/core/net/dns.odin
+++ b/core/net/dns.odin
@@ -311,7 +311,7 @@ destroy_dns_records :: proc(records: []DNS_Record, allocator := context.allocato
 		case DNS_Record_MX:
 			delete(r.host_name)
 		case DNS_Record_SRV:
-			delete(r.entire_name_buffer)
+			delete(r._entire_name_buffer)
 		}
 	}
 
@@ -646,7 +646,7 @@ parse_record :: proc(packet: []u8, cur_off: ^int, filter: DNS_Record_Type = nil)
 			}
 
 			_record = DNS_Record_SRV{
-				entire_name_buffer = name,
+				_entire_name_buffer = name,
 				service_name  = service_name,
 				protocol_name = protocol_name,
 				host_name     = host_name,

--- a/core/net/dns.odin
+++ b/core/net/dns.odin
@@ -309,7 +309,7 @@ destroy_dns_records :: proc(records: []DNS_Record, allocator := context.allocato
 		case DNS_Record_NS:
 			delete(string(r))
 		case DNS_Record_MX:
-			delete(r.host)
+			delete(r.host_name)
 		case DNS_Record_SRV:
 			delete(r.entire_name_buffer)
 		}
@@ -647,12 +647,12 @@ parse_record :: proc(packet: []u8, cur_off: ^int, filter: DNS_Record_Type = nil)
 
 			_record = DNS_Record_SRV{
 				entire_name_buffer = name,
-				service_name = service_name,
-				protocol     = protocol_name,
-				host         = host_name,
-				priority     = int(priority),
-				weight       = int(weight),
-				port         = int(port),
+				service_name  = service_name,
+				protocol_name = protocol_name,
+				host_name     = host_name,
+				priority      = int(priority),
+				weight        = int(weight),
+				port          = int(port),
 			}
 		case .MX:
 			if len(data) <= 2 {
@@ -662,7 +662,7 @@ parse_record :: proc(packet: []u8, cur_off: ^int, filter: DNS_Record_Type = nil)
 			preference: u16be = mem.slice_data_cast([]u16be, data)[0]
 			hostname, _ := decode_hostname(packet, data_off + size_of(u16be)) or_return
 			_record = DNS_Record_MX{
-				host       = hostname,
+				host_name  = hostname,
 				preference = int(preference),
 			}
 		case:

--- a/core/net/dns.odin
+++ b/core/net/dns.odin
@@ -545,7 +545,7 @@ decode_hostname :: proc(packet: []u8, start_idx: int, allocator := context.alloc
 		return
 	}
 
-	return strings.clone(strings.to_string(b)), out_size, true
+	return strings.clone(strings.to_string(b), allocator), out_size, true
 }
 
 // Uses RFC 952 & RFC 1123

--- a/core/net/dns_windows.odin
+++ b/core/net/dns_windows.odin
@@ -125,7 +125,7 @@ get_dns_records_windows :: proc(hostname: string, type: DNS_Record_Type, allocat
 			}
 
 			append(&recs, DNS_Record_SRV {
-				entire_name_buffer = name,
+				_entire_name_buffer = name,
 				service_name  = service_name,
 				protocol_name = protocol_name,
 				host_name     = host_name,

--- a/core/net/dns_windows.odin
+++ b/core/net/dns_windows.odin
@@ -100,7 +100,7 @@ get_dns_records_windows :: proc(hostname: string, type: DNS_Record_Type, allocat
 			host := string(r.Data.MX.pNameExchange)
 			preference := int(r.Data.MX.wPreference)
 			new_rec := DNS_Record_MX {
-				host       = strings.clone(host),
+				host_name  = strings.clone(host),
 				preference = preference }
 			append(&recs, new_rec)
 
@@ -126,12 +126,12 @@ get_dns_records_windows :: proc(hostname: string, type: DNS_Record_Type, allocat
 
 			append(&recs, DNS_Record_SRV {
 				entire_name_buffer = name,
-				service_name = service_name,
-				protocol     = protocol_name,
-				host         = host_name,
-				priority     = priority,
-				weight       = weight,
-				port         = port,
+				service_name  = service_name,
+				protocol_name = protocol_name,
+				host_name     = host_name,
+				priority      = priority,
+				weight        = weight,
+				port          = port,
 			})
 		}
 	}

--- a/core/net/dns_windows.odin
+++ b/core/net/dns_windows.odin
@@ -110,22 +110,24 @@ get_dns_records_windows :: proc(hostname: string, type: DNS_Record_Type, allocat
 			weight := int(r.Data.SRV.wWeight)
 			port := int(r.Data.SRV.wPort)
 
-			parts := strings.split(name, ".", context.temp_allocator)
-			defer delete(parts)
-			assert(len(parts) == 3, "Srv record name should be of the form _servicename._protocol.domain")
-			service_name, protocol, host := parts[0], parts[1], parts[2]
+			// NOTE(tetra): Srv record name should be of the form '_servicename._protocol.hostname'
+			parts := strings.split_n(name, ".", 3, context.temp_allocator)
+			if len(parts) != 3 {
+				continue
+			}
+			service_name, protocol_name, host_name := parts[0], parts[1], parts[2]
 
 			if service_name[0] == '_' {
 				service_name = service_name[1:]
 			}
-			if protocol[0] == '_' {
-				protocol = protocol[1:]
+			if protocol_name[0] == '_' {
+				protocol_name = protocol_name[1:]
 			}
 
 			append(&recs, DNS_Record_SRV {
 				service_name = service_name,
-				protocol     = protocol,
-				host         = host,
+				protocol     = protocol_name,
+				host         = host_name,
 				priority     = priority,
 				weight       = weight,
 				port         = port,

--- a/core/net/dns_windows.odin
+++ b/core/net/dns_windows.odin
@@ -125,6 +125,7 @@ get_dns_records_windows :: proc(hostname: string, type: DNS_Record_Type, allocat
 			}
 
 			append(&recs, DNS_Record_SRV {
+				entire_name_buffer = name,
 				service_name = service_name,
 				protocol     = protocol_name,
 				host         = host_name,


### PR DESCRIPTION
- Fix SRV records not being correctly parsed in the generic DNS resolver.
- Fixed a bug in `_decode_hostname` where the allocator wasn't being respected
- Ignore bad SRV records from nameserver, instead of panicking.
- Fix a bad free in `destroy_dns_records()` for SRV records.
- Remove `Addr_Type` in favor of using `Address_Family` for what address families to resolve with `resolve`.
- Remove a little bad whitespace