### PR TITLE
Have get_std_handle() no longer make the handles uninheritable

### DIFF
--- a/core/os/file_windows.odin
+++ b/core/os/file_windows.odin
@@ -320,9 +320,6 @@ stderr := get_std_handle(uint(win32.STD_ERROR_HANDLE))
 
 get_std_handle :: proc "contextless" (h: uint) -> Handle {
 	fd := win32.GetStdHandle(win32.DWORD(h))
-	when size_of(uintptr) == 8 {
-		win32.SetHandleInformation(fd, win32.HANDLE_FLAG_INHERIT, 0)
-	}
 	return Handle(fd)
 }
 


### PR DESCRIPTION
This caused all handles returned by GetStdHandle() to also not be inheritable,
which prevents you from handing them to child processes that you might create.

This fixes that.