### PR TITLE
fix #1840 invalid LLVM code gen for arithmetics between f32 and shifted untyped integer

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -2509,10 +2509,10 @@ void check_shift(CheckerContext *c, Operand *x, Operand *y, Ast *node, Type *typ
 				if (is_type_integer(type_hint)) {
 					x->type = type_hint;
 				} else {
-					gbString expr_str = expr_to_string(node);
+					gbString x_str = expr_to_string(x->expr);
 					gbString to_type = type_to_string(type_hint);
-					error(node, "Cannot convert untyped expression '%s' to '%s'", expr_str, to_type);
-					gb_string_free(expr_str);
+					error(node, "Conversion of shifted operand '%s' to '%s' is not allowed", x_str, to_type);
+					gb_string_free(x_str);
 					gb_string_free(to_type);
 					x->mode = Addressing_Invalid;
 					return;

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -2515,10 +2515,10 @@ void check_shift(CheckerContext *c, Operand *x, Operand *y, Ast *node, Type *typ
 					gb_string_free(x_str);
 					gb_string_free(to_type);
 					x->mode = Addressing_Invalid;
-					return;
 				}
 			}
 			// x->value = x_val;
+			return;
 		}
 	}
 

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -2505,11 +2505,20 @@ void check_shift(CheckerContext *c, Operand *x, Operand *y, Ast *node, Type *typ
 				x->expr->tav.is_lhs = true;
 			}
 			x->mode = Addressing_Value;
-			if (type_hint && is_type_integer(type_hint)) {
-				x->type = type_hint;
+			if (type_hint) {
+				if (is_type_integer(type_hint)) {
+					x->type = type_hint;
+				} else {
+					gbString expr_str = expr_to_string(node);
+					gbString to_type = type_to_string(type_hint);
+					error(node, "Cannot convert untyped expression '%s' to '%s'", expr_str, to_type);
+					gb_string_free(expr_str);
+					gb_string_free(to_type);
+					x->mode = Addressing_Invalid;
+					return;
+				}
 			}
 			// x->value = x_val;
-			return;
 		}
 	}
 
@@ -2522,7 +2531,7 @@ void check_shift(CheckerContext *c, Operand *x, Operand *y, Ast *node, Type *typ
 	// TODO(bill): Should we support shifts for fixed arrays and #simd vectors?
 
 	if (!is_type_integer(x->type)) {
-		gbString err_str = expr_to_string(y->expr);
+		gbString err_str = expr_to_string(x->expr);
 		error(node, "Shift operand '%s' must be an integer", err_str);
 		gb_string_free(err_str);
 		x->mode = Addressing_Invalid;


### PR DESCRIPTION
Closes #1840
Before this PR, shift expressions with untyped const lhs operands would result in invalid LLVM IR if their type hint was a non-integral type.
* the compiler now throws a `Conversion of shifted operand '[lhs operand]' to '[type hint]' is not allowed'` error when an untyped shift expression has a non-integral type hint.
* the error message shown when an lhs shift operand is not an integer now correctly displays the lhs operand