### PR TITLE
Update dxgi.odin

### DIFF
--- a/vendor/directx/dxgi/dxgi.odin
+++ b/vendor/directx/dxgi/dxgi.odin
@@ -38,10 +38,10 @@ IUnknown_VTable :: struct {
 
 @(default_calling_convention="stdcall")
 foreign dxgi {
-	CreateDXGIFactory      :: proc(riid: ^IID, ppFactory: rawptr) -> HRESULT ---
-	CreateDXGIFactory1     :: proc(riid: ^IID, ppFactory: rawptr) -> HRESULT ---
-	CreateDXGIFactory2     :: proc(Flags: u32, riid: ^IID, ppFactory: rawptr) -> HRESULT ---
-	DXGIGetDebugInterface1 :: proc(Flags: u32, riid: ^IID, pDebug: rawptr) -> HRESULT ---
+	CreateDXGIFactory      :: proc(riid: ^IID, ppFactory: ^rawptr) -> HRESULT ---
+	CreateDXGIFactory1     :: proc(riid: ^IID, ppFactory: ^rawptr) -> HRESULT ---
+	CreateDXGIFactory2     :: proc(Flags: u32, riid: ^IID, ppFactory: ^rawptr) -> HRESULT ---
+	DXGIGetDebugInterface1 :: proc(Flags: u32, riid: ^IID, pDebug: ^rawptr) -> HRESULT ---
 }
 
 STANDARD_MULTISAMPLE_QUALITY_PATTERN :: 0xffffffff


### PR DESCRIPTION
Fixed the last parameters of `CreateDXGIFactory*` procedures to be `^rawptr` instead of `rawptr`
The original functions have `void **` parameter
Note: 
Also fixed [DXGIGetDebugInterface1](https://docs.microsoft.com/en-us/windows/win32/api/dxgi1_3/nf-dxgi1_3-dxgigetdebuginterface1)
The original last parameter is `void **pDebug` . The naming confusion is MS's fault.