### PR TITLE
Map Internals Improvements

### DIFF
--- a/core/encoding/json/unmarshal.odin
+++ b/core/encoding/json/unmarshal.odin
@@ -422,19 +422,17 @@ unmarshal_object :: proc(p: ^Parser, v: any, end_token: Token_Kind) -> (err: Unm
 				delete(key, p.allocator)
 				return err
 			}
-			
-			hash := runtime.Map_Hash {
-				hash = runtime.default_hasher_string(&key, 0),
-				key_ptr = &key,
-			}
-			
+
+			key_hash := runtime.default_hasher_string(&key, 0)
+			key_ptr := rawptr(&key)
+
 			key_cstr: cstring
 			if reflect.is_cstring(t.key) {
 				key_cstr = cstring(raw_data(key))
-				hash.key_ptr = &key_cstr
+				key_ptr = &key_cstr
 			}
 			
-			set_ptr := runtime.__dynamic_map_set(header, hash, map_backing_value.data)
+			set_ptr := runtime.__dynamic_map_set(header, key_hash, key_ptr, map_backing_value.data)
 			if set_ptr == nil {
 				delete(key, p.allocator)
 			} 

--- a/core/runtime/core.odin
+++ b/core/runtime/core.odin
@@ -394,7 +394,7 @@ Raw_Dynamic_Array :: struct {
 }
 
 Raw_Map :: struct {
-	hashes:  []int,
+	hashes:  []Map_Index,
 	entries: Raw_Dynamic_Array,
 }
 

--- a/core/runtime/core_builtin.odin
+++ b/core/runtime/core_builtin.odin
@@ -296,7 +296,7 @@ clear_map :: proc "contextless" (m: ^$T/map[$K]$V) {
 @builtin
 reserve_map :: proc(m: ^$T/map[$K]$V, capacity: int, loc := #caller_location) {
 	if m != nil {
-		__dynamic_map_reserve(__get_map_header(m), capacity, loc)
+		__dynamic_map_reserve(__get_map_header(m), uint(capacity), loc)
 	}
 }
 
@@ -334,7 +334,6 @@ delete_key :: proc(m: ^$T/map[$K]$V, key: K) -> (deleted_key: K, deleted_value: 
 			__dynamic_map_erase(h, fr)
 		}
 	}
-
 	return
 }
 

