### PR TITLE
Add debug information for soa pointers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
           cd tests/vendor
           make
         timeout-minutes: 10
+      - name: Odin issues tests
+        run: |
+          cd tests/issues
+          ./run.sh
       - name: Odin check examples/all for Linux i386
         run: ./odin check examples/all -vet -strict-style -target:linux_i386
         timeout-minutes: 10
@@ -151,6 +155,10 @@ jobs:
           cd tests\vendor
           call build.bat
         timeout-minutes: 10
+      - name: Odin issues tests
+        run: |
+          cd tests/issues
+          ./run.sh
       - name: core:math/big tests
         shell: cmd
         run: |

--- a/src/llvm_backend_debug.cpp
+++ b/src/llvm_backend_debug.cpp
@@ -293,6 +293,7 @@ LLVMMetadataRef lb_debug_type_internal(lbModule *m, Type *type) {
 	case Type_Named:
 		GB_PANIC("Type_Named should be handled in lb_debug_type separately");
 
+	case Type_SoaPointer:
 	case Type_Pointer:
 		return LLVMDIBuilderCreatePointerType(m->debug_builder, lb_debug_type(m, type->Pointer.elem), word_bits, word_bits, 0, nullptr, 0);
 	case Type_MultiPointer:

--- a/tests/issues/run.bat
+++ b/tests/issues/run.bat
@@ -1,15 +1,18 @@
 @echo off
 
 if not exist "build\" mkdir build
+pushd build
 
-set COMMON=-collection:tests=..
+set COMMON=-collection:tests=..\..
 
 @echo on
 
-..\..\odin test test_issue_829.odin %COMMON% -file
-..\..\odin test test_issue_1592.odin %COMMON% -file
-..\..\odin test test_issue_2087.odin %COMMON% -file
+..\..\..\odin test ..\test_issue_829.odin %COMMON% -file
+..\..\..\odin test ..\test_issue_1592.odin %COMMON% -file
+..\..\..\odin test ..\test_issue_2087.odin %COMMON% -file
+..\..\..\odin run ..\test_issue_2113.odin %COMMON% -file -debug
 
 @echo off
 
+popd
 rmdir /S /Q build

--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -2,15 +2,18 @@
 set -eu
 
 mkdir -p build
-ODIN=../../odin
-COMMON="-collection:tests=.."
+pushd build
+ODIN=../../../odin
+COMMON="-collection:tests=../.."
 
 set -x
 
 $ODIN test test_issue_829.odin  $COMMON -file
 $ODIN test test_issue_1592.odin $COMMON -file
 $ODIN test test_issue_2087.odin $COMMON -file
+$ODIN test test_issue_2113.odin $COMMON -file -debug
 
 set +x
 
+popd build
 rm -rf build

--- a/tests/issues/test_issue_2113.odin
+++ b/tests/issues/test_issue_2113.odin
@@ -1,0 +1,13 @@
+// Tests issue #2113 https://github.com/odin-lang/Odin/issues/2113
+// Causes a panic on compilation
+package test_issues
+
+T :: struct {
+    a: int,
+}
+
+main :: proc() {
+    array: #soa[1]T
+    a := &array[0]
+    _ = a
+}


### PR DESCRIPTION
* Add `Type_SoaPointer` to `lb_debug_type_internal`
* Add compilation test case for the issue
* Build tests in the build folder when running run.bat

Soa pointer does not cause compiler panic with debug anymore after these changes.
Confirmed in RemedyBG that the debug information is correct.

Looks like https://github.com/odin-lang/Odin/pull/2078 involves refactoring tests, so my test changes here probably will be discarded for that.