### PR TITLE
Openbsd vendor

### DIFF
--- a/vendor/ENet/unix.odin
+++ b/vendor/ENet/unix.odin
@@ -1,4 +1,4 @@
-//+build linux, darwin, freebsd
+//+build linux, darwin, freebsd, openbsd
 package ENet
 
 // When we implement the appropriate bindings for Unix, the section separated

--- a/vendor/glfw/bindings/bindings.odin
+++ b/vendor/glfw/bindings/bindings.odin
@@ -5,6 +5,7 @@ import vk "vendor:vulkan"
 
 when ODIN_OS == .Linux   { foreign import glfw "system:glfw" } // TODO: Add the billion-or-so static libs to link to in linux
 when ODIN_OS == .Darwin  { foreign import glfw "system:glfw" }
+when ODIN_OS == .OpenBSD { foreign import glfw "system:glfw" }
 when ODIN_OS == .Windows {
 	foreign import glfw { 
 		"../lib/glfw3_mt.lib",

--- a/vendor/sdl2/image/sdl_image.odin
+++ b/vendor/sdl2/image/sdl_image.odin
@@ -7,6 +7,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2_image.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2_image" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2_image" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2_image" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2_image" }
 
 bool :: SDL.bool
 

--- a/vendor/sdl2/mixer/sdl_mixer.odin
+++ b/vendor/sdl2/mixer/sdl_mixer.odin
@@ -7,7 +7,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2_mixer.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2_mixer" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2_mixer" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2_mixer" }
-
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2_mixer" }
 
 MAJOR_VERSION :: 2
 MINOR_VERSION :: 0

--- a/vendor/sdl2/net/sdl_net.odin
+++ b/vendor/sdl2/net/sdl_net.odin
@@ -7,6 +7,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2_net.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2_net" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2_net" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2_net" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2_net" }
 
 bool :: SDL.bool
 

