### PR TITLE
Fix -verbose-error source lines from having last char cut off with LF files

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -41,7 +41,6 @@ gbString get_file_line_as_string(TokenPos const &pos, i32 *offset_) {
 
 	while (line_end < end) {
 		if (*line_end == '\n') {
-			line_end -= 1;
 			break;
 		}
 		line_end += 1;


### PR DESCRIPTION
Fixes #1226