### PR TITLE
Fix issue 1859

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -3249,8 +3249,9 @@ void check_binary_expr(CheckerContext *c, Operand *x, Ast *node, Type *type_hint
 		return;
 	}
 
-	
-	if (!are_types_identical(x->type, y->type)) {
+	bool treat_booleans_as_equals = op.kind == Token_CmpAnd || op.kind == Token_CmpOr;
+	if (!are_types_identical(x->type, y->type, treat_booleans_as_equals))
+	{
 		if (x->type != t_invalid &&
 		    y->type != t_invalid) {
 			gbString xt = type_to_string(x->type);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -731,7 +731,7 @@ gbString type_to_string       (Type *type, bool shorthand=false);
 i64      type_size_of_internal(Type *t, TypePath *path);
 void     init_map_internal_types(Type *type);
 Type *   bit_set_to_int(Type *t);
-bool are_types_identical(Type *x, Type *y);
+bool are_types_identical(Type *x, Type *y, bool treat_booleans_as_equals);
 
 bool is_type_pointer(Type *t);
 bool is_type_proc(Type *t);
@@ -2414,17 +2414,22 @@ Type *strip_type_aliasing(Type *x) {
 	return x;
 }
 
-bool are_types_identical_internal(Type *x, Type *y, bool check_tuple_names);
+bool are_types_identical_internal(Type *x, Type *y, bool check_tuple_names, bool treat_booleans_as_equals);
+
+bool are_types_identical(Type *x, Type *y, bool treat_booleans_as_equals) {
+	return are_types_identical_internal(x, y, false, treat_booleans_as_equals);
+}
 
 bool are_types_identical(Type *x, Type *y) {
-	return are_types_identical_internal(x, y, false);
+	return are_types_identical_internal(x, y, false, false);
 }
+
 bool are_types_identical_unique_tuples(Type *x, Type *y) {
-	return are_types_identical_internal(x, y, true);
+	return are_types_identical_internal(x, y, true, false);
 }
 
 
-bool are_types_identical_internal(Type *x, Type *y, bool check_tuple_names) {
+bool are_types_identical_internal(Type *x, Type *y, bool check_tuple_names, bool treat_booleans_as_equals) {
 	if (x == y) {
 		return true;
 	}
@@ -2446,6 +2451,9 @@ bool are_types_identical_internal(Type *x, Type *y, bool check_tuple_names) {
 
 	case Type_Basic:
 		if (y->kind == Type_Basic) {
+			if (treat_booleans_as_equals && is_type_boolean(x) && is_type_boolean(y)) {
+				return true;
+			}
 			return x->Basic.kind == y->Basic.kind;
 		}
 		break;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -731,7 +731,8 @@ gbString type_to_string       (Type *type, bool shorthand=false);
 i64      type_size_of_internal(Type *t, TypePath *path);
 void     init_map_internal_types(Type *type);
 Type *   bit_set_to_int(Type *t);
-bool are_types_identical(Type *x, Type *y, bool treat_booleans_as_equals);
+bool     are_types_identical(Type *x, Type *y);
+bool     are_types_identical(Type *x, Type *y, bool treat_booleans_as_equals);
 
 bool is_type_pointer(Type *t);
 bool is_type_proc(Type *t);


### PR DESCRIPTION
This PR allow any boolean type to be `&&` or `||` with any other boolean type and thus fixing the [issue 1859](https://github.com/odin-lang/Odin/issues/1859)