### PR TITLE
[testing] Fixed `@(test)` always fails unless `testing.set_fail_timeout` is called

### DIFF
--- a/core/testing/runner_windows.odin
+++ b/core/testing/runner_windows.odin
@@ -203,7 +203,7 @@ run_internal_test :: proc(t: ^T, it: Internal_Test) {
 		thread.it.p(t)
 		
 		sema_post(&global_fail_timeout_semaphore)
-		thread_join_and_destroy(global_fail_timeout_thread)
+		if global_fail_timeout_thread != nil do thread_join_and_destroy(global_fail_timeout_thread)
 		
 		thread.success = true
 		sema_post(&global_threaded_runner_semaphore)


### PR DESCRIPTION
Almost all `@(test)` procs (including empty procs) fail in the `odin test` command.

When `testing.set_fail_timeout` proc is not called in `@(test)` proc, `global_fail_timeout_thread` becomes nil and `thread_join_and_destroy` tries to refer nil value.