### PR TITLE
Implement `pthread_cancel`.

### DIFF
--- a/core/sys/unix/pthread_darwin.odin
+++ b/core/sys/unix/pthread_darwin.odin
@@ -81,3 +81,16 @@ PTHREAD_MUTEX_NORMAL :: 0
 PTHREAD_MUTEX_RECURSIVE :: 1
 PTHREAD_MUTEX_ERRORCHECK :: 2
 
+PTHREAD_CANCEL_ENABLE       :: 0
+PTHREAD_CANCEL_DISABLE      :: 1
+PTHREAD_CANCEL_DEFERRED     :: 0
+PTHREAD_CANCEL_ASYNCHRONOUS :: 1
+
+foreign import pthread "System.framework"
+
+@(default_calling_convention="c")
+foreign pthread {
+	pthread_setcancelstate :: proc (state: c.int, old_state: ^c.int) -> c.int ---
+	pthread_setcanceltype  :: proc (type:  c.int, old_type:  ^c.int) -> c.int ---
+	pthread_cancel         :: proc (thread: pthread_t) -> c.int ---
+}

--- a/core/sys/unix/pthread_freebsd.odin
+++ b/core/sys/unix/pthread_freebsd.odin
@@ -92,6 +92,11 @@ sem_t :: struct {
 	_padding: u32,
 }
 
+PTHREAD_CANCEL_ENABLE       :: 0
+PTHREAD_CANCEL_DISABLE      :: 1
+PTHREAD_CANCEL_DEFERRED     :: 0
+PTHREAD_CANCEL_ASYNCHRONOUS :: 1
+
 foreign import "system:pthread"
 
 @(default_calling_convention="c")
@@ -110,5 +115,8 @@ foreign pthread {
 	// NOTE: unclear whether pthread_yield is well-supported on Linux systems,
 	// see https://linux.die.net/man/3/pthread_yield
 	pthread_yield :: proc() ---
-}
 
+	pthread_setcancelstate :: proc (state: c.int, old_state: ^c.int) -> c.int ---
+	pthread_setcanceltype  :: proc (type:  c.int, old_type:  ^c.int) -> c.int ---
+	pthread_cancel         :: proc (thread: pthread_t) -> c.int ---
+}

--- a/core/sys/unix/pthread_linux.odin
+++ b/core/sys/unix/pthread_linux.odin
@@ -94,6 +94,11 @@ when size_of(int) == 8 {
 	SEM_T_SIZE :: 16
 }
 
+PTHREAD_CANCEL_ENABLE       :: 0
+PTHREAD_CANCEL_DISABLE      :: 1
+PTHREAD_CANCEL_DEFERRED     :: 0
+PTHREAD_CANCEL_ASYNCHRONOUS :: 1
+
 foreign import "system:pthread"
 
 @(default_calling_convention="c")
@@ -112,4 +117,8 @@ foreign pthread {
 	// NOTE: unclear whether pthread_yield is well-supported on Linux systems,
 	// see https://linux.die.net/man/3/pthread_yield
 	pthread_yield :: proc() -> c.int ---
+
+	pthread_setcancelstate :: proc (state: c.int, old_state: ^c.int) -> c.int ---
+	pthread_setcanceltype  :: proc (type:  c.int, old_type:  ^c.int) -> c.int ---
+	pthread_cancel         :: proc (thread: pthread_t) -> c.int ---
 }

--- a/core/sys/unix/pthread_openbsd.odin
+++ b/core/sys/unix/pthread_openbsd.odin
@@ -46,6 +46,11 @@ sched_param :: struct {
 
 sem_t :: distinct rawptr
 
+PTHREAD_CANCEL_ENABLE       :: 0
+PTHREAD_CANCEL_DISABLE      :: 1
+PTHREAD_CANCEL_DEFERRED     :: 0
+PTHREAD_CANCEL_ASYNCHRONOUS :: 1
+
 foreign import libc "system:c"
 
 @(default_calling_convention="c")
@@ -62,4 +67,8 @@ foreign libc {
 	// NOTE: unclear whether pthread_yield is well-supported on Linux systems,
 	// see https://linux.die.net/man/3/pthread_yield
 	pthread_yield :: proc() ---
+
+	pthread_setcancelstate :: proc (state: c.int, old_state: ^c.int) -> c.int ---
+	pthread_setcanceltype  :: proc (type:  c.int, old_type:  ^c.int) -> c.int ---
+	pthread_cancel         :: proc (thread: pthread_t) -> c.int ---
 }


### PR DESCRIPTION
Implement `thread._terminate` on Linux, Mac and *BSD using `pthread_cancel`, add to demo.