### PR TITLE
Removed extra space from file_console_logger

### DIFF
--- a/core/log/file_console_logger.odin
+++ b/core/log/file_console_logger.odin
@@ -95,7 +95,7 @@ file_console_logger_proc :: proc(logger_data: rawptr, level: Level, text: string
 		fmt.sbprintf(&buf, "[%s] ", data.ident)
 	}
 	//TODO(Hoej): When we have better atomics and such, make this thread-safe
-	fmt.fprintf(h, "%s %s\n", strings.to_string(buf), text)
+	fmt.fprintf(h, "%s%s\n", strings.to_string(buf), text)
 }
 
 do_level_header :: proc(opts: Options, level: Level, str: ^strings.Builder) {


### PR DESCRIPTION
Logs were always printing an extra space before the string

```
 test1
[DEBUG] --- [2022-08-03 17:22:43] [main.odin:21:main()]  test2
```

Repro:

```
package main

import "core:log"
import "core:os"

main :: proc() {
	context.logger = log.Logger{
		log.file_console_logger_proc,
		&log.File_Console_Logger_Data{file_handle = os.INVALID_HANDLE},
		log.Level.Debug,
		log.Options{},
	}
	log.log(log.Level.Debug, "test1")

	context.logger = log.Logger{
		log.file_console_logger_proc,
		&log.File_Console_Logger_Data{file_handle = os.INVALID_HANDLE},
		log.Level.Debug,
		log.Default_Console_Logger_Opts,
	}
	log.log(log.Level.Debug, "test2")
}
```