### PR TITLE
Vendors libraries portability and examples/all splitting

### DIFF
--- a/examples/all/all_vendor.odin
+++ b/examples/all/all_vendor.odin
@@ -1,4 +1,3 @@
-//+build windows
 package all
 
 import botan     "vendor:botan"
@@ -16,23 +15,11 @@ import IMG    "vendor:sdl2/image"
 import MIX    "vendor:sdl2/mixer"
 import TTF    "vendor:sdl2/ttf"
 
-import stb_easy_font "vendor:stb/easy_font"
-import stbi          "vendor:stb/image"
-import stbrp         "vendor:stb/rect_pack"
-import stbtt         "vendor:stb/truetype"
-import stb_vorbis    "vendor:stb/vorbis"
-
 import vk "vendor:vulkan"
 
-import D3D11 "vendor:directx/d3d11"
-import D3D12 "vendor:directx/d3d12"
-import DXGI  "vendor:directx/dxgi"
-
-// note these are technicaly darwin only but they are added to aid with documentation generation
 import NS  "vendor:darwin/Foundation"
 import MTL "vendor:darwin/Metal"
 import CA  "vendor:darwin/QuartzCore"
-
 
 _ :: botan
 _ :: ENet
@@ -47,15 +34,7 @@ _ :: SDLNet
 _ :: IMG
 _ :: MIX
 _ :: TTF
-_ :: stb_easy_font
-_ :: stbi
-_ :: stbrp
-_ :: stbtt
-_ :: stb_vorbis
 _ :: vk
-_ :: D3D11
-_ :: D3D12
-_ :: DXGI
 _ :: NS
 _ :: MTL
 _ :: CA

--- a/examples/all/all_vendor_directx.odin
+++ b/examples/all/all_vendor_directx.odin
@@ -1,0 +1,10 @@
+//+build windows
+package all
+
+import D3D11 "vendor:directx/d3d11"
+import D3D12 "vendor:directx/d3d12"
+import DXGI  "vendor:directx/dxgi"
+
+_ :: D3D11
+_ :: D3D12
+_ :: DXGI

--- a/examples/all/all_vendor_stl.odin
+++ b/examples/all/all_vendor_stl.odin
@@ -1,0 +1,15 @@
+//+build windows, linux
+package all
+
+import stb_easy_font "vendor:stb/easy_font"
+import stbi          "vendor:stb/image"
+import stbrp         "vendor:stb/rect_pack"
+import stbtt         "vendor:stb/truetype"
+import stb_vorbis    "vendor:stb/vorbis"
+
+_ :: stb_easy_font
+_ :: stbi
+_ :: stbrp
+_ :: stbtt
+_ :: stb_vorbis
+

--- a/vendor/ENet/unix.odin
+++ b/vendor/ENet/unix.odin
@@ -14,7 +14,7 @@ import "core:c"
 
 @(private="file") FD_ZERO :: #force_inline proc(s: ^fd_set) {
 	for i := size_of(fd_set) / size_of(c.long); i != 0; i -= 1 {
-		s.fds_bits[i] = 0;
+		s.fds_bits[i] = 0
 	}
 }
 

--- a/vendor/botan/bindings/botan.odin
+++ b/vendor/botan/bindings/botan.odin
@@ -142,11 +142,7 @@ fpe_t                :: ^fpe_struct
 
 when ODIN_OS == .Windows {
     foreign import botan_lib "botan.lib"
-} else when ODIN_OS == .Linux {
-    foreign import botan_lib "system:botan-2"
-} else when ODIN_OS == .Darwin {
-    foreign import botan_lib "system:botan-2"
-} else when ODIN_OS == .OpenBSD {
+} else {
     foreign import botan_lib "system:botan-2"
 }
 

--- a/vendor/glfw/bindings/bindings.odin
+++ b/vendor/glfw/bindings/bindings.odin
@@ -3,9 +3,6 @@ package glfw_bindings
 import "core:c"
 import vk "vendor:vulkan"
 
