### PR TITLE
Dynamic array append reserves more space when it exceeds capacity

### DIFF
--- a/core/runtime/dynamic_array_internal.odin
+++ b/core/runtime/dynamic_array_internal.odin
@@ -65,7 +65,7 @@ __dynamic_array_append :: proc(array_: rawptr, elem_size, elem_align: int,
 
 
 	ok := true
-	if array.cap <= array.len+item_count {
+	if array.cap < array.len+item_count {
 		cap := 2 * array.cap + max(8, item_count)
 		ok = __dynamic_array_reserve(array, elem_size, elem_align, cap, loc)
 	}
@@ -86,7 +86,7 @@ __dynamic_array_append_nothing :: proc(array_: rawptr, elem_size, elem_align: in
 	array := (^Raw_Dynamic_Array)(array_)
 
 	ok := true
-	if array.cap <= array.len+1 {
+	if array.cap < array.len+1 {
 		cap := 2 * array.cap + max(8, 1)
 		ok = __dynamic_array_reserve(array, elem_size, elem_align, cap, loc)
 	}


### PR DESCRIPTION
This PR makes it so an internal dynamic array will only reserve more space if you exceed the capacity. This matches the behavior of the builtin `append`. Before it was reserving more space when it reached capacity.