### PR TITLE
Add missing field for `TEXTURE_COPY_LOCATION`

### DIFF
--- a/vendor/directx/d3d12/d3d12.odin
+++ b/vendor/directx/d3d12/d3d12.odin
@@ -1459,6 +1459,10 @@ TEXTURE_COPY_TYPE :: enum i32 {
 TEXTURE_COPY_LOCATION :: struct {
 	pResource: ^IResource,
 	Type:      TEXTURE_COPY_TYPE,
+	using _: struct #raw_union {
+		PlacedFootprint:  PLACED_SUBRESOURCE_FOOTPRINT,
+		SubresourceIndex: u32,
+	},
 }
 
 RESOLVE_MODE :: enum i32 {


### PR DESCRIPTION
Add missing anonymous union field for [D3D12_TEXTURE_COPY_LOCATION ](https://docs.microsoft.com/en-us/windows/win32/api/d3d12/ns-d3d12-d3d12_texture_copy_location):
```C
union {
    D3D12_PLACED_SUBRESOURCE_FOOTPRINT PlacedFootprint;
    UINT                               SubresourceIndex;
  };
```