### PR TITLE
Fix issue #829 "Compiler crashes when declaring maps with procedure"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           make
         timeout-minutes: 10
       - name: Odin issues tests
-        run: ./odin run tests/issues -collection:tests=tests
+        run: tests/issues/run.sh
         timeout-minutes: 10
       - name: Odin check examples/all for Linux i386
         run: ./odin check examples/all -vet -strict-style -target:linux_i386
@@ -91,7 +91,7 @@ jobs:
           make
         timeout-minutes: 10
       - name: Odin issues tests
-        run: ./odin run tests/issues -collection:tests=tests
+        run: tests/issues/run.sh
         timeout-minutes: 10
       - name: Odin check examples/all for Darwin arm64
         run: ./odin check examples/all -vet -strict-style -target:darwin_arm64
@@ -163,7 +163,7 @@ jobs:
         shell: cmd
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat
-          odin run tests\issues -collection:tests=tests
+          call tests\issues\run.bat
         timeout-minutes: 10
       - name: Odin check examples/all for Windows 32bits
         shell: cmd

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -9000,6 +9000,7 @@ ExprKind check_expr_base_internal(CheckerContext *c, Operand *o, Ast *node, Type
 
 	o->mode = Addressing_Invalid;
 	o->type = t_invalid;
+	o->value = {ExactValue_Invalid};
 
 	switch (node->kind) {
 	default:

--- a/tests/issues/run.bat
+++ b/tests/issues/run.bat
@@ -1,0 +1,17 @@
+@echo off
+
+if not exist "tests\issues\build\" mkdir tests\issues\build
+
+set COMMON=-collection:tests=tests -out:tests\issues\build\test_issue
+
+@echo on
+
+.\odin build tests\issues\test_issue_829.odin %COMMON%
+tests\issues\build\test_issue
+
+.\odin build tests\issues\test_issue_1592.odin %COMMON%
+tests\issues\build\test_issue
+
+@echo off
+
+rmdir /S /Q tests\issues\build

--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eu
+
+mkdir -p tests/issues/build
+
+COMMON="-collection:tests=tests -out:tests/issues/build/test_issue"
+
+set -x
+
+./odin build tests/issues/test_issue_829.odin $COMMON
+tests/issues/build/test_issue
+
+./odin build tests/issues/test_issue_1592.odin $COMMON
+tests/issues/build/test_issue
+
+set +x
+
+rm -rf tests/issues/build

--- a/tests/issues/test_issue_829.odin
+++ b/tests/issues/test_issue_829.odin
@@ -1,0 +1,33 @@
+// Tests issue #829 https://github.com/odin-lang/Odin/issues/829
+package test_issues
+
+import "core:fmt"
+import "core:testing"
+import tc "tests:common"
+
+/* Original issue #829 example */
+
+env : map[string]proc(a, b : int) -> int = {
+	"+" = proc(a, b : int) -> int {
+		return a + b
+	},
+}
+
+test_orig :: proc() {
+	fmt.println(env["+"](1, 2))
+}
+
+main :: proc() {
+	t := testing.T{}
+
+	test_orig()
+
+	test_orig_ret(&t)
+
+	tc.report(&t)
+}
+
+test_orig_ret :: proc(t: ^testing.T) {
+	r := fmt.tprint(env["+"](1, 2))
+	tc.expect(t, r == "3", fmt.tprintf("%s: \"%s\" != \"3\"\n", #procedure, r))
+}


### PR DESCRIPTION
Closes #829 

- Inits `o->value` in `check_expr_base_internal()` so doesn't accidentally use last (the proc lit was being set to that of previous string)
- Adds test to "tests/issues" and changes CI to use new "run" shells