### PR TITLE
[runtime] fix `insert_at` procedure group.

### DIFF
--- a/core/runtime/core_builtin.odin
+++ b/core/runtime/core_builtin.odin
@@ -386,12 +386,13 @@ insert_at_elem :: proc(array: ^$T/[dynamic]$E, index: int, arg: E, loc := #calle
 	if array == nil {
 		return
 	}
-	n := len(array)
+	n := max(len(array), index)
 	m :: 1
-	resize(array, n+m, loc)
-	if n+m <= len(array) {
+	new_size := n + m
+
+	if resize(array, new_size, loc) {
 		when size_of(E) != 0 {
-			copy(array[index+m:], array[index:])
+			copy(array[index + m:], array[index:])
 			array[index] = arg
 		}
 		ok = true
@@ -409,12 +410,13 @@ insert_at_elems :: proc(array: ^$T/[dynamic]$E, index: int, args: ..E, loc := #c
 		return
 	}
 
-	n := len(array)
+	n := max(len(array), index)
 	m := len(args)
-	resize(array, n+m, loc)
-	if n+m <= len(array) {
+	new_size := n + m
+
+	if resize(array, new_size, loc) {
 		when size_of(E) != 0 {
-			copy(array[index+m:], array[index:])
+			copy(array[index + m:], array[index:])
 			copy(array[index:], args)
 		}
 		ok = true
@@ -423,21 +425,22 @@ insert_at_elems :: proc(array: ^$T/[dynamic]$E, index: int, args: ..E, loc := #c
 }
 
 @builtin
-insert_at_elem_string :: proc(array: ^$T/[dynamic]$E/u8, index: int, arg: string, loc := #caller_location) -> (ok: bool) #no_bounds_check {
+insert_at_elem_string :: proc(array: ^$T/[dynamic]$E/u8, index: int, arg: string, loc := #caller_location) -> (ok: bool) {
 	if array == nil {
 		return
 	}
-	if len(args) == 0 {
+	if len(arg) == 0 {
 		ok = true
 		return
 	}
 
-	n := len(array)
-	m := len(args)
-	resize(array, n+m, loc)
-	if n+m <= len(array) {
+	n := max(len(array), index)
+	m := len(arg)
+	new_size := n + m
+
+	if resize(array, new_size, loc) {
 		copy(array[index+m:], array[index:])
-		copy(array[index:], args)
+		copy(array[index:], arg)
 		ok = true
 	}
 	return

--- a/core/runtime/core_builtin.odin
+++ b/core/runtime/core_builtin.odin
@@ -425,7 +425,7 @@ insert_at_elems :: proc(array: ^$T/[dynamic]$E, index: int, args: ..E, loc := #c
 }
 
 @builtin
-insert_at_elem_string :: proc(array: ^$T/[dynamic]$E/u8, index: int, arg: string, loc := #caller_location) -> (ok: bool) {
+insert_at_elem_string :: proc(array: ^$T/[dynamic]$E/u8, index: int, arg: string, loc := #caller_location) -> (ok: bool) #no_bounds_check {
 	if array == nil {
 		return
 	}


### PR DESCRIPTION
Fixes typo in `runtime.insert_at_elem_string`.

Additionally fixes the case where `index` was outside of the array's length, causing an out of bounds error hidden by `#no_bounds_check`. We now take `index` into account when resizing.