### PR TITLE
Improve build_odin.sh

### DIFF
--- a/build_odin.sh
+++ b/build_odin.sh
@@ -10,142 +10,293 @@ CC='clang'
 OS="$(uname)"
 
 panic() {
-        printf '%s\n' "$1"
-        exit 1
+	printf '%s\n' "$1"
+	exit 1
 }
 
 # TODO replace awk with something portable
 version() { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
 
 config_darwin() {
-        ARCH="$(uname -m)"
-        LLVM_CONFIG='llvm-config'
+	ARCH="$(uname -m)"
+	LLVM_CONFIG='llvm-config'
 
-        # allow for arm only llvm's with version 13
-        if [ "${ARCH}" = arm64 ]; then
-                MIN_LLVM_VERSION='13.0.0'
-        else
-                # allow for x86 / amd64 all llvm versions begining from 11
-                MIN_LLVM_VERSION='11.1.0'
-        fi
+	# allow for arm only llvm's with version 13
+	if [ "${ARCH}" = arm64 ]; then
+		MIN_LLVM_VERSION='13.0.0'
+	else
+		# allow for x86 / amd64 all llvm versions begining from 11
+		MIN_LLVM_VERSION='11.1.0'
+	fi
 
-        if [ "$(version "$(${LLVM_CONFIG} --version)")" -lt "$(version "${MIN_LLVM_VERSION}")" ]; then
-                if [ "${ARCH}" = arm64 ]; then
-                        panic 'Requirement: llvm-config must be base version 13 for arm64'
-                else
-                        panic 'Requirement: llvm-config must be base version greater than 11 for amd64/x86'
-                fi
-        fi
+	if [ "$(version "$(${LLVM_CONFIG} --version)")" -lt "$(version "${MIN_LLVM_VERSION}")" ]; then
+		if [ "${ARCH}" = arm64 ]; then
+			panic 'Requirement: llvm-config must be base version 13 for arm64'
+		else
+			panic 'Requirement: llvm-config must be base version greater than 11 for amd64/x86'
+		fi
+	fi
 
-        LDFLAGS="${LDFLAGS} -liconv -ldl"
-        CFLAGS="${CFLAGS} $(${LLVM_CONFIG} --cxxflags --ldflags)"
-        LDFLAGS="${LDFLAGS} -lLLVM-C"
+	LDFLAGS="${LDFLAGS} -liconv -ldl"
+	CFLAGS="${CFLAGS} $(${LLVM_CONFIG} --cxxflags --ldflags)"
+	LDFLAGS="${LDFLAGS} -lLLVM-C"
 }
 
 config_freebsd() {
-        # Unportable? TODO replace with command -v
-        LLVM_CONFIG='/usr/local/bin/llvm-config11'
+	# Unportable? TODO replace with command -v
+	LLVM_CONFIG='/usr/local/bin/llvm-config11'
 
-        CFLAGS="${CFLAGS} $(${LLVM_CONFIG} --cxxflags --ldflags)"
-        LDFLAGS="${LDFLAGS} $(${LLVM_CONFIG} --libs core native --system-libs)"
+	CFLAGS="${CFLAGS} $(${LLVM_CONFIG} --cxxflags --ldflags)"
+	LDFLAGS="${LDFLAGS} $(${LLVM_CONFIG} --libs core native --system-libs)"
 }
 
 config_openbsd() {
-        # TODO see above
-        LLVM_CONFIG='/usr/local/bin/llvm-config'
+	# TODO see above
+	LLVM_CONFIG='/usr/local/bin/llvm-config'
 
-        LDFLAGS="${LDFLAGS} -liconv"
-        CFLAGS="${CFLAGS} $(${LLVM_CONFIG} --cxxflags --ldflags)"
-        LDFLAGS="${LDFLAGS} $(${LLVM_CONFIG} --libs core native --system-libs)"
+	LDFLAGS="${LDFLAGS} -liconv"
+	CFLAGS="${CFLAGS} $(${LLVM_CONFIG} --cxxflags --ldflags)"
+	LDFLAGS="${LDFLAGS} $(${LLVM_CONFIG} --libs core native --system-libs)"
 }
 
 config_linux() {
-        LLVM_CONFIG=
-        for l in llvm-config llvm-config-11 llvm-config-11-64;do
-                t="$(command -v "${l}" 2>/dev/null)" && LLVM_CONFIG="${t}" && break
-        done
-        [ -z "${LLVM_CONFIG}" ] && panic 'Unable to find LLVM-config'
+	LLVM_CONFIG=
+	for l in llvm-config llvm-config-11 llvm-config-11-64;do
+		t="$(command -v "${l}" 2>/dev/null)" && LLVM_CONFIG="${t}" && break
+	done
+	[ -z "${LLVM_CONFIG}" ] && panic 'Unable to find LLVM-config'
 
-        MIN_LLVM_VERSION='11.0.0'
+	MIN_LLVM_VERSION='11.0.0'
 
-        if [ "$(version "$(${LLVM_CONFIG} --version)")" -lt "$(version "${MIN_LLVM_VERSION}")" ]; then
-                printf 'Tried to use %s version %s\n' "${LLVM_CONFIG}" "$(${LLVM_CONFIG} --version)"
-                panic 'Requirement: llvm-config must be base version greater than 11'
-        fi
+	if [ "$(version "$(${LLVM_CONFIG} --version)")" -lt "$(version "${MIN_LLVM_VERSION}")" ]; then
+		printf 'Tried to use %s version %s\n' "${LLVM_CONFIG}" "$(${LLVM_CONFIG} --version)"
+		panic 'Requirement: llvm-config must be base version greater than 11'
+	fi
 
-        LDFLAGS="${LDFLAGS} -ldl"
-        CFLAGS="${CFLAGS} $(${LLVM_CONFIG} --cxxflags --ldflags)"
-        LDFLAGS="${LDFLAGS} $(${LLVM_CONFIG} --libs core native --system-libs)"
+	LDFLAGS="${LDFLAGS} -ldl"
+	CFLAGS="${CFLAGS} $(${LLVM_CONFIG} --cxxflags --ldflags)"
+	LDFLAGS="${LDFLAGS} $(${LLVM_CONFIG} --libs core native --system-libs)"
 }
 
 build_odin() {
-        case "$1" in
-        debug)
-                EXTRAFLAGS='-g'
-                ;;
-        release)
-                EXTRAFLAGS='-O3'
-                ;;
-        release-native)
-                EXTRAFLAGS='-O3 -march=native'
-                ;;
-        nightly)
-                EXTRAFLAGS='-DNIGHTLY -O3'
-                ;;
-        *)
-                panic 'Build mode unsupported!'
-        esac
+	case "$1" in
+	debug)
+		EXTRAFLAGS='-g'
+		;;
+	release)
+		EXTRAFLAGS='-O3'
+		;;
+	release-native)
+		EXTRAFLAGS='-O3 -march=native'
+		;;
+	nightly)
+		EXTRAFLAGS='-DNIGHTLY -O3'
+		;;
+	*)
+		panic 'Build mode unsupported!'
+	esac
 
