### PR TITLE
Fix GetInstanceProcAddr crash

### DIFF
--- a/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
+++ b/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
@@ -84,7 +84,7 @@ def convert_type(t, prev_name, curr_name):
         else:
             ttype = t[:len(t)-1]
             elem = convert_type(ttype, prev_name, curr_name)
-            
+
         if curr_name.endswith("s") or curr_name.endswith("Table"):
             if prev_name.endswith("Count") or prev_name.endswith("Counts"):
                 pointer = "[^]"
@@ -95,10 +95,10 @@ def convert_type(t, prev_name, curr_name):
                     pointer = "[^]"
             elif curr_name.startswith("p"):
                 pointer = "[^]"
-                
+
         if curr_name and elem.endswith("Flags"):
             pointer = "[^]"
-                    
+
         return "{}{}".format(pointer, elem)
     elif t[0].isupper():
         return t
@@ -276,7 +276,7 @@ def parse_enums(f):
     f.write("// Enums\n")
 
     data = re.findall(r"typedef enum Vk(\w+) {(.+?)} \w+;", src, re.S)
-    
+
     data.sort(key=lambda x: x[0])
 
     generated_flags = set()
@@ -458,14 +458,14 @@ def parse_procedures(f):
 
     for rt, name, fields in data:
         proc_name = no_vk(name)
-        
+
         pf = []
         prev_name = ""
         for type_, fname in re.findall(r"(?:\s*|)(.+?)\s*(\w+)(?:,|$)", fields):
             curr_name = fix_arg(fname)
             pf.append((do_type(type_, prev_name, curr_name), curr_name))
             prev_name = curr_name
-            
+
         data_fields = ', '.join(["{}: {}".format(n, t) for t, n in pf if t != ""])
 
         ts = "proc \"c\" ({})".format(data_fields)
@@ -510,7 +510,7 @@ def group_functions(f):
 
         if table_name in ('Device', 'Queue', 'CommandBuffer') and name != 'GetDeviceProcAddr':
             group_map["Device"].append(nn)
-        elif table_name in ('Instance', 'PhysicalDevice') or name == 'GetDeviceProcAddr':
+        elif table_name in ('Instance', 'PhysicalDevice') and name != 'ProcGetInstanceProcAddr' or name == 'GetDeviceProcAddr':
             group_map["Instance"].append(nn)
         elif table_name in ('rawptr', '', 'DebugReportFlagsEXT') or name == 'GetInstanceProcAddr':
             # Skip the allocation function and the dll entry point

--- a/vendor/vulkan/procedures.odin
+++ b/vendor/vulkan/procedures.odin
@@ -533,6 +533,7 @@ DeviceMemoryReportCallbackEXT:        ProcDeviceMemoryReportCallbackEXT
 EnumerateInstanceExtensionProperties: ProcEnumerateInstanceExtensionProperties
 EnumerateInstanceLayerProperties:     ProcEnumerateInstanceLayerProperties
 EnumerateInstanceVersion:             ProcEnumerateInstanceVersion
+GetInstanceProcAddr:                  ProcGetInstanceProcAddr
 
 // Instance Procedures
 AcquireDrmDisplayEXT:                                            ProcAcquireDrmDisplayEXT
@@ -564,7 +565,6 @@ GetDisplayPlaneCapabilities2KHR:                                 ProcGetDisplayP
 GetDisplayPlaneCapabilitiesKHR:                                  ProcGetDisplayPlaneCapabilitiesKHR
 GetDisplayPlaneSupportedDisplaysKHR:                             ProcGetDisplayPlaneSupportedDisplaysKHR
 GetDrmDisplayEXT:                                                ProcGetDrmDisplayEXT
-GetInstanceProcAddr:                                             ProcGetInstanceProcAddr
 GetPhysicalDeviceCalibrateableTimeDomainsEXT:                    ProcGetPhysicalDeviceCalibrateableTimeDomainsEXT
 GetPhysicalDeviceCooperativeMatrixPropertiesNV:                  ProcGetPhysicalDeviceCooperativeMatrixPropertiesNV
 GetPhysicalDeviceDisplayPlaneProperties2KHR:                     ProcGetPhysicalDeviceDisplayPlaneProperties2KHR
