### PR TITLE
Remove clamp from vector sizing: 1834, 1882

### DIFF
--- a/src/llvm_abi.cpp
+++ b/src/llvm_abi.cpp
@@ -233,7 +233,7 @@ i64 lb_sizeof(LLVMTypeRef type) {
 			i64 elem_size = lb_sizeof(elem);
 			i64 count = LLVMGetVectorSize(type);
 			i64 size = count * elem_size;
-			return gb_clamp(next_pow2(size), 1, build_context.max_align);
+			return next_pow2(size);
 		}
 
 	}


### PR DESCRIPTION
I believe this is a potential fix for https://github.com/odin-lang/Odin/issues/1834, https://github.com/odin-lang/Odin/issues/1882