### PR TITLE
Fixed `slice.is_sorted_cmp`

### DIFF
--- a/core/slice/sort.odin
+++ b/core/slice/sort.odin
@@ -103,7 +103,7 @@ is_sorted_by :: proc(array: $T/[]$E, less: proc(i, j: E) -> bool) -> bool {
 is_sorted_by_cmp :: is_sorted_cmp
 is_sorted_cmp :: proc(array: $T/[]$E, cmp: proc(i, j: E) -> Ordering) -> bool {
 	for i := len(array)-1; i > 0; i -= 1 {
-		if cmp(array[i], array[i-1]) == .Equal {
+		if cmp(array[i], array[i-1]) == .Less {
 			return false
 		}
 	}


### PR DESCRIPTION
#1499 for {1, 1, 2} will now return true instead of false