### PR TITLE
Fix incorrect behaviour of string ordering

### DIFF
--- a/core/runtime/internal.odin
+++ b/core/runtime/internal.odin
@@ -341,7 +341,12 @@ string_eq :: proc "contextless" (lhs, rhs: string) -> bool {
 string_cmp :: proc "contextless" (a, b: string) -> int {
 	x := transmute(Raw_String)a
 	y := transmute(Raw_String)b
-	return memory_compare(x.data, y.data, min(x.len, y.len))
+
+	ret := memory_compare(x.data, y.data, min(x.len, y.len))
+	if ret == 0 && x.len != y.len {
+		return -1 if x.len < y.len else +1
+	}
+	return ret
 }
 
 string_ne :: #force_inline proc "contextless" (a, b: string) -> bool { return !string_eq(a, b) }

--- a/core/sort/sort.odin
+++ b/core/sort/sort.odin
@@ -684,5 +684,10 @@ compare_f64s :: proc(a, b: f64) -> int {
 compare_strings :: proc(a, b: string) -> int {
 	x := transmute(mem.Raw_String)a
 	y := transmute(mem.Raw_String)b
-	return mem.compare_byte_ptrs(x.data, y.data, min(x.len, y.len))
+	
+	ret := mem.compare_byte_ptrs(x.data, y.data, min(x.len, y.len))
+	if ret == 0 && x.len != y.len {
+		return -1 if x.len < y.len else +1
+	}
+	return ret
 }


### PR DESCRIPTION
Currently internal.string_cmp and sort.compare_strings don't account for the case when one of the strings is a prefix of the other, which was pointed out in #1912.