### PR TITLE
Memory leak in os2 user_config_dir and user_home_dir

### DIFF
--- a/core/os/os2/user.odin
+++ b/core/os/os2/user.odin
@@ -6,19 +6,19 @@ import "core:runtime"
 user_cache_dir :: proc(allocator: runtime.Allocator) -> (dir: string, err: Error) {
 	#partial switch ODIN_OS {
 	case .Windows:
-		dir = get_env("LocalAppData")
+		dir = get_env("LocalAppData", allocator)
 		if dir != "" {
 			dir = strings.clone_safe(dir, allocator) or_return
 		}
 	case .Darwin:
-		dir = get_env("HOME")
+		dir = get_env("HOME", allocator)
 		if dir != "" {
 			dir = strings.concatenate_safe({dir, "/Library/Caches"}, allocator) or_return
 		}
 	case: // All other UNIX systems
-		dir = get_env("XDG_CACHE_HOME")
+		dir = get_env("XDG_CACHE_HOME", allocator)
 		if dir == "" {
-			dir = get_env("HOME")
+			dir = get_env("HOME", allocator)
 			if dir == "" {
 				return
 			}
@@ -34,19 +34,19 @@ user_cache_dir :: proc(allocator: runtime.Allocator) -> (dir: string, err: Error
 user_config_dir :: proc(allocator: runtime.Allocator) -> (dir: string, err: Error) {
 	#partial switch ODIN_OS {
 	case .Windows:
-		dir = get_env("AppData")
+		dir = get_env("AppData", allocator)
 		if dir != "" {
 			dir = strings.clone_safe(dir, allocator) or_return
 		}
 	case .Darwin:
-		dir = get_env("HOME")
+		dir = get_env("HOME", allocator)
 		if dir != "" {
 			dir = strings.concatenate_safe({dir, "/Library/Application Support"}, allocator) or_return
 		}
 	case: // All other UNIX systems
-		dir = get_env("XDG_CACHE_HOME")
+		dir = get_env("XDG_CACHE_HOME", allocator)
 		if dir == "" {
-			dir = get_env("HOME")
+			dir = get_env("HOME", allocator)
 			if dir == "" {
 				return
 			}
@@ -59,13 +59,13 @@ user_config_dir :: proc(allocator: runtime.Allocator) -> (dir: string, err: Erro
 	return
 }
 
-user_home_dir :: proc() -> (dir: string, err: Error) {
+user_home_dir :: proc(allocator: runtime.Allocator) -> (dir: string, err: Error) {
 	env := "HOME"
 	#partial switch ODIN_OS {
 	case .Windows:
 		env = "USERPROFILE"
 	}
-	if v := get_env(env); v != "" {
+	if v := get_env(env, allocator); v != "" {
 		return v, nil
 	}
 	return "", .Invalid_Path


### PR DESCRIPTION
`user_config_dir` and `user_home_dir` were not passing an allocator to `get_env`, causing a leak.

The leak site is in `wstring_to_utf8`

Repro:
```
package main

import "core:mem"
import "core:fmt"
import "core:os/os2"

main :: proc() {
	track: mem.Tracking_Allocator
	mem.tracking_allocator_init(&track, context.allocator)
	context.allocator = mem.tracking_allocator(&track)

	os2.user_config_dir(context.temp_allocator)
	os2.user_home_dir()

	for _, leak in track.allocation_map {
		fmt.printf("%v leaked %v bytes\n", leak.location, leak.size)
	}
}

// .../Odin/core/sys/windows/util.odin(79:10) leaked 29 bytes
// .../Odin/core/sys/windows/util.odin(79:10) leaked 13 bytes
```