### PR TITLE
Add ID3D11Debug interface to d3d11 package

### DIFF
--- a/vendor/directx/d3d11/d3d11.odin
+++ b/vendor/directx/d3d11/d3d11.odin
@@ -3625,3 +3625,36 @@ IFunctionLinkingGraph_VTable :: struct {
 	GetLastError:         proc "stdcall" (this: ^IFunctionLinkingGraph, ppErrorBuffer: ^^IBlob) -> HRESULT,
 	GenerateHlsl:         proc "stdcall" (this: ^IFunctionLinkingGraph, uFlags: u32, ppBuffer: ^^IBlob) -> HRESULT,
 }
+
+IDebug_UUID_STRING :: "79CF2233-7536-4948-9D36-1E4692DC5760"
+IDebug_UUID := &IID{0x79CF2233, 0x7536, 0x4948, {0x9D, 0x36, 0x1E, 0x46, 0x92, 0xDC, 0x57, 0x60}}
+
+IDebug :: struct #raw_union {
+	#subtype iunknown: IUnknown,
+	using id3d11debug_vtable: ^IDebug_VTable,
+}
+
+RLDO_FLAGS :: enum u32 { // TODO: make bit_set
+	SUMMARY = 0x1,
+	DETAIL = 0x2,
+	IGNORE_INTERNAL = 0x4,
+}
+
+DEBUG_FEATURE :: enum u32 { // TODO: make bit_set
+	FLUSH_PER_RENDER_OP = 0x1,
+	FINISH_PER_RENDER_OP = 0x2,
+	FEATURE_PRESENT_PER_RENDER_OP = 0x4,
+}
+
+IDebug_VTable :: struct {
+	using iunkown_vtable: IUnknown_VTable,
+	SetFeatureMask:             proc "stdcall" (this: ^IDebug, mask: DEBUG_FEATURE) -> HRESULT,
+	GetFeatureMask:             proc "stdcall" (this: ^IDebug) -> DEBUG_FEATURE,
+	SetPresentPerRenderOpDelay: proc "stdcall" (this: ^IDebug, Milliseconds: u32) -> HRESULT,
+	GetPresentPerRenderOpDelay: proc "stdcall" (this: ^IDebug) -> u32,
+	SetSwapChain:               proc "stdcall" (this: ^IDebug, pSwapChain: ^dxgi.ISwapChain) -> HRESULT,
+	GetSwapChain:               proc "stdcall" (this: ^IDebug, ppSwapChain: ^^dxgi.ISwapChain) -> HRESULT,
+	ValidateContext:            proc "stdcall" (this: ^IDebug, pContext: ^IDeviceContext) -> HRESULT,
+	ReportLiveDeviceObjects:    proc "stdcall" (this: ^IDebug, Flags: RLDO_FLAGS) -> HRESULT,
+	ValidateContextForDispatch: proc "stdcall" (this: ^IDebug, pContext: ^IDeviceContext) -> HRESULT,
+}


### PR DESCRIPTION
Title says it all.
dx12 had its IDebug but it was missing for dx11.
Interface found here:
https://docs.microsoft.com/en-us/windows/win32/api/d3d11sdklayers/nn-d3d11sdklayers-id3d11debug

Verified with:
```
debug: ^d3d11.IDebug
device->QueryInterface(d3d11.IDebug_UUID, (^rawptr)(&debug))
assert(debug != nil)

debug->SetFeatureMask(.FINISH_PER_RENDER_OP)
assert(debug->GetFeatureMask() == .FINISH_PER_RENDER_OP)

debug->SetPresentPerRenderOpDelay(0x1)
assert(debug->GetPresentPerRenderOpDelay() == 0x1)

swap: ^dxgi.ISwapChain
debug->SetSwapChain(swap)
swap_out: ^dxgi.ISwapChain
debug->GetSwapChain(&swap_out)
assert(swap_out == swap)

debug->ValidateContext(device_context)

debug->ValidateContextForDispatch(device_context)

debug->ReportLiveDeviceObjects(.DETAIL)
```