### PR TITLE
Fix issue #1856

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -183,6 +183,7 @@ parse_file :: proc(p: ^Parser, file: ^ast.File) -> bool {
 	pd.name    = pkg_name.text
 	pd.comment = p.line_comment
 	p.file.pkg_decl = pd
+	p.file.docs = docs
 
 	expect_semicolon(p, pd)
 


### PR DESCRIPTION
This PR fixes the [issue](#1856) where file.docs where left nil whether the file had a header comment or no.