### PR TITLE
fix: Expand OpenBSD include for wait.h to all Unix

### DIFF
--- a/src/gb/gb.h
+++ b/src/gb/gb.h
@@ -90,7 +90,7 @@ extern "C" {
 	#error This operating system is not supported
 #endif
 
-#if defined(GB_SYSTEM_OPENBSD)
+#if defined(GB_SYSTEM_UNIX)
 #include <sys/wait.h>
 #endif
 


### PR DESCRIPTION
closes: #1968