### PR TITLE
Add peek_front and peek_back

### DIFF
--- a/core/container/queue/queue.odin
+++ b/core/container/queue/queue.odin
@@ -99,12 +99,14 @@ get_ptr :: proc(q: ^$Q/Queue($T), #any_int i: int, loc := #caller_location) -> ^
 	return &q.data[idx]
 }
 
-peek_front :: proc(q: ^$Q/Queue($T)) -> ^T {
+peek_front :: proc(q: ^$Q/Queue($T), loc := #caller_location) -> ^T {
+	runtime.bounds_check_error_loc(loc, 0, builtin.len(q.data))
 	idx := q.offset%builtin.len(q.data)
 	return &q.data[idx]
 }
 
-peek_back :: proc(q: ^$Q/Queue($T)) -> ^T {
+peek_back :: proc(q: ^$Q/Queue($T), loc := #caller_location) -> ^T {
+	runtime.bounds_check_error_loc(loc, int(q.len - 1), builtin.len(q.data))
 	idx := (uint(q.len - 1)+q.offset)%builtin.len(q.data)
 	return &q.data[idx]
 }

--- a/core/container/queue/queue.odin
+++ b/core/container/queue/queue.odin
@@ -99,6 +99,16 @@ get_ptr :: proc(q: ^$Q/Queue($T), #any_int i: int, loc := #caller_location) -> ^
 	return &q.data[idx]
 }
 
+peek_front :: proc(q: ^$Q/Queue($T)) -> ^T {
+	idx := q.offset%builtin.len(q.data)
+	return &q.data[idx]
+}
+
+peek_back :: proc(q: ^$Q/Queue($T)) -> ^T {
+	idx := (uint(q.len - 1)+q.offset)%builtin.len(q.data)
+	return &q.data[idx]
+}
+
 // Push an element to the back of the queue
 push_back :: proc(q: ^$Q/Queue($T), elem: T) -> bool {
 	if space(q^) == 0 {


### PR DESCRIPTION
This should remove the need for all the `get_ptr(q, len(q)-1)` and `get_ptr(q, 0)` if you're using the queue as a stack