--- a/vendor/sdl2/sdl2.odin
+++ b/vendor/sdl2/sdl2.odin
@@ -29,6 +29,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 version :: struct {
 	major: u8,        /**< major version */

--- a/vendor/sdl2/sdl_audio.odin
+++ b/vendor/sdl2/sdl_audio.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 /**
  *  \brief Audio format flags.

--- a/vendor/sdl2/sdl_blendmode.odin
+++ b/vendor/sdl2/sdl_blendmode.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 /**
  *  \brief The blend mode used in SDL_RenderCopy() and drawing operations.

--- a/vendor/sdl2/sdl_cpuinfo.odin
+++ b/vendor/sdl2/sdl_cpuinfo.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 /* This is a guess for the cacheline size used for padding.
  * Most x86 processors have a 64 byte cache line.

--- a/vendor/sdl2/sdl_events.odin
+++ b/vendor/sdl2/sdl_events.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 RELEASED :: 0
 PRESSED  :: 1

--- a/vendor/sdl2/sdl_gamecontroller.odin
+++ b/vendor/sdl2/sdl_gamecontroller.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 GameController :: struct {}
 

--- a/vendor/sdl2/sdl_gesture_haptic.odin
+++ b/vendor/sdl2/sdl_gesture_haptic.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 // Gesture
 

--- a/vendor/sdl2/sdl_hints.odin
+++ b/vendor/sdl2/sdl_hints.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 HINT_ACCELEROMETER_AS_JOYSTICK                :: "SDL_ACCELEROMETER_AS_JOYSTICK"
 HINT_ALLOW_ALT_TAB_WHILE_GRABBED              :: "SDL_ALLOW_ALT_TAB_WHILE_GRABBED"

--- a/vendor/sdl2/sdl_joystick.odin
+++ b/vendor/sdl2/sdl_joystick.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 Joystick :: struct {}
 

--- a/vendor/sdl2/sdl_keyboard.odin
+++ b/vendor/sdl2/sdl_keyboard.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 Keysym :: struct {
 	scancode: Scancode, /**< SDL physical key code - see ::SDL_Scancode for details */

--- a/vendor/sdl2/sdl_log.odin
+++ b/vendor/sdl2/sdl_log.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 MAX_LOG_MESSAGE :: 4096
 

--- a/vendor/sdl2/sdl_messagebox.odin
+++ b/vendor/sdl2/sdl_messagebox.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 MessageBoxFlag :: enum u32 {
 	_ = 0,

--- a/vendor/sdl2/sdl_metal.odin
+++ b/vendor/sdl2/sdl_metal.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 MetalView :: distinct rawptr
 

--- a/vendor/sdl2/sdl_mouse.odin
+++ b/vendor/sdl2/sdl_mouse.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 Cursor :: struct {}
 

--- a/vendor/sdl2/sdl_mutex.odin
+++ b/vendor/sdl2/sdl_mutex.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 MUTEX_TIMEDOUT :: 1
 MUTEX_MAXWAIT  :: ~u32(0)

--- a/vendor/sdl2/sdl_pixels.odin
+++ b/vendor/sdl2/sdl_pixels.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 ALPHA_OPAQUE      :: 255
 ALPHA_TRANSPARENT ::   0

--- a/vendor/sdl2/sdl_rect.odin
+++ b/vendor/sdl2/sdl_rect.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 Point :: struct {
 	x: c.int,

--- a/vendor/sdl2/sdl_render.odin
+++ b/vendor/sdl2/sdl_render.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 RendererFlag :: enum u32 {
 	SOFTWARE      = 0, /**< The renderer is a software fallback */

--- a/vendor/sdl2/sdl_rwops.odin
+++ b/vendor/sdl2/sdl_rwops.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 /* RWops Types */
 RWOPS_UNKNOWN   :: 0 /**< Unknown stream type */

--- a/vendor/sdl2/sdl_stdinc.odin
+++ b/vendor/sdl2/sdl_stdinc.odin
@@ -9,6 +9,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 bool :: distinct b32
 #assert(size_of(bool) == size_of(c.int))

--- a/vendor/sdl2/sdl_surface.odin
+++ b/vendor/sdl2/sdl_surface.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 SWSURFACE       :: 0           /**< Just here for compatibility */
 PREALLOC        :: 0x00000001  /**< Surface uses preallocated memory */

--- a/vendor/sdl2/sdl_system.odin
+++ b/vendor/sdl2/sdl_system.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 // General
 @(default_calling_convention="c", link_prefix="SDL_")

--- a/vendor/sdl2/sdl_syswm.odin
+++ b/vendor/sdl2/sdl_syswm.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 SYSWM_TYPE :: enum c.int {
 	UNKNOWN,

--- a/vendor/sdl2/sdl_thread.odin
+++ b/vendor/sdl2/sdl_thread.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 Thread :: struct {}
 

--- a/vendor/sdl2/sdl_timer.odin
+++ b/vendor/sdl2/sdl_timer.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 TimerCallback :: proc "c" (interval: u32, param: rawptr) -> u32
 TimerID :: distinct c.int

--- a/vendor/sdl2/sdl_touch.odin
+++ b/vendor/sdl2/sdl_touch.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 TouchID  :: distinct i64
 FingerID :: distinct i64

--- a/vendor/sdl2/sdl_video.odin
+++ b/vendor/sdl2/sdl_video.odin
@@ -6,6 +6,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 DisplayMode :: struct {
 	format:       u32,    /**< pixel format */

--- a/vendor/sdl2/sdl_vulkan.odin
+++ b/vendor/sdl2/sdl_vulkan.odin
@@ -7,6 +7,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
 
 VkInstance   :: vk.Instance
 VkSurfaceKHR :: vk.SurfaceKHR

--- a/vendor/sdl2/ttf/sdl_ttf.odin
+++ b/vendor/sdl2/ttf/sdl_ttf.odin
@@ -7,6 +7,7 @@ when ODIN_OS == .Windows { foreign import lib "SDL2_ttf.lib"    }
 when ODIN_OS == .Linux   { foreign import lib "system:SDL2_ttf" }
 when ODIN_OS == .Darwin  { foreign import lib "system:SDL2_ttf" }
 when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2_ttf" }
+when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2_ttf" }
 
 bool :: SDL.bool
 


### PR DESCRIPTION
The PR adds some OpenBSD support for vendor libraries.
I added it where it makes sense (where the external library effectively exists in OpenBSD ports tree).
I also did some tests with sdl2 and glfw.