### PR TITLE
fix `linalg.angle_from_quaternion`

### DIFF
--- a/core/math/linalg/specific.odin
+++ b/core/math/linalg/specific.odin
@@ -476,21 +476,21 @@ quaternion_angle_axis :: proc{
 
 angle_from_quaternion_f16 :: proc(q: Quaternionf16) -> f16 {
 	if abs(q.w) > math.SQRT_THREE*0.5 {
-		return math.asin(q.x*q.x + q.y*q.y + q.z*q.z) * 2
+		return math.asin(math.sqrt(q.x*q.x + q.y*q.y + q.z*q.z)) * 2
 	}
 
 	return math.acos(q.w) * 2
 }
 angle_from_quaternion_f32 :: proc(q: Quaternionf32) -> f32 {
 	if abs(q.w) > math.SQRT_THREE*0.5 {
-		return math.asin(q.x*q.x + q.y*q.y + q.z*q.z) * 2
+		return math.asin(math.sqrt(q.x*q.x + q.y*q.y + q.z*q.z)) * 2
 	}
 
 	return math.acos(q.w) * 2
 }
 angle_from_quaternion_f64 :: proc(q: Quaternionf64) -> f64 {
 	if abs(q.w) > math.SQRT_THREE*0.5 {
-		return math.asin(q.x*q.x + q.y*q.y + q.z*q.z) * 2
+		return math.asin(math.sqrt(q.x*q.x + q.y*q.y + q.z*q.z)) * 2
 	}
 
 	return math.acos(q.w) * 2


### PR DESCRIPTION
fixes #1894 .2:
```odin
package laa
import "core:fmt"
import la "core:math/linalg"

main:: proc() {
    angle := f32(0.5)
    quat  := la.quaternion_angle_axis_f32(angle,la.Vector3f32{0,0,1})
    fmt.printf("retreived: %0.8f\n",  la.angle_from_quaternion(quat)) // should be 0.5, but wasn't
}
```