### PR TITLE
[path/slashpath] Change join() to take a slice instead of varargs

### DIFF
--- a/core/path/slashpath/path.odin
+++ b/core/path/slashpath/path.odin
@@ -146,7 +146,7 @@ clean :: proc(path: string, allocator := context.allocator) -> string {
 }
 
 // join joins numerous path elements into a single path
-join :: proc(elems: ..string, allocator := context.allocator) -> string {
+join :: proc(elems: []string, allocator := context.allocator) -> string {
 	context.allocator = allocator
 	for elem, i in elems {
 		if elem != "" {


### PR DESCRIPTION
Achieves parity with `filepath.join()`, which was similarly changed a while back.