### PR TITLE
Improved arena allocation with alignment

### DIFF
--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -52,15 +52,16 @@ arena_allocator_proc :: proc(allocator_data: rawptr, mode: Allocator_Mode,
 
 	switch mode {
 	case .Alloc:
-		total_size := size + alignment
+		#no_bounds_check end := &arena.data[arena.offset]
+
+		ptr := align_forward(end, uintptr(alignment))
+
+		total_size := size + ptr_sub((^byte)(ptr), (^byte)(end))
 
 		if arena.offset + total_size > len(arena.data) {
 			return nil, .Out_Of_Memory
 		}
 
-		#no_bounds_check end := &arena.data[arena.offset]
-
-		ptr := align_forward(end, uintptr(alignment))
 		arena.offset += total_size
 		arena.peak_used = max(arena.peak_used, arena.offset)
 		zero(ptr, size)


### PR DESCRIPTION
The arena allocator was allocating `size + alignment` no matter what, even if the pointer was already aligned. There was also a bug with the total size calculation when the pointer was not aligned. This PR fixes both of these problems.

Test code (see `Before PR` and `After PR` comments):
```
package main

import "core:mem"
import "core:fmt"

main :: proc() {
	{
		Buffer :: struct #align (4) {
			aligned_start: [16]u8,
		}

		data := Buffer{}
		arena: mem.Arena
		mem.init_arena(&arena, data.aligned_start[:])
		allocator := mem.arena_allocator(&arena)
		allocation := mem.alloc(size_of(i32), align_of(i32), allocator)
		fmt.println(arena.peak_used)

		// Before PR: 8
		// After PR: 4
	}

	{
		Buffer :: struct #align (4) {
			_:               u8,
			unaligned_start: [16]u8,
		}

		data := Buffer{}
		arena: mem.Arena
		mem.init_arena(&arena, data.unaligned_start[:])
		allocator := mem.arena_allocator(&arena)
		allocation := mem.alloc(size_of(i32), align_of(i32), allocator)
		fmt.println(arena.peak_used)

		// Before PR: 8 (This was a bug. It should have reported 11. 3 bytes of junk and 8 bytes of real space)
		// After PR: 7 (3 bytes of junk, 4 bytes of real space)
	}
}
```