### PR TITLE
fix -build-mode:shared on MacOS

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -463,8 +463,15 @@ i32 linker_stage(lbGenerator *gen) {
 				// correctly this way since all the other dependencies provided implicitly
 				// by the compiler frontend are still needed and most of the command
 				// line arguments prepared previously are incompatible with ld.
-				link_settings = gb_string_appendc(link_settings, "-Wl,-init,'_odin_entry_point' ");
-				link_settings = gb_string_appendc(link_settings, "-Wl,-fini,'_odin_exit_point' ");
+				if (build_context.metrics.os == TargetOs_darwin) {
+					link_settings = gb_string_appendc(link_settings, "-Wl,-init,'__odin_entry_point' ");
+					// NOTE(weshardee): __odin_exit_point should also be added, but -fini 
+					// does not exist on MacOS
+				} else {
+					link_settings = gb_string_appendc(link_settings, "-Wl,-init,'_odin_entry_point' ");
+					link_settings = gb_string_appendc(link_settings, "-Wl,-fini,'_odin_exit_point' ");
+				}
+				
 			} else if (build_context.metrics.os != TargetOs_openbsd) {
 				// OpenBSD defaults to PIE executable. do not pass -no-pie for it.
 				link_settings = gb_string_appendc(link_settings, "-no-pie ");


### PR DESCRIPTION
I'm attempting to address [issue 1816](https://github.com/odin-lang/Odin/issues/1816) by doing two things:

1. I omit the `-fini` flag command when using `build-mode:shared` on MacOS. This flag doesn't exist on MacOS, and I was unable to find an equivalent replacement. I'm not entirely sure what will be affected if `_odin_exit_point` is not called, but until a suitable option is discovered, it seems like being able to actually build a dylib would be preferable to not being able to do so at all.
2. `_odin_entry_point` needs to be `__odin_entry_point` on MacOS for some reason.