--- a/core/runtime/core_builtin.odin
+++ b/core/runtime/core_builtin.odin
@@ -326,7 +326,7 @@ delete_key :: proc(m: ^$T/map[$K]$V, key: K) -> (deleted_key: K, deleted_value: 
 		key := key
 		h := __get_map_header(m)
 		fr := __map_find(h, &key)
-		if fr.entry_index >= 0 {
+		if fr.entry_index != MAP_SENTINEL {
 			entry := __dynamic_map_get_entry(h, fr.entry_index)
 			deleted_key   = (^K)(uintptr(entry)+h.key_offset)^
 			deleted_value = (^V)(uintptr(entry)+h.value_offset)^

--- a/core/runtime/core_builtin.odin
+++ b/core/runtime/core_builtin.odin
@@ -325,8 +325,7 @@ delete_key :: proc(m: ^$T/map[$K]$V, key: K) -> (deleted_key: K, deleted_value: 
 	if m != nil {
 		key := key
 		h := __get_map_header(m)
-		hash := __get_map_hash(&key)
-		fr := __dynamic_map_find(h, hash)
+		fr := __map_find(h, &key)
 		if fr.entry_index >= 0 {
 			entry := __dynamic_map_get_entry(h, fr.entry_index)
 			deleted_key   = (^K)(uintptr(entry)+h.key_offset)^
@@ -674,9 +673,8 @@ shrink_dynamic_array :: proc(array: ^$T/[dynamic]$E, new_cap := -1, loc := #call
 map_insert :: proc(m: ^$T/map[$K]$V, key: K, value: V, loc := #caller_location) -> (ptr: ^V) {
 	key, value := key, value
 	h := __get_map_header(m)
-	hash := __get_map_hash(&key)
-	
-	data := uintptr(__dynamic_map_set(h, hash, &value, loc))
+
+	data := uintptr(__dynamic_map_set(h, __get_map_key_hash(&key), &key, &value, loc))
 	return (^V)(data + h.value_offset)
 }
 

--- a/core/runtime/core_builtin.odin
+++ b/core/runtime/core_builtin.odin
@@ -289,7 +289,7 @@ clear_map :: proc "contextless" (m: ^$T/map[$K]$V) {
 	entries := (^Raw_Dynamic_Array)(&raw_map.entries)
 	entries.len = 0
 	for _, i in raw_map.hashes {
-		raw_map.hashes[i] = -1
+		raw_map.hashes[i] = MAP_SENTINEL
 	}
 }
 

--- a/core/runtime/dynamic_array_internal.odin
+++ b/core/runtime/dynamic_array_internal.odin
@@ -59,6 +59,8 @@ __dynamic_array_shrink :: proc(array_: rawptr, elem_size, elem_align: int, new_c
 		return
 	}
 
+	new_cap := new_cap
+	new_cap = max(new_cap, 0)
 	old_size  := array.cap * elem_size
 	new_size  := new_cap * elem_size
 	allocator := array.allocator

--- a/core/runtime/dynamic_map_internal.odin
+++ b/core/runtime/dynamic_map_internal.odin
@@ -11,11 +11,9 @@ Map_Hash :: struct {
 	key_ptr: rawptr, // address of Map_Entry_Header.key
 }
 
-__get_map_hash :: proc "contextless" (k: ^$K) -> (map_hash: Map_Hash) {
+__get_map_key_hash :: proc "contextless" (k: ^$K) -> uintptr {
 	hasher := intrinsics.type_hasher_proc(K)
-	map_hash.key_ptr = k
-	map_hash.hash = hasher(k, 0)
-	return
+	return hasher(k, 0)
 }
 
 __get_map_hash_from_entry :: proc "contextless" (h: Map_Header, entry: ^Map_Entry_Header, hash: ^Map_Hash) {
@@ -346,6 +344,13 @@ __dynamic_map_full :: #force_inline proc "contextless" (using h: Map_Header) -> 
 __dynamic_map_hash_equal :: #force_inline proc "contextless" (h: Map_Header, a, b: Map_Hash) -> bool {
 	return a.hash == b.hash && h.equal(a.key_ptr, b.key_ptr)
 }
+
+
+__map_find :: proc "contextless" (h: Map_Header, key_ptr: ^$K) -> Map_Find_Result #no_bounds_check {
+	hash := __get_map_key_hash(key_ptr)
+	return __dynamic_map_find(h, {hash, key_ptr})
+}
+
 
 __dynamic_map_find :: proc "contextless" (using h: Map_Header, hash: Map_Hash) -> Map_Find_Result #no_bounds_check {
 	fr := Map_Find_Result{MAP_SENTINEL, MAP_SENTINEL, MAP_SENTINEL}

--- a/core/runtime/dynamic_map_internal.odin
+++ b/core/runtime/dynamic_map_internal.odin
@@ -262,7 +262,7 @@ __dynamic_map_rehash :: proc(using header: Map_Header, new_count: int, loc := #c
 
 __dynamic_map_get :: proc(h: Map_Header, hash: Map_Hash) -> rawptr {
 	index := __dynamic_map_find(h, hash).entry_index
-	if index >= 0 {
+	if index != MAP_SENTINEL {
 		data := uintptr(__dynamic_map_get_entry(h, index))
 		return rawptr(data + h.value_offset)
 	}
@@ -270,7 +270,7 @@ __dynamic_map_get :: proc(h: Map_Header, hash: Map_Hash) -> rawptr {
 }
 
 __dynamic_map_set :: proc(h: Map_Header, hash: Map_Hash, value: rawptr, loc := #caller_location) -> ^Map_Entry_Header #no_bounds_check {
-	index: Map_Index
+	index := MAP_SENTINEL
 
 	if len(h.m.hashes) == 0 {
 		__dynamic_map_reserve(h, INITIAL_MAP_CAP, loc)
@@ -278,14 +278,14 @@ __dynamic_map_set :: proc(h: Map_Header, hash: Map_Hash, value: rawptr, loc := #
 	}
 
 	fr := __dynamic_map_find(h, hash)
-	if fr.entry_index >= 0 {
+	if fr.entry_index != MAP_SENTINEL {
 		index = fr.entry_index
 	} else {
 		index = __dynamic_map_add_entry(h, hash, loc)
-		if fr.entry_prev >= 0 {
+		if fr.entry_prev != MAP_SENTINEL {
 			entry := __dynamic_map_get_entry(h, fr.entry_prev)
 			entry.next = index
-		} else if fr.hash_index >= 0 {
+		} else if fr.hash_index != MAP_SENTINEL {
 			h.m.hashes[fr.hash_index] = index
 		} else {
 			return nil

--- a/core/runtime/dynamic_map_internal.odin
+++ b/core/runtime/dynamic_map_internal.odin
@@ -334,7 +334,6 @@ ceil_to_pow2 :: proc "contextless" (n: int) -> int {
 }
 
 __dynamic_map_grow :: proc(using h: Map_Header, loc := #caller_location) {
-	// TODO(bill): Determine an efficient growing rate
 	new_count := max(m.entries.cap * 2, INITIAL_MAP_CAP)
 	__dynamic_map_rehash(h, new_count, loc)
 }
@@ -344,7 +343,7 @@ __dynamic_map_full :: #force_inline proc "contextless" (using h: Map_Header) -> 
 }
 
 
-__dynamic_map_hash_equal :: proc "contextless" (h: Map_Header, a, b: Map_Hash) -> bool {
+__dynamic_map_hash_equal :: #force_inline proc "contextless" (h: Map_Header, a, b: Map_Hash) -> bool {
 	return a.hash == b.hash && h.equal(a.key_ptr, b.key_ptr)
 }
 
@@ -388,7 +387,7 @@ __dynamic_map_delete_key :: proc "contextless" (using h: Map_Header, hash: Map_H
 	}
 }
 
-__dynamic_map_get_entry :: proc "contextless" (using h: Map_Header, index: Map_Index) -> ^Map_Entry_Header {
+__dynamic_map_get_entry :: #force_inline proc "contextless" (using h: Map_Header, index: Map_Index) -> ^Map_Entry_Header {
 	return (^Map_Entry_Header)(uintptr(m.entries.data) + uintptr(index*Map_Index(entry_size)))
 }
 

--- a/src/llvm_backend.hpp
+++ b/src/llvm_backend.hpp
@@ -444,7 +444,7 @@ String lb_get_const_string(lbModule *m, lbValue value);
 lbValue lb_generate_local_array(lbProcedure *p, Type *elem_type, i64 count, bool zero_init=true);
 lbValue lb_generate_global_array(lbModule *m, Type *elem_type, i64 count, String prefix, i64 id);
 lbValue lb_gen_map_header(lbProcedure *p, lbValue map_val_ptr, Type *map_type);
-lbValue lb_gen_map_hash(lbProcedure *p, lbValue key, Type *key_type);
+lbValue lb_gen_map_key_hash(lbProcedure *p, lbValue key, Type *key_type, lbValue *key_ptr_);
 void    lb_insert_dynamic_map_key_and_value(lbProcedure *p, lbAddr addr, Type *map_type, lbValue map_key, lbValue map_value, Ast *node);
 
 lbValue lb_find_procedure_value_from_entity(lbModule *m, Entity *e);

--- a/src/llvm_backend.hpp
+++ b/src/llvm_backend.hpp
@@ -308,6 +308,7 @@ struct lbProcedure {
 
 	PtrMap<Ast *, lbValue> selector_values;
 	PtrMap<Ast *, lbAddr>  selector_addr;
+	PtrMap<LLVMValueRef, lbAddr> map_header_cache;
 };
 
 

--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -1423,15 +1423,9 @@ lbValue lb_build_binary_expr(lbProcedure *p, Ast *expr) {
 			switch (rt->kind) {
 			case Type_Map:
 				{
-					lbValue addr = lb_address_from_load_or_generate_local(p, right);
-					lbValue h = lb_gen_map_header(p, addr, rt);
-					lbValue key = lb_gen_map_hash(p, left, rt->Map.key);
-
-					auto args = array_make<lbValue>(permanent_allocator(), 2);
-					args[0] = h;
-					args[1] = key;
-
-					lbValue ptr = lb_emit_runtime_call(p, "__dynamic_map_get", args);
+					lbValue map_ptr = lb_address_from_load_or_generate_local(p, right);
+					lbValue key = left;
+					lbValue ptr = lb_internal_dynamic_map_get_ptr(p, map_ptr, key);
 					if (be->op.kind == Token_in) {
 						return lb_emit_conv(p, lb_emit_comp_against_nil(p, Token_NotEq, ptr), t_bool);
 					} else {

--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -383,6 +383,21 @@ Type *lb_addr_type(lbAddr const &addr) {
 	return type_deref(addr.addr.type);
 }
 
+lbValue lb_internal_dynamic_map_get_ptr(lbProcedure *p, lbValue const &map_ptr, lbValue const &key) {
+	Type *map_type = base_type(type_deref(map_ptr.type));
+	lbValue h = lb_gen_map_header(p, map_ptr, map_type);
+
+	lbValue key_ptr = {};
+	auto args = array_make<lbValue>(permanent_allocator(), 3);
+	args[0] = h;
+	args[1] = lb_gen_map_key_hash(p, key, map_type->Map.key, &key_ptr);
+	args[2] = key_ptr;
+
+	lbValue ptr = lb_emit_runtime_call(p, "__dynamic_map_get", args);
+
+	return lb_emit_conv(p, ptr, alloc_type_pointer(map_type->Map.value));
+}
+
 lbValue lb_addr_get_ptr(lbProcedure *p, lbAddr const &addr) {
 	if (addr.addr.value == nullptr) {
 		GB_PANIC("Illegal addr -> nullptr");
@@ -390,19 +405,8 @@ lbValue lb_addr_get_ptr(lbProcedure *p, lbAddr const &addr) {
 	}
 
 	switch (addr.kind) {
-	case lbAddr_Map: {
-		Type *map_type = base_type(addr.map.type);
-		lbValue h = lb_gen_map_header(p, addr.addr, map_type);
-		lbValue key = lb_gen_map_hash(p, addr.map.key, map_type->Map.key);
-
-		auto args = array_make<lbValue>(permanent_allocator(), 2);
-		args[0] = h;
-		args[1] = key;
-
-		lbValue ptr = lb_emit_runtime_call(p, "__dynamic_map_get", args);
-
-		return lb_emit_conv(p, ptr, alloc_type_pointer(map_type->Map.value));
-	}
+	case lbAddr_Map:
+		return lb_internal_dynamic_map_get_ptr(p, addr.addr, addr.map.key);
 
 	case lbAddr_RelativePointer: {
 		Type *rel_ptr = base_type(lb_addr_type(addr));
@@ -1059,16 +1063,11 @@ lbValue lb_addr_load(lbProcedure *p, lbAddr const &addr) {
 
 
 	} else if (addr.kind == lbAddr_Map) {
-		Type *map_type = base_type(addr.map.type);
+		Type *map_type = base_type(type_deref(addr.addr.type));
+		GB_ASSERT(map_type->kind == Type_Map);
 		lbAddr v = lb_add_local_generated(p, map_type->Map.lookup_result_type, true);
-		lbValue h = lb_gen_map_header(p, addr.addr, map_type);
-		lbValue key = lb_gen_map_hash(p, addr.map.key, map_type->Map.key);
 
-		auto args = array_make<lbValue>(permanent_allocator(), 2);
-		args[0] = h;
-		args[1] = key;
-
-		lbValue ptr = lb_emit_runtime_call(p, "__dynamic_map_get", args);
+		lbValue ptr = lb_internal_dynamic_map_get_ptr(p, addr.addr, addr.map.key);
 		lbValue ok = lb_emit_conv(p, lb_emit_comp_against_nil(p, Token_NotEq, ptr), t_bool);
 		lb_emit_store(p, lb_emit_struct_ep(p, v.addr, 1), ok);
 

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -381,6 +381,8 @@ lbProcedure *lb_create_dummy_procedure(lbModule *m, String link_name, Type *type
 		lb_add_proc_attribute_at_index(p, offset+parameter_index, "nocapture");
 	}
 
+	map_init(&p->map_header_cache, heap_allocator(), 0);
+
 	return p;
 }
 

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -121,8 +121,9 @@ lbProcedure *lb_create_procedure(lbModule *m, Entity *entity, bool ignore_body) 
 	p->branch_blocks.allocator = a;
 	p->context_stack.allocator = a;
 	p->scope_stack.allocator   = a;
-	map_init(&p->selector_values, a, 0);
-	map_init(&p->selector_addr,   a, 0);
+	map_init(&p->selector_values,  a, 0);
+	map_init(&p->selector_addr,    a, 0);
+	map_init(&p->map_header_cache, a, 0);
 
 	if (p->is_foreign) {
 		lb_add_foreign_library_path(p->module, entity->Procedure.foreign_library);


### PR DESCRIPTION
Improve the internals of a map with the following:

* Change internal  map indices to use a distinct `uint` rather than just `int`
    * Uses explicit sentinel (`~Map_Index(0)` rather than use any negative number
* `__dynamic_map_get`  and `__dynamic_map_set` use only simple parameters (non-aggregate types) to simplify compiler internals
* Cache map header per value where possible to minimize stack usage
* Add `"contextless"` where possible to dynamic_map_internal.odin
* Update json/unmarshal.odin where needed
* Wrap `__dynamic_map_find` for certain cases