### PR TITLE
Changed nightly build for linux to include the llvm library file

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           mkdir dist
           cp odin dist
+          cp libLLVM*.so dist
           cp -r shared dist
           cp -r core dist
           cp -r vendor dist

--- a/.gitignore
+++ b/.gitignore
@@ -271,6 +271,7 @@ odin
 odin.dSYM
 *.bin
 demo.bin
+libLLVM*.so
 
 # shared collection
 shared/

--- a/build_odin.sh
+++ b/build_odin.sh
@@ -99,7 +99,8 @@ config_linux() {
 
 	LDFLAGS="$LDFLAGS -ldl"
 	CXXFLAGS="$CXXFLAGS $($LLVM_CONFIG --cxxflags --ldflags)"
-	LDFLAGS="$LDFLAGS $($LLVM_CONFIG --libs core native --system-libs)"
+	LDFLAGS="$LDFLAGS $($LLVM_CONFIG  --libs core native --system-libs --libfiles) -Wl,-rpath=\$ORIGIN"
+	cp $($LLVM_CONFIG --libfiles) ./
 }
 
 build_odin() {


### PR DESCRIPTION
This is a small change to include the `libLLVM-x.so` in the zip file for linux builds, I am aiming here to add support of odin to compiler explorer, and the server there won't have the llvm or any dependency. 

(ref: https://github.com/compiler-explorer/infra/pull/813#issuecomment-1252403332)

