### PR TITLE
Add split_iterator_byte

### DIFF
--- a/core/strings/strings.odin
+++ b/core/strings/strings.odin
@@ -339,6 +339,25 @@ _split_iterator :: proc(s: ^string, sep: string, sep_save: int) -> (res: string,
 	return
 }
 
+@private
+_split_by_byte_iterator :: proc(s: ^string, sep: u8) -> (res: string, ok: bool) {
+	m := index_byte(s^, sep)
+	if m < 0 {
+		// not found
+		res = s[:]
+		ok = res != ""
+		s^ = {}
+	} else {
+		res = s[:m]
+		ok = true
+		s^ = s[m+1:]
+	}
+	return
+}
+
+split_by_byte_iterator :: proc(s: ^string, sep: u8) -> (string, bool) {
+	return _split_by_byte_iterator(s, sep)
+}
 
 split_iterator :: proc(s: ^string, sep: string) -> (string, bool) {
 	return _split_iterator(s, sep, 0)


### PR DESCRIPTION
Add split_iterator_byte. It functions exactly like split_iterator but takes in a byte seperator rather than a string seperator.
The intention is to provide a faster split parsing if the seperator is known to be byte size.

Splitting by byte rather than string in my obj parser I saw 20% decrease in parsing time, I thought it naturally fit in the core.
If I need to extend to match all the other split functions (which only take string right now) I can in the near future.