### PR TITLE
Fix join_multiple typo

### DIFF
--- a/core/thread/thread.odin
+++ b/core/thread/thread.odin
@@ -53,7 +53,7 @@ join :: proc(thread: ^Thread) {
 }
 
 
-join_mulitple :: proc(threads: ..^Thread) {
+join_multiple :: proc(threads: ..^Thread) {
 	_join_multiple(..threads)
 }
 


### PR DESCRIPTION
Fixes a small typo of the `join_multiple` function in the `core:thread` package.