### PR TITLE
Fix #2112

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1502,44 +1502,24 @@ bool init_build_paths(String init_filename) {
 	} else {
 		Path output_path;
 
-		if (str_eq(init_filename, str_lit("."))) {
-			// We must name the output file after the current directory.
-			debugf("Output name will be created from current base name %.*s.\n", LIT(bc->build_paths[BuildPath_Main_Package].basename));
-			String last_element  = last_path_element(bc->build_paths[BuildPath_Main_Package].basename);
+		// We must name the output file after the current directory.
+		debugf("Output name will be created from current base name %.*s.\n", LIT(bc->build_paths[BuildPath_Main_Package].basename));
+		String last_element  = last_path_element(bc->build_paths[BuildPath_Main_Package].basename);
 
-			if (last_element.len == 0) {
-				gb_printf_err("The output name is created from the last path element. `%.*s` has none. Use `-out:output_name.ext` to set it.\n", LIT(bc->build_paths[BuildPath_Main_Package].basename));
-				return false;
-			}
-			output_path.basename = copy_string(ha, bc->build_paths[BuildPath_Main_Package].basename);
-			output_path.name     = copy_string(ha, last_element);
-
-		} else {
-			// Init filename was not 'current path'.
-			// Contruct the output name from the path elements as usual.
-			String output_name = init_filename;
-			// If it ends with a trailing (back)slash, strip it before continuing.
-			while (output_name.len > 0 && (output_name[output_name.len-1] == '/' || output_name[output_name.len-1] == '\\')) {
-				output_name.len -= 1;
-			}
-			output_name = remove_directory_from_path(output_name);
-			output_name = remove_extension_from_path(output_name);
-			output_name = copy_string(ha, string_trim_whitespace(output_name));
-			output_path = path_from_string(ha, output_name);
-
-			// Replace extension.
-			if (output_path.ext.len > 0) {
-				gb_free(ha, output_path.ext.text);
-			}
+		if (last_element.len == 0) {
+			gb_printf_err("The output name is created from the last path element. `%.*s` has none. Use `-out:output_name.ext` to set it.\n", LIT(bc->build_paths[BuildPath_Main_Package].basename));
+			return false;
 		}
-		output_path.ext  = copy_string(ha, output_extension);
+		output_path.basename = copy_string(ha, bc->build_paths[BuildPath_Main_Package].basename);
+		output_path.name     = copy_string(ha, last_element);
+		output_path.ext      = copy_string(ha, output_extension);
 
 		bc->build_paths[BuildPath_Output] = output_path;
 	}
 
 	// Do we have an extension? We might not if the output filename was supplied.
 	if (bc->build_paths[BuildPath_Output].ext.len == 0) {
-		if (build_context.metrics.os == TargetOs_windows || build_context.build_mode != BuildMode_Executable) {
+		if (bc->metrics.os == TargetOs_windows || bc->build_mode != BuildMode_Executable) {
 			bc->build_paths[BuildPath_Output].ext = copy_string(ha, output_extension);
 		}
 	}


### PR DESCRIPTION
If `-out` is not provided, always create the output filename using the last path element.