### PR TITLE
Added missing #includes on OpenBSD

### DIFF
--- a/build_odin.sh
+++ b/build_odin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 GIT_SHA=$(git rev-parse --short HEAD)

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -25,11 +25,6 @@
 #include <psapi.h>
 #endif
 
-#if defined(GB_SYSTEM_OPENBSD)
-#include <sys/resource.h>
-#include <sys/wait.h>
-#endif
-
 #include <math.h>
 #include <string.h>
 #include <atomic> // Because I wanted the C++11 memory order semantics, of which gb.h does not offer (because it was a C89 library)

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -25,6 +25,11 @@
 #include <psapi.h>
 #endif
 
+#if defined(GB_SYSTEM_OPENBSD)
+#include <sys/resource.h>
+#include <sys/wait.h>
+#endif
+
 #include <math.h>
 #include <string.h>
 #include <atomic> // Because I wanted the C++11 memory order semantics, of which gb.h does not offer (because it was a C89 library)

--- a/src/gb/gb.h
+++ b/src/gb/gb.h
@@ -90,6 +90,10 @@ extern "C" {
 	#error This operating system is not supported
 #endif
 
+#if defined(GB_SYSTEM_OPENBSD)
+#include <sys/wait.h>
+#endif
+
 #if defined(_MSC_VER)
 	#define GB_COMPILER_MSVC 1
 #elif defined(__GNUC__)


### PR DESCRIPTION
Resolves issues with compiling Odin on OpenBSD, sys/resource.h and sys/wait.h are required for WIFEXITED and WEXITSTATUS.