### PR TITLE
Improvements to `#load`

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -1196,10 +1196,14 @@ LoadDirectiveResult check_load_directive(CheckerContext *c, Operand *operand, As
 
 	GB_ASSERT(o.value.kind == ExactValue_String);
 
+	operand->type = t_u8_slice;
+	if (type_hint && is_type_string(type_hint)) {
+		operand->type = type_hint;
+	}
+	operand->mode = Addressing_Constant;
+
 	LoadFileCache *cache = nullptr;
 	if (cache_load_file_directive(c, call, o.value.value_string, err_on_not_found, &cache)) {
-		operand->type = t_u8_slice;
-		operand->mode = Addressing_Constant;
 		operand->value = exact_value_string(cache->data);
 		return LoadDirective_Success;
 	}

--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -1170,6 +1170,8 @@ void init_checker_info(CheckerInfo *i) {
 
 	mutex_init(&i->objc_types_mutex);
 	map_init(&i->objc_msgSend_types, a);
+	mutex_init(&i->load_file_mutex);
+	string_map_init(&i->load_file_cache, a);
 }
 
 void destroy_checker_info(CheckerInfo *i) {
@@ -1205,6 +1207,8 @@ void destroy_checker_info(CheckerInfo *i) {
 
 	mutex_destroy(&i->objc_types_mutex);
 	map_destroy(&i->objc_msgSend_types);
+	mutex_init(&i->load_file_mutex);
+	string_map_destroy(&i->load_file_cache);
 }
 
 CheckerContext make_checker_context(Checker *c) {

--- a/src/checker.hpp
+++ b/src/checker.hpp
@@ -287,6 +287,12 @@ struct ObjcMsgData {
 	ObjcMsgKind kind;
 	Type *proc_type;
 };
+struct LoadFileCache {
+	String         path;
+	gbFileError    file_error;
+	String         data;
+	StringMap<u64> hashes;
+};
 
 // CheckerInfo stores all the symbol information for a type-checked program
 struct CheckerInfo {
@@ -363,6 +369,9 @@ struct CheckerInfo {
 
 	BlockingMutex objc_types_mutex;
 	PtrMap<Ast *, ObjcMsgData> objc_msgSend_types;
+
+	BlockingMutex load_file_mutex;
+	StringMap<LoadFileCache *> load_file_cache;
 };
 
 struct CheckerContext {

--- a/src/llvm_backend_const.cpp
+++ b/src/llvm_backend_const.cpp
@@ -391,8 +391,8 @@ lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, bool allow_loc
 
 	if (is_type_slice(type)) {
 		if (value.kind == ExactValue_String) {
-			GB_ASSERT(is_type_u8_slice(type));
-			res.value = lb_find_or_add_entity_string_byte_slice(m, value.value_string).value;
+			GB_ASSERT(is_type_slice(type));
+			res.value = lb_find_or_add_entity_string_byte_slice_with_type(m, value.value_string, original_type).value;
 			return res;
 		} else {
 			ast_node(cl, CompoundLit, value.value_compound);

--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -2523,7 +2523,55 @@ lbValue lb_find_or_add_entity_string_byte_slice(lbModule *m, String const &str) 
 	res.type = t_u8_slice;
 	return res;
 }
+lbValue lb_find_or_add_entity_string_byte_slice_with_type(lbModule *m, String const &str, Type *slice_type) {
+	GB_ASSERT(is_type_slice(slice_type));
+	LLVMValueRef indices[2] = {llvm_zero(m), llvm_zero(m)};
+	LLVMValueRef data = LLVMConstStringInContext(m->ctx,
+		cast(char const *)str.text,
+		cast(unsigned)str.len,
+		false);
 
+
+	char *name = nullptr;
+	{
+		isize max_len = 7+8+1;
+		name = gb_alloc_array(permanent_allocator(), char, max_len);
+		u32 id = m->gen->global_array_index.fetch_add(1);
+		isize len = gb_snprintf(name, max_len, "csbs$%x", id);
+		len -= 1;
+	}
+	LLVMTypeRef type = LLVMTypeOf(data);
+	LLVMValueRef global_data = LLVMAddGlobal(m->mod, type, name);
+	LLVMSetInitializer(global_data, data);
+	LLVMSetLinkage(global_data, LLVMPrivateLinkage);
+	LLVMSetUnnamedAddress(global_data, LLVMGlobalUnnamedAddr);
+	LLVMSetAlignment(global_data, 1);
+	LLVMSetGlobalConstant(global_data, true);
+
+	i64 data_len = str.len;
+	LLVMValueRef ptr = nullptr;
+	if (data_len != 0) {
+		ptr = LLVMConstInBoundsGEP2(type, global_data, indices, 2);
+	} else {
+		ptr = LLVMConstNull(lb_type(m, t_u8_ptr));
+	}
+	if (!is_type_u8_slice(slice_type)) {
+		Type *bt = base_type(slice_type);
+		Type *elem = bt->Slice.elem;
+		i64 sz = type_size_of(elem);
+		GB_ASSERT(sz > 0);
+		ptr = LLVMConstPointerCast(ptr, lb_type(m, alloc_type_pointer(elem)));
+		data_len /= sz;
+	}
+
+	LLVMValueRef len = LLVMConstInt(lb_type(m, t_int), data_len, true);
+	LLVMValueRef values[2] = {ptr, len};
+
+	lbValue res = {};
+	res.value = llvm_const_named_struct(m, slice_type, values, 2);
+	res.type = slice_type;
+	return res;
+}
 
 
 

--- a/src/llvm_backend_utility.cpp
+++ b/src/llvm_backend_utility.cpp
@@ -351,6 +351,10 @@ lbValue lb_emit_try_has_value(lbProcedure *p, lbValue rhs) {
 
 
 lbValue lb_emit_or_else(lbProcedure *p, Ast *arg, Ast *else_expr, TypeAndValue const &tv) {
+	if (arg->state_flags & StateFlag_DirectiveWasFalse) {
+		return lb_build_expr(p, else_expr);
+	}
+
 	lbValue lhs = {};
 	lbValue rhs = {};
 	lb_emit_try_lhs_rhs(p, arg, tv, &lhs, &rhs);

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -282,7 +282,8 @@ enum StateFlag : u8 {
 	StateFlag_type_assert     = 1<<2,
 	StateFlag_no_type_assert  = 1<<3,
 
-	StateFlag_SelectorCallExpr = 1<<6,
+	StateFlag_SelectorCallExpr = 1<<5,
+	StateFlag_DirectiveWasFalse = 1<<6,
 
 	StateFlag_BeenHandled = 1<<7,
 };


### PR DESCRIPTION
Numerous improvements to `#load` et al.

* Allow for `#load(path) or_else default`
* Deprecate `#load_or`
* Cache `#load` data
* Cache `#load_hash` hashes
* Allow for giving the data type: `#load(path, type)`, where `type` must be one of the following:
    * `string`
    * `[]T` where `T` must be a simple data type containing not (internal) pointers