### PR TITLE
Refactor odin report

### DIFF
--- a/src/bug_report.cpp
+++ b/src/bug_report.cpp
@@ -246,24 +246,24 @@ void report_ram_info() {
 		uint64_t ram_amount;
 		size_t   val_size = sizeof(ram_amount);
 
-		int sysctls[] = { CTL_HW, HW_MEMSIZE };
-		if (sysctl(sysctls, 2, &ram_amount, &val_size, NULL, 0) != -1) {
+		int mibs[] = { CTL_HW, HW_MEMSIZE };
+		if (sysctl(mibs, 2, &ram_amount, &val_size, NULL, 0) != -1) {
 			gb_printf("%lld MiB\n", ram_amount / gb_megabytes(1));
 		}
 	#elif defined(GB_SYSTEM_OPENBSD)
 		uint64_t ram_amount;
 		size_t   val_size = sizeof(ram_amount);
 
-		int sysctls[] = { CTL_HW, HW_PHYSMEM64 };
-		if (sysctl(sysctls, 2, &ram_amount, &val_size, NULL, 0) != -1) {
+		int mibs[] = { CTL_HW, HW_PHYSMEM64 };
+		if (sysctl(mibs, 2, &ram_amount, &val_size, NULL, 0) != -1) {
 			gb_printf("%lld MiB\n", ram_amount / gb_megabytes(1));
 		}
 	#elif defined(GB_SYSTEM_FREEBSD)
 		uint64_t ram_amount;
 		size_t   val_size = sizeof(ram_amount);
 
-		int sysctls[] = { CTL_HW, HW_PHYSMEM };
-		if (sysctl(sysctls, 2, &ram_amount, &val_size, NULL, 0) != -1) {
+		int mibs[] = { CTL_HW, HW_PHYSMEM };
+		if (sysctl(mibs, 2, &ram_amount, &val_size, NULL, 0) != -1) {
 			gb_printf("%lu MiB\n", ram_amount / gb_megabytes(1));
 		}
 	#else
@@ -520,123 +520,411 @@ void report_os_info() {
 		gb_printf(", %s %s\n", info->sysname, info->release);
 
 	#elif defined(GB_SYSTEM_OSX)
-		b32 found = 1;
-		uint32_t major, minor;
+		struct Darwin_To_Release {
+			const char* build;    // 21G83
+			int   darwin[3];      // Darwin kernel triplet
+			const char* os_name;  // OS X, MacOS
+			struct {
+				const char* name; // Monterey, Mojave, etc.
+				int version[3];   // 12.4, etc.
+			} release;
+		};
 
-		#define freebsd_version_buffer 100
-		char buffer[freebsd_version_buffer];
-		size_t buffer_size = freebsd_version_buffer - 1;
-		#undef freebsd_version_buffer
+		Darwin_To_Release macos_release_map[] = {
+			{"8A428",    { 8,  0,  0}, "macOS", {"Tiger",         {10,  4,  0}}},
+			{"8A432",    { 8,  0,  0}, "macOS", {"Tiger",         {10,  4,  0}}},
+			{"8B15",     { 8,  1,  0}, "macOS", {"Tiger",         {10,  4,  1}}},
+			{"8B17",     { 8,  1,  0}, "macOS", {"Tiger",         {10,  4,  1}}},
+			{"8C46",     { 8,  2,  0}, "macOS", {"Tiger",         {10,  4,  2}}},
+			{"8C47",     { 8,  2,  0}, "macOS", {"Tiger",         {10,  4,  2}}},
+			{"8E102",    { 8,  2,  0}, "macOS", {"Tiger",         {10,  4,  2}}},
+			{"8E45",     { 8,  2,  0}, "macOS", {"Tiger",         {10,  4,  2}}},
+			{"8E90",     { 8,  2,  0}, "macOS", {"Tiger",         {10,  4,  2}}},
+			{"8F46",     { 8,  3,  0}, "macOS", {"Tiger",         {10,  4,  3}}},
+			{"8G32",     { 8,  4,  0}, "macOS", {"Tiger",         {10,  4,  4}}},
+			{"8G1165",   { 8,  4,  0}, "macOS", {"Tiger",         {10,  4,  4}}},
+			{"8H14",     { 8,  5,  0}, "macOS", {"Tiger",         {10,  4,  5}}},
+			{"8G1454",   { 8,  5,  0}, "macOS", {"Tiger",         {10,  4,  5}}},
+			{"8I127",    { 8,  6,  0}, "macOS", {"Tiger",         {10,  4,  6}}},
+			{"8I1119",   { 8,  6,  0}, "macOS", {"Tiger",         {10,  4,  6}}},
+			{"8J135",    { 8,  7,  0}, "macOS", {"Tiger",         {10,  4,  7}}},
+			{"8J2135a",  { 8,  7,  0}, "macOS", {"Tiger",         {10,  4,  7}}},
+			{"8K1079",   { 8,  7,  0}, "macOS", {"Tiger",         {10,  4,  7}}},
+			{"8N5107",   { 8,  7,  0}, "macOS", {"Tiger",         {10,  4,  7}}},
+			{"8L127",    { 8,  8,  0}, "macOS", {"Tiger",         {10,  4,  8}}},
+			{"8L2127",   { 8,  8,  0}, "macOS", {"Tiger",         {10,  4,  8}}},
+			{"8P135",    { 8,  9,  0}, "macOS", {"Tiger",         {10,  4,  9}}},
+			{"8P2137",   { 8,  9,  0}, "macOS", {"Tiger",         {10,  4,  9}}},
+			{"8R218",    { 8, 10,  0}, "macOS", {"Tiger",         {10,  4, 10}}},
+			{"8R2218",   { 8, 10,  0}, "macOS", {"Tiger",         {10,  4, 10}}},
+			{"8R2232",   { 8, 10,  0}, "macOS", {"Tiger",         {10,  4, 10}}},
+			{"8S165",    { 8, 11,  0}, "macOS", {"Tiger",         {10,  4, 11}}},
+			{"8S2167",   { 8, 11,  0}, "macOS", {"Tiger",         {10,  4, 11}}},
+			{"9A581",    { 9,  0,  0}, "macOS", {"Leopard",       {10,  5,  0}}},
+			{"9B18",     { 9,  1,  0}, "macOS", {"Leopard",       {10,  5,  1}}},
+			{"9B2117",   { 9,  1,  1}, "macOS", {"Leopard",       {10,  5,  1}}},
+			{"9C31",     { 9,  2,  0}, "macOS", {"Leopard",       {10,  5,  2}}},
+			{"9C7010",   { 9,  2,  0}, "macOS", {"Leopard",       {10,  5,  2}}},
+			{"9D34",     { 9,  3,  0}, "macOS", {"Leopard",       {10,  5,  3}}},
+			{"9E17",     { 9,  4,  0}, "macOS", {"Leopard",       {10,  5,  4}}},
+			{"9F33",     { 9,  5,  0}, "macOS", {"Leopard",       {10,  5,  5}}},
+			{"9G55",     { 9,  6,  0}, "macOS", {"Leopard",       {10,  5,  6}}},
+			{"9G66",     { 9,  6,  0}, "macOS", {"Leopard",       {10,  5,  6}}},
+			{"9G71",     { 9,  6,  0}, "macOS", {"Leopard",       {10,  5,  6}}},
+			{"9J61",     { 9,  7,  0}, "macOS", {"Leopard",       {10,  5,  7}}},
+			{"9L30",     { 9,  8,  0}, "macOS", {"Leopard",       {10,  5,  8}}},
+			{"9L34",     { 9,  8,  0}, "macOS", {"Leopard",       {10,  5,  8}}},
+			{"10A432",   {10,  0,  0}, "macOS", {"Snow Leopard",  {10,  6,  0}}},
+			{"10A433",   {10,  0,  0}, "macOS", {"Snow Leopard",  {10,  6,  0}}},
+			{"10B504",   {10,  1,  0}, "macOS", {"Snow Leopard",  {10,  6,  1}}},
+			{"10C540",   {10,  2,  0}, "macOS", {"Snow Leopard",  {10,  6,  2}}},
+			{"10D573",   {10,  3,  0}, "macOS", {"Snow Leopard",  {10,  6,  3}}},
+			{"10D575",   {10,  3,  0}, "macOS", {"Snow Leopard",  {10,  6,  3}}},
+			{"10D578",   {10,  3,  0}, "macOS", {"Snow Leopard",  {10,  6,  3}}},
+			{"10F569",   {10,  4,  0}, "macOS", {"Snow Leopard",  {10,  6,  4}}},
+			{"10H574",   {10,  5,  0}, "macOS", {"Snow Leopard",  {10,  6,  5}}},
+			{"10J567",   {10,  6,  0}, "macOS", {"Snow Leopard",  {10,  6,  6}}},
+			{"10J869",   {10,  7,  0}, "macOS", {"Snow Leopard",  {10,  6,  7}}},
+			{"10J3250",  {10,  7,  0}, "macOS", {"Snow Leopard",  {10,  6,  7}}},
+			{"10J4138",  {10,  7,  0}, "macOS", {"Snow Leopard",  {10,  6,  7}}},
+			{"10K540",   {10,  8,  0}, "macOS", {"Snow Leopard",  {10,  6,  8}}},
+			{"10K549",   {10,  8,  0}, "macOS", {"Snow Leopard",  {10,  6,  8}}},
+			{"11A511",   {11,  0,  0}, "macOS", {"Lion",          {10,  7,  0}}},
+			{"11A511s",  {11,  0,  0}, "macOS", {"Lion",          {10,  7,  0}}},
+			{"11A2061",  {11,  0,  2}, "macOS", {"Lion",          {10,  7,  0}}},
+			{"11A2063",  {11,  0,  2}, "macOS", {"Lion",          {10,  7,  0}}},
+			{"11B26",    {11,  1,  0}, "macOS", {"Lion",          {10,  7,  1}}},
+			{"11B2118",  {11,  1,  0}, "macOS", {"Lion",          {10,  7,  1}}},
+			{"11C74",    {11,  2,  0}, "macOS", {"Lion",          {10,  7,  2}}},
+			{"11D50",    {11,  3,  0}, "macOS", {"Lion",          {10,  7,  3}}},
+			{"11E53",    {11,  4,  0}, "macOS", {"Lion",          {10,  7,  4}}},
+			{"11G56",    {11,  4,  2}, "macOS", {"Lion",          {10,  7,  5}}},
+			{"11G63",    {11,  4,  2}, "macOS", {"Lion",          {10,  7,  5}}},
+			{"12A269",   {12,  0,  0}, "macOS", {"Mountain Lion", {10,  8,  0}}},
+			{"12B19",    {12,  1,  0}, "macOS", {"Mountain Lion", {10,  8,  1}}},
+			{"12C54",    {12,  2,  0}, "macOS", {"Mountain Lion", {10,  8,  2}}},
+			{"12C60",    {12,  2,  0}, "macOS", {"Mountain Lion", {10,  8,  2}}},
+			{"12C2034",  {12,  2,  0}, "macOS", {"Mountain Lion", {10,  8,  2}}},
+			{"12C3104",  {12,  2,  0}, "macOS", {"Mountain Lion", {10,  8,  2}}},
+			{"12D78",    {12,  3,  0}, "macOS", {"Mountain Lion", {10,  8,  3}}},
+			{"12E55",    {12,  4,  0}, "macOS", {"Mountain Lion", {10,  8,  4}}},
+			{"12E3067",  {12,  4,  0}, "macOS", {"Mountain Lion", {10,  8,  4}}},
+			{"12E4022",  {12,  4,  0}, "macOS", {"Mountain Lion", {10,  8,  4}}},
+			{"12F37",    {12,  5,  0}, "macOS", {"Mountain Lion", {10,  8,  5}}},
+			{"12F45",    {12,  5,  0}, "macOS", {"Mountain Lion", {10,  8,  5}}},
+			{"12F2501",  {12,  5,  0}, "macOS", {"Mountain Lion", {10,  8,  5}}},
+			{"12F2518",  {12,  5,  0}, "macOS", {"Mountain Lion", {10,  8,  5}}},
+			{"12F2542",  {12,  5,  0}, "macOS", {"Mountain Lion", {10,  8,  5}}},
+			{"12F2560",  {12,  5,  0}, "macOS", {"Mountain Lion", {10,  8,  5}}},
+			{"13A603",   {13,  0,  0}, "macOS", {"Mavericks",     {10,  9,  0}}},
+			{"13B42",    {13,  0,  0}, "macOS", {"Mavericks",     {10,  9,  1}}},
+			{"13C64",    {13,  1,  0}, "macOS", {"Mavericks",     {10,  9,  2}}},
+			{"13C1021",  {13,  1,  0}, "macOS", {"Mavericks",     {10,  9,  2}}},
+			{"13D65",    {13,  2,  0}, "macOS", {"Mavericks",     {10,  9,  3}}},
+			{"13E28",    {13,  3,  0}, "macOS", {"Mavericks",     {10,  9,  4}}},
+			{"13F34",    {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
+			{"13F1066",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
+			{"13F1077",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
+			{"13F1096",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
+			{"13F1112",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
+			{"13F1134",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
+			{"13F1507",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
+			{"13F1603",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
+			{"13F1712",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
+			{"13F1808",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
+			{"13F1911",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
+			{"14A389",   {14,  0,  0}, "macOS", {"Yosemite",      {10, 10,  0}}},
+			{"14B25",    {14,  0,  0}, "macOS", {"Yosemite",      {10, 10,  1}}},
+			{"14C109",   {14,  1,  0}, "macOS", {"Yosemite",      {10, 10,  2}}},
+			{"14C1510",  {14,  1,  0}, "macOS", {"Yosemite",      {10, 10,  2}}},
+			{"14C2043",  {14,  1,  0}, "macOS", {"Yosemite",      {10, 10,  2}}},
+			{"14C1514",  {14,  1,  0}, "macOS", {"Yosemite",      {10, 10,  2}}},
+			{"14C2513",  {14,  1,  0}, "macOS", {"Yosemite",      {10, 10,  2}}},
+			{"14D131",   {14,  3,  0}, "macOS", {"Yosemite",      {10, 10,  3}}},
+			{"14D136",   {14,  3,  0}, "macOS", {"Yosemite",      {10, 10,  3}}},
+			{"14E46",    {14,  4,  0}, "macOS", {"Yosemite",      {10, 10,  4}}},
+			{"14F27",    {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
+			{"14F1021",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
+			{"14F1505",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
+			{"14F1509",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
+			{"14F1605",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
+			{"14F1713",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
+			{"14F1808",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
+			{"14F1909",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
+			{"14F1912",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
+			{"14F2009",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
+			{"14F2109",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
+			{"14F2315",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
+			{"14F2411",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
+			{"14F2511",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
+			{"15A284",   {15,  0,  0}, "macOS", {"El Capitan",    {10, 11,  0}}},
+			{"15B42",    {15,  0,  0}, "macOS", {"El Capitan",    {10, 11,  1}}},
+			{"15C50",    {15,  2,  0}, "macOS", {"El Capitan",    {10, 11,  2}}},
+			{"15D21",    {15,  3,  0}, "macOS", {"El Capitan",    {10, 11,  3}}},
+			{"15E65",    {15,  4,  0}, "macOS", {"El Capitan",    {10, 11,  4}}},
+			{"15F34",    {15,  5,  0}, "macOS", {"El Capitan",    {10, 11,  5}}},
+			{"15G31",    {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
+			{"15G1004",  {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
+			{"15G1011",  {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
+			{"15G1108",  {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
+			{"15G1212",  {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
+			{"15G1217",  {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
+			{"15G1421",  {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
+			{"15G1510",  {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
+			{"15G1611",  {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
+			{"15G17023", {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
+			{"15G18013", {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
+			{"15G19009", {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
+			{"15G20015", {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
+			{"15G21013", {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
+			{"15G22010", {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
+			{"16A323",   {16,  0,  0}, "macOS", {"Sierra",        {10, 12,  0}}},
+			{"16B2555",  {16,  1,  0}, "macOS", {"Sierra",        {10, 12,  1}}},
+			{"16B2657",  {16,  1,  0}, "macOS", {"Sierra",        {10, 12,  1}}},
+			{"16C67",    {16,  3,  0}, "macOS", {"Sierra",        {10, 12,  2}}},
+			{"16C68",    {16,  3,  0}, "macOS", {"Sierra",        {10, 12,  2}}},
+			{"16D32",    {16,  4,  0}, "macOS", {"Sierra",        {10, 12,  3}}},
+			{"16E195",   {16,  5,  0}, "macOS", {"Sierra",        {10, 12,  4}}},
+			{"16F73",    {16,  6,  0}, "macOS", {"Sierra",        {10, 12,  5}}},
+			{"16F2073",  {16,  6,  0}, "macOS", {"Sierra",        {10, 12,  5}}},
+			{"16G29",    {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
+			{"16G1036",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
+			{"16G1114",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
+			{"16G1212",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
+			{"16G1314",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
+			{"16G1408",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
+			{"16G1510",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
+			{"16G1618",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
+			{"16G1710",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
+			{"16G1815",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
+			{"16G1917",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
+			{"16G1918",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
+			{"16G2016",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
+			{"16G2127",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
+			{"16G2128",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
+			{"16G2136",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
+			{"17A365",   {17,  0,  0}, "macOS", {"High Sierra",   {10, 13,  0}}},
+			{"17A405",   {17,  0,  0}, "macOS", {"High Sierra",   {10, 13,  0}}},
+			{"17B48",    {17,  2,  0}, "macOS", {"High Sierra",   {10, 13,  1}}},
+			{"17B1002",  {17,  2,  0}, "macOS", {"High Sierra",   {10, 13,  1}}},
+			{"17B1003",  {17,  2,  0}, "macOS", {"High Sierra",   {10, 13,  1}}},
+			{"17C88",    {17,  3,  0}, "macOS", {"High Sierra",   {10, 13,  2}}},
+			{"17C89",    {17,  3,  0}, "macOS", {"High Sierra",   {10, 13,  2}}},
+			{"17C205",   {17,  3,  0}, "macOS", {"High Sierra",   {10, 13,  2}}},
+			{"17C2205",  {17,  3,  0}, "macOS", {"High Sierra",   {10, 13,  2}}},
+			{"17D47",    {17,  4,  0}, "macOS", {"High Sierra",   {10, 13,  3}}},
+			{"17D2047",  {17,  4,  0}, "macOS", {"High Sierra",   {10, 13,  3}}},
+			{"17D102",   {17,  4,  0}, "macOS", {"High Sierra",   {10, 13,  3}}},
+			{"17D2102",  {17,  4,  0}, "macOS", {"High Sierra",   {10, 13,  3}}},
+			{"17E199",   {17,  5,  0}, "macOS", {"High Sierra",   {10, 13,  4}}},
+			{"17E202",   {17,  5,  0}, "macOS", {"High Sierra",   {10, 13,  4}}},
+			{"17F77",    {17,  6,  0}, "macOS", {"High Sierra",   {10, 13,  5}}},
+			{"17G65",    {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G2208",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G2307",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G3025",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G4015",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G5019",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G6029",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G6030",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G7024",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G8029",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G8030",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G8037",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G9016",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G10021", {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G11023", {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G12034", {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G13033", {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G13035", {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G14019", {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G14033", {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"17G14042", {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
+			{"18A391",   {18,  0,  0}, "macOS", {"Mojave",        {10, 14,  0}}},
+			{"18B75",    {18,  2,  0}, "macOS", {"Mojave",        {10, 14,  1}}},
+			{"18B2107",  {18,  2,  0}, "macOS", {"Mojave",        {10, 14,  1}}},
+			{"18B3094",  {18,  2,  0}, "macOS", {"Mojave",        {10, 14,  1}}},
+			{"18C54",    {18,  2,  0}, "macOS", {"Mojave",        {10, 14,  2}}},
+			{"18D42",    {18,  2,  0}, "macOS", {"Mojave",        {10, 14,  3}}},
+			{"18D43",    {18,  2,  0}, "macOS", {"Mojave",        {10, 14,  3}}},
+			{"18D109",   {18,  2,  0}, "macOS", {"Mojave",        {10, 14,  3}}},
+			{"18E226",   {18,  5,  0}, "macOS", {"Mojave",        {10, 14,  4}}},
+			{"18E227",   {18,  5,  0}, "macOS", {"Mojave",        {10, 14,  4}}},
+			{"18F132",   {18,  6,  0}, "macOS", {"Mojave",        {10, 14,  5}}},
+			{"18G84",    {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
+			{"18G87",    {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
+			{"18G95",    {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
+			{"18G103",   {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
+			{"18G1012",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
+			{"18G2022",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
+			{"18G3020",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
+			{"18G4032",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
+			{"18G5033",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
+			{"18G6020",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
+			{"18G6032",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
+			{"18G6042",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
+			{"18G7016",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
+			{"18G8012",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
+			{"18G8022",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
+			{"18G9028",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
+			{"18G9216",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
+			{"18G9323",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
+			{"19A583",   {19,  0,  0}, "macOS", {"Catalina",      {10, 15,  0}}},
+			{"19A602",   {19,  0,  0}, "macOS", {"Catalina",      {10, 15,  0}}},
+			{"19A603",   {19,  0,  0}, "macOS", {"Catalina",      {10, 15,  0}}},
+			{"19B88",    {19,  0,  0}, "macOS", {"Catalina",      {10, 15,  1}}},
+			{"19C57",    {19,  2,  0}, "macOS", {"Catalina",      {10, 15,  2}}},
+			{"19C58",    {19,  2,  0}, "macOS", {"Catalina",      {10, 15,  2}}},
+			{"19D76",    {19,  3,  0}, "macOS", {"Catalina",      {10, 15,  3}}},
+			{"19E266",   {19,  4,  0}, "macOS", {"Catalina",      {10, 15,  4}}},
+			{"19E287",   {19,  4,  0}, "macOS", {"Catalina",      {10, 15,  4}}},
+			{"19F96",    {19,  5,  0}, "macOS", {"Catalina",      {10, 15,  5}}},
+			{"19F101",   {19,  5,  0}, "macOS", {"Catalina",      {10, 15,  5}}},
+			{"19G73",    {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  6}}},
+			{"19G2021",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  6}}},
+			{"19H2",     {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
+			{"19H4",     {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
+			{"19H15",    {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
+			{"19H114",   {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
+			{"19H512",   {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
+			{"19H524",   {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
+			{"19H1030",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
+			{"19H1217",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
+			{"19H1323",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
+			{"19H1417",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
+			{"19H1419",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
+			{"19H1519",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
+			{"19H1615",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
+			{"19H1713",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
+			{"19H1715",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
+			{"19H1824",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
+			{"19H1922",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
+			{"19H2026",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
+			{"20A2411",  {20,  1,  0}, "macOS", {"Big Sur",       {11,  0,  0}}},
+			{"20B29",    {20,  1,  0}, "macOS", {"Big Sur",       {11,  0,  1}}},
+			{"20B50",    {20,  1,  0}, "macOS", {"Big Sur",       {11,  0,  1}}},
+			{"20C69",    {20,  2,  0}, "macOS", {"Big Sur",       {11,  1,  0}}},
+			{"20D64",    {20,  3,  0}, "macOS", {"Big Sur",       {11,  2,  0}}},
+			{"20D74",    {20,  3,  0}, "macOS", {"Big Sur",       {11,  2,  1}}},
+			{"20D75",    {20,  3,  0}, "macOS", {"Big Sur",       {11,  2,  1}}},
+			{"20D80",    {20,  3,  0}, "macOS", {"Big Sur",       {11,  2,  2}}},
+			{"20D91",    {20,  3,  0}, "macOS", {"Big Sur",       {11,  2,  3}}},
+			{"20E232",   {20,  4,  0}, "macOS", {"Big Sur",       {11,  3,  0}}},
+			{"20E241",   {20,  4,  0}, "macOS", {"Big Sur",       {11,  3,  1}}},
+			{"20F71",    {20,  5,  0}, "macOS", {"Big Sur",       {11,  4,  0}}},
+			{"20G71",    {20,  6,  0}, "macOS", {"Big Sur",       {11,  5,  0}}},
+			{"20G80",    {20,  6,  0}, "macOS", {"Big Sur",       {11,  5,  1}}},
+			{"20G95",    {20,  6,  0}, "macOS", {"Big Sur",       {11,  5,  2}}},
+			{"20G165",   {20,  6,  0}, "macOS", {"Big Sur",       {11,  6,  0}}},
+			{"20G224",   {20,  6,  0}, "macOS", {"Big Sur",       {11,  6,  1}}},
+			{"20G314",   {20,  6,  0}, "macOS", {"Big Sur",       {11,  6,  2}}},
+			{"20G415",   {20,  6,  0}, "macOS", {"Big Sur",       {11,  6,  3}}},
+			{"20G417",   {20,  6,  0}, "macOS", {"Big Sur",       {11,  6,  4}}},
+			{"20G527",   {20,  6,  0}, "macOS", {"Big Sur",       {11,  6,  5}}},
+			{"20G624",   {20,  6,  0}, "macOS", {"Big Sur",       {11,  6,  6}}},
+			{"20G630",   {20,  6,  0}, "macOS", {"Big Sur",       {11,  6,  7}}},
+			{"20G730",   {20,  6,  0}, "macOS", {"Big Sur",       {11,  6,  8}}},
+			{"21A344",   {21,  0,  1}, "macOS", {"Monterey",      {12,  0,  0}}},
+			{"21A559",   {21,  1,  0}, "macOS", {"Monterey",      {12,  0,  1}}},
+			{"21C52",    {21,  2,  0}, "macOS", {"Monterey",      {12,  1,  0}}},
+			{"21D49",    {21,  3,  0}, "macOS", {"Monterey",      {12,  2,  0}}},
+			{"21D62",    {21,  3,  0}, "macOS", {"Monterey",      {12,  2,  1}}},
+			{"21E230",   {21,  4,  0}, "macOS", {"Monterey",      {12,  3,  0}}},
+			{"21E258",   {21,  4,  0}, "macOS", {"Monterey",      {12,  3,  1}}},
+			{"21F79",    {21,  5,  0}, "macOS", {"Monterey",      {12,  4,  0}}},
+			{"21F2081",  {21,  5,  0}, "macOS", {"Monterey",      {12,  4,  0}}},
+			{"21F2092",  {21,  5,  0}, "macOS", {"Monterey",      {12,  4,  0}}},
+			{"21G72",    {21,  6,  0}, "macOS", {"Monterey",      {12,  5,  0}}},
+			{"21G83",    {21,  6,  0}, "macOS", {"Monterey",      {12,  5,  1}}},
+		};
 
-		int sysctls[] = { CTL_KERN, KERN_OSRELEASE };
-		if (sysctl(sysctls, 2, buffer, &buffer_size, NULL, 0) == -1) {
-			found = 0;
+
+		b32 build_found  = 1;
+		b32 darwin_found = 1;
+		uint32_t major, minor, patch;
+
+		#define MACOS_VERSION_BUFFER_SIZE 100
+		char build_buffer[MACOS_VERSION_BUFFER_SIZE];
+		char darwin_buffer[MACOS_VERSION_BUFFER_SIZE];
+		size_t build_buffer_size  = MACOS_VERSION_BUFFER_SIZE - 1;
+		size_t darwin_buffer_size = MACOS_VERSION_BUFFER_SIZE - 1;
+		#undef MACOS_VERSION_BUFFER_SIZE
+
+		int build_mibs[] = { CTL_KERN, KERN_OSVERSION };
+		if (sysctl(build_mibs, 2, build_buffer, &build_buffer_size, NULL, 0) == -1) {
+			build_found = 0;
+		}
+
+		int darwin_mibs[] = { CTL_KERN, KERN_OSRELEASE };
+		if (sysctl(darwin_mibs, 2, darwin_buffer, &darwin_buffer_size, NULL, 0) == -1) {
+			gb_printf("macOS Unknown\n");
+			return;
 		} else {
-			if (sscanf(buffer, "%u.%u", &major, &minor) != 2) {
-				found = 0;
+			if (sscanf(darwin_buffer, "%u.%u.%u", &major, &minor, &patch) != 3) {
+				darwin_found = 0;
 			}
 		}
 
-		if (found) {
-			switch (major) {
-			case 21:
-				/*
-					macOS Big Sur and newer
-				*/
-				major -= 9;
+		// Scan table for match on BUILD
+		int macos_release_count = sizeof(macos_release_map) / sizeof(macos_release_map[0]);
+		Darwin_To_Release match = {};
 
-				gb_printf("macOS 12.0.%d Monterey\n", minor);
+		for (int build = 0; build < macos_release_count; build++) {
+			Darwin_To_Release rel = macos_release_map[build];
 
-				break;
-			case 20:
-				/*
-					macOS Big Sur and newer
-				*/
-				major -= 9;
-
-				gb_printf("macOS 11.%d Big Sur\n", minor);
-
-				break;
-			case 14:
-				/*
-					macOS 10.1.1 and newer
-				*/
-				major -= 4;
-
-				switch (minor) {
-				case 1:
-					gb_printf("macOS Puma 10.1\n");
-					break;
-
-				case 2:
-					gb_printf("macOS Jaguar 10.2\n");
-					break;
-
-				case 3:
-					gb_printf("macOS Panther 10.3\n");
-					break;
-
-				case 4:
-					gb_printf("macOS Tiger 10.4\n");
-					break;
-
-				case 5:
-					gb_printf("macOS Leopard 10.5\n");
-					break;
-
-				case 6:
-					gb_printf("macOS Snow Leopard 10.6\n");
-					break;
-
-				case 7:
-					gb_printf("macOS Lion 10.7\n");
-					break;
-
-				case 8:
-					gb_printf("macOS Mountain Lion 10.8\n");
-					break;
-
-				case 9:
-					gb_printf("macOS Mavericks 10.9\n");
-					break;
-
-				case 10:
-					gb_printf("macOS Yosemite 10.10\n");
-					break;
-
-				case 11:
-					gb_printf("macOS El Capitan 10.11\n");
-					break;
-
-				case 12:
-					gb_printf("macOS Sierra 10.12\n");
-					break;
-
-				case 13:
-					gb_printf("macOS High Sierra 10.13\n");
-					break;
-
-				case 14:
-					gb_printf("macOS Mojave 10.14\n");
-					break;
-
-				case 15:
-					gb_printf("macOS Catalina 10.15\n");
-					break;
-
-				default:
-					gb_printf("macOS %d.%d\n", major, minor);
-					break;
-				}
-
-				break;
-			default:
-				gb_printf("macOS Unknown (kernel version %d.%d)\n", major, minor);
+			// Do we have an exact match on the BUILD?
+			if (gb_strcmp(rel.build, (const char *)build_buffer) == 0) {
+				match = rel;
 				break;
 			}
-		} else {
-			gb_printf("macOS: Unknown\n");
-		}			
+
+			// Do we have an exact Darwin match?
+			if (rel.darwin[0] == major && rel.darwin[1] == minor && rel.darwin[2] == patch) {
+				match = rel;
+				break;
+			}
+
+			// Major kernel version needs to match exactly,
+			if (rel.darwin[0] == major) {
+				// No major version match yet.
+				if (!match.os_name) {
+					match = rel;
+				}
+				if (minor >= rel.darwin[1]) {
+					match = rel;
+					if (patch >= rel.darwin[2]) {
+						match = rel;
+					}
+				}
+			}
+		}
+
+		if (match.os_name) {
+			gb_printf("%s %s %d", match.os_name, match.release.name, match.release.version[0]);
+			if (match.release.version[1] > 0 || match.release.version[2] > 0) {
+				gb_printf(".%d", match.release.version[1]);
+			}
+			if (match.release.version[2] > 0) {
+				gb_printf(".%d", match.release.version[2]);
+			}
+			if (build_found) {
+				gb_printf(" (build: %s, kernel: %d.%d.%d)\n", build_buffer, match.darwin[0], match.darwin[1], match.darwin[2]);
+			} else {
+				gb_printf(" (build: %s?, kernel: %d.%d.%d)\n", match.build, match.darwin[0], match.darwin[1], match.darwin[2]);				
+			}
+			return;
+		}
+
+		if (build_found && darwin_found) {
+			gb_printf("macOS Unknown (build: %s, kernel: %d.%d.%d)\n", build_buffer, major, minor, patch);
+			return;
+		} else if (build_found) {
+			gb_printf("macOS Unknown (build: %s)\n", build_buffer);
+			return;
+		} else if (darwin_found) {
+			gb_printf("macOS Unknown (kernel: %d.%d.%d)\n", major, minor, patch);
+			return;
+		}
 	#elif defined(GB_SYSTEM_OPENBSD)
 		struct utsname un;
 		
@@ -651,8 +939,8 @@ void report_os_info() {
 		size_t buffer_size = freebsd_version_buffer - 1;
 		#undef freebsd_version_buffer
 
-		int sysctls[] = { CTL_KERN, KERN_VERSION };
-		if (sysctl(sysctls, 2, buffer, &buffer_size, NULL, 0) == -1) {
+		int mibs[] = { CTL_KERN, KERN_VERSION };
+		if (sysctl(mibs, 2, buffer, &buffer_size, NULL, 0) == -1) {
 			gb_printf("FreeBSD: Unknown\n");
 		} else {
 			// KERN_VERSION can end in a \n, replace it with a \0
@@ -662,31 +950,16 @@ void report_os_info() {
 			gb_printf("%s", &buffer[0]);
 
 			// Retrieve kernel revision using `sysctl`, e.g. 199506
-			sysctls[1] = KERN_OSREV;
+			mibs[1] = KERN_OSREV;
 			uint64_t revision;
 			size_t revision_size = sizeof(revision);
 
-			if (sysctl(sysctls, 2, &revision, &revision_size, NULL, 0) == -1) {
+			if (sysctl(mibs, 2, &revision, &revision_size, NULL, 0) == -1) {
 				gb_printf("\n");
 			} else {
 				gb_printf(", revision %ld\n", revision);
 			}
 		}
-
-		// if (found) {
-		// 	gb_printf("FreeBSD ")
-		// }
-
-		// // Retrieve kernel revision using `sysctl`, e.g. 199506
-		// mib = []i32{sys.CTL_KERN, sys.KERN_OSREV}
-		// revision: int
-		// if !sys.sysctl(mib, &revision) {
-		// 	return
-		// }
-		// os_version.patch = revision
-
-		// strings.write_string(&b, ", revision ")
-		// strings.write_int(&b, revision)
 	#else
 		gb_printf("Unknown");
 	#endif


### PR DESCRIPTION
Add FreeBSD detection to `odin report`.
Improve its macOS build and version detection as well.