### PR TITLE
[path/filepath] Change join() to take a []string instead of varargs

### DIFF
--- a/core/c/frontend/preprocessor/preprocess.odin
+++ b/core/c/frontend/preprocessor/preprocess.odin
@@ -1276,7 +1276,7 @@ preprocess_internal :: proc(cpp: ^Preprocessor, tok: ^Token) -> ^Token {
 				if start.file != nil {
 					dir = filepath.dir(start.file.name)
 				}
-				path := filepath.join(dir, filename)
+				path := filepath.join({dir, filename})
 				if os.exists(path) {
 					tok = include_file(cpp, tok, path, start.next.next)
 					continue

--- a/core/path/filepath/match.odin
+++ b/core/path/filepath/match.odin
@@ -305,7 +305,7 @@ _glob :: proc(dir, pattern: string, matches: ^[dynamic]string, allocator := cont
 		n := fi.name
 		matched := match(pattern, n) or_return
 		if matched {
-			append(&m, join(dir, n))
+			append(&m, join({dir, n}))
 		}
 	}
 	return

--- a/core/path/filepath/path_unix.odin
+++ b/core/path/filepath/path_unix.odin
@@ -38,7 +38,7 @@ abs :: proc(path: string, allocator := context.allocator) -> (string, bool) {
 	return path_str, true
 }
 
-join :: proc(elems: ..string, allocator := context.allocator) -> string {
+join :: proc(elems: []string, allocator := context.allocator) -> string {
 	for e, i in elems {
 		if e != "" {
 			p := strings.join(elems[i:], SEPARATOR_STRING, context.temp_allocator)

--- a/core/path/filepath/path_windows.odin
+++ b/core/path/filepath/path_windows.odin
@@ -88,7 +88,7 @@ abs :: proc(path: string, allocator := context.allocator) -> (string, bool) {
 }
 
 
-join :: proc(elems: ..string, allocator := context.allocator) -> string {
+join :: proc(elems: []string, allocator := context.allocator) -> string {
 	for e, i in elems {
 		if e != "" {
 			return join_non_empty(elems[i:], allocator)


### PR DESCRIPTION
This makes passing an allocator easier, as you no longer have to resort to
named arguments:

Current master:
> `join(a, b, c)` became `join(elems={a, b, c}, allocator=ally)`

This PR:
> `join({a, b, c})` becomes `join({a, b, c}, ally)`

Note also that `strings.join` already takes `[]string`:
```odin
join :: proc(a: []string, sep: string, allocator := context.allocator) -> string { ... }
```