### PR TITLE
Add GL_DEBUG config that falls back to ODIN_DEBUG to preserve previou…

### DIFF
--- a/vendor/OpenGL/constants.odin
+++ b/vendor/OpenGL/constants.odin
@@ -1,5 +1,7 @@
 package odin_gl
 
+GL_DEBUG :: #config(GL_DEBUG, ODIN_DEBUG)
+
 FALSE                          :: false
 TRUE                           :: true
 

--- a/vendor/OpenGL/helpers.odin
+++ b/vendor/OpenGL/helpers.odin
@@ -46,7 +46,7 @@ get_last_error_message :: proc() -> (compile_message: string, compile_type: Shad
 // Shader checking and linking checking are identical
 // except for calling differently named GL functions
 // it's a bit ugly looking, but meh
-when ODIN_DEBUG {
+when GL_DEBUG {
 	import "core:runtime"
 	
 	@private

--- a/vendor/OpenGL/wrappers.odin
+++ b/vendor/OpenGL/wrappers.odin
@@ -2,7 +2,7 @@ package odin_gl
 
 #assert(size_of(bool) == size_of(u8))
 
-when !ODIN_DEBUG {
+when !GL_DEBUG {
 	// VERSION_1_0
 	CullFace               :: proc "c" (mode: u32)                                                                                         {        impl_CullFace(mode)                                                                         }
 	FrontFace              :: proc "c" (mode: u32)                                                                                         {        impl_FrontFace(mode)                                                                        }


### PR DESCRIPTION
…s behaviour, but allows debug builds without OpenGL debug features


This will particularly aid in profiling OpenGL programs, where you need debug symbols but don't want the glGetError overhead.