-        set -x
-        # shellcheck disable=SC2086,SC2090
-        ${CC} src/main.cpp src/libtommath.cpp ${DISABLED_WARNINGS} ${CFLAGS} ${EXTRAFLAGS} ${LDFLAGS} -o odin
-        set +x
+	set -x
+	# shellcheck disable=SC2086,SC2090
+	${CC} src/main.cpp src/libtommath.cpp ${DISABLED_WARNINGS} ${CFLAGS} ${EXTRAFLAGS} ${LDFLAGS} -o odin
+	set +x
 }
 
 run_demo() {
-        ./odin run examples/demo/demo.odin -file
+	./odin run examples/demo/demo.odin -file
 }
 
 case "${OS}" in
 Linux)
-        config_linux
-        ;;
+	config_linux
+	;;
 Darwin)
-        config_darwin
-        ;;
+	config_darwin
+	;;
 OpenBSD)
-        config_openbsd
-        ;;
+	config_openbsd
+	;;
 FreeBSD)
-        config_freebsd
-        ;;
+	config_freebsd
+	;;
 *)
-        panic 'Platform unsupported!'
+	panic 'Platform unsupported!'
 esac
 
 if [ "$#" -eq 0 ]; then
-        build_odin debug
-        run_demo
-        exit 0
+	build_odin debug
+	run_demo
+	exit 0
 fi
 
 if [ "$#" -eq 1 ]; then
