### PR TITLE
Support for Quaternion marshal unmarshal json

### DIFF
--- a/core/encoding/json/marshal.odin
+++ b/core/encoding/json/marshal.odin
@@ -116,7 +116,23 @@ marshal_to_writer :: proc(w: io.Writer, v: any) -> (err: Marshal_Error) {
 		io.write_byte(w, ']')    or_return
 
 	case runtime.Type_Info_Quaternion:
-		return .Unsupported_Type
+		r, i, j, k: f64
+		switch q in a {
+		case quaternion64:  r, i, j, k = f64(q.x), f64(q.y), f64(q.z), f64(q.w)
+		case quaternion128: r, i, j, k = f64(q.x), f64(q.y), f64(q.z), f64(q.w)
+		case quaternion256: r, i, j, k = f64(q.x), f64(q.y), f64(q.z), f64(q.w)
+		case: return .Unsupported_Type
+		}
+
+		io.write_byte(w, '[')    or_return
+		io.write_f64(w, r)       or_return
+		io.write_string(w, ", ") or_return
+		io.write_f64(w, i)       or_return
+		io.write_string(w, ", ") or_return
+		io.write_f64(w, j)       or_return
+		io.write_string(w, ", ") or_return
+		io.write_f64(w, k)       or_return
+		io.write_byte(w, ']')    or_return
 
 	case runtime.Type_Info_String:
 		switch s in a {

--- a/core/encoding/json/unmarshal.odin
+++ b/core/encoding/json/unmarshal.odin
@@ -575,6 +575,20 @@ unmarshal_array :: proc(p: ^Parser, v: any) -> (err: Unmarshal_Error) {
 		
 		return UNSUPPORTED_TYPE
 		
+	case reflect.Type_Info_Quaternion:
+		// NOTE(bill): Allow lengths which are less than the dst array
+		if int(length) > 4 {
+			return UNSUPPORTED_TYPE
+		}
+	
+		switch ti.id {
+		case quaternion64:  return assign_array(p, v.data, type_info_of(f16), 4)
+		case quaternion128:  return assign_array(p, v.data, type_info_of(f32), 4)
+		case quaternion256: return assign_array(p, v.data, type_info_of(f64), 4)
+		}
+		
+		return UNSUPPORTED_TYPE
+		
 	}
 		
 	return UNSUPPORTED_TYPE


### PR DESCRIPTION
At this time Quaternions are not supported in marshalling and unmarshalling json.

This PR hopes to alleviate that issue as it is  a very simple addition that is helpful.

Serializing any kind of 3d or 2d in quaternions is quite common therefor I propose this PR to help with that and any other use case that this may be beneficial.