### PR TITLE
[xxhash] For the streaming tests, randomly select the size to use.

### DIFF
--- a/core/hash/xxhash/streaming.odin
+++ b/core/hash/xxhash/streaming.odin
@@ -211,7 +211,9 @@ XXH3_update :: #force_inline proc(
 	length := len(input)
 	secret := state.custom_secret[:] if len(state.external_secret) == 0 else state.external_secret[:]
 
-	assert(len(input) > 0)
+	if len(input) == 0 {
+		return
+	}
 
 	state.total_length += u64(length)
 	assert(state.buffered_size <= XXH3_INTERNAL_BUFFER_SIZE)


### PR DESCRIPTION
Randomize size used with `update`.

It'll print "Using user-selected seed {18109872483301276539,2000259725719371} for update size randomness."

If a streaming test then fails, you can repeat it using:
`odin run . -define:RAND_STATE=18109872483301276539 -define:RAND_INC=2000259725719371`