### PR TITLE
Fix SDK detection if no SDK installed.

### DIFF
--- a/src/microsoft_craziness.h
+++ b/src/microsoft_craziness.h
@@ -707,8 +707,8 @@ bool find_msvc_install_from_env_vars(Find_Result_Utf8 *result) {
 
 			isize lo = {0};
 			isize hi = {0};
-			for (isize c = 0; c <= path.len; c += 1) {
-				if (c != path.len && path[c] != ';') {
+			for (isize c = 0; c < path.len; c += 1) {
+				if (path[c] != ';') {
 					continue;
 				}
 


### PR DESCRIPTION
If the SDK has never been installed and we rely on environment and path fall-back to find `link` and `cl`, Odin now no longer crashes on the path search fall-back.