### PR TITLE
Add convenience functions to print formatted cstrings to temp memory.

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -116,6 +116,30 @@ tprintf :: proc(fmt: string, args: ..any) -> string {
 	return strings.to_string(str)
 }
 
+// ctprint procedure returns a cstring that was allocated with the current context's temporary allocator
+ctprint :: proc(args: ..any, sep := " ") -> cstring {
+	str: strings.Builder
+	strings.init_builder(&str, context.temp_allocator)
+	sbprint(buf=&str, args=args, sep=sep)
+	strings.write_byte(&str, 0)
+	return strings.to_cstring(str)
+}
+// ctprintln procedure returns a cstring that was allocated with the current context's temporary allocator
+ctprintln :: proc(args: ..any, sep := " ") -> cstring {
+	str: strings.Builder
+	strings.init_builder(&str, context.temp_allocator)
+	sbprintln(buf=&str, args=args, sep=sep)
+	strings.write_byte(&str, 0)
+	return strings.to_cstring(str)
+}
+// ctprintf procedure returns a cstring that was allocated with the current context's temporary allocator
+ctprintf :: proc(fmt: string, args: ..any) -> cstring {
+	str: strings.Builder
+	strings.init_builder(&str, context.temp_allocator)
+	sbprintf(&str, fmt, ..args)
+	strings.write_byte(&str, 0)
+	return strings.to_cstring(str);
+}
 
 // bprint procedures return a string using a buffer from an array
 bprint :: proc(buf: []byte, args: ..any, sep := " ") -> string {

--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -138,7 +138,7 @@ ctprintf :: proc(fmt: string, args: ..any) -> cstring {
 	strings.init_builder(&str, context.temp_allocator)
 	sbprintf(&str, fmt, ..args)
 	strings.write_byte(&str, 0)
-	return strings.to_cstring(str);
+	return strings.to_cstring(str)
 }
 
 // bprint procedures return a string using a buffer from an array

--- a/core/strings/builder.odin
+++ b/core/strings/builder.odin
@@ -146,6 +146,12 @@ to_string :: proc(b: Builder) -> string {
 	return string(b.buf[:])
 }
 
+// cast the builder byte buffer to a cstring and return it. assert that the buffer ends with a terminating nul byte.
+to_cstring :: proc(b: Builder) -> cstring {
+	assert(b.buf[len(b.buf)-1] == 0)
+	return cstring(&b.buf[0])
+}
+
 // return the length of the builder byte buffer
 builder_len :: proc(b: Builder) -> int {
 	return len(b.buf)


### PR DESCRIPTION
Add procedures ctprint, ctrpintln and ctprintf that uses contexs temp_allocator and prints formatted cstrings. This reduces the amount of copies needed when interacting with c libraries.