### PR TITLE
Make GLFW.TRUE and GLFW.FALSE useable with glfwWindowHint

### DIFF
--- a/vendor/glfw/constants.odin
+++ b/vendor/glfw/constants.odin
@@ -7,8 +7,8 @@ VERSION_MINOR    :: 3
 VERSION_REVISION :: 4
 
 /* Booleans */
-TRUE  :: true
-FALSE :: false
+TRUE  :: 1
+FALSE :: 0
 
 /* Button/Key states */
 RELEASE :: 0


### PR DESCRIPTION
First, I provide an excerpt from [GLFW Documentation](https://www.glfw.org/docs/3.3/window_guide.html#window_hints):

> GLFW_VISIBLE specifies whether the windowed mode window will be initially visible. Possible values are GLFW_TRUE and GLFW_FALSE

That is, the usage of glfwWindowHint in this case would look something like this:

```
glfwWindowHint(GLFW_VISIBLE, GLFW_TRUE);
```

In `vendor:glfw` the `glfwWindowHint` function is defined to take two parameters of type i32. So if glfw.TRUE is an untyped integer constant, then there would be no need for extra casts when calling the function. This is why I propose to make this change