### PR TITLE
mem: replace size procedures with constants

### DIFF
--- a/core/mem/mem.odin
+++ b/core/mem/mem.odin
@@ -3,6 +3,12 @@ package mem
 import "core:runtime"
 import "core:intrinsics"
 
+Byte     :: 1
+Kilobyte :: 1024 * Byte
+Megabyte :: 1024 * Kilobyte
+Gigabyte :: 1024 * Megabyte
+Terabyte :: 1024 * Gigabyte
+
 set :: proc "contextless" (data: rawptr, value: byte, len: int) -> rawptr {
 	return runtime.memset(data, i32(value), len)
 }
@@ -191,11 +197,6 @@ any_to_bytes :: proc "contextless" (val: any) -> []byte {
 	return transmute([]byte)Raw_Slice{val.data, size}
 }
 
-
-kilobytes :: proc "contextless" (x: int) -> int { return          (x) * 1024 }
-megabytes :: proc "contextless" (x: int) -> int { return kilobytes(x) * 1024 }
-gigabytes :: proc "contextless" (x: int) -> int { return megabytes(x) * 1024 }
-terabytes :: proc "contextless" (x: int) -> int { return gigabytes(x) * 1024 }
 
 is_power_of_two :: proc "contextless" (x: uintptr) -> bool {
 	if x <= 0 {

--- a/core/odin/printer/printer.odin
+++ b/core/odin/printer/printer.odin
@@ -151,7 +151,7 @@ print :: proc(p: ^Printer, file: ^ast.File) -> string {
 
 	fix_lines(p)
 
-	builder := strings.make_builder(0, mem.megabytes(5), p.allocator)
+	builder := strings.make_builder(0, 5 * mem.Megabyte, p.allocator)
 
 	last_line := 0
 

--- a/core/runtime/core.odin
+++ b/core/runtime/core.odin
@@ -565,7 +565,7 @@ __init_context :: proc "contextless" (c: ^Context) {
 		return
 	}
 
-	// NOTE(bill): Do not initialize these procedures with a call as they are not defined with the "contexless" calling convention
+	// NOTE(bill): Do not initialize these procedures with a call as they are not defined with the "contextless" calling convention
 	c.allocator.procedure = default_allocator_proc
 	c.allocator.data = nil
 

--- a/core/sys/windows/util.odin
+++ b/core/sys/windows/util.odin
@@ -15,6 +15,14 @@ HIWORD :: #force_inline proc "contextless" (x: DWORD) -> WORD {
 	return WORD(x >> 16)
 }
 
+GET_X_LPARAM :: #force_inline proc "contextless" (lp: LPARAM) -> c_int {
+	return cast(c_int)cast(c_short)LOWORD(cast(DWORD)lp)
+}
+
+GET_Y_LPARAM :: #force_inline proc "contextless" (lp: LPARAM) -> c_int {
+	return cast(c_int)cast(c_short)HIWORD(cast(DWORD)lp)
+}
+
 utf8_to_utf16 :: proc(s: string, allocator := context.temp_allocator) -> []u16 {
 	if len(s) < 1 {
 		return nil


### PR DESCRIPTION
This makes it easier to use with different allocators, since they accept different types for the size of memory, some use `int`, some use `uint`. It is also more consistent with the way `core:time` does constants for Second/Millisecond/etc.