### PR TITLE
Map header changes

### DIFF
--- a/core/encoding/json/unmarshal.odin
+++ b/core/encoding/json/unmarshal.odin
@@ -405,7 +405,7 @@ unmarshal_object :: proc(p: ^Parser, v: any, end_token: Token_Kind) -> (err: Unm
 			raw_map.entries.allocator = p.allocator
 		}
 		
-		header := runtime.__get_map_header_runtime(raw_map, t)
+		header := runtime.__get_map_header_table_runtime(t)
 		
 		elem_backing := bytes_make(t.value.size, t.value.align, p.allocator) or_return
 		defer delete(elem_backing, p.allocator)
@@ -432,7 +432,7 @@ unmarshal_object :: proc(p: ^Parser, v: any, end_token: Token_Kind) -> (err: Unm
 				key_ptr = &key_cstr
 			}
 			
-			set_ptr := runtime.__dynamic_map_set(header, key_hash, key_ptr, map_backing_value.data)
+			set_ptr := runtime.__dynamic_map_set(raw_map, header, key_hash, key_ptr, map_backing_value.data)
 			if set_ptr == nil {
 				delete(key, p.allocator)
 			} 

--- a/core/runtime/core_builtin.odin
+++ b/core/runtime/core_builtin.odin
@@ -296,7 +296,8 @@ clear_map :: proc "contextless" (m: ^$T/map[$K]$V) {
 @builtin
 reserve_map :: proc(m: ^$T/map[$K]$V, capacity: int, loc := #caller_location) {
 	if m != nil {
-		__dynamic_map_reserve(__get_map_header(m), uint(capacity), loc)
+		h := __get_map_header_table(T)
+		__dynamic_map_reserve(m, h, uint(capacity), loc)
 	}
 }
 

--- a/core/runtime/dynamic_map_internal.odin
+++ b/core/runtime/dynamic_map_internal.odin
@@ -82,7 +82,6 @@ __dynamic_map_set :: proc "odin" (m: rawptr, table: Map_Header_Table, key_hash: 
 		}
 		return prev
 	}
-	assert(condition = m != nil)
 
 	h := Map_Header{(^Raw_Map)(m), table}
 
