### PR TITLE
fixed math.log2

### DIFF
--- a/core/math/math.odin
+++ b/core/math/math.odin
@@ -185,16 +185,23 @@ log       :: proc{
 	log_f64, log_f64le, log_f64be,
 }
 
-log2_f16   :: logb_f16
-log2_f16le :: logb_f16le
-log2_f16be :: logb_f16be
-log2_f32   :: logb_f32
-log2_f32le :: logb_f32le
-log2_f32be :: logb_f32be
-log2_f64   :: logb_f64
-log2_f64le :: logb_f64le
-log2_f64be :: logb_f64be
-log2       :: logb
+log2_f16   :: proc "contextless" (x: f16)   -> f16   { return log(f16(x), f16(2.0)) }
+log2_f16le :: proc "contextless" (x: f16le) -> f16le { return f16le(log_f16(f16(x), f16(2.0))) }
+log2_f16be :: proc "contextless" (x: f16be) -> f16be { return f16be(log_f16(f16(x), f16(2.0))) }
+
+log2_f32   :: proc "contextless" (x: f32)   -> f32   { return log(f32(x), f32(2.0)) }
+log2_f32le :: proc "contextless" (x: f32le) -> f32le { return f32le(log_f32(f32(x), f32(2.0))) }
+log2_f32be :: proc "contextless" (x: f32be) -> f32be { return f32be(log_f32(f32(x), f32(2.0))) }
+
+log2_f64   :: proc "contextless" (x: f64)   -> f64   { return log(f64(x), f64(2.0)) }
+log2_f64le :: proc "contextless" (x: f64le) -> f64le { return f64le(log_f64(f64(x), f64(2.0))) }
+log2_f64be :: proc "contextless" (x: f64be) -> f64be { return f64be(log_f64(f64(x), f64(2.0))) }
+
+log2       :: proc{
+	log2_f16, log2_f16le, log2_f16be,
+	log2_f32, log2_f32le, log2_f32be,
+	log2_f64, log2_f64le, log2_f64be,
+}
 
 log10_f16   :: proc "contextless" (x: f16)   -> f16   { return ln(x)/LN10 }
 log10_f16le :: proc "contextless" (x: f16le) -> f16le { return f16le(log10_f16(f16(x))) }


### PR DESCRIPTION
### What
- Change math:log2 proc, which called logb() and returned truncated result, to call log, log_f16, log_f32, etc instead. Now it returns the correct full floating-point result.

 ### Why
 - Issue opened: math.log2 returns truncated result #1924 

### Testing
- I have tested this on the Issue's case, log2(f16(10)), log2(f32(10)), log2(f64(10)) and it returns 3.32 ... 
