### PR TITLE
fix panic when typeid used as operand for ternary if expression

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -7347,7 +7347,7 @@ ExprKind check_ternary_if_expr(CheckerContext *c, Operand *o, Ast *node, Type *t
 	check_expr_or_type(c, &x, te->x, type_hint);
 	node->viral_state_flags |= te->x->viral_state_flags;
 
-    if (x.mode == Addressing_Type || x.mode == Addressing_Type) {
+    if (x.mode == Addressing_Type) {
         gbString type_string = expr_to_string(x.expr);
         error(node, "Type %s is invalid operand for ternary if expression", type_string);
         gb_string_free(type_string);
@@ -7366,7 +7366,7 @@ ExprKind check_ternary_if_expr(CheckerContext *c, Operand *o, Ast *node, Type *t
 		return kind;
 	}
 
-    if (y.mode == Addressing_Type || y.mode == Addressing_Type) {
+    if (y.mode == Addressing_Type) {
         gbString type_string = expr_to_string(y.expr);
         error(node, "Type %s is invalid operand for ternary if expression", type_string);
         gb_string_free(type_string);

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -7347,6 +7347,13 @@ ExprKind check_ternary_if_expr(CheckerContext *c, Operand *o, Ast *node, Type *t
 	check_expr_or_type(c, &x, te->x, type_hint);
 	node->viral_state_flags |= te->x->viral_state_flags;
 
+    if (x.mode == Addressing_Type || x.mode == Addressing_Type) {
+        gbString type_string = expr_to_string(x.expr);
+        error(node, "Type %s is invalid operand for ternary if expression", type_string);
+        gb_string_free(type_string);
+        return kind;
+    }
+
 	if (te->y != nullptr) {
 		Type *th = type_hint;
 		if (type_hint == nullptr && is_type_typed(x.type)) {
@@ -7358,6 +7365,13 @@ ExprKind check_ternary_if_expr(CheckerContext *c, Operand *o, Ast *node, Type *t
 		error(node, "A ternary expression must have an else clause");
 		return kind;
 	}
+
+    if (y.mode == Addressing_Type || y.mode == Addressing_Type) {
+        gbString type_string = expr_to_string(y.expr);
+        error(node, "Type %s is invalid operand for ternary if expression", type_string);
+        gb_string_free(type_string);
+        return kind;
+    }
 
 	if (x.type == nullptr || x.type == t_invalid ||
 	    y.type == nullptr || y.type == t_invalid) {

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -7347,13 +7347,6 @@ ExprKind check_ternary_if_expr(CheckerContext *c, Operand *o, Ast *node, Type *t
 	check_expr_or_type(c, &x, te->x, type_hint);
 	node->viral_state_flags |= te->x->viral_state_flags;
 
-    if (x.mode == Addressing_Type) {
-        gbString type_string = expr_to_string(x.expr);
-        error(node, "Type %s is invalid operand for ternary if expression", type_string);
-        gb_string_free(type_string);
-        return kind;
-    }
-
 	if (te->y != nullptr) {
 		Type *th = type_hint;
 		if (type_hint == nullptr && is_type_typed(x.type)) {
@@ -7366,8 +7359,9 @@ ExprKind check_ternary_if_expr(CheckerContext *c, Operand *o, Ast *node, Type *t
 		return kind;
 	}
 
-    if (y.mode == Addressing_Type) {
-        gbString type_string = expr_to_string(y.expr);
+    if (x.mode == Addressing_Type || y.mode == Addressing_Type) {
+        Ast *type_expr = (x.mode == Addressing_Type) ? x.expr : y.expr;
+        gbString type_string = expr_to_string(type_expr);
         error(node, "Type %s is invalid operand for ternary if expression", type_string);
         gb_string_free(type_string);
         return kind;


### PR DESCRIPTION
Before this PR, using a typeid as an operand to a ternary if expression would cause a compiler panic in the backend, which varied depending on whether or not the type used was an array.

For example,
```
buggy := true ? []int : []int
```
would cause:
```
src/llvm_backend_expr.cpp(3352): Panic: lb_build_expr: array type
```
And
```
buggy := true ? int : int
```
would cause:
```
src/llvm_backend_general.cpp(2648): Panic: nullptr value for expression from identifier: .int (105b96450) : int @ 109ba32f0
```

The compiler now throws a `Type [type] is invalid operand for ternary if expression` error when a typeid is passed as either operand to a ternary if expression.

This fixes issue #1219.