### PR TITLE
Use ints for TRUE/FALSE constants instead of booleans.

### DIFF
--- a/vendor/glfw/constants.odin
+++ b/vendor/glfw/constants.odin
@@ -7,8 +7,8 @@ VERSION_MINOR    :: 3
 VERSION_REVISION :: 4
 
 /* Booleans */
-TRUE  :: true
-FALSE :: false
+TRUE  :: 1
+FALSE :: 0
 
 /* Button/Key states */
 RELEASE :: 0


### PR DESCRIPTION
When trying to build something like
```
glfw.WindowHint(glfw.OPENGL_FORWARD_COMPAT, glfw.TRUE)
```
we get the following error
```
odin-examples/math/noise/draw_texture/noise.odin(163:51) Cannot convert 'glfw.TRUE' to 'i32' from 'untyped bool
```
Which is because the `TRUE`/`FALSE` constants were declared as:
```
/* Booleans */
TRUE  :: true
FALSE :: false
```
in `Odin/vendor/glfw/constants.odin`

We could case `glfw.TRUE` to `i32` to get of the error, or we can declare them as ints to begin with.