### PR TITLE
[os] Linux: os.unset_env()

### DIFF
--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -794,6 +794,15 @@ set_env :: proc(key, value: string) -> Errno {
 	return ERROR_NONE
 }
 
+unset_env :: proc(key: string) -> Errno {
+	s := strings.clone_to_cstring(key, context.temp_allocator)
+	res := _unix_putenv(s)
+	if res < 0 {
+		return Errno(get_last_error())
+	}
+	return ERROR_NONE
+}
+
 get_current_directory :: proc() -> string {
 	// NOTE(tetra): I would use PATH_MAX here, but I was not able to find
 	// an authoritative value for it across all systems.


### PR DESCRIPTION
`putenv` works by having it's string argument being either:
- `NAME=VALUE`, which sets `NAME` to `VALUE`, or;
- `NAME`, which unsets `NAME`.

The latter is used in this PR to implement `os.unset_env()` - at least until os/os2 is up.