-        case "$1" in
-        report)
-                if ! [ -f './odin' ]; then
-                        build_odin debug
-                fi
+	case "$1" in
+	report)
+		if ! [ -f './odin' ]; then
+			build_odin debug
+		fi
 
-                ./odin report
-                exit 0
-                ;;
-        *)
-                build_odin "${1}"
-                ;;
-        esac
+		./odin report
+		exit 0
+		;;
+	*)
+		build_odin "${1}"
+		;;
+	esac
 
-        run_demo
-        exit 0
+	run_demo
+	exit 0
 else
-        panic 'Too many arguments!'
+	panic 'Too many arguments!'
+fi
+#! /bin/sh
+
+GIT_SHA="$(git rev-parse --short HEAD)"
+DISABLED_WARNINGS='-Wno-switch -Wno-macro-redefined -Wno-unused-value'
+LDFLAGS='-pthread -lm -lstdc++'
+# shellcheck disable=SC2089
+CFLAGS="-std=c++14 -DGIT_SHA=\"${GIT_SHA}\""
+CFLAGS="$CFLAGS -DODIN_VERSION_RAW=\"dev-$(date '+%Y-%m')\""
+CC='clang'
+OS="$(uname)"
+
+panic() {
+	printf '%s\n' "$1"
+	exit 1
+}
+
+# TODO replace awk with something else
+version() { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+
+config_darwin() {
+	ARCH="$(uname -m)"
+	LLVM_CONFIG='llvm-config'
+
+	# allow for arm only llvm's with version 13
+	if [ "${ARCH}" = arm64 ]; then
+		MIN_LLVM_VERSION='13.0.0'
+	else
+		# allow for x86 / amd64 all llvm versions begining from 11
+		MIN_LLVM_VERSION='11.1.0'
+	fi
+
+	if [ "$(version "$(${LLVM_CONFIG} --version)")" -lt "$(version "${MIN_LLVM_VERSION}")" ]; then
+		if [ "${ARCH}" = arm64 ]; then
+			panic 'Requirement: llvm-config must be base version 13 for arm64'
+		else
+			panic 'Requirement: llvm-config must be base version greater than 11 for amd64/x86'
+		fi
+	fi
+
+	LDFLAGS="${LDFLAGS} -liconv -ldl"
+	CFLAGS="${CFLAGS} $(${LLVM_CONFIG} --cxxflags --ldflags)"
+	LDFLAGS="${LDFLAGS} -lLLVM-C"
+}
+
+config_freebsd() {
+	# Unportable? TODO replace with command -v
+	LLVM_CONFIG='/usr/local/bin/llvm-config11'
+
+	CFLAGS="${CFLAGS} $(${LLVM_CONFIG} --cxxflags --ldflags)"
+	LDFLAGS="${LDFLAGS} $(${LLVM_CONFIG} --libs core native --system-libs)"
+}
+
+config_openbsd() {
+	# TODO see above
+	LLVM_CONFIG='/usr/local/bin/llvm-config'
+
+	LDFLAGS="${LDFLAGS} -liconv"
+	CFLAGS="${CFLAGS} $(${LLVM_CONFIG} --cxxflags --ldflags)"
+	LDFLAGS="${LDFLAGS} $(${LLVM_CONFIG} --libs core native --system-libs)"
+}
+
+config_linux() {
+	LLVM_CONFIG=
+	for l in llvm-config llvm-config-11 llvm-config-11-64;do
+		t="$(command -v "${l}" 2>/dev/null)" && LLVM_CONFIG="${t}" && break
+	done
+	[ -z "${LLVM_CONFIG}" ] && panic 'Unable to find LLVM-config'
+	
+	MIN_LLVM_VERSION='11.0.0'
+	
+	if [ "$(version "$(${LLVM_CONFIG} --version)")" -lt "$(version "${MIN_LLVM_VERSION}")" ]; then
+		printf 'Tried to use %s version %s\n' "${LLVM_CONFIG}" "$(${LLVM_CONFIG} --version)"
+		panic 'Requirement: llvm-config must be base version greater than 11'
+	fi
+
+	LDFLAGS="${LDFLAGS} -ldl"
+	CFLAGS="${CFLAGS} $(${LLVM_CONFIG} --cxxflags --ldflags)"
+	LDFLAGS="${LDFLAGS} $(${LLVM_CONFIG} --libs core native --system-libs)"
+}
+
+build_odin() {
+	case "$1" in
+	debug)
+		EXTRAFLAGS='-g'
+		;;
+	release)
+		EXTRAFLAGS='-O3'
+		;;
+	release-native)
+		EXTRAFLAGS='-O3 -march=native'
+		;;
+	nightly)
+		EXTRAFLAGS='-DNIGHTLY -O3'
+		;;
+	*)
+		panic 'Build mode unsupported!'
+	esac
+
+	set -x
+	# shellcheck disable=SC2086,SC2090
+	${CC} src/main.cpp src/libtommath.cpp ${DISABLED_WARNINGS} ${CFLAGS} ${EXTRAFLAGS} ${LDFLAGS} -o odin
+	set +x
+}
+
+run_demo() {
+	./odin run examples/demo/demo.odin -file
+}
+
+case "${OS}" in
+Linux)
+	config_linux
+	;;
+Darwin)
+	config_darwin
+	;;
+OpenBSD)
+	config_openbsd
+	;;
+FreeBSD)
+	config_freebsd
+	;;
+*)
+	panic "Platform unsupported!"
+esac
+
+if [ "$#" -eq 0 ]; then
+	build_odin debug
+	run_demo
+	exit 0
+fi
+
+if [ "$#" -eq 1 ]; then
+	case "$1" in
+	report)
+		if ! [ -f './odin' ]; then
+			build_odin debug
+		fi
+
+		./odin report
+		exit 0
+		;;
+	*)
+		build_odin "${1}"
+		;;
+	esac
+
+	run_demo
+	exit 0
+else
+	panic 'Too many arguments!'
 fi

