### PR TITLE
[core:container/lru] Avoid unnecessary allocations

### DIFF
--- a/core/container/lru/lru_cache.odin
+++ b/core/container/lru/lru_cache.odin
@@ -65,20 +65,22 @@ set :: proc(c: ^$C/Cache($Key, $Value), key: Key, value: Value) -> runtime.Alloc
 		return nil
 	}
 
-	e := new(Node(Key, Value), c.node_allocator) or_return
-	e.key = key
-	e.value = value
-
+	e : ^Node(Key, Value) = nil
 	assert(c.count <= c.capacity)
 	if c.count == c.capacity {
-		_remove_node(c, c.tail)
+		e = c.tail
+		_remove_node(c, e)
 	}
 	else {
 		c.count += 1
+		e = new(Node(Key, Value), c.node_allocator) or_return
 	}
-	_push_front_node(c, e)
 
+	e.key = key
+	e.value = value
+	_push_front_node(c, e)
 	c.entries[key] = e
+
 	return nil
 }
 
@@ -128,6 +130,7 @@ remove :: proc(c: ^$C/Cache($Key, $Value), key: Key) -> bool {
 		return false
 	}
 	_remove_node(c, e)
+	free(node, c.node_allocator)
 	c.count -= 1
 	return true
 }
@@ -153,9 +156,6 @@ _remove_node :: proc(c: ^$C/Cache($Key, $Value), node: ^Node(Key, Value)) {
 	delete_key(&c.entries, node.key)
 
 	_call_on_remove(c, node)
-
-	free(node, c.node_allocator)
-
 }
 
 @(private)


### PR DESCRIPTION
This PR tries to avoid unnecessary allocations in `set` when the cache is full, by reusing the removed node object from the doubly-linked list instead of freeing it and allocating a new one.
