### PR TITLE
allow json struct unused fields

### DIFF
--- a/core/encoding/json/unmarshal.odin
+++ b/core/encoding/json/unmarshal.odin
@@ -384,16 +384,14 @@ unmarshal_object :: proc(p: ^Parser, v: any, end_token: Token_Kind) -> (err: Unm
 					break struct_loop
 				}
 				continue struct_loop
+			} else {
+				// allows skipping unused struct fields
+				parse_value(p) or_return
+				if parse_comma(p) {
+					break struct_loop
+				}
+				continue struct_loop
 			}
-			
-			// NOTE(bill, 2022-09-14): Previously this would not be allowed
-			//         {"foo": 123, "bar": 456}
-			//         T :: struct{foo: int}
-			// `T` is missing the `bar` field
-			// The line below is commented out to ignore fields in an object which
-			// do not have a corresponding target field
-			//
-			// return Unsupported_Type_Error{v.id, p.curr_token}
 		}
 		
 	case reflect.Type_Info_Map:


### PR DESCRIPTION
extended with an else statement to allow skipping unused struct fields. Seems to work fine for me. Before it used to assert because it tried to interpret the other upcoming tokens wrong.

```odin
main :: proc() {
	Test_Struct1 :: struct {
		a: int,
		b: bool,
		array: []int,
		d: string,
	}

	Test_Struct2 :: struct {
		a: int,
		b: bool,
		// array: []int,
		d: string,
	}

	output := Test_Struct1 {
		100, 
		true, 
		{
			1,2,3,4,5
		},
		"yoooooo",
	}
	output_data, output_err := json.marshal(output, {})
	output_string := transmute(string) output_data[:]

	fmt.eprintln(output_string)
	assert(output_err == nil)

	input: Test_Struct2
	input_err := json.unmarshal(output_data, &input, .JSON)

	fmt.eprintln(input, input_err)
	assert(input_err == nil)
}
```
outputs
```odin
{"a": 100, "b": true, "array": [1, 2, 3, 4, 5], "d": "yoooooo"}
Test_Struct2{a = 100, b = true, d = "yoooooo"} nil
```
without crashing / asserting :+1: 