### PR TITLE
Improve debug info

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -58,7 +58,7 @@ set libs= ^
 set linker_flags= -incremental:no -opt:ref -subsystem:console
 
 if %release_mode% EQU 0 ( rem Debug
-	set linker_flags=%linker_flags% -debug
+	set linker_flags=%linker_flags% -debug /NATVIS:src\odin_compiler.natvis
 ) else ( rem Release
 	set linker_flags=%linker_flags% -debug
 )

--- a/src/llvm_backend_debug.cpp
+++ b/src/llvm_backend_debug.cpp
@@ -43,6 +43,10 @@ LLVMMetadataRef lb_debug_location_from_ast(lbProcedure *p, Ast *node) {
 	GB_ASSERT(node != nullptr);
 	return lb_debug_location_from_token_pos(p, ast_token(node).pos);
 }
+LLVMMetadataRef lb_debug_end_location_from_ast(lbProcedure *p, Ast *node) {
+	GB_ASSERT(node != nullptr);
+	return lb_debug_location_from_token_pos(p, ast_end_token(node).pos);
+}
 
 LLVMMetadataRef lb_debug_type_internal_proc(lbModule *m, Type *type) {
 	i64 size = type_size_of(type); // Check size

--- a/src/llvm_backend_stmt.cpp
+++ b/src/llvm_backend_stmt.cpp
@@ -1210,8 +1210,8 @@ void lb_build_switch_stmt(lbProcedure *p, AstSwitchStmt *ss, Scope *scope) {
 	}
 
 	lb_emit_jump(p, done);
-	lb_close_scope(p, lbDeferExit_Default, done);
 	lb_start_block(p, done);
+	lb_close_scope(p, lbDeferExit_Default, done);
 }
 
 void lb_store_type_case_implicit(lbProcedure *p, Ast *clause, lbValue value) {
@@ -1253,7 +1253,6 @@ void lb_type_case_body(lbProcedure *p, Ast *label, Ast *clause, lbBlock *body, l
 	ast_node(cc, CaseClause, clause);
 
 	lb_push_target_list(p, label, done, nullptr, nullptr);
-	lb_open_scope(p, body->scope);
 	lb_build_stmt_list(p, cc->stmts);
 	lb_close_scope(p, lbDeferExit_Default, body);
 	lb_pop_target_list(p);
@@ -1263,6 +1262,7 @@ void lb_type_case_body(lbProcedure *p, Ast *label, Ast *clause, lbBlock *body, l
 
 void lb_build_type_switch_stmt(lbProcedure *p, AstTypeSwitchStmt *ss) {
 	lbModule *m = p->module;
+	lb_open_scope(p, ss->scope);
 
 	ast_node(as, AssignStmt, ss->tag);
 	GB_ASSERT(as->lhs.count == 1);
@@ -1321,6 +1321,7 @@ void lb_build_type_switch_stmt(lbProcedure *p, AstTypeSwitchStmt *ss) {
 	for_array(i, body->stmts) {
 		Ast *clause = body->stmts[i];
 		ast_node(cc, CaseClause, clause);
+		lb_open_scope(p, cc->scope);
 		if (cc->list.count == 0) {
 			lb_start_block(p, default_block);
 			lb_store_type_case_implicit(p, clause, parent_value);
@@ -1329,6 +1330,9 @@ void lb_build_type_switch_stmt(lbProcedure *p, AstTypeSwitchStmt *ss) {
 		}
 
 		lbBlock *body = lb_create_block(p, "typeswitch.body");
+		if (p->debug_info != nullptr) {
+			LLVMSetCurrentDebugLocation2(p->builder, lb_debug_location_from_ast(p, clause));
+		}
 		Type *case_type = nullptr;
 		for_array(type_index, cc->list) {
 			case_type = type_of_expr(cc->list[type_index]);
@@ -1375,6 +1379,7 @@ void lb_build_type_switch_stmt(lbProcedure *p, AstTypeSwitchStmt *ss) {
 
 	lb_emit_jump(p, done);
 	lb_start_block(p, done);
+	lb_close_scope(p, lbDeferExit_Default, done);
 }
 
 

--- a/src/odin_compiler.natvis
+++ b/src/odin_compiler.natvis
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+	<Type Name="String">
+		<DisplayString>{text,[len]s8}</DisplayString>
+		<StringView>text,[len]s8</StringView>
+	</Type>
+	<Type Name="Array&lt;*&gt;">
+		<DisplayString>{{ size={count} capacity={capacity} }}</DisplayString>
+		<Expand>
+			<ArrayItems>
+				<Size>count</Size>
+				<ValuePointer>data</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+	<Type Name="Slice&lt;*&gt;">
+		<DisplayString>{{ size={count} }}</DisplayString>
+		<Expand>
+			<ArrayItems>
+				<Size>count</Size>
+				<ValuePointer>data</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+	<Type Name="lbProcedure">
+		<DisplayString>Procedure {name}</DisplayString>
+	</Type>
+</AutoVisualizer>


### PR DESCRIPTION
Improve generation of llvm debug source locations:
- begin/end of procedure (e.g. previously stepping in the debugger would jump from end of proc to the beginning)
- fix scopes of some instruction in the for loop #1858

Embed a natvis file when building the compiler on windows as a debug build to improve debugging experience (at least in msvc) by providing views for String and Array<>