### PR TITLE
openbsd: defaults to PIE executable

### DIFF
--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -1295,6 +1295,11 @@ void lb_generate_code(lbGenerator *gen) {
 		reloc_mode = LLVMRelocPIC;
 	}
 
+	if (build_context.metrics.os == TargetOs_openbsd) {
+		// Always use PIC for OpenBSD: it defaults to PIE
+		reloc_mode = LLVMRelocPIC;
+	}
+
 	for_array(i, gen->modules.entries) {
 		target_machines[i] = LLVMCreateTargetMachine(
 			target, target_triple, llvm_cpu,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -463,7 +463,8 @@ i32 linker_stage(lbGenerator *gen) {
 			#endif
 			link_settings = gb_string_appendc(link_settings, "-Wl,-init,'_odin_entry_point' ");
 			link_settings = gb_string_appendc(link_settings, "-Wl,-fini,'_odin_exit_point' ");
-		} else {
+		} else if (build_context.metrics.os != TargetOs_openbsd) {
+			// OpenBSD defaults to PIE executable. do not pass -no-pie for it.
 			link_settings = gb_string_appendc(link_settings, "-no-pie ");
 		}
 		if (build_context.out_filepath.len > 0) {


### PR DESCRIPTION
OpenBSD uses PIE code by default to allow the system to load the binary at a random location.

don't pass -no-pie to preserve this behaviour, and build objects with -fPIC (LLVMRelocPIC) (-fPIC is required for PIE).