--- a/build_odin.sh
+++ b/build_odin.sh
@@ -1,150 +1,151 @@
-#!/bin/bash
-set -eu
+#! /bin/sh
 
-GIT_SHA=$(git rev-parse --short HEAD)
-DISABLED_WARNINGS="-Wno-switch -Wno-macro-redefined -Wno-unused-value"
-LDFLAGS="-pthread -lm -lstdc++"
-CFLAGS="-std=c++14 -DGIT_SHA=\"$GIT_SHA\""
-CFLAGS="$CFLAGS -DODIN_VERSION_RAW=\"dev-$(date +"%Y-%m")\""
-CC=clang
-OS=$(uname)
+GIT_SHA="$(git rev-parse --short HEAD)"
+DISABLED_WARNINGS='-Wno-switch -Wno-macro-redefined -Wno-unused-value'
+LDFLAGS='-pthread -lm -lstdc++'
+# shellcheck disable=SC2089
+CFLAGS="-std=c++14 -DGIT_SHA=\"${GIT_SHA}\""
+CFLAGS="$CFLAGS -DODIN_VERSION_RAW=\"dev-$(date '+%Y-%m')\""
+CC='clang'
+OS="$(uname)"
 
 panic() {
-	printf "%s\n" "$1"
-	exit 1
+        printf '%s\n' "$1"
+        exit 1
 }
 
