### PR TITLE
fix #1840 invalid LLVM code gen for arithmetics between f32 and shifted untyped integer

### DIFF
--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -1345,7 +1345,13 @@ lbValue lb_build_binary_expr(lbProcedure *p, Ast *expr) {
 	case Token_Shr: {
 		lbValue left, right;
 		Type *type = default_type(tv.type);
-		left = lb_build_expr(p, be->left);
+
+		if (lb_is_expr_untyped_const(be->left) && !is_type_integer(type)) {
+			type = t_int;
+			left = lb_expr_untyped_const_to_typed(p->module, be->left, t_int);
+		} else {
+			left = lb_build_expr(p, be->left);
+		}
 
 		if (lb_is_expr_untyped_const(be->right)) {
 			// NOTE(bill): RHS shift operands can still be untyped

--- a/tests/issues/run.bat
+++ b/tests/issues/run.bat
@@ -12,6 +12,9 @@ build\test_issue
 ..\..\odin build test_issue_1592.odin %COMMON% -file
 build\test_issue
 
+..\..\odin build test_issue_1840.odin %COMMON% -file
+build\test_issue
+
 @echo off
 
 rmdir /S /Q build

--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -13,6 +13,9 @@ $ODIN build test_issue_829.odin $COMMON -file
 $ODIN build test_issue_1592.odin $COMMON -file
 ./build/test_issue
 
+$ODIN build test_issue_1840.odin $COMMON -file
+./build/test_issue
+
 set +x
 
 rm -rf build

--- a/tests/issues/test_issue_1840.odin
+++ b/tests/issues/test_issue_1840.odin
@@ -1,0 +1,59 @@
+// Tests issue #1840 https://github.com/odin-lang/Odin/issues/1840
+package test_issues
+
+import "core:fmt"
+import "core:testing"
+import tc "tests:common"
+
+main :: proc() {
+    t := testing.T{}
+
+	test_orig()
+
+    test_f32(&t)
+    test_f64(&t)
+
+	tc.report(&t)
+}
+
+/* Original issue #1840 example */
+
+// Compilation fails with invalid LLVM code gen.
+@test
+test_orig :: proc() {
+    r := u32(3)
+    a := f32(1.0)
+    x := a * (1>>r)
+}
+
+@test
+test_f32 :: proc(t: ^testing.T) {
+    r := u32(2)
+    a := f32(1.0)
+
+    // Unsigned const should result in unsigned shift
+    xs := a * ((-1)>>r)
+    xe_expect := f32(i32(-1)>>r)
+    tc.expect(t, xs == xe_expect, fmt.tprintf("%s: %f != %f \n", #procedure, xs, xe_expect))
+
+    // Signed const should result in signed shift
+    xu := a * (0xffffffff>>r)
+    xu_expect := f32(u32(0xffffffff)>>r)
+    tc.expect(t, xu == xu_expect, fmt.tprintf("%s: %f != %f \n", #procedure, xu, xu_expect))
+}
+
+@test
+test_f64 :: proc(t: ^testing.T) {
+    r := u64(2)
+    a := f64(1.0)
+
+    // Unsigned const should result in unsigned shift
+    xs := a * ((-1)>>r)
+    xe_expect := f64(i64(-1)>>r)
+    tc.expect(t, xs == xe_expect, fmt.tprintf("%s: %f != %f \n", #procedure, xs, xe_expect))
+
+    // Signed const should result in signed shift
+    xu := a * (0xffffffffffffffff>>r)
+    xu_expect := f64(u64(0xffffffffffffffff)>>r)
+    tc.expect(t, xu == xu_expect, fmt.tprintf("%s: %f != %f \n", #procedure, xu, xu_expect))
+}


### PR DESCRIPTION
Closes #1840 

Before this PR, shift expressions with untyped const LHS operands would result in invalid LLVM IR if their parent node had a non-integral type.

* converts untyped const LHS operands of shift expressions with non-integer typed parent nodes to `t_int`
* adds tests to tests/issues

This is my first PR and I'm new to the codebase so feedback is very much appreciated!