### PR TITLE
fix #1759 endian float type conversion errors

### DIFF
--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -1777,9 +1777,6 @@ lbValue lb_emit_conv(lbProcedure *p, lbValue value, Type *t) {
 			lbValue res = {};
 			res = lb_emit_conv(p, value, platform_src_type);
 			res = lb_emit_conv(p, res, platform_dst_type);
-			if (is_type_different_to_arch_endianness(dst)) {
-				res = lb_emit_byte_swap(p, res, platform_dst_type);
-			}
 			return lb_emit_conv(p, res, t);
 		}
 


### PR DESCRIPTION
The PR addresses the part of issue #1759 in which casting floating point values to integers of non-native endianness caused unexpected value changes. It does not address `f32be` values being initialized as `0` on little endian machines as this occurs even outside of the context of a type cast. I created a new issue to refer to it specifically.

Produced expected behavior on all of the test cases created by @WalterPlinge's generator except for those with an `f32be` source value.