### PR TITLE
[math/big] Tell Python test runner how many nails we use.

### DIFF
--- a/tests/core/math/big/build.bat
+++ b/tests/core/math/big/build.bat
@@ -10,8 +10,5 @@ echo ---
 echo Running core:math/big tests
 echo ---
 
-rem Fails
-:%PATH_TO_ODIN% build . %COMMON% -o:speed -out:%OUT_NAME%
-rem Passes
-%PATH_TO_ODIN% build . %COMMON% -o:size -out:%OUT_NAME%
+%PATH_TO_ODIN% build . %COMMON% -o:speed -out:%OUT_NAME%
 python3 test.py %TEST_ARGS%

--- a/tests/core/math/big/test.odin
+++ b/tests/core/math/big/test.odin
@@ -32,9 +32,9 @@ print_to_buffer :: proc(val: ^big.Int) -> cstring {
 
 @export test_initialize_constants :: proc "c" () -> (res: u64) {
 	context = runtime.default_context()
-	res = u64(big.initialize_constants())
-	//assert(MUL_KARATSUBA_CUTOFF >= 40);
-	return res
+	_  = big.initialize_constants()
+
+	return u64(big._DIGIT_NAILS)
 }
 
 @export test_error_string :: proc "c" (err: big.Error) -> (res: cstring) {

--- a/tests/core/math/big/test.py
+++ b/tests/core/math/big/test.py
@@ -17,7 +17,6 @@ import gc
 from enum import Enum
 import argparse
 
-
 parser = argparse.ArgumentParser(
 	description     = "Odin core:math/big test suite",
 	epilog          = "By default we run regression and random tests with preset parameters.",
@@ -163,6 +162,8 @@ def load(export_name, args, res):
 	export_name.restype  = res
 	return export_name
 
+
+
 #
 # Result values will be passed in a struct { res: cstring, err: Error }
 #
@@ -170,7 +171,11 @@ class Res(Structure):
 	_fields_ = [("res", c_char_p), ("err", c_uint64)]
 
 initialize_constants = load(l.test_initialize_constants, [], c_uint64)
-print("initialize_constants: ", initialize_constants())
+
+NAILS    = initialize_constants()
+LEG_BITS = 64 - NAILS
+
+print("LEG BITS: ", LEG_BITS)
 
 error_string = load(l.test_error_string, [c_byte], c_char_p)
 
@@ -407,7 +412,7 @@ def test_shl_leg(a = 0, digits = 0, expected_error = Error.Okay):
 	res   = int_shl_leg(*args)
 	expected_result = None
 	if expected_error == Error.Okay:
-		expected_result = a << (digits * 60)
+		expected_result = a << (digits * LEG_BITS)
 	return test("test_shl_leg", res, [a, digits], expected_error, expected_result)
 
 def test_shr_leg(a = 0, digits = 0, expected_error = Error.Okay):
@@ -419,7 +424,7 @@ def test_shr_leg(a = 0, digits = 0, expected_error = Error.Okay):
 			# Don't pass negative numbers. We have a shr_signed.
 			return False
 		else:
-			expected_result = a >> (digits * 60)
+			expected_result = a >> (digits * LEG_BITS)
 		
 	return test("test_shr_leg", res, [a, digits], expected_error, expected_result)
 


### PR DESCRIPTION
`_DIGIT_NAILS` is defined as 4, meaning that we use 60 out of every 64 bits.
We can use as few as 1 nail, using 63 bits out of every 64, and all tests will still pass.

However, it needs more testing to see if that's a worthwhile change to make.

For the tests to work properly when changing the nails, Python needs to know about it as well.

In addition, compile the big math code with `-o:speed` going forward.