### PR TITLE
[core:net] Assorted fixes and resolve() refactor

### DIFF
--- a/core/net/addr.odin
+++ b/core/net/addr.odin
@@ -249,7 +249,7 @@ address_to_string :: proc(addr: Address, allocator := context.temp_allocator) ->
 // Returns a temporarily-allocated string representation of the endpoint.
 // If there's a port, uses the `[address]:port` format.
 endpoint_to_string :: proc(ep: Endpoint, allocator := context.temp_allocator) -> string {
-	if ep.port != 0 {
+	if ep.port == 0 {
 		return address_to_string(ep.address, allocator)
 	} else {
 		s := address_to_string(ep.address, context.temp_allocator)

--- a/core/net/addr.odin
+++ b/core/net/addr.odin
@@ -21,7 +21,7 @@ import "core:strings"
 import "core:fmt"
 import "core:mem"
 
-parse_ipv4_address :: proc(address_and_maybe_port: string) -> (addr: IPv4_Address, ok: bool) {
+parse_ip4_address :: proc(address_and_maybe_port: string) -> (addr: IP4_Address, ok: bool) {
 	buf: [1024]byte
 	arena: mem.Arena
 	mem.init_arena(&arena, buf[:])
@@ -50,7 +50,7 @@ parse_ipv4_address :: proc(address_and_maybe_port: string) -> (addr: IPv4_Addres
 }
 
 // TODO(tetra): Scopeid?
-parse_ipv6_address :: proc(address_and_maybe_port: string) -> (addr: IPv6_Address, ok: bool) {
+parse_ip6_address :: proc(address_and_maybe_port: string) -> (addr: IP6_Address, ok: bool) {
 	// Rule 1: If the high-byte of any block is zero, it can be omitted. (00XX => XX)
 	// Rule 2: Two or more all-zero blocks in a row can be replaced with '::' (FF00:0000:0000:XXXX => FF00::XXXX)
 	//         but this can only happen _once_.
@@ -99,9 +99,9 @@ parse_ipv6_address :: proc(address_and_maybe_port: string) -> (addr: IPv6_Addres
 }
 
 parse_address :: proc(address_and_maybe_port: string) -> Address {
-	addr6, ok6 := parse_ipv6_address(address_and_maybe_port)
+	addr6, ok6 := parse_ip6_address(address_and_maybe_port)
 	if ok6 do return addr6
-	addr4, ok4 := parse_ipv4_address(address_and_maybe_port)
+	addr4, ok4 := parse_ip4_address(address_and_maybe_port)
 	if ok4 do return addr4
 	return nil
 }
@@ -152,7 +152,7 @@ parse_hostname_or_endpoint :: proc(endpoint_str: string) -> (target: Host_Or_End
 // Takes an endpoint string and returns its parts.
 // Returns ok=false if port is not a number.
 split_port :: proc(endpoint_str: string) -> (addr_or_host: string, port: int, ok: bool) {
-	// IPv6 [addr_or_host]:port
+	// IP6 [addr_or_host]:port
 	if i := strings.last_index(endpoint_str, "]:"); i != -1 {
 		addr_or_host = endpoint_str[1:i]
 		port, ok = strconv.parse_int(endpoint_str[i+2:], 10)
@@ -160,7 +160,7 @@ split_port :: proc(endpoint_str: string) -> (addr_or_host: string, port: int, ok
 	}
 
 	if n := strings.count(endpoint_str, ":"); n == 1 {
-		// IPv4 addr_or_host:port
+		// IP4 addr_or_host:port
 		i := strings.last_index(endpoint_str, ":")
 		assert(i != -1)
 
@@ -168,7 +168,7 @@ split_port :: proc(endpoint_str: string) -> (addr_or_host: string, port: int, ok
 		port, ok = strconv.parse_int(endpoint_str[i+1:], 10)
 		return
 	} else if n > 1 {
-		// IPv6 address without port
+		// IP6 address without port
 	}
 
 	// No port
@@ -191,9 +191,9 @@ join_port :: proc(address_or_host: string, port: int, allocator := context.alloc
 		fmt.sbprintf(&b, "%v:%v", addr_or_host, port)
 	} else {
 		switch in addr {
-		case IPv4_Address:
+		case IP4_Address:
 			fmt.sbprintf(&b, "%v:%v", address_to_string(addr), port)
-		case IPv6_Address:
+		case IP6_Address:
 			fmt.sbprintf(&b, "[%v]:%v", address_to_string(addr), port)
 		}
 	}
@@ -203,13 +203,13 @@ join_port :: proc(address_or_host: string, port: int, allocator := context.alloc
 
 
 // TODO(tetra): Do we need this?
-map_to_ipv6 :: proc(addr: Address) -> Address {
-	if addr6, ok := addr.(IPv6_Address); ok {
+map_to_ip6 :: proc(addr: Address) -> Address {
+	if addr6, ok := addr.(IP6_Address); ok {
 		return addr6
 	}
-	addr4 := addr.(IPv4_Address)
+	addr4 := addr.(IP4_Address)
 	addr4_u16 := transmute([2]u16be) addr4
-	addr6: IPv6_Address
+	addr6: IP6_Address
 	addr6[4] = 0xffff
 	copy(addr6[5:], addr4_u16[:])
 	return addr6
@@ -220,9 +220,9 @@ map_to_ipv6 :: proc(addr: Address) -> Address {
 address_to_string :: proc(addr: Address, allocator := context.temp_allocator) -> string {
 	b := strings.make_builder(allocator)
 	switch v in addr {
-	case IPv4_Address:
+	case IP4_Address:
 		fmt.sbprintf(&b, "%v.%v.%v.%v", v[0], v[1], v[2], v[3])
-	case IPv6_Address:
+	case IP6_Address:
 		i := 0
 		seen_double_colon := false
 		for i < len(v) {
@@ -255,8 +255,8 @@ endpoint_to_string :: proc(ep: Endpoint, allocator := context.temp_allocator) ->
 		s := address_to_string(ep.address, context.temp_allocator)
 		b := strings.make_builder(allocator)
 		switch a in ep.address {
-		case IPv4_Address:  fmt.sbprintf(&b, "%v:%v",   s, ep.port)
-		case IPv6_Address:  fmt.sbprintf(&b, "[%v]:%v", s, ep.port)
+		case IP4_Address:  fmt.sbprintf(&b, "%v:%v",   s, ep.port)
+		case IP6_Address:  fmt.sbprintf(&b, "[%v]:%v", s, ep.port)
 		}
 		return strings.to_string(b)
 	}
@@ -267,8 +267,8 @@ to_string :: proc{address_to_string, endpoint_to_string}
 
 family_from_address :: proc(addr: Address) -> Address_Family {
 	switch in addr {
-	case IPv4_Address: return .IPv4
-	case IPv6_Address: return .IPv6
+	case IP4_Address: return .IP4
+	case IP6_Address: return .IP6
 	case:
 		unreachable()
 	}

--- a/core/net/addr.odin
+++ b/core/net/addr.odin
@@ -118,6 +118,36 @@ parse_endpoint :: proc(endpoint_str: string) -> (ep: Endpoint, ok: bool) {
 	return
 }
 
+Host :: struct {
+	hostname: string,
+	port:     int,
+}
+Host_Or_Endpoint :: union {
+	Host,
+	Endpoint,
+}
+Parse_Endpoint_Error :: enum {
+	Bad_Port = 1,
+	Bad_Address,
+	Bad_Hostname,
+}
+
+// Takes a string consisting of a hostname or IP address, and an optional port,
+// and return the component parts in a useful form.
+parse_hostname_or_endpoint :: proc(endpoint_str: string) -> (target: Host_Or_Endpoint, err: Network_Error) {
+	host, port, port_ok := split_port(endpoint_str)
+	if !port_ok {
+		return nil, .Bad_Port
+	}
+	if addr := parse_address(host); addr != nil {
+		return Endpoint{addr, port}, nil
+	}
+	if !validate_hostname(host) {
+		return nil, .Bad_Hostname
+	}
+	return Host{host, port}, nil
+}
+
 
 // Takes an endpoint string and returns its parts.
 // Returns ok=false if port is not a number.

--- a/core/net/addr.odin
+++ b/core/net/addr.odin
@@ -106,8 +106,8 @@ parse_address :: proc(address_and_maybe_port: string) -> Address {
 	return nil
 }
 
-parse_endpoint :: proc(address: string) -> (ep: Endpoint, ok: bool) {
-	addr_str, port, split_ok := split_port(address)
+parse_endpoint :: proc(endpoint_str: string) -> (ep: Endpoint, ok: bool) {
+	addr_str, port, split_ok := split_port(endpoint_str)
 	if !split_ok do return
 
 	addr := parse_address(addr_str)

--- a/core/net/addr_darwin.odin
+++ b/core/net/addr_darwin.odin
@@ -27,7 +27,7 @@ get_network_interfaces :: proc() -> []Address {
 @private
 endpoint_to_sockaddr :: proc(ep: Endpoint) -> (sockaddr: os.SOCKADDR_STORAGE_LH) {
 	switch a in ep.address {
-	case IPv4_Address:
+	case IP4_Address:
 		(^os.sockaddr_in)(&sockaddr)^ = os.sockaddr_in {
 			sin_port = u16be(ep.port),
 			sin_addr = transmute(os.in_addr) a,
@@ -35,7 +35,7 @@ endpoint_to_sockaddr :: proc(ep: Endpoint) -> (sockaddr: os.SOCKADDR_STORAGE_LH)
 			sin_len = size_of(os.sockaddr_in),
 		}
 		return
-	case IPv6_Address:
+	case IP6_Address:
 		(^os.sockaddr_in6)(&sockaddr)^ = os.sockaddr_in6 {
 			sin6_port = u16be(ep.port),
 			sin6_addr = transmute(os.in6_addr) a,
@@ -54,18 +54,18 @@ sockaddr_to_endpoint :: proc(native_addr: ^os.SOCKADDR_STORAGE_LH) -> (ep: Endpo
 		addr := cast(^os.sockaddr_in) native_addr
 		port := int(addr.sin_port)
 		ep = Endpoint {
-			address = IPv4_Address(transmute([4]byte) addr.sin_addr),
+			address = IP4_Address(transmute([4]byte) addr.sin_addr),
 			port = port,
 		}
 	case u8(os.AF_INET6):
 		addr := cast(^os.sockaddr_in6) native_addr
 		port := int(addr.sin6_port)
 		ep = Endpoint {
-			address = IPv6_Address(transmute([8]u16be) addr.sin6_addr),
+			address = IP6_Address(transmute([8]u16be) addr.sin6_addr),
 			port = port,
 		}
 	case:
-		panic("native_addr is neither IPv4 or IPv6 address")
+		panic("native_addr is neither IP4 or IP6 address")
 	}
 	return
 }

--- a/core/net/addr_linux.odin
+++ b/core/net/addr_linux.odin
@@ -27,14 +27,14 @@ get_network_interfaces :: proc() -> []Address {
 @private
 endpoint_to_sockaddr :: proc(ep: Endpoint) -> (sockaddr: os.SOCKADDR_STORAGE_LH) {
 	switch a in ep.address {
-	case IPv4_Address:
+	case IP4_Address:
 		(^os.sockaddr_in)(&sockaddr)^ = os.sockaddr_in {
 			sin_port = u16be(ep.port),
 			sin_addr = transmute(os.in_addr) a,
 			sin_family = u16(os.AF_INET),
 		}
 		return
-	case IPv6_Address:
+	case IP6_Address:
 		(^os.sockaddr_in6)(&sockaddr)^ = os.sockaddr_in6 {
 			sin6_port = u16be(ep.port),
 			sin6_addr = transmute(os.in6_addr) a,
@@ -52,18 +52,18 @@ sockaddr_to_endpoint :: proc(native_addr: ^os.SOCKADDR_STORAGE_LH) -> (ep: Endpo
 		addr := cast(^os.sockaddr_in) native_addr
 		port := int(addr.sin_port)
 		ep = Endpoint {
-			address = IPv4_Address(transmute([4]byte) addr.sin_addr),
+			address = IP4_Address(transmute([4]byte) addr.sin_addr),
 			port = port,
 		}
 	case u16(os.AF_INET6):
 		addr := cast(^os.sockaddr_in6) native_addr
 		port := int(addr.sin6_port)
 		ep = Endpoint {
-			address = IPv6_Address(transmute([8]u16be) addr.sin6_addr),
+			address = IP6_Address(transmute([8]u16be) addr.sin6_addr),
 			port = port,
 		}
 	case:
-		panic("native_addr is neither IPv4 or IPv6 address")
+		panic("native_addr is neither IP4 or IP6 address")
 	}
 	return
 }

--- a/core/net/addr_windows.odin
+++ b/core/net/addr_windows.odin
@@ -27,14 +27,14 @@ get_network_interfaces :: proc() -> []Address {
 @private
 endpoint_to_sockaddr :: proc(ep: Endpoint) -> (sockaddr: win.SOCKADDR_STORAGE_LH) {
 	switch a in ep.address {
-	case IPv4_Address:
+	case IP4_Address:
 		(^win.sockaddr_in)(&sockaddr)^ = win.sockaddr_in {
 			sin_port = u16be(win.USHORT(ep.port)),
 			sin_addr = transmute(win.in_addr) a,
 			sin_family = u16(win.AF_INET),
 		}
 		return
-	case IPv6_Address:
+	case IP6_Address:
 		(^win.sockaddr_in6)(&sockaddr)^ = win.sockaddr_in6 {
 			sin6_port = u16be(win.USHORT(ep.port)),
 			sin6_addr = transmute(win.in6_addr) a,
@@ -52,18 +52,18 @@ sockaddr_to_endpoint :: proc(native_addr: ^win.SOCKADDR_STORAGE_LH) -> (ep: Endp
 		addr := cast(^win.sockaddr_in) native_addr
 		port := int(addr.sin_port)
 		ep = Endpoint {
-			address = IPv4_Address(transmute([4]byte) addr.sin_addr),
+			address = IP4_Address(transmute([4]byte) addr.sin_addr),
 			port = port,
 		}
 	case u16(win.AF_INET6):
 		addr := cast(^win.sockaddr_in6) native_addr
 		port := int(addr.sin6_port)
 		ep = Endpoint {
-			address = IPv6_Address(transmute([8]u16be) addr.sin6_addr),
+			address = IP6_Address(transmute([8]u16be) addr.sin6_addr),
 			port = port,
 		}
 	case:
-		panic("native_addr is neither IPv4 or IPv6 address")
+		panic("native_addr is neither IP4 or IP6 address")
 	}
 	return
 }

--- a/core/net/common.odin
+++ b/core/net/common.odin
@@ -65,12 +65,12 @@ General_Error :: enum {
 */
 Platform_Error :: enum u32 {}
 
+// NOTE(tetra): Enums in Network_Error cannot have a named zero value, else or_return breaks.
 Network_Error :: union {
 	General_Error,
 	Platform_Error,
 	Create_Socket_Error,
 	Dial_Error,
-	Dial_String_Error,
 	Listen_Error,
 	Accept_Error,
 	Bind_Error,
@@ -80,6 +80,8 @@ Network_Error :: union {
 	UDP_Recv_Error,
 	Shutdown_Error,
 	Socket_Option_Error,
+	Parse_Endpoint_Error,
+	Resolve_Error,
 }
 
 /*

--- a/core/net/common.odin
+++ b/core/net/common.odin
@@ -121,15 +121,15 @@ Any_Socket :: union {
 	ADDRESS DEFINITIONS
 */
 
-IPv4_Address :: distinct [4]u8
-IPv6_Address :: distinct [8]u16be
-Address :: union {IPv4_Address, IPv6_Address}
+IP4_Address :: distinct [4]u8
+IP6_Address :: distinct [8]u16be
+Address :: union {IP4_Address, IP6_Address}
 
-IPv4_Loopback := IPv4_Address{127, 0, 0, 1}
-IPv6_Loopback := IPv6_Address{0, 0, 0, 0, 0, 0, 0, 1}
+IP4_Loopback := IP4_Address{127, 0, 0, 1}
+IP6_Loopback := IP6_Address{0, 0, 0, 0, 0, 0, 0, 1}
 
-IPv4_Any := IPv4_Address{}
-IPv6_Any := IPv6_Address{}
+IP4_Any := IP4_Address{}
+IP6_Any := IP6_Address{}
 
 Endpoint :: struct {
 	address: Address,
@@ -137,8 +137,8 @@ Endpoint :: struct {
 }
 
 Address_Family :: enum {
-	IPv4,
-	IPv6,
+	IP4,
+	IP6,
 }
 
 /*
@@ -244,16 +244,16 @@ DNS_Configuration :: struct {
 }
 
 DNS_Record_Type :: enum u16 {
-	DNS_TYPE_A     = 0x1,  // IPv4 address.
-	DNS_TYPE_NS    = 0x2,  // IPv6 address.
+	DNS_TYPE_A     = 0x1,  // IP4 address.
+	DNS_TYPE_NS    = 0x2,  // IP6 address.
 	DNS_TYPE_CNAME = 0x5,  // Another host name.
 	DNS_TYPE_MX    = 0xf,  // Arbitrary binary data or text.
 	DNS_TYPE_AAAA  = 0x1c, // Address of a name (DNS) server.
 	DNS_TYPE_TEXT  = 0x10, // Address and preference priority of a mail exchange server.
 	DNS_TYPE_SRV   = 0x21, // Address, port, priority, and weight of a host that provides a particular service.
 
-	IPv4           = DNS_TYPE_A,
-	IPv6           = DNS_TYPE_AAAA,
+	IP4            = DNS_TYPE_A,
+	IP6            = DNS_TYPE_AAAA,
 	CNAME          = DNS_TYPE_CNAME,
 	TXT            = DNS_TYPE_TEXT,
 	NS             = DNS_TYPE_NS,
@@ -270,19 +270,19 @@ DNS_Record_Base :: struct {
 }
 
 /*
-	An IPv4 address that the domain name maps to. There can be any number of these.
+	An IP4 address that the domain name maps to. There can be any number of these.
 */
-DNS_Record_IPv4 :: struct {
+DNS_Record_IP4 :: struct {
 	using base: DNS_Record_Base,
-	address:    IPv4_Address,
+	address:    IP4_Address,
 }
 
 /*
 	An IPv6 address that the domain name maps to. There can be any number of these.
 */
-DNS_Record_IPv6 :: struct {
+DNS_Record_IP6 :: struct {
 	using base: DNS_Record_Base,
-	address:    IPv6_Address,
+	address:    IP6_Address,
 }
 
 /*
@@ -352,8 +352,8 @@ DNS_Record_SRV :: struct {
 }
 
 DNS_Record :: union {
-	DNS_Record_IPv4,
-	DNS_Record_IPv6,
+	DNS_Record_IP4,
+	DNS_Record_IP6,
 	DNS_Record_CNAME,
 	DNS_Record_TXT,
 	DNS_Record_NS,

--- a/core/net/common.odin
+++ b/core/net/common.odin
@@ -70,6 +70,7 @@ Network_Error :: union {
 	Platform_Error,
 	Create_Socket_Error,
 	Dial_Error,
+	Dial_String_Error,
 	Listen_Error,
 	Accept_Error,
 	Bind_Error,

--- a/core/net/dns_unix.odin
+++ b/core/net/dns_unix.odin
@@ -42,22 +42,22 @@ get_dns_records_unix :: proc(hostname: string, type: DNS_Record_Type, allocator 
 	host_overrides := make([dynamic]DNS_Record, 0)
 	for host in hosts {
 		if strings.compare(host.name, hostname) == 0 {
-			if type == .IPv4 && family_from_address(host.addr) == .IPv4 {
-				record := DNS_Record_IPv4{
+			if type == .IP4 && family_from_address(host.addr) == .IP4 {
+				record := DNS_Record_IP4{
 					base = {
 						record_name = strings.clone(hostname),
 						ttl_seconds = 0,
 					},
-					address = host.addr.(IPv4_Address),
+					address = host.addr.(IP4_Address),
 				}
 				append(&host_overrides, record)
-			} else if type == .IPv6 && family_from_address(host.addr) == .IPv6 {
-				record := DNS_Record_IPv6{
+			} else if type == .IP6 && family_from_address(host.addr) == .IP6 {
+				record := DNS_Record_IP6{
 					base = {
 						record_name = strings.clone(hostname),
 						ttl_seconds = 0,
 					},
-					address = host.addr.(IPv6_Address),
+					address = host.addr.(IP6_Address),
 				}
 				append(&host_overrides, record)
 			}

--- a/core/net/dns_windows.odin
+++ b/core/net/dns_windows.odin
@@ -69,17 +69,17 @@ get_dns_records_windows :: proc(hostname: string, type: DNS_Record_Type, allocat
 		}
 
 		switch DNS_Record_Type(r.wType) {
-		case .IPv4:
-			addr := IPv4_Address(transmute([4]u8)r.Data.A)
-			record := DNS_Record_IPv4{
+		case .IP4:
+			addr := IP4_Address(transmute([4]u8)r.Data.A)
+			record := DNS_Record_IP4{
 				base    = base_record,
 				address = addr,
 			}
 			append(&recs, record)
 
-		case .IPv6:
-			addr := IPv6_Address(transmute([8]u16be) r.Data.AAAA)
-			record := DNS_Record_IPv6{
+		case .IP6:
+			addr := IP6_Address(transmute([8]u16be) r.Data.AAAA)
+			record := DNS_Record_IP6{
 				base    = base_record,
 				address = addr,
 			}

--- a/core/net/http/http.odin
+++ b/core/net/http/http.odin
@@ -225,7 +225,7 @@ recv_response :: proc(skt: net.TCP_Socket, allocator := context.allocator) -> (r
 		for len(remaining) > 0 {
 			if has_suffix(to_string(body_buf), "\r\n\r\n") do break
 			chunk := remaining[0]
-			write_bytes(&body_buf, transmute([]byte) trim_right_space(chunk))
+			write_string(&body_buf, trim_right_space(chunk))
 			remaining = remaining[1:]
 		}
 	case explicit_encoding == "chunked":
@@ -249,19 +249,9 @@ recv_response :: proc(skt: net.TCP_Socket, allocator := context.allocator) -> (r
 				was_blank = true
 				continue
 			}
-			// fmt.printf("committing chunk with %v bytes: %v\n", len(chunk), chunk if len(chunk) <= 16 else "<...>")
-			write_bytes(&body_buf, transmute([]byte) trim_right_space(chunk))
+			write_string(&body_buf, trim_right_space(chunk))
 			expect_count = true
 		}
-		// for len(remaining) > 0 {
-		// 	if len(remaining) < 3 do break;
-		// 	size_part := remaining[0];
-		// 	chunk := remaining[1];
-		// 	empty := remaining[2];
-		// 	assert(empty == "");
-		// 	remaining = remaining[3:];
-		// 	write_bytes(&body_buf, transmute([]byte) chunk);
-		// }
 	case:
 		return
 	}

--- a/core/net/http/http.odin
+++ b/core/net/http/http.odin
@@ -127,8 +127,12 @@ request_destroy :: proc(using req: Request) {
 
 
 send_request :: proc(r: Request, allocator := context.allocator) -> (socket: net.TCP_Socket, ok: bool) {
-	if r.scheme != "http" {
-		fmt.panicf("%v is not a supported scheme at this time", r.scheme)
+	scheme := r.scheme
+	if scheme == "" {
+		scheme = "http"
+	}
+	if scheme != "http" {
+		fmt.panicf("%v is not a supported scheme at this time", scheme)
 	}
 
 	host, port, port_ok := net.split_port(r.host)

--- a/core/net/http/http.odin
+++ b/core/net/http/http.odin
@@ -135,16 +135,8 @@ send_request :: proc(r: Request, allocator := context.allocator) -> (socket: net
 		fmt.panicf("%v is not a supported scheme at this time", scheme)
 	}
 
-	host, port, port_ok := net.split_port(r.host)
-	if !port_ok do return
-	if port == 0 do port = 80
-
-	addr4, addr6, resolve_ok := net.resolve(host)
-	if !resolve_ok do return
-	addr := addr4 != nil ? addr4 : addr6
-
 	// TODO(tetra): SSL/TLS.
-	skt, err := net.dial_tcp(addr, port)
+	skt, err := net.dial_tcp(r.host, 80)
 	if err != nil do return
 
 	bytes := request_to_bytes(r, allocator)

--- a/core/net/http/http.odin
+++ b/core/net/http/http.odin
@@ -135,8 +135,16 @@ send_request :: proc(r: Request, allocator := context.allocator) -> (socket: net
 		fmt.panicf("%v is not a supported scheme at this time", scheme)
 	}
 
+	// NOTE(tetra): The host string may or may not have a port,
+	// but dial needs one.
+	// This means we have to resolve it ourselves.
+	host, port := net.split_port(r.host) or_return
+	if port == 0 {
+		port = 80
+	}
+
 	// TODO(tetra): SSL/TLS.
-	skt, err := net.dial_tcp(r.host, 80)
+	skt, err := net.dial_tcp(host, port)
 	if err != nil do return
 
 	bytes := request_to_bytes(r, allocator)

--- a/core/net/interface_windows.odin
+++ b/core/net/interface_windows.odin
@@ -24,7 +24,7 @@ import strings "core:strings"
 MAX_INTERFACE_ENUMERATION_TRIES :: 3
 
 DEFAULT_INTERFACE_ENUMERATION_FLAGS :: sys.GAA_Flags{
-	.Include_Prefix,               // (XP SP1+) Return a list of IP address prefixes on this adapter. When this flag is set, IP address prefixes are returned for both IPv6 and IPv4 addresses.
+	.Include_Prefix,               // (XP SP1+) Return a list of IP address prefixes on this adapter. When this flag is set, IP address prefixes are returned for both IP6 and IP4 addresses.
 	.Include_Gateways,             // (Vista+) Return the addresses of default gateways.
 	.Include_Tunnel_Binding_Order, // (Vista+) Return the adapter addresses sorted in tunnel binding order.
 }
@@ -43,7 +43,7 @@ enumerate_interfaces :: proc(flags := DEFAULT_INTERFACE_ENUMERATION_FLAGS, alloc
 
  	gaa: for _ in 1..=MAX_INTERFACE_ENUMERATION_TRIES {
  	 	res = sys.get_adapters_addresses(
- 			.Unspecified, // Return both IPv4 and IPv6 adapters.
+ 			.Unspecified, // Return both IP4 and IP6 adapters.
  			flags,        // Flags,
  			nil,          // Reserved
  			(^sys.IP_Adapter_Addresses)(raw_data(buf)),
@@ -187,7 +187,7 @@ parse_socket_address :: proc(addr_in: sys.SOCKET_ADDRESS) -> (addr: Endpoint) {
 		win_addr := cast(^sys.sockaddr_in)addr_in.lpSockaddr
 		port     := int(win_addr.sin_port)
 		return Endpoint {
-			address = IPv4_Address(transmute([4]byte)win_addr.sin_addr),
+			address = IP4_Address(transmute([4]byte)win_addr.sin_addr),
 			port    = port,
 		}
 
@@ -195,7 +195,7 @@ parse_socket_address :: proc(addr_in: sys.SOCKET_ADDRESS) -> (addr: Endpoint) {
 		win_addr := cast(^sys.sockaddr_in6)addr_in.lpSockaddr
 		port     := int(win_addr.sin6_port)
 		return Endpoint {
-			address = IPv6_Address(transmute([8]u16be)win_addr.sin6_addr),
+			address = IP6_Address(transmute([8]u16be)win_addr.sin6_addr),
 			port = port,
 		}
 

--- a/core/net/socket.odin
+++ b/core/net/socket.odin
@@ -28,3 +28,28 @@ any_socket_to_socket :: proc(any_socket: Any_Socket) -> Socket {
 		unreachable()
 	}
 }
+
+Dial_String_Error :: enum {
+	Bad_Port,
+	Port_Required,
+	Resolve_Failure,
+}
+
+dial_tcp_from_endpoint_string :: proc(endpoint: string, default_port := 0, options := default_tcp_options) -> (skt: TCP_Socket, err: Network_Error) {
+	host, port, split_ok := split_port(endpoint)
+	if !split_ok {
+		return 0, .Bad_Port
+	}
+	port = port if port != 0 else default_port
+	if port == 0 {
+		return 0, .Port_Required
+	}
+	addr4, addr6, ok := resolve(host)
+	if !ok {
+		return 0, .Resolve_Failure  // TODO: replace with Resolve_Error when that's a thing
+	}
+	addr := addr4 if addr4 != nil else addr6 // NOTE(tetra): We don't know what family the server uses, so we just default to IPv4.
+	return dial_tcp_from_endpoint({addr, port}, options)
+}
+
+dial_tcp :: proc{dial_tcp_from_endpoint, dial_tcp_from_endpoint_string}

--- a/core/net/socket.odin
+++ b/core/net/socket.odin
@@ -31,7 +31,7 @@ any_socket_to_socket :: proc(any_socket: Any_Socket) -> Socket {
 
 /*
     Expects both hostname and port to be present in the `hostname_and_port` parameter, either as:
-    `a.host.name:9999`, or as `1.2.3.4:9999`, or IPv6 equivalent.
+    `a.host.name:9999`, or as `1.2.3.4:9999`, or IP6 equivalent.
 
     Calls `parse_hostname_or_endpoint` and `resolve`, then `dial_tcp_from_endpoint`.
 */

--- a/core/net/socket_darwin.odin
+++ b/core/net/socket_darwin.odin
@@ -80,7 +80,7 @@ Dial_Error :: enum c.int {
 	Would_Block = c.int(os.EWOULDBLOCK), // TODO: we may need special handling for this; maybe make a socket a struct with metadata?
 }
 
-dial_tcp :: proc(addr: Address, port: int) -> (skt: TCP_Socket, err: Network_Error) {
+dial_tcp_from_endpoint :: proc(addr: Address, port: int, options := default_tcp_options) -> (skt: TCP_Socket, err: Network_Error) {
 	family := family_from_address(addr)
 	sock := create_socket(family, .TCP) or_return
 	skt = sock.(TCP_Socket)

--- a/core/net/socket_darwin.odin
+++ b/core/net/socket_darwin.odin
@@ -65,6 +65,8 @@ create_socket :: proc(family: Address_Family, protocol: Socket_Protocol) -> (soc
 
 
 Dial_Error :: enum c.int {
+	Port_Required = -1,
+
 	Address_In_Use = c.int(os.EADDRINUSE),
 	In_Progress = c.int(os.EINPROGRESS),
 	Cannot_Use_Any_Address = c.int(os.EADDRNOTAVAIL),
@@ -81,6 +83,10 @@ Dial_Error :: enum c.int {
 }
 
 dial_tcp_from_endpoint :: proc(endpoint: Endpoint, options := default_tcp_options) -> (skt: TCP_Socket, err: Network_Error) {
+	if endpoint.port == 0 {
+		return nil, .Port_Required
+	}
+
 	family := family_from_endpoint(endpoint)
 	sock := create_socket(family, .TCP) or_return
 	skt = sock.(TCP_Socket)

--- a/core/net/socket_darwin.odin
+++ b/core/net/socket_darwin.odin
@@ -36,8 +36,8 @@ create_socket :: proc(family: Address_Family, protocol: Socket_Protocol) -> (soc
 	c_type, c_protocol, c_family: int
 
 	switch family {
-	case .IPv4:  c_family = os.AF_INET
-	case .IPv6:  c_family = os.AF_INET6
+	case .IP4:  c_family = os.AF_INET
+	case .IP6:  c_family = os.AF_INET6
 	case:
 		unreachable()
 	}
@@ -84,7 +84,7 @@ Dial_Error :: enum c.int {
 
 dial_tcp_from_endpoint :: proc(endpoint: Endpoint, options := default_tcp_options) -> (skt: TCP_Socket, err: Network_Error) {
 	if endpoint.port == 0 {
-		return nil, .Port_Required
+		return 0, .Port_Required
 	}
 
 	family := family_from_endpoint(endpoint)

--- a/core/net/socket_linux.odin
+++ b/core/net/socket_linux.odin
@@ -36,8 +36,8 @@ create_socket :: proc(family: Address_Family, protocol: Socket_Protocol) -> (soc
 	c_type, c_protocol, c_family: int
 
 	switch family {
-	case .IPv4:  c_family = os.AF_INET
-	case .IPv6:  c_family = os.AF_INET6
+	case .IP4:  c_family = os.AF_INET
+	case .IP6:  c_family = os.AF_INET6
 	case:
 		unreachable()
 	}
@@ -84,7 +84,7 @@ Dial_Error :: enum c.int {
 
 dial_tcp_from_endpoint :: proc(endpoint: Endpoint, options := default_tcp_options) -> (skt: TCP_Socket, err: Network_Error) {
 	if endpoint.port == 0 {
-		return nil, .Port_Required
+		return 0, .Port_Required
 	}
 
 	family := family_from_endpoint(endpoint)
@@ -174,7 +174,7 @@ Listen_Error :: enum c.int {
 listen_tcp :: proc(interface_endpoint: Endpoint, backlog := 1000) -> (skt: TCP_Socket, err: Network_Error) {
 	assert(backlog > 0 && i32(backlog) < max(i32))
 
-	family := family_from_address(local_addr)
+	family := family_from_endpoint(interface_endpoint)
 	sock := create_socket(family, .TCP) or_return
 	skt = sock.(TCP_Socket)
 

--- a/core/net/socket_linux.odin
+++ b/core/net/socket_linux.odin
@@ -80,8 +80,8 @@ Dial_Error :: enum c.int {
 	Would_Block = c.int(os.EWOULDBLOCK), // TODO: we may need special handling for this; maybe make a socket a struct with metadata?
 }
 
-dial_tcp_from_endpoint :: proc(addr: Address, port: int, options := default_tcp_options) -> (skt: TCP_Socket, err: Network_Error) {
-	family := family_from_address(addr)
+dial_tcp_from_endpoint :: proc(endpoint: Endpoint, options := default_tcp_options) -> (skt: TCP_Socket, err: Network_Error) {
+	family := family_from_endpoint(endpoint)
 	sock := create_socket(family, .TCP) or_return
 	skt = sock.(TCP_Socket)
 
@@ -90,7 +90,7 @@ dial_tcp_from_endpoint :: proc(addr: Address, port: int, options := default_tcp_
 	// use the same address immediately.
 	_ = set_option(skt, .Reuse_Address, true)
 
-	sockaddr := endpoint_to_sockaddr({addr, port})
+	sockaddr := endpoint_to_sockaddr(endpoint)
 	res := os.connect(Platform_Socket(skt), (^os.SOCKADDR)(&sockaddr), size_of(sockaddr))
 	if res != os.ERROR_NONE {
 		err = Dial_Error(res)
@@ -165,7 +165,7 @@ Listen_Error :: enum c.int {
 	Listening_Not_Supported_For_This_Socket = c.int(os.EOPNOTSUPP),
 }
 
-listen_tcp :: proc(local_addr: Address, port: int, backlog := 1000) -> (skt: TCP_Socket, err: Network_Error) {
+listen_tcp :: proc(interface_endpoint: Endpoint, backlog := 1000) -> (skt: TCP_Socket, err: Network_Error) {
 	assert(backlog > 0 && i32(backlog) < max(i32))
 
 	family := family_from_address(local_addr)
@@ -179,7 +179,7 @@ listen_tcp :: proc(local_addr: Address, port: int, backlog := 1000) -> (skt: TCP
 	// TODO(tetra, 2022-02-15): Confirm that this doesn't mean other processes can hijack the address!
 	set_option(sock, .Reuse_Address, true) or_return
 
-	bind(sock, {local_addr, port}) or_return
+	bind(sock, interface_endpoint) or_return
 
 	res := os.listen(Platform_Socket(skt), backlog)
 	if res != os.ERROR_NONE {

--- a/core/net/socket_linux.odin
+++ b/core/net/socket_linux.odin
@@ -65,6 +65,8 @@ create_socket :: proc(family: Address_Family, protocol: Socket_Protocol) -> (soc
 
 
 Dial_Error :: enum c.int {
+	Port_Required = -1,
+
 	Address_In_Use = c.int(os.EADDRINUSE),
 	In_Progress = c.int(os.EINPROGRESS),
 	Cannot_Use_Any_Address = c.int(os.EADDRNOTAVAIL),
@@ -81,6 +83,10 @@ Dial_Error :: enum c.int {
 }
 
 dial_tcp_from_endpoint :: proc(endpoint: Endpoint, options := default_tcp_options) -> (skt: TCP_Socket, err: Network_Error) {
+	if endpoint.port == 0 {
+		return nil, .Port_Required
+	}
+
 	family := family_from_endpoint(endpoint)
 	sock := create_socket(family, .TCP) or_return
 	skt = sock.(TCP_Socket)

--- a/core/net/socket_linux.odin
+++ b/core/net/socket_linux.odin
@@ -80,7 +80,7 @@ Dial_Error :: enum c.int {
 	Would_Block = c.int(os.EWOULDBLOCK), // TODO: we may need special handling for this; maybe make a socket a struct with metadata?
 }
 
-dial_tcp :: proc(addr: Address, port: int, options := default_tcp_options) -> (skt: TCP_Socket, err: Network_Error) {
+dial_tcp_from_endpoint :: proc(addr: Address, port: int, options := default_tcp_options) -> (skt: TCP_Socket, err: Network_Error) {
 	family := family_from_address(addr)
 	sock := create_socket(family, .TCP) or_return
 	skt = sock.(TCP_Socket)

--- a/core/net/socket_windows.odin
+++ b/core/net/socket_windows.odin
@@ -41,8 +41,8 @@ create_socket :: proc(family: Address_Family, protocol: Socket_Protocol) -> (soc
 	c_type, c_protocol, c_family: c.int
 
 	switch family {
-	case .IPv4:  c_family = win.AF_INET
-	case .IPv6:  c_family = win.AF_INET6
+	case .IP4:  c_family = win.AF_INET
+	case .IP6:  c_family = win.AF_INET6
 	case:
 		unreachable()
 	}

--- a/core/net/socket_windows.odin
+++ b/core/net/socket_windows.odin
@@ -85,7 +85,7 @@ Dial_Error :: enum c.int {
 	Would_Block = win.WSAEWOULDBLOCK, // TODO: we may need special handling for this; maybe make a socket a struct with metadata?
 }
 
-dial_tcp :: proc(addr: Address, port: int, options := default_tcp_options) -> (skt: TCP_Socket, err: Network_Error) {
+dial_tcp_from_endpoint :: proc(addr: Address, port: int, options := default_tcp_options) -> (skt: TCP_Socket, err: Network_Error) {
 	family := family_from_address(addr)
 	sock := create_socket(family, .TCP) or_return
 	skt = sock.(TCP_Socket)

--- a/core/net/socket_windows.odin
+++ b/core/net/socket_windows.odin
@@ -70,6 +70,8 @@ create_socket :: proc(family: Address_Family, protocol: Socket_Protocol) -> (soc
 
 
 Dial_Error :: enum c.int {
+	Port_Required = -1,
+
 	Address_In_Use = win.WSAEADDRINUSE,
 	In_Progress = win.WSAEALREADY,
 	Cannot_Use_Any_Address = win.WSAEADDRNOTAVAIL,
@@ -86,6 +88,11 @@ Dial_Error :: enum c.int {
 }
 
 dial_tcp_from_endpoint :: proc(endpoint: Endpoint, options := default_tcp_options) -> (skt: TCP_Socket, err: Network_Error) {
+	if endpoint.port == 0 {
+		err = .Port_Required
+		return
+	}
+
 	family := family_from_endpoint(endpoint)
 	sock := create_socket(family, .TCP) or_return
 	skt = sock.(TCP_Socket)

--- a/core/net/socket_windows.odin
+++ b/core/net/socket_windows.odin
@@ -85,8 +85,8 @@ Dial_Error :: enum c.int {
 	Would_Block = win.WSAEWOULDBLOCK, // TODO: we may need special handling for this; maybe make a socket a struct with metadata?
 }
 
-dial_tcp_from_endpoint :: proc(addr: Address, port: int, options := default_tcp_options) -> (skt: TCP_Socket, err: Network_Error) {
-	family := family_from_address(addr)
+dial_tcp_from_endpoint :: proc(endpoint: Endpoint, options := default_tcp_options) -> (skt: TCP_Socket, err: Network_Error) {
+	family := family_from_endpoint(endpoint)
 	sock := create_socket(family, .TCP) or_return
 	skt = sock.(TCP_Socket)
 
@@ -95,7 +95,7 @@ dial_tcp_from_endpoint :: proc(addr: Address, port: int, options := default_tcp_
 	// use the same address immediately.
 	_ = set_option(skt, .Reuse_Address, true)
 
-	sockaddr := endpoint_to_sockaddr({addr, port})
+	sockaddr := endpoint_to_sockaddr(endpoint)
 	res := win.connect(Platform_Socket(skt), &sockaddr, size_of(sockaddr))
 	if res < 0 {
 		err = Dial_Error(win.WSAGetLastError())
@@ -169,10 +169,10 @@ Listen_Error :: enum c.int {
 	Listening_Not_Supported_For_This_Socket = win.WSAEOPNOTSUPP,
 }
 
-listen_tcp :: proc(local_addr: Address, port: int, backlog := 1000) -> (skt: TCP_Socket, err: Network_Error) {
+listen_tcp :: proc(interface_endpoint: Endpoint, backlog := 1000) -> (skt: TCP_Socket, err: Network_Error) {
 	assert(backlog > 0 && i32(backlog) < max(i32))
 
-	family := family_from_address(local_addr)
+	family := family_from_endpoint(interface_endpoint)
 	sock := create_socket(family, .TCP) or_return
 	skt = sock.(TCP_Socket)
 
@@ -180,7 +180,7 @@ listen_tcp :: proc(local_addr: Address, port: int, backlog := 1000) -> (skt: TCP
 	// prevent hijacking of the server's endpoint by other applications.
 	set_option(skt, .Exclusive_Addr_Use, true) or_return
 
-	bind(sock, {local_addr, port}) or_return
+	bind(sock, interface_endpoint) or_return
 
 	res := win.listen(Platform_Socket(skt), i32(backlog))
 	if res == win.SOCKET_ERROR {


### PR DESCRIPTION
- Fix blank HTTP scheme not being normalised to `http`
- Minor cleanup to `http.recv_response`
- Use `IP4` and `IP6` terminology instead of `IPv4` and `IPv6`
- Add a way to dial with endpoint strings (`"localhost:9000"`, `"1.2.3.4:9000"`, `"[::1]:9000"`)
- Take an `Endpoint` when dialling or listening
- Refactor `resolve()` to handle ports better by returning `Endpoint`s and parsing endpoint strings
- Have `resolve()` return a `Network_Error`
- Add a guard to dialling procedures to catch port=0.
- Fix typo in `endpoint_to_string`
- Add `parse_hostname_or_endpoint` which turns an endpoint string into either a `Host` (hostname + port) or an `Endpoint`.