### PR TITLE
Use `WIFEXITED()` and `WEXITSTATUS()` on Unix `system()` exit code

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,6 +117,9 @@ i32 system_exec_command_line_app(char const *name, char const *fmt, ...) {
 		gb_printf_err("%s\n\n", cmd_line);
 	}
 	exit_code = system(cmd_line);
+	if (WIFEXITED(exit_code)) {
+		exit_code = WEXITSTATUS(exit_code);
+	}
 #endif
 
 	if (exit_code) {

--- a/tests/core/Makefile
+++ b/tests/core/Makefile
@@ -2,7 +2,7 @@ ODIN=../../odin
 PYTHON=$(shell which python3)
 
 all: download_test_assets image_test compress_test strings_test hash_test crypto_test noise_test encoding_test \
-	 math_test linalg_glsl_math_test filepath_test reflect_test
+	 math_test linalg_glsl_math_test filepath_test reflect_test os_exit_test
 
 download_test_assets:
 	$(PYTHON) download_assets.py
@@ -41,3 +41,6 @@ filepath_test:
 
 reflect_test:
 	$(ODIN) run reflect/test_core_reflect.odin -out=test_core_reflect -collection:tests=..
+
+os_exit_test:
+	$(ODIN) run os/test_core_os_exit.odin -out=test_core_os_exit && exit 1 || exit 0

--- a/tests/core/os/test_core_os_exit.odin
+++ b/tests/core/os/test_core_os_exit.odin
@@ -1,0 +1,10 @@
+// Tests that Odin run returns exit code of built executable on Unix
+// Needs exit status to be inverted to return 0 on success, e.g.
+// $(./odin run tests/core/os/test_core_os_exit.odin && exit 1 || exit 0)
+package test_core_os_exit
+
+import "core:os"
+
+main :: proc() {
+	os.exit(1)
+}


### PR DESCRIPTION
- Ensures Odin run returns correct exit code of built executable (previously returning 0 regardless)
- Adds test "tests/core/os/test_core_os_exit.odin" (Unix only)