### PR TITLE
32 bit fixes

### DIFF
--- a/core/compress/common.odin
+++ b/core/compress/common.odin
@@ -139,7 +139,13 @@ Context_Memory_Input :: struct #packed {
 	size_packed:       i64,
 	size_unpacked:     i64,
 }
-#assert(size_of(Context_Memory_Input) == 64)
+when size_of(rawptr) == 8 {
+	#assert(size_of(Context_Memory_Input) == 64)
+} else {
+	// e.g. `-target:windows_386`
+	#assert(size_of(Context_Memory_Input) == 52)
+}
+
 
 Context_Stream_Input :: struct #packed {
 	input_data:        []u8,

--- a/core/compress/gzip/gzip.odin
+++ b/core/compress/gzip/gzip.odin
@@ -100,7 +100,7 @@ E_GZIP    :: compress.GZIP_Error
 E_ZLIB    :: compress.ZLIB_Error
 E_Deflate :: compress.Deflate_Error
 
-GZIP_MAX_PAYLOAD_SIZE :: int(max(u32le))
+GZIP_MAX_PAYLOAD_SIZE :: i64(max(u32le))
 
 load :: proc{load_from_slice, load_from_file, load_from_context}
 
@@ -136,7 +136,7 @@ load_from_context :: proc(z: ^$C, buf: ^bytes.Buffer, known_gzip_size := -1, exp
 
 	z.output = buf
 
-	if expected_output_size > GZIP_MAX_PAYLOAD_SIZE {
+	if i64(expected_output_size) > i64(GZIP_MAX_PAYLOAD_SIZE) {
 		return E_GZIP.Payload_Size_Exceeds_Max_Payload
 	}
 

--- a/tests/core/compress/test_core_compress.odin
+++ b/tests/core/compress/test_core_compress.odin
@@ -52,6 +52,9 @@ main :: proc() {
 	gzip_test(&t)
 
 	fmt.printf("%v/%v tests successful.\n", TEST_count - TEST_fail, TEST_count)
+	if TEST_fail > 0 {
+		os.exit(1)
+	}
 }
 
 @test

--- a/tests/core/crypto/test_core_crypto.odin
+++ b/tests/core/crypto/test_core_crypto.odin
@@ -37,6 +37,7 @@ import "core:crypto/jh"
 import "core:crypto/groestl"
 import "core:crypto/haval"
 import "core:crypto/siphash"
+import "core:os"
 
 TEST_count := 0
 TEST_fail  := 0
@@ -127,6 +128,9 @@ main :: proc() {
     bench_modern(&t)
 
     fmt.printf("%v/%v tests successful.\n", TEST_count - TEST_fail, TEST_count)
+    if TEST_fail > 0 {
+        os.exit(1)
+    }
 }
 
 TestHash :: struct {

--- a/tests/core/encoding/test_core_json.odin
+++ b/tests/core/encoding/test_core_json.odin
@@ -3,6 +3,7 @@ package test_core_json
 import "core:encoding/json"
 import "core:testing"
 import "core:fmt"
+import "core:os"
 
 TEST_count := 0
 TEST_fail  := 0
@@ -34,6 +35,9 @@ main :: proc() {
 	marshal_json(&t)
 
     fmt.printf("%v/%v tests successful.\n", TEST_count - TEST_fail, TEST_count)
+	if TEST_fail > 0 {
+		os.exit(1)
+	}
 }
 
 @test

--- a/tests/core/hash/test_core_hash.odin
+++ b/tests/core/hash/test_core_hash.odin
@@ -5,6 +5,7 @@ import "core:hash"
 import "core:time"
 import "core:testing"
 import "core:fmt"
+import "core:os"
 
 TEST_count := 0
 TEST_fail  := 0
@@ -35,6 +36,9 @@ main :: proc() {
 	test_xxhash_vectors(&t)
 	test_crc64_vectors(&t)
 	fmt.printf("%v/%v tests successful.\n", TEST_count - TEST_fail, TEST_count)
+	if TEST_fail > 0 {
+		os.exit(1)
+	}
 }
 
 /*

--- a/tests/core/image/test_core_image.odin
+++ b/tests/core/image/test_core_image.odin
@@ -57,6 +57,9 @@ main :: proc() {
 	png_test(&t)
 
 	fmt.printf("%v/%v tests successful.\n", TEST_count - TEST_fail, TEST_count)
+	if TEST_fail > 0 {
+		os.exit(1)
+	}
 }
 
 PNG_Test :: struct {

--- a/tests/core/math/noise/test_core_math_noise.odin
+++ b/tests/core/math/noise/test_core_math_noise.odin
@@ -3,6 +3,7 @@ package test_core_math_noise
 import "core:testing"
 import "core:math/noise"
 import "core:fmt"
+import "core:os"
 
 TEST_count := 0
 TEST_fail  := 0
@@ -35,6 +36,9 @@ main :: proc() {
 	t := testing.T{}
 	noise_test(&t)
 	fmt.printf("%v/%v tests successful.\n", TEST_count - TEST_fail, TEST_count)
+	if TEST_fail > 0 {
+		os.exit(1)
+	}
 }
 
 Test_Vector :: struct {

--- a/tests/core/odin/test_parser.odin
+++ b/tests/core/odin/test_parser.odin
@@ -2,7 +2,7 @@ package test_core_odin_parser
 
 import "core:testing"
 import "core:fmt"
-
+import "core:os"
 import "core:odin/parser"
 
 
@@ -35,6 +35,9 @@ main :: proc() {
     test_parse_demo(&t)
 
     fmt.printf("%v/%v tests successful.\n", TEST_count - TEST_fail, TEST_count)
+    if TEST_fail > 0 {
+        os.exit(1)
+    }
 }
 
 

--- a/tests/core/strings/test_core_strings.odin
+++ b/tests/core/strings/test_core_strings.odin
@@ -3,6 +3,7 @@ package test_core_image
 import "core:strings"
 import "core:testing"
 import "core:fmt"
+import "core:os"
 
 TEST_count := 0
 TEST_fail  := 0
@@ -35,6 +36,9 @@ main :: proc() {
     test_index_any_larger_string_found(&t)
 
     fmt.printf("%v/%v tests successful.\n", TEST_count - TEST_fail, TEST_count)
+    if TEST_fail > 0 {
+        os.exit(1)
+    }
 }
 
 @test

--- a/tests/vendor/botan/test_vendor_botan.odin
+++ b/tests/vendor/botan/test_vendor_botan.odin
@@ -14,6 +14,7 @@ package test_vendor_botan
 
 import "core:testing"
 import "core:fmt"
+import "core:os"
 
 import "vendor:botan/md4"
 import "vendor:botan/md5"
@@ -86,6 +87,9 @@ main :: proc() {
     test_siphash_2_4(&t)
 
     fmt.printf("%v/%v tests successful.\n", TEST_count - TEST_fail, TEST_count)
+    if TEST_fail > 0 {
+        os.exit(1)
+    }
 }
 
 TestHash :: struct {

--- a/tests/vendor/glfw/test_vendor_glfw.odin
+++ b/tests/vendor/glfw/test_vendor_glfw.odin
@@ -3,6 +3,7 @@ package test_vendor_glfw
 import "core:testing"
 import "core:fmt"
 import "vendor:glfw"
+import "core:os"
 
 GLFW_MAJOR :: 3
 GLFW_MINOR :: 3
@@ -36,6 +37,9 @@ main :: proc() {
 	test_glfw(&t)
 
 	fmt.printf("%v/%v tests successful.\n", TEST_count - TEST_fail, TEST_count)
+	if TEST_fail > 0 {
+		os.exit(1)
+	}
 }
 
 @(test)


### PR DESCRIPTION
Fixes 32-bit cleanliness of `core:compress`.

Also, make the tests return error level 1 if a test fails so the CI notices.