-when ODIN_OS == .Linux   { foreign import glfw "system:glfw" } // TODO: Add the billion-or-so static libs to link to in linux
-when ODIN_OS == .Darwin  { foreign import glfw "system:glfw" }
-when ODIN_OS == .OpenBSD { foreign import glfw "system:glfw" }
 when ODIN_OS == .Windows {
 	foreign import glfw { 
 		"../lib/glfw3_mt.lib",
@@ -13,6 +10,11 @@ when ODIN_OS == .Windows {
 		"system:gdi32.lib", 
 		"system:shell32.lib",
 	} 
+} else when ODIN_OS == .Linux {
+	// TODO: Add the billion-or-so static libs to link to in linux
+	foreign import glfw "system:glfw"
+} else {
+	foreign import glfw "system:glfw"
 }
 
 #assert(size_of(c.int) == size_of(b32))

--- a/vendor/miniaudio/common.odin
+++ b/vendor/miniaudio/common.odin
@@ -2,8 +2,13 @@ package miniaudio
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "lib/miniaudio.lib" }
-when ODIN_OS == .Linux   { foreign import lib "lib/miniaudio.a" }
+when ODIN_OS == .Windows {
+	foreign import lib "lib/miniaudio.lib"
+} else when ODIN_OS == .Linux {
+	foreign import lib "lib/miniaudio.a"
+} else {
+	foreign import lib "system:miniaudio"
+}
 
 handle :: distinct rawptr
 

