### PR TITLE
Emit LLVM IR to never optimize/inline procs when building debug and -o:minimal

### DIFF
--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -139,33 +139,38 @@ lbProcedure *lb_create_procedure(lbModule *m, Entity *entity, bool ignore_body) 
 		lb_add_attribute_to_proc(m, p->value, "noredzone");
 	}
 
-	switch (p->inlining) {
-	case ProcInlining_inline:
-		lb_add_attribute_to_proc(m, p->value, "alwaysinline");
-		break;
-	case ProcInlining_no_inline:
+	if (build_context.optimization_level == 0 && build_context.ODIN_DEBUG) {
 		lb_add_attribute_to_proc(m, p->value, "noinline");
-		break;
+		lb_add_attribute_to_proc(m, p->value, "optnone");
+	} else {
+		switch (p->inlining) {
+		case ProcInlining_inline:
+			lb_add_attribute_to_proc(m, p->value, "alwaysinline");
+			break;
+		case ProcInlining_no_inline:
+			lb_add_attribute_to_proc(m, p->value, "noinline");
+			break;
+		}
+
+		switch (entity->Procedure.optimization_mode) {
+		case ProcedureOptimizationMode_None:
+			lb_add_attribute_to_proc(m, p->value, "optnone");
+			break;
+		case ProcedureOptimizationMode_Minimal:
+			lb_add_attribute_to_proc(m, p->value, "optnone");
+			break;
+		case ProcedureOptimizationMode_Size:
+			lb_add_attribute_to_proc(m, p->value, "optsize");
+			break;
+		case ProcedureOptimizationMode_Speed:
+			// TODO(bill): handle this correctly
+			lb_add_attribute_to_proc(m, p->value, "optsize");
+			break;
+		}
 	}
 
 	if (entity->flags & EntityFlag_Cold) {
 		lb_add_attribute_to_proc(m, p->value, "cold");
-	}
-
-	switch (entity->Procedure.optimization_mode) {
-	case ProcedureOptimizationMode_None:
-		lb_add_attribute_to_proc(m, p->value, "optnone");
-		break;
-	case ProcedureOptimizationMode_Minimal:
-		lb_add_attribute_to_proc(m, p->value, "optnone");
-		break;
-	case ProcedureOptimizationMode_Size:
-		lb_add_attribute_to_proc(m, p->value, "optsize");
-		break;
-	case ProcedureOptimizationMode_Speed:
-		// TODO(bill): handle this correctly
-		lb_add_attribute_to_proc(m, p->value, "optsize");
-		break;
 	}
 
 	lbValue proc_value = {p->value, p->type};


### PR DESCRIPTION
Hello! ✨ 

When stepping through a loop in `lldb` during debugging I bounced around unexpected source lines, ending up at proc entry, at `:0` in the file etc. Especially when stepping on instruction level with `si`. Even when I was building with `-debug -o:minimal`.

After further digging there seem to be some optimizations at play. I noticed that clang slaps on `optnone` and `noinline` function attrs in the LLVM IR when disabling optimizations. I emulated the behaviour by adding `#force_no_inline` and `@(optimization_mode="none")` on my proc which made stepping linear as expected.

So I simply amended the backend to always add `optnone` (which in turn requires `noinline`) to all procs when building `-debug -o:minimal` _as if_ all procs had `#force_no_inline` and `@(optimization_mode="none")`.

I've only encountered this issue when debugging in `lldb` on macOS. Stepping in RemedyBG on Windows seems to work as it should with and without this change. Not quite sure why, I kind of expected it to behave similarily iffy but I don't know how LLVM IR is made into the PDB when building on Windows. 🤷 

Let me know if there's any questions. 🙏 

### Example

```odin
package main

main :: proc() {
	loop := 0
	for loop < 5 {
		loop += 1
	}
}
```

#### Source locs on `master`
```
0x100005364:  E8 07 40 F9      ldr      x8, [sp, #8]           // hello.odin:3
0x100005368:  E8 03 00 F9      str      x8, [sp]               // hello.odin:3
0x10000536c:  08 15 00 F1      subs     x8, x8, #5             // hello.odin:5:2 -- break on main.main is here
0x100005370:  AA 00 00 54      b.ge     #0x100005384           // hello.odin:5:2
0x100005374:  E8 03 40 F9      ldr      x8, [sp]               // hello.odin:0:2
0x100005378:  08 05 00 91      add      x8, x8, #1             // hello.odin:6:8
0x10000537c:  E8 07 00 F9      str      x8, [sp, #8]           // hello.odin:0:2
0x100005380:  F9 FF FF 17      b        #0x100005364           // hello.odin:5:2
```

#### Source locs in PR
```
0x1000049d4:  FF 07 00 F9      str      xzr, [sp, #8]          // hello.odin:4:2 -- break on main.main is here
0x1000049d8:  FF 07 00 F9      str      xzr, [sp, #8]          // hello.odin:4:2
0x1000049dc:  E8 07 40 F9      ldr      x8, [sp, #8]           // hello.odin:5:2
0x1000049e0:  08 15 00 F1      subs     x8, x8, #5             // hello.odin:5:2
0x1000049e4:  E8 A7 9F 1A      cset     w8, lt                 // hello.odin:5:2
0x1000049e8:  A8 00 00 36      tbz      w8, #0, #0x1000049fc   // hello.odin:5:2
0x1000049ec:  E8 07 40 F9      ldr      x8, [sp, #8]           // hello.odin:6:8
0x1000049f0:  08 05 00 91      add      x8, x8, #1             // hello.odin:6:8
0x1000049f4:  E8 07 00 F9      str      x8, [sp, #8]           // hello.odin:6:8
0x1000049f8:  F9 FF FF 17      b        #0x1000049dc           // hello.odin:5:2
```