### PR TITLE
Add runtime.dll_forward_reason for Windows DLLs.

### DIFF
--- a/core/runtime/core.odin
+++ b/core/runtime/core.odin
@@ -267,6 +267,19 @@ type_table: []Type_Info
 
 args__: []cstring
 
+when ODIN_OS == .Windows {
+	// NOTE(Jeroen): If we're a Windows DLL, fwdReason will be populated.
+	// This tells a DLL if it's first loaded, about to be unloaded, or a thread is joining/exiting.
+
+	DLL_Forward_Reason :: enum u32 {
+		Process_Detach = 0, // About to unload DLL
+		Process_Attach = 1, // Entry point
+		Thread_Attach  = 2,
+		Thread_Detach  = 3,
+	}
+	dll_forward_reason: DLL_Forward_Reason
+}
+
 // IMPORTANT NOTE(bill): Must be in this order (as the compiler relies upon it)
 
 

--- a/core/runtime/entry_windows.odin
+++ b/core/runtime/entry_windows.odin
@@ -8,15 +8,19 @@ when ODIN_BUILD_MODE == .Dynamic {
 	@(link_name="DllMain", linkage="strong", require)
 	DllMain :: proc "stdcall" (hinstDLL: rawptr, fdwReason: u32, lpReserved: rawptr) -> b32 {
 		context = default_context()
-		switch fdwReason {
-		case 1: // DLL_PROCESS_ATTACH
+
+		// Populate Windows DLL-specific global
+		dll_forward_reason = DLL_Forward_Reason(fdwReason)
+
+		switch dll_forward_reason {
+		case .Process_Attach:
 			#force_no_inline _startup_runtime()
 			intrinsics.__entry_point()
-		case 0: // DLL_PROCESS_DETACH
+		case .Process_Detach:
 			#force_no_inline _cleanup_runtime()
-		case 2: // DLL_THREAD_ATTACH
+		case .Thread_Attach:
 			break
-		case 3: // DLL_THREAD_DETACH
+		case .Thread_Detach:
 			break
 		}
 		return true


### PR DESCRIPTION
Some plugin architectures require you to know when your DLL (written in Odin) is about to be unloaded, or another thread's about to make use of it.

`fwdReason` as passed to the DLL's entry point will now populate `dll_forward_reason` on Windows to allow you to handle this.