### PR TITLE
Find rc.exe in Windows SDK

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -204,7 +204,7 @@ enum BuildPath : u8 {
 	BuildPath_Main_Package,     // Input  Path to the package directory (or file) we're building.
 	BuildPath_RC,               // Input  Path for .rc  file, can be set with `-resource:`.
 	BuildPath_RES,              // Output Path for .res file, generated from previous.
-	BuildPath_Win_SDK_Root,     // windows_sdk_root
+	BuildPath_Win_SDK_Bin_Path, // windows_sdk_bin_path
 	BuildPath_Win_SDK_UM_Lib,   // windows_sdk_um_library_path
 	BuildPath_Win_SDK_UCRT_Lib, // windows_sdk_ucrt_library_path
 	BuildPath_VS_EXE,           // vs_exe_path
@@ -1336,7 +1336,7 @@ bool init_build_paths(String init_filename) {
 
 		if ((bc->command_kind & Command__does_build) && (!bc->ignore_microsoft_magic)) {
 			// NOTE(ic): It would be nice to extend this so that we could specify the Visual Studio version that we want instead of defaulting to the latest.
-			Find_Result_Utf8 find_result = find_visual_studio_and_windows_sdk_utf8();
+			Find_Result find_result = find_visual_studio_and_windows_sdk();
 			defer (mc_free_all());
 
 			if (find_result.windows_sdk_version == 0) {
@@ -1357,8 +1357,8 @@ bool init_build_paths(String init_filename) {
 			if (find_result.windows_sdk_um_library_path.len > 0) {
 				GB_ASSERT(find_result.windows_sdk_ucrt_library_path.len > 0);
 
-				if (find_result.windows_sdk_root.len > 0) {
-					bc->build_paths[BuildPath_Win_SDK_Root]     = path_from_string(ha, find_result.windows_sdk_root);
+				if (find_result.windows_sdk_bin_path.len > 0) {
+					bc->build_paths[BuildPath_Win_SDK_Bin_Path]  = path_from_string(ha, find_result.windows_sdk_bin_path);
 				}
 
 				if (find_result.windows_sdk_um_library_path.len > 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -283,6 +283,9 @@ i32 linker_stage(lbGenerator *gen) {
 			String vs_exe_path = path_to_string(heap_allocator(), build_context.build_paths[BuildPath_VS_EXE]);
 			defer (gb_free(heap_allocator(), vs_exe_path.text));
 
+			String windows_sdk_bin_path = path_to_string(heap_allocator(), build_context.build_paths[BuildPath_Win_SDK_Bin_Path]);
+			defer (gb_free(heap_allocator(), windows_sdk_bin_path.text));
+
 			char const *subsystem_str = build_context.use_subsystem_windows ? "WINDOWS" : "CONSOLE";
 			if (!build_context.use_lld) { // msvc
 				if (build_context.has_resource) {
@@ -292,7 +295,8 @@ i32 linker_stage(lbGenerator *gen) {
 					defer (gb_free(heap_allocator(), res_path.text));
 
 					result = system_exec_command_line_app("msvc-link",
-						"\"rc.exe\" /nologo /fo \"%.*s\" \"%.*s\"",
+						"\"%.*src.exe\" /nologo /fo \"%.*s\" \"%.*s\"",
+						LIT(windows_sdk_bin_path),
 						LIT(res_path),
 						LIT(rc_path)
 					);

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -324,6 +324,16 @@ String concatenate3_strings(gbAllocator a, String const &x, String const &y, Str
 	data[len] = 0;
 	return make_string(data, len);
 }
+String concatenate4_strings(gbAllocator a, String const &x, String const &y, String const &z, String const &w) {
+	isize len = x.len+y.len+z.len+w.len;
+	u8 *data = gb_alloc_array(a, u8, len+1);
+	gb_memmove(data,                   x.text, x.len);
+	gb_memmove(data+x.len,             y.text, y.len);
+	gb_memmove(data+x.len+y.len,       z.text, z.len);
+	gb_memmove(data+x.len+y.len+z.len, w.text, w.len);
+	data[len] = 0;
+	return make_string(data, len);
+}
 
 String string_join_and_quote(gbAllocator a, Array<String> strings) {
 	if (!strings.count) {


### PR DESCRIPTION
This PR finds the location of `rc.exe` in the Windows SDK. Before it would error when passing `-resource:icon.rc`

It includes changes from https://github.com/odin-lang/Odin/pull/1935 so that should be merged first. Or close that one and only review this. Whatever is easier.

Along the way I found several bugs in the environment variable parsing and ended up refactoring a good portion of `microsoft_craziness.h`

To test:
- download [icon.zip](https://github.com/odin-lang/Odin/files/9277669/icon.zip)
- run `odin build main.odin -file -resource:icon.rc`

Before: 
```
Failed to execute command: "rc.exe" ...
```
After:

![image](https://user-images.githubusercontent.com/1328450/183312889-e2b5d6ca-f545-463d-bd2a-3a1917378504.png)