--- a/vendor/miniaudio/data_conversion.odin
+++ b/vendor/miniaudio/data_conversion.odin
@@ -2,9 +2,13 @@ package miniaudio
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "lib/miniaudio.lib" }
-when ODIN_OS == .Linux   { foreign import lib "lib/miniaudio.a" }
-
+when ODIN_OS == .Windows {
+	foreign import lib "lib/miniaudio.lib"
+} else when ODIN_OS == .Linux {
+	foreign import lib "lib/miniaudio.a"
+} else {
+	foreign import lib "system:miniaudio"
+}
 
 /************************************************************************************************************************************************************
 *************************************************************************************************************************************************************

--- a/vendor/miniaudio/decoding.odin
+++ b/vendor/miniaudio/decoding.odin
@@ -2,10 +2,13 @@ package miniaudio
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "lib/miniaudio.lib" }
-when ODIN_OS == .Linux   { foreign import lib "lib/miniaudio.a" }
-
-
+when ODIN_OS == .Windows {
+	foreign import lib "lib/miniaudio.lib"
+} else when ODIN_OS == .Linux {
+	foreign import lib "lib/miniaudio.a"
+} else {
+	foreign import lib "system:miniaudio"
+}
 
 /************************************************************************************************************************************************************
 

--- a/vendor/miniaudio/device_io_procs.odin
+++ b/vendor/miniaudio/device_io_procs.odin
@@ -1,7 +1,12 @@
 package miniaudio
 
-when ODIN_OS == .Windows { foreign import lib "lib/miniaudio.lib" }
-when ODIN_OS == .Linux   { foreign import lib "lib/miniaudio.a" }
+when ODIN_OS == .Windows {
+	foreign import lib "lib/miniaudio.lib"
+} else when ODIN_OS == .Linux {
+	foreign import lib "lib/miniaudio.a"
+} else {
+	foreign import lib "system:miniaudio"
+}
 
 import "core:c"
 

--- a/vendor/miniaudio/device_io_types.odin
+++ b/vendor/miniaudio/device_io_types.odin
@@ -6,7 +6,7 @@ SUPPORT_WASAPI     :: ODIN_OS == .Windows
 SUPPORT_DSOUND     :: ODIN_OS == .Windows
 SUPPORT_WINMM      :: ODIN_OS == .Windows
 SUPPORT_COREAUDIO  :: ODIN_OS == .Darwin
-SUPPORT_SNDIO      :: false // ODIN_OS == .OpenBSD
+SUPPORT_SNDIO      :: ODIN_OS == .OpenBSD
 SUPPORT_AUDIO4     :: false // ODIN_OS == .OpenBSD || ODIN_OS == .NetBSD
 SUPPORT_OSS        :: ODIN_OS == .FreeBSD
 SUPPORT_PULSEAUDIO :: ODIN_OS == .Linux
@@ -739,8 +739,8 @@ context_type :: struct {
 			pa_stream_writable_size:            proc "system" (),
 			pa_stream_readable_size:            proc "system" (),
 
-			/*pa_mainloop**/ pMainLoop:     ptr,
-			/*pa_context**/  pPulseContext: ptr,
+			/*pa_mainloop**/ pMainLoop:     rawptr,
+			/*pa_context**/  pPulseContext: rawptr,
 		} when SUPPORT_PULSEAUDIO else struct {}),
 		
 		jack: (struct {
@@ -791,7 +791,7 @@ context_type :: struct {
 			AudioUnitInitialize:           proc "system" (),
 			AudioUnitRender:               proc "system" (),
 
-			/*AudioComponent*/ component: ptr,
+			/*AudioComponent*/ component: rawptr,
 			noAudioSessionDeactivate:     b32, /* For tracking whether or not the iOS audio session should be explicitly deactivated. Set from the config in ma_context_init__coreaudio(). */
 		} when SUPPORT_COREAUDIO else struct {}),
 		

--- a/vendor/miniaudio/encoding.odin
+++ b/vendor/miniaudio/encoding.odin
@@ -2,8 +2,13 @@ package miniaudio
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "lib/miniaudio.lib" }
-when ODIN_OS == .Linux   { foreign import lib "lib/miniaudio.a" }
+when ODIN_OS == .Windows {
+	foreign import lib "lib/miniaudio.lib"
+} else when ODIN_OS == .Linux {
+	foreign import lib "lib/miniaudio.a"
+} else {
+	foreign import lib "system:miniaudio"
+}
 
 /************************************************************************************************************************************************************
 

--- a/vendor/miniaudio/filtering.odin
+++ b/vendor/miniaudio/filtering.odin
@@ -1,7 +1,12 @@
 package miniaudio
 
-when ODIN_OS == .Windows { foreign import lib "lib/miniaudio.lib" }
-when ODIN_OS == .Linux   { foreign import lib "lib/miniaudio.a" }
+when ODIN_OS == .Windows {
+	foreign import lib "lib/miniaudio.lib"
+} else when ODIN_OS == .Linux {
+	foreign import lib "lib/miniaudio.a"
+} else {
+	foreign import lib "system:miniaudio"
+}
 
 /**************************************************************************************************************************************************************
 

--- a/vendor/miniaudio/generation.odin
+++ b/vendor/miniaudio/generation.odin
@@ -2,8 +2,13 @@ package miniaudio
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "lib/miniaudio.lib" }
-when ODIN_OS == .Linux   { foreign import lib "lib/miniaudio.a" }
+when ODIN_OS == .Windows {
+	foreign import lib "lib/miniaudio.lib"
+} else when ODIN_OS == .Linux {
+	foreign import lib "lib/miniaudio.a"
+} else {
+	foreign import lib "system:miniaudio"
+}
 
 waveform_type :: enum c.int {
 	sine,

--- a/vendor/miniaudio/logging.odin
+++ b/vendor/miniaudio/logging.odin
@@ -2,8 +2,13 @@ package miniaudio
 
 import c "core:c/libc"
 
-when ODIN_OS == .Windows { foreign import lib "lib/miniaudio.lib" }
-when ODIN_OS == .Linux   { foreign import lib "lib/miniaudio.a" }
+when ODIN_OS == .Windows {
+	foreign import lib "lib/miniaudio.lib"
+} else when ODIN_OS == .Linux {
+	foreign import lib "lib/miniaudio.a"
+} else {
+	foreign import lib "system:miniaudio"
+}
 
 MAX_LOG_CALLBACKS :: 4
 

--- a/vendor/miniaudio/src/Makefile
+++ b/vendor/miniaudio/src/Makefile
@@ -1,6 +1,6 @@
 all:
 	mkdir -p ../lib
-	gcc -c -O2 -Os -fPIC miniaudio.c
-	ar rcs ../lib/miniaudio.a miniaudio.o
-	#gcc -fPIC -shared -Wl,-soname=miniaudio.so -o ../lib/miniaudio.so miniaudio.o
+	$(CC) -c -O2 -Os -fPIC miniaudio.c
+	$(AR) rcs ../lib/miniaudio.a miniaudio.o
+	#$(CC) -fPIC -shared -Wl,-soname=miniaudio.so -o ../lib/miniaudio.so miniaudio.o
 	rm *.o

--- a/vendor/miniaudio/utilities.odin
+++ b/vendor/miniaudio/utilities.odin
@@ -1,7 +1,12 @@
 package miniaudio
 
-when ODIN_OS == .Windows { foreign import lib "lib/miniaudio.lib" }
-when ODIN_OS == .Linux   { foreign import lib "lib/miniaudio.a" }
+when ODIN_OS == .Windows {
+	foreign import lib "lib/miniaudio.lib"
+} else when ODIN_OS == .Linux {
+	foreign import lib "lib/miniaudio.a"
+} else {
+	foreign import lib "system:miniaudio"
+}
 
 @(default_calling_convention="c", link_prefix="ma_")
 foreign lib {

--- a/vendor/miniaudio/vfs.odin
+++ b/vendor/miniaudio/vfs.odin
@@ -2,8 +2,13 @@ package miniaudio
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "lib/miniaudio.lib" }
-when ODIN_OS == .Linux   { foreign import lib "lib/miniaudio.a" }
+when ODIN_OS == .Windows {
+	foreign import lib "lib/miniaudio.lib"
+} else when ODIN_OS == .Linux {
+	foreign import lib "lib/miniaudio.a"
+} else {
+	foreign import lib "system:miniaudio"
+}
 
 /************************************************************************************************************************************************************
 

--- a/vendor/portmidi/portmidi.odin
+++ b/vendor/portmidi/portmidi.odin
@@ -9,6 +9,8 @@ when ODIN_OS == .Windows {
 		"system:Winmm.lib",
 		"system:Advapi32.lib",
 	}
+} else {
+	foreign import lib "system:portmidi"
 }
 
 #assert(size_of(b32) == size_of(c.int))

--- a/vendor/portmidi/util.odin
+++ b/vendor/portmidi/util.odin
@@ -7,7 +7,11 @@ package portmidi
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "portmidi_s.lib" }
+when ODIN_OS == .Windows {
+	foreign import lib "portmidi_s.lib"
+} else {
+	foreign import lib "system:portmidi"
+}
 
 
 Queue :: distinct rawptr

--- a/vendor/raylib/raylib.odin
+++ b/vendor/raylib/raylib.odin
@@ -99,15 +99,17 @@ when ODIN_OS == .Windows {
 		"system:User32.lib",
 		"system:Shell32.lib",
 	}
-}
-when ODIN_OS == .Linux  {
+} else when ODIN_OS == .Linux  {
 	foreign import lib { 
 		"linux/libraylib.a",
 		"system:dl",
 		"system:pthread",
 	}
+} else when ODIN_OS == .Darwin {
+	foreign import lib "macos/libraylib.a"
+} else {
+	foreign import lib "system:raylib"
 }
-when ODIN_OS == .Darwin { foreign import lib "macos/libraylib.a" }
 
 VERSION :: "4.0"
 

--- a/vendor/raylib/rlgl.odin
+++ b/vendor/raylib/rlgl.odin
@@ -10,9 +10,13 @@ when ODIN_OS == .Windows {
 		"system:User32.lib",
 		"system:Shell32.lib",
 	}
+} else when ODIN_OS == .Linux  {
+	foreign import lib "linux/libraylib.a"
+} else when ODIN_OS == .Darwin {
+	foreign import lib "macos/libraylib.a"
+} else {
+	foreign import lib "system:raylib"
 }
-when ODIN_OS == .Linux  { foreign import lib "linux/libraylib.a" }
-when ODIN_OS == .Darwin { foreign import lib "macos/libraylib.a" }
 
 GRAPHICS_API_OPENGL_11  :: false
 GRAPHICS_API_OPENGL_21  :: true

--- a/vendor/sdl2/image/sdl_image.odin
+++ b/vendor/sdl2/image/sdl_image.odin
@@ -3,11 +3,11 @@ package sdl2_image
 import "core:c"
 import SDL ".."
 
-when ODIN_OS == .Windows { foreign import lib "SDL2_image.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2_image" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2_image" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2_image" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2_image" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2_image.lib"
+} else {
+	foreign import lib "system:SDL2_image"
+}
 
 bool :: SDL.bool
 

--- a/vendor/sdl2/mixer/sdl_mixer.odin
+++ b/vendor/sdl2/mixer/sdl_mixer.odin
@@ -3,11 +3,11 @@ package sdl2_mixer
 import "core:c"
 import SDL ".."
 
-when ODIN_OS == .Windows { foreign import lib "SDL2_mixer.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2_mixer" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2_mixer" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2_mixer" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2_mixer" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2_mixer.lib"
+} else {
+	foreign import lib "system:SDL2_mixer"
+}
 
 MAJOR_VERSION :: 2
 MINOR_VERSION :: 0

--- a/vendor/sdl2/net/sdl_net.odin
+++ b/vendor/sdl2/net/sdl_net.odin
@@ -3,11 +3,11 @@ package sdl2_net
 import "core:c"
 import SDL ".."
 
-when ODIN_OS == .Windows { foreign import lib "SDL2_net.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2_net" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2_net" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2_net" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2_net" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2_net.lib"
+} else {
+	foreign import lib "system:SDL2_net"
+}
 
 bool :: SDL.bool
 

--- a/vendor/sdl2/sdl2.odin
+++ b/vendor/sdl2/sdl2.odin
@@ -25,11 +25,11 @@ package sdl2
 import "core:c"
 import "core:intrinsics"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 version :: struct {
 	major: u8,        /**< major version */

