### PR TITLE
Fix bug unmarshalling JSON with assertions disabled

### DIFF
--- a/core/encoding/json/unmarshal.odin
+++ b/core/encoding/json/unmarshal.odin
@@ -325,7 +325,7 @@ unmarshal_object :: proc(p: ^Parser, v: any, end_token: Token_Kind) -> (err: Unm
 	UNSUPPORTED_TYPE := Unsupported_Type_Error{v.id, p.curr_token}
 	
 	if end_token == .Close_Brace {
-		assert(expect_token(p, .Open_Brace) == nil)
+		unmarshal_expect_token(p, .Open_Brace)
 	}
 
 	v := v
@@ -473,7 +473,7 @@ unmarshal_object :: proc(p: ^Parser, v: any, end_token: Token_Kind) -> (err: Unm
 	}
 	
 	if end_token == .Close_Brace {
-		assert(expect_token(p, .Close_Brace) == nil)
+		unmarshal_expect_token(p, .Close_Brace)
 	}
 	return
 }


### PR DESCRIPTION
When asserts are disabled, code within the assert isn't run. Having
expect_token within an assert means that the state of the Parser is
mutated when asserts are run, but not when they aren't.

There's already a wrapper procedure for this pattern, which I have
reused here.

Fixes #1890 