### PR TITLE
Allocator: tidying up Query_Info return values when not part of Query_Features

### DIFF
--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -886,6 +886,10 @@ tracking_allocator_proc :: proc(allocator_data: rawptr, mode: Allocator_Mode,
 		}
 	case .Free:
 		delete_key(&data.allocation_map, old_memory)
+	case .Free_All:
+		if data.clear_on_free_all {
+			clear_map(&data.allocation_map)
+		}	
 	case .Resize:
 		if old_memory != result_ptr {
 			delete_key(&data.allocation_map, old_memory)
@@ -896,11 +900,6 @@ tracking_allocator_proc :: proc(allocator_data: rawptr, mode: Allocator_Mode,
 			alignment = alignment,
 			err = err,
 			location = loc,
-		}
-
-	case .Free_All:
-		if data.clear_on_free_all {
-			clear_map(&data.allocation_map)
 		}
 
 	case .Query_Features:

--- a/core/os/os2/heap_windows.odin
+++ b/core/os/os2/heap_windows.odin
@@ -99,7 +99,7 @@ _heap_allocator_proc :: proc(allocator_data: rawptr, mode: mem.Allocator_Mode,
 		return nil, nil
 
 	case .Query_Info:
-		return nil, nil
+		return nil, .Mode_Not_Implemented
 	}
 
 	return nil, nil

--- a/core/runtime/default_allocators_windows.odin
+++ b/core/runtime/default_allocators_windows.odin
@@ -17,7 +17,7 @@ when ODIN_DEFAULT_TO_NIL_ALLOCATOR {
 			_windows_default_free(old_memory)
 
 		case .Free_All:
-			// NOTE(tetra): Do nothing.
+			return nil, .Mode_Not_Implemented
 
 		case .Resize:
 			data, err = _windows_default_resize(old_memory, old_size, size, alignment)
@@ -29,7 +29,7 @@ when ODIN_DEFAULT_TO_NIL_ALLOCATOR {
 			}
 
 		case .Query_Info:
-			// Do nothing
+			return nil, .Mode_Not_Implemented
 		}
 
 		return

--- a/core/runtime/default_temporary_allocator.odin
+++ b/core/runtime/default_temporary_allocator.odin
@@ -185,7 +185,7 @@ when ODIN_OS == .Freestanding || ODIN_OS == .JS || ODIN_DEFAULT_TO_NIL_ALLOCATOR
 			}
 
 		case .Query_Info:
-			// Nothing to give
+			return nil, .Mode_Not_Implemented
 		}
 
 		return


### PR DESCRIPTION
Some allocators were returning `nil, nil` instead of `nil, .Mode_Not_Implemented` when `Query_Info` was not part of the `Query_Features`