--- a/vendor/sdl2/sdl_audio.odin
+++ b/vendor/sdl2/sdl_audio.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 /**
  *  \brief Audio format flags.

--- a/vendor/sdl2/sdl_blendmode.odin
+++ b/vendor/sdl2/sdl_blendmode.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 /**
  *  \brief The blend mode used in SDL_RenderCopy() and drawing operations.

--- a/vendor/sdl2/sdl_cpuinfo.odin
+++ b/vendor/sdl2/sdl_cpuinfo.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 /* This is a guess for the cacheline size used for padding.
  * Most x86 processors have a 64 byte cache line.

--- a/vendor/sdl2/sdl_events.odin
+++ b/vendor/sdl2/sdl_events.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 RELEASED :: 0
 PRESSED  :: 1

--- a/vendor/sdl2/sdl_gamecontroller.odin
+++ b/vendor/sdl2/sdl_gamecontroller.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 GameController :: struct {}
 

--- a/vendor/sdl2/sdl_gesture_haptic.odin
+++ b/vendor/sdl2/sdl_gesture_haptic.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 // Gesture
 

--- a/vendor/sdl2/sdl_hints.odin
+++ b/vendor/sdl2/sdl_hints.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 HINT_ACCELEROMETER_AS_JOYSTICK                :: "SDL_ACCELEROMETER_AS_JOYSTICK"
 HINT_ALLOW_ALT_TAB_WHILE_GRABBED              :: "SDL_ALLOW_ALT_TAB_WHILE_GRABBED"

--- a/vendor/sdl2/sdl_joystick.odin
+++ b/vendor/sdl2/sdl_joystick.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 Joystick :: struct {}
 

--- a/vendor/sdl2/sdl_keyboard.odin
+++ b/vendor/sdl2/sdl_keyboard.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 Keysym :: struct {
 	scancode: Scancode, /**< SDL physical key code - see ::SDL_Scancode for details */

