### PR TITLE
Debug symbols for range-based for loop over number range

### DIFF
--- a/src/llvm_backend_stmt.cpp
+++ b/src/llvm_backend_stmt.cpp
@@ -481,7 +481,7 @@ void lb_build_range_interval(lbProcedure *p, AstBinaryExpr *node,
 	lbAddr index;
 	if (val1_type != nullptr) {
 		Entity *e = entity_of_node(rs->vals[1]);
-		index = lb_add_local(p, t_int, e, false);
+		index = lb_add_local(p, val1_type, e, false);
 	} else {
 		index = lb_add_local_generated(p, t_int, false);
 	}

--- a/src/llvm_backend_stmt.cpp
+++ b/src/llvm_backend_stmt.cpp
@@ -472,9 +472,9 @@ void lb_build_range_interval(lbProcedure *p, AstBinaryExpr *node,
 	lbAddr value;
 	if (val0_type != nullptr) {
 		Entity *e = entity_of_node(rs->vals[0]);
-		value = lb_add_local(p, val0_type ? val0_type : lower.type, e, false);
+		value = lb_add_local(p, val0_type, e, false);
 	} else {
-		value = lb_add_local_generated(p, val0_type ? val0_type : lower.type, false);
+		value = lb_add_local_generated(p, lower.type, false);
 	}
 	lb_addr_store(p, value, lower);
 

--- a/src/llvm_backend_stmt.cpp
+++ b/src/llvm_backend_stmt.cpp
@@ -458,15 +458,6 @@ void lb_build_range_interval(lbProcedure *p, AstBinaryExpr *node,
 		val1_type = type_of_expr(rs->vals[1]);
 	}
 
-	if (val0_type != nullptr) {
-		Entity *e = entity_of_node(rs->vals[0]);
-		lb_add_local(p, e->type, e, true);
-	}
-	if (val1_type != nullptr) {
-		Entity *e = entity_of_node(rs->vals[1]);
-		lb_add_local(p, e->type, e, true);
-	}
-
 	TokenKind op = Token_Lt;
 	switch (node->op.kind) {
 	case Token_Ellipsis:  op = Token_LtEq; break;
@@ -478,10 +469,22 @@ void lb_build_range_interval(lbProcedure *p, AstBinaryExpr *node,
 	lbValue lower = lb_build_expr(p, node->left);
 	lbValue upper = {}; // initialized each time in the loop
 
-	lbAddr value = lb_add_local_generated(p, val0_type ? val0_type : lower.type, false);
+	lbAddr value;
+	if (val0_type != nullptr) {
+		Entity *e = entity_of_node(rs->vals[0]);
+		value = lb_add_local(p, val0_type ? val0_type : lower.type, e, false);
+	} else {
+		value = lb_add_local_generated(p, val0_type ? val0_type : lower.type, false);
+	}
 	lb_addr_store(p, value, lower);
 
-	lbAddr index = lb_add_local_generated(p, t_int, false);
+	lbAddr index;
+	if (val1_type != nullptr) {
+		Entity *e = entity_of_node(rs->vals[1]);
+		index = lb_add_local(p, t_int, e, false);
+	} else {
+		index = lb_add_local_generated(p, t_int, false);
+	}
 	lb_addr_store(p, index, lb_const_int(m, t_int, 0));
 
 	lbBlock *loop = lb_create_block(p, "for.interval.loop");


### PR DESCRIPTION
Before this PR the debugger showed `0` for `val` and `i` at every step of the loop. Now it shows `0` `1` `2`.

```
sum := 0
for val, i in 0 ..< 3 {
	sum += val
}
```

This PR doesn't fix debug symbols for the other kinds of range-based for loops. Those looked more difficult to fix but I think it's the same underlying problem.

I tested with `cppvsdbg` in vscode.