### PR TITLE
Fix signature for `shouldTerminateAfterLastWindowClosed` delegate proc

### DIFF
--- a/vendor/darwin/Foundation/NSApplication.odin
+++ b/vendor/darwin/Foundation/NSApplication.odin
@@ -11,7 +11,7 @@ ActivationPolicy :: enum UInteger {
 ApplicationDelegate :: struct {
 	willFinishLaunching:                  proc "c" (self: ^ApplicationDelegate, notification: ^Notification),
 	didFinishLaunching:                   proc "c" (self: ^ApplicationDelegate, notification: ^Notification),
-	shouldTerminateAfterLastWindowClosed: proc "c" (self: ^ApplicationDelegate, sender: ^Application),
+	shouldTerminateAfterLastWindowClosed: proc "c" (self: ^ApplicationDelegate, sender: ^Application) -> bool,
 
 	user_data: rawptr,
 }
@@ -34,9 +34,9 @@ Application_setDelegate :: proc(self: ^Application, delegate: ^ApplicationDelega
 		del := (^ApplicationDelegate)(self->pointerValue())
 		del->didFinishLaunching(notification)
 	}
-	shouldTerminateAfterLastWindowClosed :: proc "c" (self: ^Value, _: SEL, application: ^Application) {
+	shouldTerminateAfterLastWindowClosed :: proc "c" (self: ^Value, _: SEL, application: ^Application) -> bool {
 		del := (^ApplicationDelegate)(self->pointerValue())
-		del->shouldTerminateAfterLastWindowClosed(application)
+		return del->shouldTerminateAfterLastWindowClosed(application)
 	}
 
 	wrapper := Value.valueWithPointer(delegate)

--- a/vendor/darwin/Foundation/NSApplication.odin
+++ b/vendor/darwin/Foundation/NSApplication.odin
@@ -11,7 +11,7 @@ ActivationPolicy :: enum UInteger {
 ApplicationDelegate :: struct {
 	willFinishLaunching:                  proc "c" (self: ^ApplicationDelegate, notification: ^Notification),
 	didFinishLaunching:                   proc "c" (self: ^ApplicationDelegate, notification: ^Notification),
-	shouldTerminateAfterLastWindowClosed: proc "c" (self: ^ApplicationDelegate, sender: ^Application) -> bool,
+	shouldTerminateAfterLastWindowClosed: proc "c" (self: ^ApplicationDelegate, sender: ^Application) -> BOOL,
 
 	user_data: rawptr,
 }
@@ -34,7 +34,7 @@ Application_setDelegate :: proc(self: ^Application, delegate: ^ApplicationDelega
 		del := (^ApplicationDelegate)(self->pointerValue())
 		del->didFinishLaunching(notification)
 	}
-	shouldTerminateAfterLastWindowClosed :: proc "c" (self: ^Value, _: SEL, application: ^Application) -> bool {
+	shouldTerminateAfterLastWindowClosed :: proc "c" (self: ^Value, _: SEL, application: ^Application) -> BOOL {
 		del := (^ApplicationDelegate)(self->pointerValue())
 		return del->shouldTerminateAfterLastWindowClosed(application)
 	}


### PR DESCRIPTION
The existing `shouldTerminateAfterLastWindowClosed` proc used in `ApplicationDelegate` declares no return value, which prevents programmers using Odin from choosing whether closing the last window in an NSApplication should terminate the application.

Per [Apple's documentation](https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428381-applicationshouldterminateafterl?language=objc), `NSApplicationDelegate`'s `applicationShouldTerminateAfterLastWindowClosed` method should return a `BOOL` value:

```
- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender;
```

This PR fixes the signature discrepancy by using ~a `bool` signature.
NOTE: strictly speaking, BOOL is not equivalent to a C bool per https://developer.apple.com/documentation/objectivec/bool/, but I suspect that doesn't matter in this case.~
an `NS.BOOL` signature.

```
Odin: dev-2022-10-nightly:775c9648
OS:   macOS Monterey 12.5 (build: 21G115, kernel: 21.6.0)
CPU:  Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
RAM:  32768 MiB
```