### PR TITLE
smaller allocation for non-null-terminated wstring

### DIFF
--- a/core/sys/windows/util.odin
+++ b/core/sys/windows/util.odin
@@ -73,10 +73,10 @@ wstring_to_utf8 :: proc(s: wstring, N: int, allocator := context.temp_allocator)
 
 	// If N == -1 the call to WideCharToMultiByte assume the wide string is null terminated
 	// and will scan it to find the first null terminated character. The resulting string will
-	// also null terminated.
+	// also be null terminated.
 	// If N != -1 it assumes the wide string is not null terminated and the resulting string
-	// will not be null terminated, we therefore have to force it to be null terminated manually.
-	text := make([]byte, n+1 if N != -1 else n) or_return
+	// will not be null terminated.
+	text := make([]byte, n) or_return
 
 	n1 := WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, s, i32(N), raw_data(text), n, nil, nil)
 	if n1 == 0 {


### PR DESCRIPTION
There's no need to allocate space for a null terminator when the wstring is not null-terminated to begin with, since `WideCharToMultiByte` will write exactly as many bytes as you provide.

https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte
> If this parameter is set to a positive integer, the function processes exactly the specified number of characters. If the provided size does not include a terminating null character, the resulting character string is not null-terminated, and the returned length does not include this character.