+# TODO replace awk with something portable
 version() { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
 
 config_darwin() {
-	ARCH=$(uname -m)
-	LLVM_CONFIG=llvm-config
+        ARCH="$(uname -m)"
+        LLVM_CONFIG='llvm-config'
 
-	# allow for arm only llvm's with version 13
-	if [ ARCH == arm64 ]; then
-		MIN_LLVM_VERSION=("13.0.0")
-	else
-		# allow for x86 / amd64 all llvm versions begining from 11
-		MIN_LLVM_VERSION=("11.1.0")
-	fi
+        # allow for arm only llvm's with version 13
+        if [ "${ARCH}" = arm64 ]; then
+                MIN_LLVM_VERSION='13.0.0'
+        else
+                # allow for x86 / amd64 all llvm versions begining from 11
+                MIN_LLVM_VERSION='11.1.0'
+        fi
 
-	if [ $(version $($LLVM_CONFIG --version)) -lt $(version $MIN_LLVM_VERSION) ]; then
-		if [ ARCH == arm64 ]; then
-			panic "Requirement: llvm-config must be base version 13 for arm64"
-		else
-			panic "Requirement: llvm-config must be base version greater than 11 for amd64/x86"
-		fi
-	fi
+        if [ "$(version "$(${LLVM_CONFIG} --version)")" -lt "$(version "${MIN_LLVM_VERSION}")" ]; then
+                if [ "${ARCH}" = arm64 ]; then
+                        panic 'Requirement: llvm-config must be base version 13 for arm64'
+                else
+                        panic 'Requirement: llvm-config must be base version greater than 11 for amd64/x86'
+                fi
+        fi
 
-	LDFLAGS="$LDFLAGS -liconv -ldl"
-	CFLAGS="$CFLAGS $($LLVM_CONFIG --cxxflags --ldflags)"
-	LDFLAGS="$LDFLAGS -lLLVM-C"
+        LDFLAGS="${LDFLAGS} -liconv -ldl"
+        CFLAGS="${CFLAGS} $(${LLVM_CONFIG} --cxxflags --ldflags)"
+        LDFLAGS="${LDFLAGS} -lLLVM-C"
 }
 
 config_freebsd() {
-	LLVM_CONFIG=/usr/local/bin/llvm-config11
+        # Unportable? TODO replace with command -v
+        LLVM_CONFIG='/usr/local/bin/llvm-config11'
 
-	CFLAGS="$CFLAGS $($LLVM_CONFIG --cxxflags --ldflags)"
-	LDFLAGS="$LDFLAGS $($LLVM_CONFIG --libs core native --system-libs)"
+        CFLAGS="${CFLAGS} $(${LLVM_CONFIG} --cxxflags --ldflags)"
+        LDFLAGS="${LDFLAGS} $(${LLVM_CONFIG} --libs core native --system-libs)"
 }
 
 config_openbsd() {
-	LLVM_CONFIG=/usr/local/bin/llvm-config
+        # TODO see above
+        LLVM_CONFIG='/usr/local/bin/llvm-config'
 
-	LDFLAGS="$LDFLAGS -liconv"
-	CFLAGS="$CFLAGS $($LLVM_CONFIG --cxxflags --ldflags)"
-	LDFLAGS="$LDFLAGS $($LLVM_CONFIG --libs core native --system-libs)"
+        LDFLAGS="${LDFLAGS} -liconv"
+        CFLAGS="${CFLAGS} $(${LLVM_CONFIG} --cxxflags --ldflags)"
+        LDFLAGS="${LDFLAGS} $(${LLVM_CONFIG} --libs core native --system-libs)"
 }
 
 config_linux() {
-	if which llvm-config > /dev/null 2>&1; then
-		LLVM_CONFIG=llvm-config
-	elif which llvm-config-11 > /dev/null 2>&1; then
-		LLVM_CONFIG=llvm-config-11
-	elif which llvm-config-11-64 > /dev/null 2>&1; then
-		LLVM_CONFIG=llvm-config-11-64
-	else
-		panic "Unable to find LLVM-config"
-	fi
+        LLVM_CONFIG=
+        for l in llvm-config llvm-config-11 llvm-config-11-64;do
+                t="$(command -v "${l}" 2>/dev/null)" && LLVM_CONFIG="${t}" && break
+        done
+        [ -z "${LLVM_CONFIG}" ] && panic 'Unable to find LLVM-config'
 
-	MIN_LLVM_VERSION=("11.0.0")
-	if [ $(version $($LLVM_CONFIG --version)) -lt $(version $MIN_LLVM_VERSION) ]; then
-		echo "Tried to use " $(which $LLVM_CONFIG) "version" $($LLVM_CONFIG --version)
-		panic "Requirement: llvm-config must be base version greater than 11"
-	fi
+        MIN_LLVM_VERSION='11.0.0'
 
-	LDFLAGS="$LDFLAGS -ldl"
-	CFLAGS="$CFLAGS $($LLVM_CONFIG --cxxflags --ldflags)"
-	LDFLAGS="$LDFLAGS $($LLVM_CONFIG --libs core native --system-libs)"
+        if [ "$(version "$(${LLVM_CONFIG} --version)")" -lt "$(version "${MIN_LLVM_VERSION}")" ]; then
+                printf 'Tried to use %s version %s\n' "${LLVM_CONFIG}" "$(${LLVM_CONFIG} --version)"
+                panic 'Requirement: llvm-config must be base version greater than 11'
+        fi
+
+        LDFLAGS="${LDFLAGS} -ldl"
+        CFLAGS="${CFLAGS} $(${LLVM_CONFIG} --cxxflags --ldflags)"
+        LDFLAGS="${LDFLAGS} $(${LLVM_CONFIG} --libs core native --system-libs)"
 }
 
 build_odin() {
-	case $1 in
-	debug)
-		EXTRAFLAGS="-g"
-		;;
-	release)
-		EXTRAFLAGS="-O3"
-		;;
-	release-native)
-		EXTRAFLAGS="-O3 -march=native"
-		;;
-	nightly)
-		EXTRAFLAGS="-DNIGHTLY -O3"
-		;;
-	*)
-		panic "Build mode unsupported!"
-	esac
+        case "$1" in
+        debug)
+                EXTRAFLAGS='-g'
+                ;;
+        release)
+                EXTRAFLAGS='-O3'
+                ;;
+        release-native)
+                EXTRAFLAGS='-O3 -march=native'
+                ;;
+        nightly)
+                EXTRAFLAGS='-DNIGHTLY -O3'
+                ;;
+        *)
+                panic 'Build mode unsupported!'
+        esac
 
