### PR TITLE
[bit_array] Really fix the leak.

### DIFF
--- a/core/container/bit_array/bit_array.odin
+++ b/core/container/bit_array/bit_array.odin
@@ -16,15 +16,16 @@ INDEX_MASK  :: 63
 NUM_BITS :: 64
 
 Bit_Array :: struct {
-	bits: [dynamic]u64,
-	bias: int,
-	max_index: int,
+	bits:         [dynamic]u64,
+	bias:         int,
+	max_index:    int,
+	free_pointer: bool,
 }
 
 Bit_Array_Iterator :: struct {
-	array: ^Bit_Array,
+	array:    ^Bit_Array,
 	word_idx: int,
-	bit_idx: uint,
+	bit_idx:  uint,
 }
 
 /*
@@ -187,7 +188,7 @@ set :: proc(ba: ^Bit_Array, #any_int index: uint, allocator := context.allocator
 /*
 	A helper function to create a Bit Array with optional bias, in case your smallest index is non-zero (including negative).
 */
-create :: proc(max_index: int, min_index := 0, allocator := context.allocator) -> (res: Bit_Array, ok: bool) #optional_ok {
+create :: proc(max_index: int, min_index := 0, allocator := context.allocator) -> (res: ^Bit_Array, ok: bool) #optional_ok {
 	context.allocator = allocator
 	size_in_bits := max_index - min_index
 
@@ -195,11 +196,11 @@ create :: proc(max_index: int, min_index := 0, allocator := context.allocator) -
 
 	legs := size_in_bits >> INDEX_SHIFT
 
-	res = Bit_Array{
-		bias = min_index,
-		max_index = max_index,
-	}
-	return res, resize_if_needed(&res, legs)
+	res = new(Bit_Array)
+	res.bias         = min_index
+	res.max_index    = max_index
+	res.free_pointer = true
+	return res, resize_if_needed(res, legs)
 }
 
 /*
@@ -216,6 +217,9 @@ clear :: proc(ba: ^Bit_Array) {
 destroy :: proc(ba: ^Bit_Array) {
 	if ba == nil { return }
 	delete(ba.bits)
+	if ba.free_pointer { // Only free if this Bit_Array was created using `create`, not when on the stack.
+		free(ba)
+	}
 }
 
 /*

--- a/core/container/bit_array/doc.odin
+++ b/core/container/bit_array/doc.odin
@@ -21,6 +21,7 @@ package dynamic_bit_array
 			// returns `false`, `false`, because this Bit Array wasn't created to allow negative indices.
 			was_set, was_retrieved := get(&bits, -1)
 			fmt.println(was_set, was_retrieved) 
+			destroy(&bits)
 		}
 
 	-- A Bit Array can optionally allow for negative indices, if the mininum value was given during creation:
@@ -40,13 +41,13 @@ package dynamic_bit_array
 			using bit_array
 
 			bits := create(int(max(Foo)), int(min(Foo)))
-			defer destroy(&bits)
+			defer destroy(bits)
 
-			fmt.printf("Set(Bar):           %v\n",     set(&bits, Foo.Bar))
-			fmt.printf("Get(Bar):           %v, %v\n", get(&bits, Foo.Bar))
-			fmt.printf("Set(Negative_Test): %v\n",     set(&bits, Foo.Negative_Test))
-			fmt.printf("Get(Leaves):        %v, %v\n", get(&bits, Foo.Leaves))
-			fmt.printf("Get(Negative_Test): %v, %v\n", get(&bits, Foo.Negative_Test))
+			fmt.printf("Set(Bar):           %v\n",     set(bits, Foo.Bar))
+			fmt.printf("Get(Bar):           %v, %v\n", get(bits, Foo.Bar))
+			fmt.printf("Set(Negative_Test): %v\n",     set(bits, Foo.Negative_Test))
+			fmt.printf("Get(Leaves):        %v, %v\n", get(bits, Foo.Leaves))
+			fmt.printf("Get(Negative_Test): %v, %v\n", get(bits, Foo.Negative_Test))
 			fmt.printf("Freed.\n")
 		}
 */


### PR DESCRIPTION
The previous fix didn't properly release the array. This does regardless of the `Bit_Array` being used uninitialized on the stack, or having `create` make you one. Updated `doc.odin` to reflect.