### PR TITLE
removed do

### DIFF
--- a/vendor/zlib/zlib.odin
+++ b/vendor/zlib/zlib.odin
@@ -2,8 +2,8 @@ package zlib
 
 import "core:c"
 
-when ODIN_OS == .Windows do foreign import zlib "libz.lib"
-when ODIN_OS == .Linux   do foreign import zlib "system:z"
+when ODIN_OS == .Windows { foreign import zlib "libz.lib" }
+when ODIN_OS == .Linux   { foreign import zlib "system:z" }
 
 VERSION         :: "1.2.12"
 VERNUM          :: 0x12c0


### PR DESCRIPTION
We should remove `do` in both `core` and `vendor` so people using `disallow-do` don't get error messages. 
Proposal based on commit `Remove usage of do in core library` https://github.com/odin-lang/Odin/commit/fc4fdd588e5bd0c45d04c792267a0f4434c6a38e