-	set -x
-	$CC src/main.cpp src/libtommath.cpp $DISABLED_WARNINGS $CFLAGS $EXTRAFLAGS $LDFLAGS -o odin
-	set +x
+        set -x
+        # shellcheck disable=SC2086,SC2090
+        ${CC} src/main.cpp src/libtommath.cpp ${DISABLED_WARNINGS} ${CFLAGS} ${EXTRAFLAGS} ${LDFLAGS} -o odin
+        set +x
 }
 
 run_demo() {
-	./odin run examples/demo/demo.odin -file
+        ./odin run examples/demo/demo.odin -file
 }
 
-case $OS in
+case "${OS}" in
 Linux)
-	config_linux
-	;;
+        config_linux
+        ;;
 Darwin)
-	config_darwin
-	;;
+        config_darwin
+        ;;
 OpenBSD)
-	config_openbsd
-	;;
+        config_openbsd
+        ;;
 FreeBSD)
-	config_freebsd
-	;;
+        config_freebsd
+        ;;
 *)
-	panic "Platform unsupported!"
+        panic 'Platform unsupported!'
 esac
 
-if [[ $# -eq 0 ]]; then
-	build_odin debug
-	run_demo
-	exit 0
+if [ "$#" -eq 0 ]; then
+        build_odin debug
+        run_demo
+        exit 0
 fi
 
-if [[ $# -eq 1 ]]; then
-	case $1 in
-	report)
-		if [[ ! -f "./odin" ]]; then
-			build_odin debug
-		fi
+if [ "$#" -eq 1 ]; then
+        case "$1" in
+        report)
+                if ! [ -f './odin' ]; then
+                        build_odin debug
+                fi
 
-		./odin report
-		exit 0
-		;;
-	*)
-		build_odin $1
-		;;
-	esac
+                ./odin report
+                exit 0
+                ;;
+        *)
+                build_odin "${1}"
+                ;;
+        esac
 
-	run_demo
-	exit 0
+        run_demo
+        exit 0
 else
-	panic "Too many arguments!"
+        panic 'Too many arguments!'
 fi


### PR DESCRIPTION
- Fix a bug in `config_darwin` where a llvm-config version less than 13 would be accepted because a parameter expansion was forgotten.
- Port the script to POSIX sh (replace `[[ ]]` with `[ ]`, remove set -eu)
- Quote Every Fucking Substitution consistently.
- Style changes: Braces around variable names. Single quotes when no substitution is required.