### PR TITLE
Fix for `slice_to_components` compilation error

### DIFF
--- a/core/mem/mem.odin
+++ b/core/mem/mem.odin
@@ -166,7 +166,7 @@ slice_data_cast :: proc "contextless" ($T: typeid/[]$A, slice: $S/[]$B) -> T {
 
 slice_to_components :: proc "contextless" (slice: $E/[]$T) -> (data: ^T, len: int) {
 	s := transmute(Raw_Slice)slice
-	return s.data, s.len
+	return (^T)(s.data), s.len
 }
 
 buffer_from_slice :: proc "contextless" (backing: $T/[]$E) -> [dynamic]E {


### PR DESCRIPTION
Using `slice_to_components` didn't compile because `s.data` is type of `rawptr` and return type is `^T`