### PR TITLE
Refactor ms_craziness.h

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1221,12 +1221,13 @@ bool init_build_paths(String init_filename) {
 		}
 
 		if (bc->pdb_filepath.len > 0) {
-			bc->build_paths[BuildPath_PDB]          = path_from_string(ha, bc->pdb_filepath);
+			bc->build_paths[BuildPath_PDB]     = path_from_string(ha, bc->pdb_filepath);
 		}
 
 		if ((bc->command_kind & Command__does_build) && (!bc->ignore_microsoft_magic)) {
 			// NOTE(ic): It would be nice to extend this so that we could specify the Visual Studio version that we want instead of defaulting to the latest.
 			Find_Result_Utf8 find_result = find_visual_studio_and_windows_sdk_utf8();
+			defer (mc_free_all());
 
 			if (find_result.windows_sdk_version == 0) {
 				gb_printf_err("Windows SDK not found.\n");
@@ -1256,13 +1257,6 @@ bool init_build_paths(String init_filename) {
 					bc->build_paths[BuildPath_VS_LIB]           = path_from_string(ha, find_result.vs_library_path);
 				}
 			}
-
-			gb_free(ha, find_result.windows_sdk_root.text);
-			gb_free(ha, find_result.windows_sdk_um_library_path.text);
-			gb_free(ha, find_result.windows_sdk_ucrt_library_path.text);
-			gb_free(ha, find_result.vs_exe_path.text);
-			gb_free(ha, find_result.vs_library_path.text);
-
 		}
 	#endif
 
@@ -1344,9 +1338,9 @@ bool init_build_paths(String init_filename) {
 				output_name.len -= 1;
 			}
 			output_name = remove_directory_from_path(output_name);
