### PR TITLE
Fix for SDL `GetPreferredLocales`

### DIFF
--- a/vendor/sdl2/sdl2.odin
+++ b/vendor/sdl2/sdl2.odin
@@ -200,7 +200,7 @@ Locale :: struct {
 
 @(default_calling_convention="c", link_prefix="SDL_")
 foreign lib {
-	GetPreferredLocales :: proc() -> ^Locale ---
+	GetPreferredLocales :: proc() -> [^]Locale ---
 }
 
 // misc


### PR DESCRIPTION
The function returns an array of locales, so changing to a multi-pointer

[SDL source](https://github.com/libsdl-org/SDL/blob/00452e47fa022314b4c21af2d4e5b63a53f89b8f/include/SDL_locale.h#L86)