### PR TITLE
Add missing result parameter names

### DIFF
--- a/core/container/small_array/small_array.odin
+++ b/core/container/small_array/small_array.odin
@@ -86,7 +86,7 @@ pop_back_safe :: proc(a: ^$A/Small_Array($N, $T)) -> (item: T, ok: bool) {
 	return
 }
 
-pop_front_safe :: proc(a: ^$A/Small_Array($N, $T)) -> (T, bool) {
+pop_front_safe :: proc(a: ^$A/Small_Array($N, $T)) -> (item: T, ok: bool) {
 	if N > 0 && a.len > 0 {
 		item = a.data[0]
 		s := slice(a)


### PR DESCRIPTION
This adds some missing result parameters names back to pop_front_safe.

Currently the procedure won't compile since it's referencing missing variable names.