@@ -126,8 +125,6 @@ __dynamic_map_set :: proc "odin" (m: rawptr, table: Map_Header_Table, key_hash: 
 
 // USED INTERNALLY BY THE COMPILER
 __dynamic_map_reserve :: proc "odin" (m: rawptr, table: Map_Header_Table, cap: uint, loc := #caller_location) {
-	assert(condition = m != nil)
-
 	h := Map_Header{(^Raw_Map)(m), table}
 
 	c := context

--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -2831,23 +2831,12 @@ void init_core_source_code_location(Checker *c) {
 }
 
 void init_core_map_type(Checker *c) {
-	if (t_map_hash == nullptr) {
-		Entity *e = find_core_entity(c, str_lit("Map_Hash"));
-		if (e->state == EntityState_Unresolved) {
-			check_entity_decl(&c->builtin_ctx, e, nullptr, nullptr);
-		}
-		t_map_hash = e->type;
-		GB_ASSERT(t_map_hash != nullptr);
+	if (t_map_hash != nullptr) {
+		return;
 	}
-
-	if (t_map_header == nullptr) {
-		Entity *e = find_core_entity(c, str_lit("Map_Header"));
-		if (e->state == EntityState_Unresolved) {
-			check_entity_decl(&c->builtin_ctx, e, nullptr, nullptr);
-		}
-		t_map_header = e->type;
-		GB_ASSERT(t_map_header != nullptr);
-	}
+	t_map_hash = find_core_type(c, str_lit("Map_Hash"));
+	t_map_header = find_core_type(c, str_lit("Map_Header"));
+	t_map_header_table = find_core_type(c, str_lit("Map_Header_Table"));
 }
 
 void init_preload(Checker *c) {

--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -578,31 +578,6 @@ lbAddr lb_gen_map_header_internal(lbProcedure *p, lbValue map_val_ptr, Type *map
 	return h;
 }
 
-
-lbValue lb_gen_map_header(lbProcedure *p, lbValue map_val_ptr, Type *map_type) {
-	GB_ASSERT_MSG(is_type_pointer(map_val_ptr.type), "%s", type_to_string(map_val_ptr.type));
-	GB_ASSERT(is_type_map(map_type));
-
-
-	// TODO(bill): this is a temporary fix since this caching is not working other platforms
-	bool allow_caching = build_context.metrics.os == TargetOs_windows || is_arch_wasm();
-
-	lbAddr h = {};
-	if (!allow_caching) {
-		h = lb_gen_map_header_internal(p, map_val_ptr, map_type);
-	} else {
-		lbAddr *found = map_get(&p->map_header_cache, map_val_ptr.value);
-		if (found != nullptr) {
-			h = *found;
-		} else {
-			h = lb_gen_map_header_internal(p, map_val_ptr, map_type);
-			map_set(&p->map_header_cache, map_val_ptr.value, h);
-		}
-	}
-
-	return lb_addr_load(p, h);
-}
-
 lbValue lb_const_hash(lbModule *m, lbValue key, Type *key_type) {
 	if (true) {
 		return {};

--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -670,10 +670,6 @@ lbValue lb_gen_map_key_hash(lbProcedure *p, lbValue key, Type *key_type, lbValue
 }
 
 lbValue lb_internal_dynamic_map_get_ptr(lbProcedure *p, lbValue const &map_ptr, lbValue const &key) {
-	if (p->name == "main.map_type") {
-		gb_printf_err("HERE!\n");
-	}
-
 	Type *map_type = base_type(type_deref(map_ptr.type));
 
 	lbValue key_ptr = {};

--- a/src/llvm_backend.hpp
+++ b/src/llvm_backend.hpp
@@ -310,7 +310,6 @@ struct lbProcedure {
 
 	PtrMap<Ast *, lbValue> selector_values;
 	PtrMap<Ast *, lbAddr>  selector_addr;
-	PtrMap<LLVMValueRef, lbAddr> map_header_cache;
 };
 
 
@@ -446,7 +445,6 @@ String lb_get_const_string(lbModule *m, lbValue value);
 
 lbValue lb_generate_local_array(lbProcedure *p, Type *elem_type, i64 count, bool zero_init=true);
 lbValue lb_generate_global_array(lbModule *m, Type *elem_type, i64 count, String prefix, i64 id);
-lbValue lb_gen_map_header(lbProcedure *p, lbValue map_val_ptr, Type *map_type);
 lbValue lb_gen_map_key_hash(lbProcedure *p, lbValue key, Type *key_type, lbValue *key_ptr_);
 
 lbValue lb_internal_dynamic_map_get_ptr(lbProcedure *p, lbValue const &map_ptr, lbValue const &key);

--- a/src/llvm_backend.hpp
+++ b/src/llvm_backend.hpp
@@ -159,6 +159,8 @@ struct lbModule {
 
 	StringMap<lbAddr> objc_classes;
 	StringMap<lbAddr> objc_selectors;
+
+	PtrMap<Type *, lbAddr> map_header_table_map;
 };
 
 struct lbGenerator {
@@ -446,7 +448,10 @@ lbValue lb_generate_local_array(lbProcedure *p, Type *elem_type, i64 count, bool
 lbValue lb_generate_global_array(lbModule *m, Type *elem_type, i64 count, String prefix, i64 id);
 lbValue lb_gen_map_header(lbProcedure *p, lbValue map_val_ptr, Type *map_type);
 lbValue lb_gen_map_key_hash(lbProcedure *p, lbValue key, Type *key_type, lbValue *key_ptr_);
-void    lb_insert_dynamic_map_key_and_value(lbProcedure *p, lbAddr addr, Type *map_type, lbValue map_key, lbValue map_value, Ast *node);
+
+lbValue lb_internal_dynamic_map_get_ptr(lbProcedure *p, lbValue const &map_ptr, lbValue const &key);
+void    lb_insert_dynamic_map_key_and_value(lbProcedure *p, lbValue const &map_ptr, Type *map_type, lbValue const &map_key, lbValue const &map_value, Ast *node);
+void    lb_dynamic_map_reserve(lbProcedure *p, lbValue const &map_ptr, isize const capacity, TokenPos const &pos);
 
 lbValue lb_find_procedure_value_from_entity(lbModule *m, Entity *e);
 lbValue lb_find_value_from_entity(lbModule *m, Entity *e);

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -889,7 +889,7 @@ lbValue lb_emit_call(lbProcedure *p, lbValue value, Array<lbValue> const &args, 
 		GB_ASSERT(param_count-1 <= args.count);
 		param_count -= 1;
 	} else {
-		GB_ASSERT_MSG(param_count == args.count, "%td == %td", param_count, args.count);
+		GB_ASSERT_MSG(param_count == args.count, "%td == %td (%s)", param_count, args.count, LLVMPrintValueToString(value.value));
 	}
 
 	lbValue result = {};

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -123,7 +123,6 @@ lbProcedure *lb_create_procedure(lbModule *m, Entity *entity, bool ignore_body) 
 	p->scope_stack.allocator   = a;
 	map_init(&p->selector_values,  a, 0);
 	map_init(&p->selector_addr,    a, 0);
-	map_init(&p->map_header_cache, a, 0);
 
 	if (p->is_foreign) {
 		lb_add_foreign_library_path(p->module, entity->Procedure.foreign_library);
@@ -380,9 +379,6 @@ lbProcedure *lb_create_dummy_procedure(lbModule *m, String link_name, Type *type
 		lb_add_proc_attribute_at_index(p, offset+parameter_index, "nonnull");
 		lb_add_proc_attribute_at_index(p, offset+parameter_index, "nocapture");
 	}
-
-	map_init(&p->map_header_cache, heap_allocator(), 0);
-
 	return p;
 }
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -688,6 +688,7 @@ gb_global Type *t_source_code_location_ptr       = nullptr;
 
 gb_global Type *t_map_hash                       = nullptr;
 gb_global Type *t_map_header                     = nullptr;
+gb_global Type *t_map_header_table               = nullptr;
 
 
 gb_global Type *t_equal_proc  = nullptr;


### PR DESCRIPTION
* Split the map pointer and map header table
* Remove unnecessary map gets 


The entire runtime uses 2+1 calls now:

* `__dynamic_map_get`
* `__dynamic_map_set`
* `__dynamic_map_reserve` (not necessary if `-no-dynamic-literals` is set)

```odin
__dynamic_map_get :: proc "contextless" (m: rawptr, table: Map_Header_Table, key_hash: uintptr, key_ptr: rawptr) -> rawptr {...}
```
```odin
__dynamic_map_set :: proc "odin" (m: rawptr, table: Map_Header_Table, key_hash: uintptr, key_ptr: rawptr, value: rawptr, loc := #caller_location) -> ^Map_Entry_Header #no_bounds_check {...}
```
```odin
__dynamic_map_reserve :: proc "odin" (m: rawptr, table: Map_Header_Table, cap: uint, loc := #caller_location) {...}
```