-			output_name        = remove_extension_from_path(output_name);
-			output_name        = copy_string(ha, string_trim_whitespace(output_name));
-			output_path        = path_from_string(ha, output_name);
+			output_name = remove_extension_from_path(output_name);
+			output_name = copy_string(ha, string_trim_whitespace(output_name));
+			output_path = path_from_string(ha, output_name);
 
 			// Replace extension.
 			if (output_path.ext.len > 0) {

--- a/src/microsoft_craziness.h
+++ b/src/microsoft_craziness.h
@@ -45,53 +45,92 @@
 //
 // Here is the API you need to know about:
 //
-
-
 gb_global gbAllocator mc_allocator = heap_allocator();
 
 struct Find_Result {
-    int windows_sdk_version;   // Zero if no Windows SDK found.
+	int windows_sdk_version;   // Zero if no Windows SDK found.
 
-    wchar_t const *windows_sdk_root;
-    wchar_t const *windows_sdk_um_library_path;
-    wchar_t const *windows_sdk_ucrt_library_path;
+	wchar_t const *windows_sdk_root;
+	wchar_t const *windows_sdk_um_library_path;
+	wchar_t const *windows_sdk_ucrt_library_path;
 
-    wchar_t const *vs_exe_path;
-    wchar_t const *vs_library_path;
+	wchar_t const *vs_exe_path;
+	wchar_t const *vs_library_path;
 };
 
 struct Find_Result_Utf8 {
-    int windows_sdk_version;   // Zero if no Windows SDK found.
+	int windows_sdk_version;   // Zero if no Windows SDK found.
 
-    String windows_sdk_root;
-    String windows_sdk_um_library_path;
-    String windows_sdk_ucrt_library_path;
+	String windows_sdk_root;
+	String windows_sdk_um_library_path;
+	String windows_sdk_ucrt_library_path;
 
-    String vs_exe_path;
-    String vs_library_path;
+	String vs_exe_path;
+	String vs_library_path;
 };
 
-
-Find_Result find_visual_studio_and_windows_sdk();
 Find_Result_Utf8 find_visual_studio_and_windows_sdk_utf8();
 
-void free_resources(Find_Result *result) {
-    // free(result->windows_sdk_root);
-    // free(result->windows_sdk_um_library_path);
-    // free(result->windows_sdk_ucrt_library_path);
-    // free(result->vs_exe_path);
-    // free(result->vs_library_path);
+String mc_wstring_to_string(wchar_t const *str) {
+	return string16_to_string(mc_allocator, make_string16_c(str));
 }
 
-void free_resources(Find_Result_Utf8 *result) {
-    // gbAllocator a = heap_allocator();
-    // gb_free(a, result->windows_sdk_root.text);
-    // gb_free(a, result->windows_sdk_um_library_path.text);
-    // gb_free(a, result->windows_sdk_ucrt_library_path.text);
-    // gb_free(a, result->vs_exe_path.text);
-    // gb_free(a, result->vs_library_path.text);
+String16 mc_string_to_wstring(String str) {
+	return string_to_string16(mc_allocator, str);
 }
 
+String mc_concat(String a, String b) {
+	return concatenate_strings(mc_allocator, a, b);
+}
+
+String mc_concat(String a, String b, String c) {
+	return concatenate3_strings(mc_allocator, a, b, c);
+}
+
+void mc_free(String str) {
+	gb_free(mc_allocator, str.text);
+}
+
+void mc_free(String16 str) {
+	gb_free(mc_allocator, str.text);
+}
+
+void mc_free_all() {
+	gb_free_all(mc_allocator);
+}
+
+typedef struct _MC_Find_Data {
+	DWORD  file_attributes;
+	String filename;
+} MC_Find_Data;
+
+
+HANDLE mc_find_first(String wildcard, MC_Find_Data *find_data) {
+ 	WIN32_FIND_DATAW _find_data;
+
+ 	String16 wildcard_wide = mc_string_to_wstring(wildcard);
+ 	defer (mc_free(wildcard_wide));
+
+ 	HANDLE handle = FindFirstFileW(wildcard_wide.text, &_find_data);
+ 	if (handle == INVALID_HANDLE_VALUE) return false;
+
+ 	find_data->file_attributes = _find_data.dwFileAttributes;
+ 	find_data->filename        = mc_wstring_to_string(_find_data.cFileName);
+ 	return handle;
+}
+
+bool mc_find_next(HANDLE handle, MC_Find_Data *find_data) {
+ 	WIN32_FIND_DATAW _find_data;
+ 	bool success = FindNextFileW(handle, &_find_data);
+
+ 	find_data->file_attributes = _find_data.dwFileAttributes;
+ 	find_data->filename        = mc_wstring_to_string(_find_data.cFileName);
+ 	return success;
+}
+
+void mc_find_close(HANDLE handle) {
+	FindClose(handle);
+}
 
 //
 // Call find_visual_studio_and_windows_sdk, look at the resulting
@@ -149,474 +188,453 @@ typedef const WCHAR* LPCOLESTR;
 
 struct DECLSPEC_UUID("B41463C3-8866-43B5-BC33-2B0676F7F42E") DECLSPEC_NOVTABLE ISetupInstance : public IUnknown
 {
-    virtual HRESULT STDMETHODCALLTYPE GetInstanceId(BSTR* pbstrInstanceId) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetInstallDate(LPFILETIME pInstallDate) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetInstallationName(BSTR* pbstrInstallationName) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetInstallationPath(BSTR* pbstrInstallationPath) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetInstallationVersion(BSTR* pbstrInstallationVersion) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetDisplayName(LCID lcid, BSTR* pbstrDisplayName) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetDescription(LCID lcid, BSTR* pbstrDescription) = 0;
-    virtual HRESULT STDMETHODCALLTYPE ResolvePath(LPCOLESTR pwszRelativePath, BSTR* pbstrAbsolutePath) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetInstanceId(BSTR* pbstrInstanceId) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetInstallDate(LPFILETIME pInstallDate) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetInstallationName(BSTR* pbstrInstallationName) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetInstallationPath(BSTR* pbstrInstallationPath) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetInstallationVersion(BSTR* pbstrInstallationVersion) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetDisplayName(LCID lcid, BSTR* pbstrDisplayName) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetDescription(LCID lcid, BSTR* pbstrDescription) = 0;
+	virtual HRESULT STDMETHODCALLTYPE ResolvePath(LPCOLESTR pwszRelativePath, BSTR* pbstrAbsolutePath) = 0;
 };
 
 struct DECLSPEC_UUID("6380BCFF-41D3-4B2E-8B2E-BF8A6810C848") DECLSPEC_NOVTABLE IEnumSetupInstances : public IUnknown
 {
-    virtual HRESULT STDMETHODCALLTYPE Next(ULONG celt, ISetupInstance** rgelt, ULONG* pceltFetched) = 0;
-    virtual HRESULT STDMETHODCALLTYPE Skip(ULONG celt) = 0;
-    virtual HRESULT STDMETHODCALLTYPE Reset(void) = 0;
-    virtual HRESULT STDMETHODCALLTYPE Clone(IEnumSetupInstances** ppenum) = 0;
+	virtual HRESULT STDMETHODCALLTYPE Next(ULONG celt, ISetupInstance** rgelt, ULONG* pceltFetched) = 0;
+	virtual HRESULT STDMETHODCALLTYPE Skip(ULONG celt) = 0;
+	virtual HRESULT STDMETHODCALLTYPE Reset(void) = 0;
+	virtual HRESULT STDMETHODCALLTYPE Clone(IEnumSetupInstances** ppenum) = 0;
 };
 
 struct DECLSPEC_UUID("42843719-DB4C-46C2-8E7C-64F1816EFD5B") DECLSPEC_NOVTABLE ISetupConfiguration : public IUnknown
 {
-    virtual HRESULT STDMETHODCALLTYPE EnumInstances(IEnumSetupInstances** ppEnumInstances) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetInstanceForCurrentProcess(ISetupInstance** ppInstance) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetInstanceForPath(LPCWSTR wzPath, ISetupInstance** ppInstance) = 0;
+	virtual HRESULT STDMETHODCALLTYPE EnumInstances(IEnumSetupInstances** ppEnumInstances) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetInstanceForCurrentProcess(ISetupInstance** ppInstance) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetInstanceForPath(LPCWSTR wzPath, ISetupInstance** ppInstance) = 0;
 };
 
 
 // The beginning of the actual code that does things.
 
 struct Version_Data {
-    i32 best_version[4];  // For Windows 8 versions, only two of these numbers are used.
-    wchar_t const *best_name;
+	i32 best_version[4];  // For Windows 8 versions, only two of these numbers are used.
+	wchar_t const *best_name;
 };
 
 bool os_file_exists(wchar_t const *name) {
-    // @Robustness: What flags do we really want to check here?
+	// @Robustness: What flags do we really want to check here?
 
-    auto attrib = GetFileAttributesW(name);
-    if (attrib == INVALID_FILE_ATTRIBUTES) return false;
-    if (attrib & FILE_ATTRIBUTE_DIRECTORY) return false;
+	auto attrib = GetFileAttributesW(name);
+	if (attrib == INVALID_FILE_ATTRIBUTES) return false;
+	if (attrib & FILE_ATTRIBUTE_DIRECTORY) return false;
 
-    return true;
+	return true;
 }
 
 wchar_t *concat(wchar_t const *a, wchar_t const *b, wchar_t const *c = nullptr, wchar_t const *d = nullptr) {
-    // Concatenate up to 4 wide strings together. Allocated with malloc.
-    // If you don't like that, use a programming language that actually
-    // helps you with using custom allocators. Or just edit the code.
+	// Concatenate up to 4 wide strings together. Allocated with malloc.
+	// If you don't like that, use a programming language that actually
+	// helps you with using custom allocators. Or just edit the code.
 
-    isize len_a = string16_len(a);
-    isize len_b = string16_len(b);
-    isize len_c = string16_len(c);
-    isize len_d = string16_len(d);
+	isize len_a = string16_len(a);
+	isize len_b = string16_len(b);
+	isize len_c = string16_len(c);
+	isize len_d = string16_len(d);
 
-    wchar_t *result = (wchar_t *)calloc(2, (len_a + len_b + len_c + len_d + 1));
-    gb_memmove(result, a, len_a*2);
-    gb_memmove(result + len_a, b, len_b*2);
+	wchar_t *result = (wchar_t *)calloc(2, (len_a + len_b + len_c + len_d + 1));
+	gb_memmove(result, a, len_a*2);
+	gb_memmove(result + len_a, b, len_b*2);
 
-    if (c) gb_memmove(result + len_a + len_b, c, len_c * 2);
-    if (d) gb_memmove(result + len_a + len_b + len_c, d, len_d * 2);
+	if (c) gb_memmove(result + len_a + len_b, c, len_c * 2);
+	if (d) gb_memmove(result + len_a + len_b + len_c, d, len_d * 2);
 
-    result[len_a + len_b + len_c + len_d] = 0;
+	result[len_a + len_b + len_c + len_d] = 0;
 
-    return result;
+	return result;
 }
 
-typedef void (*Visit_Proc_W)(wchar_t const *short_name, wchar_t const *full_name, Version_Data *data);
-bool visit_files_w(wchar_t const *dir_name, Version_Data *data, Visit_Proc_W proc) {
+struct Version_Data_Utf8 {
+	i32 best_version[4];  // For Windows 8 versions, only two of these numbers are used.
+	String best_name;
+};
 
-    // Visit everything in one folder (non-recursively). If it's a directory
-    // that doesn't start with ".", call the visit proc on it. The visit proc
-    // will see if the filename conforms to the expected versioning pattern.
+typedef void (*MC_Visit_Proc)(String short_name, String full_name, Version_Data_Utf8 *data);
+bool mc_visit_files(String dir_name, Version_Data_Utf8 *data, MC_Visit_Proc proc) {
 
-    auto wildcard_name = concat(dir_name, L"\\*");
-    defer (free(wildcard_name));
+	// Visit everything in one folder (non-recursively). If it's a directory
+	// that doesn't start with ".", call the visit proc on it. The visit proc
+	// will see if the filename conforms to the expected versioning pattern.
 
-    WIN32_FIND_DATAW find_data;
-    auto handle = FindFirstFileW(wildcard_name, &find_data);
-    if (handle == INVALID_HANDLE_VALUE) return false;
+	String wildcard_name = mc_concat(dir_name, str_lit("\\*"));
+	defer (mc_free(wildcard_name));
 
-    while (true) {
-        if ((find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) && (find_data.cFileName[0] != '.')) {
-            auto full_name = concat(dir_name, L"\\", find_data.cFileName);
-            defer (free(full_name));
+	MC_Find_Data find_data;
 
-            proc(find_data.cFileName, full_name, data);
-        }
+	HANDLE handle = mc_find_first(wildcard_name, &find_data);
+	if (handle == INVALID_HANDLE_VALUE) return false;
 
-        auto success = FindNextFileW(handle, &find_data);
-        if (!success) break;
-    }
+	bool success = true;
+	while (success) {
+		if ((find_data.file_attributes & FILE_ATTRIBUTE_DIRECTORY) && (find_data.filename[0] != '.')) {
+			String full_name = mc_concat(dir_name, str_lit("\\"), find_data.filename);
+			defer (mc_free(full_name));
 
-    FindClose(handle);
+			proc(find_data.filename, full_name, data);
+		}
 
-    return true;
+		success = mc_find_next(handle, &find_data);
+		if (!success) break;
+	}
+	mc_find_close(handle);
+	return true;
 }
 
+String find_windows_kit_root(HKEY key, String const version) {
+	// Given a key to an already opened registry entry,
+	// get the value stored under the 'version' subkey.
+	// If that's not the right terminology, hey, I never do registry stuff.
 
-wchar_t *find_windows_kit_root(HKEY key, wchar_t const *version) {
-    // Given a key to an already opened registry entry,
-    // get the value stored under the 'version' subkey.
-    // If that's not the right terminology, hey, I never do registry stuff.
+	char *version_str = (char*)version.text;
 
-    DWORD required_length;
-    auto rc = RegQueryValueExW(key, version, NULL, NULL, NULL, &required_length);
-    if (rc != 0)  return NULL;
+	DWORD required_length;
+	auto rc = RegQueryValueExA(key, version_str, NULL, NULL, NULL, &required_length);
+	if (rc != 0)  return {};
 
-    DWORD length = required_length + 2;  // The +2 is for the maybe optional zero later on. Probably we are over-allocating.
-    wchar_t *value = (wchar_t *)calloc(1, length);
-    if (!value) return NULL;
+	DWORD length = required_length + 2;  // The +2 is for the maybe optional zero later on. Probably we are over-allocating.
+	char *c_str = gb_alloc_array(mc_allocator, char, length);
 
-    rc = RegQueryValueExW(key, version, NULL, NULL, (LPBYTE)value, &length);  // We know that version is zero-terminated...
-    if (rc != 0)  return NULL;
+	rc = RegQueryValueExA(key, version_str, NULL, NULL, (LPBYTE)c_str, &length);  // We know that version is zero-terminated...
+	if (rc != 0)  return {};
 
-    // The documentation says that if the string for some reason was not stored
-    // with zero-termination, we need to manually terminate it. Sigh!!
+	// The documentation says that if the string for some reason was not stored
+	// with zero-termination, we need to manually terminate it. Sigh!!
 
-    if (value[length]) {
-        value[length+1] = 0;
-    }
+	if (c_str[required_length]) {
+		c_str[required_length+1] = 0;
+	}
 
-    return value;
+	String value = make_string_c(c_str);
+
+	return value;
 }
 
-void win10_best(wchar_t const *short_name, wchar_t const *full_name, Version_Data *data) {
-    // Find the Windows 10 subdirectory with the highest version number.
+void win10_best(String short_name, String full_name, Version_Data_Utf8 *data) {
+	// Find the Windows 10 subdirectory with the highest version number.
 
-    int i0, i1, i2, i3;
-    auto success = swscanf_s(short_name, L"%d.%d.%d.%d", &i0, &i1, &i2, &i3);
-    if (success < 4) return;
+	int i0, i1, i2, i3;
+	auto success = sscanf_s((const char *const)short_name.text, "%d.%d.%d.%d", &i0, &i1, &i2, &i3);
+	if (success < 4) return;
 
-    if (i0 < data->best_version[0]) return;
-    else if (i0 == data->best_version[0]) {
-        if (i1 < data->best_version[1]) return;
-        else if (i1 == data->best_version[1]) {
-            if (i2 < data->best_version[2]) return;
-            else if (i2 == data->best_version[2]) {
-                if (i3 < data->best_version[3]) return;
-            }
-        }
-    }
+	if (i0 < data->best_version[0]) return;
+	else if (i0 == data->best_version[0]) {
+		if (i1 < data->best_version[1]) return;
+		else if (i1 == data->best_version[1]) {
+			if (i2 < data->best_version[2]) return;
+			else if (i2 == data->best_version[2]) {
+				if (i3 < data->best_version[3]) return;
+			}
+		}
+	}
 
-    // we have to copy_string and free here because visit_files free's the full_name string
-    // after we execute this function, so Win*_Data would contain an invalid pointer.
-    if (data->best_name) free((void *)data->best_name);
-    data->best_name = _wcsdup(full_name);
+	// we have to copy_string and free here because visit_files free's the full_name string
+	// after we execute this function, so Win*_Data would contain an invalid pointer.
+	if (data->best_name.len > 0) mc_free(data->best_name);
 
-    if (data->best_name) {
-        data->best_version[0] = i0;
-        data->best_version[1] = i1;
-        data->best_version[2] = i2;
-        data->best_version[3] = i3;
-    }
+	data->best_name = copy_string(mc_allocator, full_name);
+
+	if (data->best_name.len > 0) {
+		data->best_version[0] = i0;
+		data->best_version[1] = i1;
+		data->best_version[2] = i2;
+		data->best_version[3] = i3;
+	}
 }
 
-void win8_best(wchar_t const *short_name, wchar_t const *full_name, Version_Data *data) {
-    // Find the Windows 8 subdirectory with the highest version number.
+void win8_best(String short_name, String full_name, Version_Data_Utf8 *data) {
+	// Find the Windows 8 subdirectory with the highest version number.
 
-    int i0, i1;
-    auto success = swscanf_s(short_name, L"winv%d.%d", &i0, &i1);
-    if (success < 2) return;
+	int i0, i1;
+	auto success = sscanf_s((const char *const)short_name.text, "winv%d.%d", &i0, &i1);
+	if (success < 2) return;
 
-    if (i0 < data->best_version[0]) return;
-    else if (i0 == data->best_version[0]) {
-        if (i1 < data->best_version[1]) return;
-    }
+	if (i0 < data->best_version[0]) return;
+	else if (i0 == data->best_version[0]) {
+		if (i1 < data->best_version[1]) return;
+	}
 
-    // we have to copy_string and free here because visit_files free's the full_name string
-    // after we execute this function, so Win*_Data would contain an invalid pointer.
-    if (data->best_name) free((void *)data->best_name);
-    data->best_name = _wcsdup(full_name);
+	// we have to copy_string and free here because visit_files free's the full_name string
+	// after we execute this function, so Win*_Data would contain an invalid pointer.
+	if (data->best_name.len > 0) mc_free(data->best_name);
+	data->best_name = copy_string(mc_allocator, full_name);
 
-    if (data->best_name) {
-        data->best_version[0] = i0;
-        data->best_version[1] = i1;
-    }
+	if (data->best_name.len > 0) {
+		data->best_version[0] = i0;
+		data->best_version[1] = i1;
+	}
 }
 
-void find_windows_kit_root(Find_Result *result) {
-    // Information about the Windows 10 and Windows 8 development kits
-    // is stored in the same place in the registry. We open a key
-    // to that place, first checking preferntially for a Windows 10 kit,
-    // then, if that's not found, a Windows 8 kit.
+void find_windows_kit_root(Find_Result_Utf8 *result) {
+	// Information about the Windows 10 and Windows 8 development kits
+	// is stored in the same place in the registry. We open a key
+	// to that place, first checking preferntially for a Windows 10 kit,
+	// then, if that's not found, a Windows 8 kit.
 
-    HKEY main_key;
+	HKEY main_key;
 
-    auto rc = RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots",
-                            0, KEY_QUERY_VALUE | KEY_WOW64_32KEY | KEY_ENUMERATE_SUB_KEYS, &main_key);
-    if (rc != S_OK) return;
-    defer (RegCloseKey(main_key));
+	auto rc = RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots",
+							0, KEY_QUERY_VALUE | KEY_WOW64_32KEY | KEY_ENUMERATE_SUB_KEYS, &main_key);
+	if (rc != S_OK) return;
+	defer (RegCloseKey(main_key));
 
-    // Look for a Windows 10 entry.
-    auto windows10_root = find_windows_kit_root(main_key, L"KitsRoot10");
+	// Look for a Windows 10 entry.
+	String windows10_root = find_windows_kit_root(main_key, str_lit("KitsRoot10"));
 
+	if (windows10_root.len > 0) {
+		defer (mc_free(windows10_root));
 
-    if (windows10_root) {
-        defer (free(windows10_root));
+		String windows10_lib = mc_concat(windows10_root, str_lit("Lib"));
+		defer (mc_free(windows10_lib));
 
+		Version_Data_Utf8 data = {0};
+		mc_visit_files(windows10_lib, &data, win10_best);
+		if (data.best_name.len > 0) {
+			result->windows_sdk_version = 10;
+			result->windows_sdk_root    = mc_concat(data.best_name, str_lit("\\"));
+			return;
+		}
+		mc_free(data.best_name);
+	}
 
-        Version_Data data = {0};
-        auto windows10_lib = concat(windows10_root, L"Lib");
-        defer (free(windows10_lib));
+	// Look for a Windows 8 entry.
+	String windows8_root = find_windows_kit_root(main_key, str_lit("KitsRoot81"));
 
+	if (windows8_root.len > 0) {
+		defer (mc_free(windows8_root));
 
-        visit_files_w(windows10_lib, &data, win10_best);
-        if (data.best_name) {
-            result->windows_sdk_version = 10;
-            result->windows_sdk_root = concat(data.best_name, L"\\");
-            return;
-        }
-    }
+		String windows8_lib = mc_concat(windows8_root, str_lit("Lib"));
+		defer (mc_free(windows8_lib));
 
-    // Look for a Windows 8 entry.
-    auto windows8_root = find_windows_kit_root(main_key, L"KitsRoot81");
-
-    if (windows8_root) {
-        defer (free(windows8_root));
-
-        auto windows8_lib = concat(windows8_root, L"Lib");
-        defer (free(windows8_lib));
-
-        Version_Data data = {0};
-        visit_files_w(windows8_lib, &data, win8_best);
-        if (data.best_name) {
-            result->windows_sdk_version = 8;
-            result->windows_sdk_root = concat(data.best_name, L"\\");
-            return;
-        }
-    }
-
-    // If we get here, we failed to find anything.
+		Version_Data_Utf8 data = {0};
+		mc_visit_files(windows8_lib, &data, win8_best);
+		if (data.best_name.len > 0) {
+			result->windows_sdk_version = 8;
+			result->windows_sdk_root    = mc_concat(data.best_name, str_lit("\\"));
+			return;
+		}
+		mc_free(data.best_name);
+	}
+	// If we get here, we failed to find anything.
 }
-
 
 bool find_visual_studio_by_fighting_through_microsoft_craziness(Find_Result *result) {
-    // The name of this procedure is kind of cryptic. Its purpose is
-    // to fight through Microsoft craziness. The things that the fine
-    // Visual Studio team want you to do, JUST TO FIND A SINGLE FOLDER
-    // THAT EVERYONE NEEDS TO FIND, are ridiculous garbage.
+	// The name of this procedure is kind of cryptic. Its purpose is
+	// to fight through Microsoft craziness. The things that the fine
+	// Visual Studio team want you to do, JUST TO FIND A SINGLE FOLDER
+	// THAT EVERYONE NEEDS TO FIND, are ridiculous garbage.
 
-    // For earlier versions of Visual Studio, you'd find this information in the registry,
-    // similarly to the Windows Kits above. But no, now it's the future, so to ask the
-    // question "Where is the Visual Studio folder?" you have to do a bunch of COM object
-    // instantiation, enumeration, and querying. (For extra bonus points, try doing this in
-    // a new, underdeveloped programming language where you don't have COM routines up
-    // and running yet. So fun.)
-    //
-    // If all this COM object instantiation, enumeration, and querying doesn't give us
-    // a useful result, we drop back to the registry-checking method.
-
-
-    auto rc = CoInitialize(NULL);
-    // "Subsequent valid calls return false." So ignore false.
-    if (rc != S_OK)  return false;
-
-    GUID my_uid                   = {0x42843719, 0xDB4C, 0x46C2, {0x8E, 0x7C, 0x64, 0xF1, 0x81, 0x6E, 0xFD, 0x5B}};
-    GUID CLSID_SetupConfiguration = {0x177F0C4A, 0x1CD3, 0x4DE7, {0xA3, 0x2C, 0x71, 0xDB, 0xBB, 0x9F, 0xA3, 0x6D}};
-
-    ISetupConfiguration *config = NULL;
-    HRESULT hr = 0;
-    hr = CoCreateInstance(CLSID_SetupConfiguration, NULL, CLSCTX_INPROC_SERVER, my_uid, (void **)&config);
-    if (hr == 0) {
-        defer (config->Release());
-
-        IEnumSetupInstances *instances = NULL;
-        hr = config->EnumInstances(&instances);
-        if (hr != 0)     return false;
-        if (!instances)  return false;
-        defer (instances->Release());
-
-        for (;;) {
-            ULONG found = 0;
-            ISetupInstance *instance = NULL;
-            auto hr = instances->Next(1, &instance, &found);
-            if (hr != S_OK) break;
-
-            defer (instance->Release());
-
-            BSTR bstr_inst_path;
-            hr = instance->GetInstallationPath(&bstr_inst_path);
-            if (hr != S_OK)  continue;
-            defer (SysFreeString(bstr_inst_path));
-
-            auto tools_filename = concat(bstr_inst_path, L"\\VC\\Auxiliary\\Build\\Microsoft.VCToolsVersion.default.txt");
-            defer (free(tools_filename));
-
-            FILE *f = nullptr;
-            auto open_result = _wfopen_s(&f, tools_filename, L"rt");
-            if (open_result != 0) continue;
-            if (!f) continue;
-            defer (fclose(f));
-
-            LARGE_INTEGER tools_file_size;
-            auto file_handle = (HANDLE)_get_osfhandle(_fileno(f));
-            BOOL success = GetFileSizeEx(file_handle, &tools_file_size);
-            if (!success) continue;
-
-            auto version_bytes = (tools_file_size.QuadPart + 1) * 2;  // Warning: This multiplication by 2 presumes there is no variable-length encoding in the wchars (wacky characters in the file could betray this expectation).
-            if (version_bytes > 0x7FFFFFFF) continue;   // Avoid overflow.
-
-            wchar_t *version = (wchar_t *)calloc(1, (usize)version_bytes);
-            defer (free(version));
-
-            auto read_result = fgetws(version, (int)version_bytes, f);
-            if (!read_result) continue;
-
-            auto version_tail = wcschr(version, '\n');
-            if (version_tail)  *version_tail = 0;  // Stomp the data, because nobody cares about it.
-
-            wchar_t *library_path = nullptr;
-            if (build_context.metrics.arch == TargetArch_amd64) {
-                library_path = concat(bstr_inst_path, L"\\VC\\Tools\\MSVC\\", version, L"\\lib\\x64\\");
-            } else if (build_context.metrics.arch == TargetArch_i386) {
-                library_path = concat(bstr_inst_path, L"\\VC\\Tools\\MSVC\\", version, L"\\lib\\x86\\");
-            } else {
-                continue;
-            }
-
-            auto library_file = concat(library_path, L"vcruntime.lib");  // @Speed: Could have library_path point to this string, with a smaller count, to save on memory flailing!
-
-            if (os_file_exists(library_file)) {
-                wchar_t *link_exe_path = nullptr;
-                if (build_context.metrics.arch == TargetArch_amd64) {
-                    link_exe_path = concat(bstr_inst_path, L"\\VC\\Tools\\MSVC\\", version, L"\\bin\\Hostx64\\x64\\");
-                } else if (build_context.metrics.arch == TargetArch_i386) {
-                    link_exe_path = concat(bstr_inst_path, L"\\VC\\Tools\\MSVC\\", version, L"\\bin\\Hostx86\\x86\\");
-                } else {
-                    continue;
-                }
+	// For earlier versions of Visual Studio, you'd find this information in the registry,
+	// similarly to the Windows Kits above. But no, now it's the future, so to ask the
+	// question "Where is the Visual Studio folder?" you have to do a bunch of COM object
+	// instantiation, enumeration, and querying. (For extra bonus points, try doing this in
+	// a new, underdeveloped programming language where you don't have COM routines up
+	// and running yet. So fun.)
+	//
+	// If all this COM object instantiation, enumeration, and querying doesn't give us
+	// a useful result, we drop back to the registry-checking method.
 
 
-                result->vs_exe_path     = link_exe_path;
-                result->vs_library_path = library_path;
-                return true;
-            }
+	auto rc = CoInitialize(NULL);
+	// "Subsequent valid calls return false." So ignore false.
+	if (rc != S_OK)  return false;
 
-            /*
-               Ryan Saunderson said:
-               "Clang uses the 'SetupInstance->GetInstallationVersion' / ISetupHelper->ParseVersion to find the newest version
-               and then reads the tools file to define the tools path - which is definitely better than what i did."
+	GUID my_uid                   = {0x42843719, 0xDB4C, 0x46C2, {0x8E, 0x7C, 0x64, 0xF1, 0x81, 0x6E, 0xFD, 0x5B}};
+	GUID CLSID_SetupConfiguration = {0x177F0C4A, 0x1CD3, 0x4DE7, {0xA3, 0x2C, 0x71, 0xDB, 0xBB, 0x9F, 0xA3, 0x6D}};
 
-               So... @Incomplete: Should probably pick the newest version...
-            */
-        }
-    }
+	ISetupConfiguration *config = NULL;
+	HRESULT hr = 0;
+	hr = CoCreateInstance(CLSID_SetupConfiguration, NULL, CLSCTX_INPROC_SERVER, my_uid, (void **)&config);
+	if (hr == 0) {
+		defer (config->Release());
 
-    // If we get here, we didn't find Visual Studio 2017. Try earlier versions.
-    {
-        HKEY vs7_key;
-        rc = RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\VisualStudio\\SxS\\VS7", 0, KEY_QUERY_VALUE | KEY_WOW64_32KEY, &vs7_key);
-        if (rc != S_OK)  return false;
-        defer (RegCloseKey(vs7_key));
+		IEnumSetupInstances *instances = NULL;
+		hr = config->EnumInstances(&instances);
+		if (hr != 0)     return false;
+		if (!instances)  return false;
+		defer (instances->Release());
 
-        // Hardcoded search for 4 prior Visual Studio versions. Is there something better to do here?
-        wchar_t const *versions[] = { L"14.0", L"13.0",  L"12.0", L"11.0", L"10.0", L"9.0", };
-        const int NUM_VERSIONS = sizeof(versions) / sizeof(versions[0]);
+		for (;;) {
+			ULONG found = 0;
+			ISetupInstance *instance = NULL;
+			auto hr = instances->Next(1, &instance, &found);
+			if (hr != S_OK) break;
 
-        for (int i = 0; i < NUM_VERSIONS; i++) {
-            wchar_t const *v = versions[i];
+			defer (instance->Release());
 
-            DWORD dw_type;
-            DWORD cb_data;
+			BSTR bstr_inst_path;
+			hr = instance->GetInstallationPath(&bstr_inst_path);
+			if (hr != S_OK)  continue;
+			defer (SysFreeString(bstr_inst_path));
 
-            auto rc = RegQueryValueExW(vs7_key, v, NULL, &dw_type, NULL, &cb_data);
-            if ((rc == ERROR_FILE_NOT_FOUND) || (dw_type != REG_SZ)) {
-                continue;
-            }
+			auto tools_filename = concat(bstr_inst_path, L"\\VC\\Auxiliary\\Build\\Microsoft.VCToolsVersion.default.txt");
+			defer (free(tools_filename));
 
-            auto buffer = (wchar_t *)calloc(1, cb_data);
-            if (!buffer)  return false;
-            defer (free(buffer));
+			FILE *f = nullptr;
+			auto open_result = _wfopen_s(&f, tools_filename, L"rt");
+			if (open_result != 0) continue;
+			if (!f) continue;
+			defer (fclose(f));
 
-            rc = RegQueryValueExW(vs7_key, v, NULL, NULL, (LPBYTE)buffer, &cb_data);
-            if (rc != 0)  continue;
+			LARGE_INTEGER tools_file_size;
+			auto file_handle = (HANDLE)_get_osfhandle(_fileno(f));
+			BOOL success = GetFileSizeEx(file_handle, &tools_file_size);
+			if (!success) continue;
 
-            // @Robustness: Do the zero-termination thing suggested in the RegQueryValue docs?
+			auto version_bytes = (tools_file_size.QuadPart + 1) * 2;  // Warning: This multiplication by 2 presumes there is no variable-length encoding in the wchars (wacky characters in the file could betray this expectation).
+			if (version_bytes > 0x7FFFFFFF) continue;   // Avoid overflow.
 
-            wchar_t *lib_path = nullptr;
+			wchar_t *version = (wchar_t *)calloc(1, (usize)version_bytes);
+			defer (free(version));
 
-            if (build_context.metrics.arch == TargetArch_amd64) {
-                lib_path = concat(buffer, L"VC\\Lib\\amd64\\");
-            } else if (build_context.metrics.arch == TargetArch_i386) {
-                lib_path = concat(buffer, L"VC\\Lib\\");
-            } else {
-                continue;
-            }
+			auto read_result = fgetws(version, (int)version_bytes, f);
+			if (!read_result) continue;
 
-            // Check to see whether a vcruntime.lib actually exists here.
-            auto vcruntime_filename = concat(lib_path, L"vcruntime.lib");
-            defer (free(vcruntime_filename));
+			auto version_tail = wcschr(version, '\n');
+			if (version_tail)  *version_tail = 0;  // Stomp the data, because nobody cares about it.
 
-            if (os_file_exists(vcruntime_filename)) {
-                if (build_context.metrics.arch == TargetArch_amd64) {
-                    result->vs_exe_path = concat(buffer, L"VC\\bin\\");
-                } else if (build_context.metrics.arch == TargetArch_i386) {
-                    // result->vs_exe_path = concat(buffer, L"VC\\bin\\amd64_x86\\");
-                    result->vs_exe_path = concat(buffer, L"VC\\bin\\x86_amd64\\");
-                } else {
-                    continue;
-                }
+			wchar_t *library_path = nullptr;
+			if (build_context.metrics.arch == TargetArch_amd64) {
+				library_path = concat(bstr_inst_path, L"\\VC\\Tools\\MSVC\\", version, L"\\lib\\x64\\");
+			} else if (build_context.metrics.arch == TargetArch_i386) {
+				library_path = concat(bstr_inst_path, L"\\VC\\Tools\\MSVC\\", version, L"\\lib\\x86\\");
+			} else {
+				continue;
+			}
 
-                result->vs_library_path = lib_path;
-                return true;
-            }
+			auto library_file = concat(library_path, L"vcruntime.lib");  // @Speed: Could have library_path point to this string, with a smaller count, to save on memory flailing!
 
-            free(lib_path);
-        }
+			if (os_file_exists(library_file)) {
+				wchar_t *link_exe_path = nullptr;
+				if (build_context.metrics.arch == TargetArch_amd64) {
+					link_exe_path = concat(bstr_inst_path, L"\\VC\\Tools\\MSVC\\", version, L"\\bin\\Hostx64\\x64\\");
+				} else if (build_context.metrics.arch == TargetArch_i386) {
+					link_exe_path = concat(bstr_inst_path, L"\\VC\\Tools\\MSVC\\", version, L"\\bin\\Hostx86\\x86\\");
+				} else {
+					continue;
+				}
 
-        // If we get here, we failed to find anything.
-    }
 
-    return false;
+				result->vs_exe_path     = link_exe_path;
+				result->vs_library_path = library_path;
+				return true;
+			}
+
+			/*
+			   Ryan Saunderson said:
+			   "Clang uses the 'SetupInstance->GetInstallationVersion' / ISetupHelper->ParseVersion to find the newest version
+			   and then reads the tools file to define the tools path - which is definitely better than what i did."
+
+			   So... @Incomplete: Should probably pick the newest version...
+			*/
+		}
+	}
+
+	// If we get here, we didn't find Visual Studio 2017. Try earlier versions.
+	{
+		HKEY vs7_key;
+		rc = RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\VisualStudio\\SxS\\VS7", 0, KEY_QUERY_VALUE | KEY_WOW64_32KEY, &vs7_key);
+		if (rc != S_OK)  return false;
+		defer (RegCloseKey(vs7_key));
+
+		// Hardcoded search for 4 prior Visual Studio versions. Is there something better to do here?
+		wchar_t const *versions[] = { L"14.0", L"13.0",  L"12.0", L"11.0", L"10.0", L"9.0", };
+		const int NUM_VERSIONS = sizeof(versions) / sizeof(versions[0]);
+
+		for (int i = 0; i < NUM_VERSIONS; i++) {
+			wchar_t const *v = versions[i];
+
+			DWORD dw_type;
+			DWORD cb_data;
+
+			auto rc = RegQueryValueExW(vs7_key, v, NULL, &dw_type, NULL, &cb_data);
+			if ((rc == ERROR_FILE_NOT_FOUND) || (dw_type != REG_SZ)) {
+				continue;
+			}
+
+			auto buffer = (wchar_t *)calloc(1, cb_data);
+			if (!buffer)  return false;
+			defer (free(buffer));
+
+			rc = RegQueryValueExW(vs7_key, v, NULL, NULL, (LPBYTE)buffer, &cb_data);
+			if (rc != 0)  continue;
+
+			// @Robustness: Do the zero-termination thing suggested in the RegQueryValue docs?
+
+			wchar_t *lib_path = nullptr;
+
+			if (build_context.metrics.arch == TargetArch_amd64) {
+				lib_path = concat(buffer, L"VC\\Lib\\amd64\\");
+			} else if (build_context.metrics.arch == TargetArch_i386) {
+				lib_path = concat(buffer, L"VC\\Lib\\");
+			} else {
+				continue;
+			}
+
+			// Check to see whether a vcruntime.lib actually exists here.
+			auto vcruntime_filename = concat(lib_path, L"vcruntime.lib");
+			defer (free(vcruntime_filename));
+
+			if (os_file_exists(vcruntime_filename)) {
+				if (build_context.metrics.arch == TargetArch_amd64) {
+					result->vs_exe_path = concat(buffer, L"VC\\bin\\");
+				} else if (build_context.metrics.arch == TargetArch_i386) {
+					result->vs_exe_path = concat(buffer, L"VC\\bin\\x86_amd64\\");
+				} else {
+					continue;
+				}
+
+				result->vs_library_path = lib_path;
+				return true;
+			}
+
+			free(lib_path);
+		}
+		// If we get here, we failed to find anything.
+	}
+
+	return false;
 }
-
-
-Find_Result find_visual_studio_and_windows_sdk() {
-    Find_Result result = {};
-
-    find_windows_kit_root(&result);
-
-
-    if (result.windows_sdk_root) {
-        if (build_context.metrics.arch == TargetArch_amd64) {
-            result.windows_sdk_um_library_path   = concat(result.windows_sdk_root, L"um\\x64\\");
-            result.windows_sdk_ucrt_library_path = concat(result.windows_sdk_root, L"ucrt\\x64\\");
-        } else if (build_context.metrics.arch == TargetArch_i386) {
-            result.windows_sdk_um_library_path   = concat(result.windows_sdk_root, L"um\\x86\\");
-            result.windows_sdk_ucrt_library_path = concat(result.windows_sdk_root, L"ucrt\\x86\\");
-        }
-    }
-
-    bool ok = find_visual_studio_by_fighting_through_microsoft_craziness(&result);
-
-    if (!ok) {
-        result.vs_exe_path     = concat(L"", L"");
-        result.vs_library_path = concat(L"", L"");
-    }
-
-    return result;
-}
-
-String mc_wstring_to_string(wchar_t const *str) {
-    return string16_to_string(mc_allocator, make_string16_c(str));
-}
-
 
 Find_Result_Utf8 find_visual_studio_and_windows_sdk_utf8() {
-    Find_Result result = find_visual_studio_and_windows_sdk();
-    defer (free_resources(&result));
+	Find_Result_Utf8 r = {};
+	find_windows_kit_root(&r);
 
-    Find_Result_Utf8 r = {};
-    r.windows_sdk_version = result.windows_sdk_version;
+	if (r.windows_sdk_root.len > 0) {
+		if (build_context.metrics.arch == TargetArch_amd64) {
+			r.windows_sdk_um_library_path   = mc_concat(r.windows_sdk_root, str_lit("um\\x64\\"));
+			r.windows_sdk_ucrt_library_path = mc_concat(r.windows_sdk_root, str_lit("ucrt\\x64\\"));
+		} else if (build_context.metrics.arch == TargetArch_i386) {
+			r.windows_sdk_um_library_path   = mc_concat(r.windows_sdk_root, str_lit("um\\x86\\"));
+			r.windows_sdk_ucrt_library_path = mc_concat(r.windows_sdk_root, str_lit("ucrt\\x86\\"));
+		}
+	}
 
-    r.windows_sdk_root              = mc_wstring_to_string(result.windows_sdk_root);
-    r.windows_sdk_um_library_path   = mc_wstring_to_string(result.windows_sdk_um_library_path);
-    r.windows_sdk_ucrt_library_path = mc_wstring_to_string(result.windows_sdk_ucrt_library_path);
-    r.vs_exe_path                   = mc_wstring_to_string(result.vs_exe_path);
-    r.vs_library_path               = mc_wstring_to_string(result.vs_library_path);
+	Find_Result result = {};
+	bool ok = find_visual_studio_by_fighting_through_microsoft_craziness(&result);
+
+	if (ok) {
+		r.vs_exe_path     = mc_wstring_to_string(result.vs_exe_path);
+		r.vs_library_path = mc_wstring_to_string(result.vs_library_path);
+	}
 
 #if 0
-    printf("windows_sdk_root:              %.*s\n", LIT(r.windows_sdk_root));
-    printf("windows_sdk_um_library_path:   %.*s\n", LIT(r.windows_sdk_um_library_path));
-    printf("windows_sdk_ucrt_library_path: %.*s\n", LIT(r.windows_sdk_ucrt_library_path));
-    printf("vs_exe_path:                   %.*s\n", LIT(r.vs_exe_path));
-    printf("vs_library_path:               %.*s\n", LIT(r.vs_library_path));
+	printf("windows_sdk_root:              %.*s\n", LIT(r.windows_sdk_root));
+	printf("windows_sdk_um_library_path:   %.*s\n", LIT(r.windows_sdk_um_library_path));
+	printf("windows_sdk_ucrt_library_path: %.*s\n", LIT(r.windows_sdk_ucrt_library_path));
+	printf("vs_exe_path:                   %.*s\n", LIT(r.vs_exe_path));
+	printf("vs_library_path:               %.*s\n", LIT(r.vs_library_path));
 
-    gb_exit(1);
+	gb_exit(1);
 #endif
 
-    return r;
+	return r;
 }
-


### PR DESCRIPTION
Factor out or wrap a lot of the original libc wide string handling, using the `String` type instead.
We can also free any memory allocated by this code wholesale by calling `mc_free_all`.