### PR TITLE
Changed `//+ignore` to `//+build ignore` and emit a warning for unknown tags

### DIFF
--- a/core/compress/gzip/example.odin
+++ b/core/compress/gzip/example.odin
@@ -1,4 +1,4 @@
-//+ignore
+//+build ignore
 package gzip
 
 /*

--- a/core/compress/zlib/example.odin
+++ b/core/compress/zlib/example.odin
@@ -1,4 +1,4 @@
-//+ignore
+//+build ignore
 package zlib
 
 /*

--- a/core/image/png/example.odin
+++ b/core/image/png/example.odin
@@ -8,7 +8,7 @@
 
 	An example of how to use `load`.
 */
-//+ignore
+//+build ignore
 package png
 
 import "core:image"

--- a/core/intrinsics/intrinsics.odin
+++ b/core/intrinsics/intrinsics.odin
@@ -1,5 +1,5 @@
 // This is purely for documentation
-//+ignore
+//+build ignore
 package intrinsics
 
 // Package-Related

--- a/core/math/big/internal.odin
+++ b/core/math/big/internal.odin
@@ -25,8 +25,6 @@
 	TODO: Handle +/- Infinity and NaN.
 */
 
-
-//+ignore
 package math_big
 
 import "core:mem"

--- a/core/math/big/tune.odin
+++ b/core/math/big/tune.odin
@@ -7,7 +7,7 @@
 	The code started out as an idiomatic source port of libTomMath, which is in the public domain, with thanks.
 */
 
-//+ignore
+//+build ignore
 package math_big
 
 import "core:time"

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -5578,6 +5578,8 @@ bool parse_file(Parser *p, AstFile *f) {
 						} else {
 							f->flags |= AstFile_IsLazy;
 						}
+					} else {
+						warning(tok, "Ignoring unknown tag '%.*s'", LIT(lc));
 					}
 				}
 			}

--- a/tests/core/math/big/test.odin
+++ b/tests/core/math/big/test.odin
@@ -1,4 +1,4 @@
-//+ignore
+//+build ignore
 /*
 	Copyright 2021 Jeroen van Rijn <nom@duclavier.com>.
 	Made available under Odin's BSD-3 license.


### PR DESCRIPTION
I changed the files that used `//+ignore` to use `//+build ignore` as they should.

Also removed the ignore tag from `core:math/big/internal.odin` since those procedures can be called from elsewhere, like the demo.

Also made the parser emit a warning when encountering an unknown tag, so that tags like `//+ignore` will emit `Warning: Ignoring unknown tag '+ignore'`