--- a/vendor/sdl2/sdl_log.odin
+++ b/vendor/sdl2/sdl_log.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 MAX_LOG_MESSAGE :: 4096
 

--- a/vendor/sdl2/sdl_messagebox.odin
+++ b/vendor/sdl2/sdl_messagebox.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 MessageBoxFlag :: enum u32 {
 	_ = 0,

--- a/vendor/sdl2/sdl_metal.odin
+++ b/vendor/sdl2/sdl_metal.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 MetalView :: distinct rawptr
 

--- a/vendor/sdl2/sdl_mouse.odin
+++ b/vendor/sdl2/sdl_mouse.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 Cursor :: struct {}
 

--- a/vendor/sdl2/sdl_mutex.odin
+++ b/vendor/sdl2/sdl_mutex.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 MUTEX_TIMEDOUT :: 1
 MUTEX_MAXWAIT  :: ~u32(0)

--- a/vendor/sdl2/sdl_pixels.odin
+++ b/vendor/sdl2/sdl_pixels.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 ALPHA_OPAQUE      :: 255
 ALPHA_TRANSPARENT ::   0

--- a/vendor/sdl2/sdl_rect.odin
+++ b/vendor/sdl2/sdl_rect.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 Point :: struct {
 	x: c.int,

--- a/vendor/sdl2/sdl_render.odin
+++ b/vendor/sdl2/sdl_render.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 RendererFlag :: enum u32 {
 	SOFTWARE      = 0, /**< The renderer is a software fallback */

--- a/vendor/sdl2/sdl_rwops.odin
+++ b/vendor/sdl2/sdl_rwops.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 /* RWops Types */
 RWOPS_UNKNOWN   :: 0 /**< Unknown stream type */

--- a/vendor/sdl2/sdl_stdinc.odin
+++ b/vendor/sdl2/sdl_stdinc.odin
@@ -5,11 +5,11 @@ import "core:intrinsics"
 import "core:runtime"
 _, _ :: intrinsics, runtime
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 bool :: distinct b32
 #assert(size_of(bool) == size_of(c.int))

--- a/vendor/sdl2/sdl_surface.odin
+++ b/vendor/sdl2/sdl_surface.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 SWSURFACE       :: 0           /**< Just here for compatibility */
 PREALLOC        :: 0x00000001  /**< Surface uses preallocated memory */

--- a/vendor/sdl2/sdl_system.odin
+++ b/vendor/sdl2/sdl_system.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 // General
 @(default_calling_convention="c", link_prefix="SDL_")

--- a/vendor/sdl2/sdl_syswm.odin
+++ b/vendor/sdl2/sdl_syswm.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 SYSWM_TYPE :: enum c.int {
 	UNKNOWN,

--- a/vendor/sdl2/sdl_thread.odin
+++ b/vendor/sdl2/sdl_thread.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 Thread :: struct {}
 

--- a/vendor/sdl2/sdl_timer.odin
+++ b/vendor/sdl2/sdl_timer.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 TimerCallback :: proc "c" (interval: u32, param: rawptr) -> u32
 TimerID :: distinct c.int

--- a/vendor/sdl2/sdl_touch.odin
+++ b/vendor/sdl2/sdl_touch.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 TouchID  :: distinct i64
 FingerID :: distinct i64

--- a/vendor/sdl2/sdl_video.odin
+++ b/vendor/sdl2/sdl_video.odin
@@ -2,11 +2,11 @@ package sdl2
 
 import "core:c"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 DisplayMode :: struct {
 	format:       u32,    /**< pixel format */

--- a/vendor/sdl2/sdl_vulkan.odin
+++ b/vendor/sdl2/sdl_vulkan.odin
@@ -3,11 +3,11 @@ package sdl2
 import "core:c"
 import vk "vendor:vulkan"
 
-when ODIN_OS == .Windows { foreign import lib "SDL2.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2.lib"
+} else {
+	foreign import lib "system:SDL2"
+}
 
 VkInstance   :: vk.Instance
 VkSurfaceKHR :: vk.SurfaceKHR

--- a/vendor/sdl2/ttf/sdl_ttf.odin
+++ b/vendor/sdl2/ttf/sdl_ttf.odin
@@ -3,11 +3,11 @@ package sdl2_ttf
 import "core:c"
 import SDL ".."
 
-when ODIN_OS == .Windows { foreign import lib "SDL2_ttf.lib"    }
-when ODIN_OS == .Linux   { foreign import lib "system:SDL2_ttf" }
-when ODIN_OS == .Darwin  { foreign import lib "system:SDL2_ttf" }
-when ODIN_OS == .FreeBSD { foreign import lib "system:SDL2_ttf" }
-when ODIN_OS == .OpenBSD { foreign import lib "system:SDL2_ttf" }
+when ODIN_OS == .Windows {
+	foreign import lib "SDL2_ttf.lib"
+} else {
+	foreign import lib "system:SDL2_ttf"
+}
 
 bool :: SDL.bool
 

--- a/vendor/stb/src/Makefile
+++ b/vendor/stb/src/Makefile
@@ -1,16 +1,16 @@
 all:
 	mkdir -p ../lib
-	gcc -c -O2 -Os -fPIC stb_image.c stb_image_write.c stb_image_resize.c stb_truetype.c stb_rect_pack.c stb_vorbis.c
-	ar rcs ../lib/stb_image.a        stb_image.o
-	ar rcs ../lib/stb_image_write.a  stb_image_write.o
-	ar rcs ../lib/stb_image_resize.a stb_image_resize.o
-	ar rcs ../lib/stb_truetype.a     stb_truetype.o
-	ar rcs ../lib/stb_rect_pack.a    stb_rect_pack.o
-	#ar rcs ../lib/stb_vorbis_pack.a  stb_vorbis_pack.o
-	#gcc -fPIC -shared -Wl,-soname=stb_image.so         -o ../lib/stb_image.so        stb_image.o
-	#gcc -fPIC -shared -Wl,-soname=stb_image_write.so   -o ../lib/stb_image_write.so  stb_image_write.o
-	#gcc -fPIC -shared -Wl,-soname=stb_image_resize.so  -o ../lib/stb_image_resize.so stb_image_resize.o
-	#gcc -fPIC -shared -Wl,-soname=stb_truetype.so      -o ../lib/stb_truetype.so     stb_image_truetype.o
-	#gcc -fPIC -shared -Wl,-soname=stb_rect_pack.so     -o ../lib/stb_rect_pack.so    stb_rect_packl.o
-	#gcc -fPIC -shared -Wl,-soname=stb_vorbis.so        -o ../lib/stb_vorbis.so       stb_vorbisl.o
+	$(CC) -c -O2 -Os -fPIC stb_image.c stb_image_write.c stb_image_resize.c stb_truetype.c stb_rect_pack.c stb_vorbis.c
+	$(AR) rcs ../lib/stb_image.a        stb_image.o
+	$(AR) rcs ../lib/stb_image_write.a  stb_image_write.o
+	$(AR) rcs ../lib/stb_image_resize.a stb_image_resize.o
+	$(AR) rcs ../lib/stb_truetype.a     stb_truetype.o
+	$(AR) rcs ../lib/stb_rect_pack.a    stb_rect_pack.o
+	#$(AR) rcs ../lib/stb_vorbis_pack.a  stb_vorbis_pack.o
+	#$(CC) -fPIC -shared -Wl,-soname=stb_image.so         -o ../lib/stb_image.so        stb_image.o
+	#$(CC) -fPIC -shared -Wl,-soname=stb_image_write.so   -o ../lib/stb_image_write.so  stb_image_write.o
+	#$(CC) -fPIC -shared -Wl,-soname=stb_image_resize.so  -o ../lib/stb_image_resize.so stb_image_resize.o
+	#$(CC) -fPIC -shared -Wl,-soname=stb_truetype.so      -o ../lib/stb_truetype.so     stb_image_truetype.o
+	#$(CC) -fPIC -shared -Wl,-soname=stb_rect_pack.so     -o ../lib/stb_rect_pack.so    stb_rect_packl.o
+	#$(CC) -fPIC -shared -Wl,-soname=stb_vorbis.so        -o ../lib/stb_vorbis.so       stb_vorbisl.o
 	rm *.o


### PR DESCRIPTION
I worked in vendor libraries to make them buildable in wider manner. Most of them are portable, but need a system library installed on the system. So I simplified the `foreign import` logic to use the system version systematically (but I kept the static library usage where present).

It makes all vendor libraries buildable as soon you have the library installed, and all vendor libraries are checkable (with `odin check`).

I only kept two libraries with different traitment:
- directx libraries (Windows only)
- stb

Regarding stb, I am still not satisfied with it. It is open source, buildable, but upstream doesn't provide library, so we can't rely on it.

I also made `miniaudio` and `stb` makefile a bit more portable by using make builtin variable for CC and AR value.

I hope it doesn't break your workflow for generating documentation. if it is the case, I could look if it is possible to do things differently.