### PR TITLE
add pretty json output in marshal

### DIFF
--- a/core/encoding/json/marshal.odin
+++ b/core/encoding/json/marshal.odin
@@ -22,13 +22,13 @@ Pretty :: struct {
 	indentation: int,
 }
 
-marshal :: proc(v: any, pretty: Pretty = {}, allocator := context.allocator) -> (data: []byte, err: Marshal_Error) {
+marshal :: proc(v: any, pretty_print := false, allocator := context.allocator) -> (data: []byte, err: Marshal_Error) {
 	b := strings.make_builder(allocator)
 	defer if err != nil {
 		strings.destroy_builder(&b)
 	}
 
-	pretty := pretty
+	pretty := Pretty { apply = pretty_print }
 	marshal_to_builder(&b, v, &pretty) or_return
 	
 	if len(b.buf) != 0 {


### PR DESCRIPTION
adds `pretty_print` option to the `json.marshal` procedure and will properly indent generated json by indentations - struct or array scopes

could add more options like `use_spaces` into the `Pretty` struct but this is enough for my taste :+1:  