### PR TITLE
Fixed marshal_to_writer not supporting i128

### DIFF
--- a/core/encoding/json/marshal.odin
+++ b/core/encoding/json/marshal.odin
@@ -85,6 +85,7 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 		case i16:     u = u128(i)
 		case i32:     u = u128(i)
 		case i64:     u = u128(i)
+		case i128:    u = u128(i)
 		case int:     u = u128(i)
 		case u8:      u = u128(i)
 		case u16:     u = u128(i)


### PR DESCRIPTION
Previously json.marshal(i128(696969)) would print 0 as there was no `u = u128(i)` initialization.