### PR TITLE
Fix assert in issue #1555 and improve error messages with 'using _'

### DIFF
--- a/src/check_decl.cpp
+++ b/src/check_decl.cpp
@@ -1488,6 +1488,11 @@ void check_proc_body(CheckerContext *ctx_, Token token, DeclInfo *decl, Type *ty
 				if (!(e->flags & EntityFlag_Using)) {
 					continue;
 				}
+				if (is_blank_ident(e->token)) {
+                    error(e->token, "'using' a procedure parameter requires a non blank identifier");
+					break;
+				}
+
 				bool is_value = (e->flags & EntityFlag_Value) != 0 && !is_type_pointer(e->type);
 				String name = e->token.string;
 				Type *t = base_type(type_deref(e->type));

--- a/src/check_stmt.cpp
+++ b/src/check_stmt.cpp
@@ -584,7 +584,11 @@ void check_label(CheckerContext *ctx, Ast *label, Ast *parent) {
 // Returns 'true' for 'continue', 'false' for 'return'
 bool check_using_stmt_entity(CheckerContext *ctx, AstUsingStmt *us, Ast *expr, bool is_selector, Entity *e) {
 	if (e == nullptr) {
-		error(us->token, "'using' applied to an unknown entity");
+		if (is_blank_ident(expr)) {
+			error(us->token, "'using' in a statement is not allowed with the blank identifier '_'");
+		} else {
+			error(us->token, "'using' applied to an unknown entity");
+		}
 		return true;
 	}
 


### PR DESCRIPTION
Issue #1555 was caused by blank identifiers not being present in the module values map.
Since `using _` was illegal in a procedures body I extended the check for procedure parameters to be the same.

Additionally for consistency I made `foo :: struct(using _: ^Bar) `have the same error message as `using _`
Being: `'using' is not allowed with the blank identifier '_'`

Since empty identifiers in a procedure get a blank identifier added for them, I also added a check for the character at the tokens location to be `_`. This produces a clearer message in statements like `foo :: struct(using ^Bar)` which also triggered the assert in #1555. Being: `'using' with a procedure parameter requires an identifier`
I didn't really know how to go around identifying if this was an inserted `_` or if it was present in the source code.
Change as needed.

Tested the below which no longer asserts
```
package main

Foo :: struct {
    value: int,
}

bar0 :: proc(using _: ^Foo) { // <- error 'using' is not allowed with the blank identifier '_'
}

bar1 :: proc(using ^Foo) { // <- error: 'using' with a procedure parameter requires an identifier
}

main :: proc(){
    using _  // <- error 'using' is not allowed with the blank identifier '_'
    bar0(&{})
    bar1(&{})
}
```
