### PR TITLE
Add foreign imports for Darwin to vendor:stb

### DIFF
--- a/vendor/stb/image/stb_image.odin
+++ b/vendor/stb/image/stb_image.odin
@@ -6,6 +6,7 @@ import c "core:c/libc"
 
 when ODIN_OS == .Windows { foreign import stbi "../lib/stb_image.lib" }
 when ODIN_OS == .Linux   { foreign import stbi "../lib/stb_image.a"   }
+when ODIN_OS == .Darwin  { foreign import stbi "../lib/stb_image.a"   }
 
 #assert(size_of(b32) == size_of(c.int))
 

--- a/vendor/stb/image/stb_image_resize.odin
+++ b/vendor/stb/image/stb_image_resize.odin
@@ -4,6 +4,7 @@ import c "core:c/libc"
 
 when ODIN_OS == .Windows { foreign import lib "../lib/stb_image_resize.lib" }
 when ODIN_OS == .Linux   { foreign import lib "../lib/stb_image_resize.a"   }
+when ODIN_OS == .Darwin  { foreign import lib "../lib/stb_image_resize.a"   }
 
 //////////////////////////////////////////////////////////////////////////////
 //

--- a/vendor/stb/image/stb_image_write.odin
+++ b/vendor/stb/image/stb_image_write.odin
@@ -4,6 +4,7 @@ import c "core:c/libc"
 
 when ODIN_OS == .Windows { foreign import stbiw "../lib/stb_image_write.lib" }
 when ODIN_OS == .Linux   { foreign import stbiw "../lib/stb_image_write.a"   }
+when ODIN_OS == .Darwin  { foreign import stbiw "../lib/stb_image_write.a"   }
 
 
 write_func :: proc "c" (ctx: rawptr, data: rawptr, size: c.int)

--- a/vendor/stb/rect_pack/stb_rect_pack.odin
+++ b/vendor/stb/rect_pack/stb_rect_pack.odin
@@ -6,6 +6,7 @@ import c "core:c/libc"
 
 when ODIN_OS == .Windows { foreign import lib "../lib/stb_rect_pack.lib" }
 when ODIN_OS == .Linux   { foreign import lib "../lib/stb_rect_pack.a"   }
+when ODIN_OS == .Darwin  { foreign import lib "../lib/stb_rect_pack.a"   }
 
 Coord :: distinct c.int
 _MAXVAL :: max(Coord)

--- a/vendor/stb/truetype/stb_truetype.odin
+++ b/vendor/stb/truetype/stb_truetype.odin
@@ -5,6 +5,7 @@ import stbrp "vendor:stb/rect_pack"
 
 when ODIN_OS == .Windows { foreign import stbtt "../lib/stb_truetype.lib" }
 when ODIN_OS == .Linux   { foreign import stbtt "../lib/stb_truetype.a"   }
+when ODIN_OS == .Darwin  { foreign import stbtt "../lib/stb_truetype.a"   }
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/vendor/stb/vorbis/stb_vorbis.odin
+++ b/vendor/stb/vorbis/stb_vorbis.odin
@@ -5,6 +5,7 @@ import c "core:c/libc"
 
 when ODIN_OS == .Windows { foreign import lib "../lib/stb_vorbis.lib" }
 when ODIN_OS == .Linux   { foreign import lib "../lib/stb_vorbis.a"   }
+when ODIN_OS == .Darwin  { foreign import lib "../lib/stb_vorbis.a"   }
 
 
 


### PR DESCRIPTION
Just adding some additional foreign import statements so that vendor:stb can be used on MacOS.