@@ -1045,6 +1045,7 @@ load_proc_addresses_custom :: proc(set_proc_address: SetProcAddressType) {
 	set_proc_address(&EnumerateInstanceExtensionProperties, "vkEnumerateInstanceExtensionProperties")
 	set_proc_address(&EnumerateInstanceLayerProperties,     "vkEnumerateInstanceLayerProperties")
 	set_proc_address(&EnumerateInstanceVersion,             "vkEnumerateInstanceVersion")
+	set_proc_address(&GetInstanceProcAddr,                  "vkGetInstanceProcAddr")
 
 	// Instance Procedures
 	set_proc_address(&AcquireDrmDisplayEXT,                                            "vkAcquireDrmDisplayEXT")
@@ -1076,7 +1077,6 @@ load_proc_addresses_custom :: proc(set_proc_address: SetProcAddressType) {
 	set_proc_address(&GetDisplayPlaneCapabilitiesKHR,                                  "vkGetDisplayPlaneCapabilitiesKHR")
 	set_proc_address(&GetDisplayPlaneSupportedDisplaysKHR,                             "vkGetDisplayPlaneSupportedDisplaysKHR")
 	set_proc_address(&GetDrmDisplayEXT,                                                "vkGetDrmDisplayEXT")
-	set_proc_address(&GetInstanceProcAddr,                                             "vkGetInstanceProcAddr")
 	set_proc_address(&GetPhysicalDeviceCalibrateableTimeDomainsEXT,                    "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT")
 	set_proc_address(&GetPhysicalDeviceCooperativeMatrixPropertiesNV,                  "vkGetPhysicalDeviceCooperativeMatrixPropertiesNV")
 	set_proc_address(&GetPhysicalDeviceDisplayPlaneProperties2KHR,                     "vkGetPhysicalDeviceDisplayPlaneProperties2KHR")
@@ -2839,7 +2839,6 @@ load_proc_addresses_instance :: proc(instance: Instance) {
 	GetDisplayPlaneCapabilitiesKHR                                  = auto_cast GetInstanceProcAddr(instance, "vkGetDisplayPlaneCapabilitiesKHR")
 	GetDisplayPlaneSupportedDisplaysKHR                             = auto_cast GetInstanceProcAddr(instance, "vkGetDisplayPlaneSupportedDisplaysKHR")
 	GetDrmDisplayEXT                                                = auto_cast GetInstanceProcAddr(instance, "vkGetDrmDisplayEXT")
-	GetInstanceProcAddr                                             = auto_cast GetInstanceProcAddr(instance, "vkGetInstanceProcAddr")
 	GetPhysicalDeviceCalibrateableTimeDomainsEXT                    = auto_cast GetInstanceProcAddr(instance, "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT")
 	GetPhysicalDeviceCooperativeMatrixPropertiesNV                  = auto_cast GetInstanceProcAddr(instance, "vkGetPhysicalDeviceCooperativeMatrixPropertiesNV")
 	GetPhysicalDeviceDisplayPlaneProperties2KHR                     = auto_cast GetInstanceProcAddr(instance, "vkGetPhysicalDeviceDisplayPlaneProperties2KHR")
@@ -3322,6 +3321,7 @@ load_proc_addresses_global :: proc(vk_get_instance_proc_addr: rawptr) {
 	EnumerateInstanceExtensionProperties = auto_cast GetInstanceProcAddr(nil, "vkEnumerateInstanceExtensionProperties")
 	EnumerateInstanceLayerProperties     = auto_cast GetInstanceProcAddr(nil, "vkEnumerateInstanceLayerProperties")
 	EnumerateInstanceVersion             = auto_cast GetInstanceProcAddr(nil, "vkEnumerateInstanceVersion")
+	GetInstanceProcAddr                  = auto_cast GetInstanceProcAddr(nil, "vkGetInstanceProcAddr")
 }
 
 load_proc_addresses :: proc{


### PR DESCRIPTION
GetInstanceProcAddr was trying to initialise itself with itself when calling `load_proc_addresses(Instance)`
Discord bug-discussions message reference https://discord.com/channels/568138951836172421/585072813954564100/1030265964572450867