### PR TITLE
Do not remove .rc extension from resource path to prevent expansion t…

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1562,7 +1562,7 @@ bool parse_build_flags(Array<String> args) {
 									bad_flags = true;
 									break;
 								}
-								build_context.resource_filepath = substring(path, 0, string_extension_position(path));
+								build_context.resource_filepath = path;
 								build_context.has_resource = true;
 							} else {
 								gb_printf_err("Invalid -resource path, got %.*s\n", LIT(path));


### PR DESCRIPTION
…o full path assuming it's a directory if a folder with the same name exists in the same folder as the resource file

The issue will occur in the following scenario

odin build src -resource=src\folder.rc

+src
-+folder
-+folder.rc


The issues stems from this code in build_settings.cpp using resource path:
```
			bc->build_paths[BuildPath_RC]      = path_from_string(ha, bc->resource_filepath);
			bc->build_paths[BuildPath_RES]     = path_from_string(ha, bc->resource_filepath);
			bc->build_paths[BuildPath_RC].ext  = copy_string(ha, STR_LIT("rc"));
			bc->build_paths[BuildPath_RES].ext = copy_string(ha, STR_LIT("res"));
```

If the .rc extension is missing path_from_string will determine the path is to a folder, and use that.
Keeping the .rc extension avoids this situation, and changing the ext on the Path will still work fine.

