### PR TITLE
os/file_windows: Fix "create or append" file open behavior

### DIFF
--- a/core/os/file_windows.odin
+++ b/core/os/file_windows.odin
@@ -20,12 +20,12 @@ open :: proc(path: string, mode: int = O_RDONLY, perm: int = 0) -> (Handle, Errn
 	case O_RDWR:   access = win32.FILE_GENERIC_READ | win32.FILE_GENERIC_WRITE
 	}
 
+	if mode&O_CREATE != 0 {
+		access |= win32.FILE_GENERIC_WRITE
+	}
 	if mode&O_APPEND != 0 {
 		access &~= win32.FILE_GENERIC_WRITE
 		access |=  win32.FILE_APPEND_DATA
-	}
-	if mode&O_CREATE != 0 {
-		access |= win32.FILE_GENERIC_WRITE
 	}
 
 	share_mode := win32.FILE_SHARE_READ|win32.FILE_SHARE_WRITE


### PR DESCRIPTION
When combining the flags `os.O_CREATE | os.O_APPEND` to get the file open behavior of "create or append", the current order of the `O_CREATE` and `O_APPEND` conditions, results in the `FILE_GENERIC_WRITE` flag being set again on the `access` flags variable after it's been cleared. This results in a behavior that is more like "create or overwrite" because `CreateFileW` fill no longer automatically seek to the end of the opened file, which it does when using the `FILE_APPEND_DATA` flag explicitly.

I noticed this when writing debug log files that I expected to be appended to. This PR changes the order of the above mentioned conditions which resulted in the expected behavior of the log files being properly appended to.