### PR TITLE
Change LPCSTR to LPCWSTR in windows _W procedures

### DIFF
--- a/core/sys/windows/kernel32.odin
+++ b/core/sys/windows/kernel32.odin
@@ -6,7 +6,7 @@ foreign import kernel32 "system:Kernel32.lib"
 @(default_calling_convention="stdcall")
 foreign kernel32 {
 	OutputDebugStringA :: proc(lpOutputString: LPCSTR) --- // The only A thing that is allowed
-	OutputDebugStringW :: proc(lpOutputString: LPCSTR) ---
+	OutputDebugStringW :: proc(lpOutputString: LPCWSTR) ---
 
 	ReadConsoleW :: proc(hConsoleInput: HANDLE,
 	                     lpBuffer: LPVOID,
@@ -101,7 +101,7 @@ foreign kernel32 {
 	GetExitCodeThread :: proc(thread: HANDLE, exit_code: ^DWORD) -> BOOL ---
 	TerminateThread :: proc(thread: HANDLE, exit_code: DWORD) -> BOOL ---
 
-	CreateSemaphoreW :: proc(attributes: LPSECURITY_ATTRIBUTES, initial_count, maximum_count: LONG, name: LPCSTR) -> HANDLE ---
+	CreateSemaphoreW :: proc(attributes: LPSECURITY_ATTRIBUTES, initial_count, maximum_count: LONG, name: LPCWSTR) -> HANDLE ---
 	ReleaseSemaphore :: proc(semaphore: HANDLE, release_count: LONG, previous_count: ^LONG) -> BOOL ---
 
 	CreateWaitableTimerW :: proc(


### PR DESCRIPTION
Some W-suffixed procedures still had LPCSTR specified as arguments. Thus, they do not quite work as expected, which is fixed by changing the parameter types to LPCWSTR.