### PR TITLE
Make allocator in pool_add_task() explicit

### DIFF
--- a/core/thread/thread_pool.odin
+++ b/core/thread/thread_pool.odin
@@ -47,7 +47,7 @@ Pool :: struct {
 // it is destroyed. 
 //
 // The thread pool requires an allocator which it either owns, or which is thread safe.
-pool_init :: proc(pool: ^Pool, thread_count: int, allocator: mem.Allocator) {
+pool_init :: proc(pool: ^Pool, allocator: mem.Allocator, thread_count: int) {
 	context.allocator = allocator
 	pool.allocator = allocator
 	pool.tasks      = make([dynamic]Task)
@@ -114,7 +114,7 @@ pool_join :: proc(pool: ^Pool) {
 //
 // Each task also needs an allocator which it either owns, or which is thread
 // safe. 
-pool_add_task :: proc(pool: ^Pool, procedure: Task_Proc, data: rawptr, user_index: int = 0, allocator: mem.Allocator) {
+pool_add_task :: proc(pool: ^Pool, allocator: mem.Allocator, procedure: Task_Proc, data: rawptr, user_index: int = 0) {
 	sync.guard(&pool.mutex)
 
 	append(&pool.tasks, Task{

--- a/core/thread/thread_pool.odin
+++ b/core/thread/thread_pool.odin
@@ -44,7 +44,7 @@ Pool :: struct {
 }
 
 // Once initialized, the pool's memory address is not allowed to change until
-// it is destroyed. If thread_count < 1, thread count 1 will be used.
+// it is destroyed. 
 //
 // The thread pool requires an allocator which it either owns, or which is thread safe.
 pool_init :: proc(pool: ^Pool, thread_count: int, allocator: mem.Allocator) {

--- a/core/thread/thread_pool.odin
+++ b/core/thread/thread_pool.odin
@@ -113,9 +113,8 @@ pool_join :: proc(pool: ^Pool) {
 // the thread pool. You can even add tasks from inside other tasks.
 //
 // Each task also needs an allocator which it either owns, or which is thread
-// safe. By default, allocations in the task are disabled by use of the
-// nil_allocator.
-pool_add_task :: proc(pool: ^Pool, procedure: Task_Proc, data: rawptr, user_index: int = 0, allocator := context.allocator) {
+// safe. 
+pool_add_task :: proc(pool: ^Pool, procedure: Task_Proc, data: rawptr, user_index: int = 0, allocator: mem.Allocator) {
 	sync.guard(&pool.mutex)
 
 	append(&pool.tasks, Task{

--- a/examples/demo/demo.odin
+++ b/examples/demo/demo.odin
@@ -1166,7 +1166,8 @@ threading_example :: proc() {
 
 
 		for i in 0..<30 {
-			thread.pool_add_task(pool=&pool, procedure=task_proc, data=nil, user_index=i)
+			// be mindful of the allocator used for tasks. The allocator needs to be thread safe, or be owned by the task for exclusive use 
+			thread.pool_add_task(pool=&pool, procedure=task_proc, data=nil, user_index=i, allocator=context.allocator)
 		}
 
 		thread.pool_start(&pool)


### PR DESCRIPTION
There is no reason to assume the context allocator will be the correct one to use for the tasks. The user should definitely have to stop and think about the allocator when calling the procedure.