### PR TITLE
fix core:c/libc.errno link_name for Linux and FreeBSD

### DIFF
--- a/core/c/libc/errno.odin
+++ b/core/c/libc/errno.odin
@@ -14,11 +14,24 @@ when ODIN_OS == .Windows {
 //	EDOM,
 //	EILSEQ
 //	ERANGE
-when ODIN_OS == .Linux || ODIN_OS == .FreeBSD {
+when ODIN_OS == .Linux {
 	@(private="file")
 	@(default_calling_convention="c")
 	foreign libc {
-		@(link_name="__libc_errno_location")
+		@(link_name="__errno_location")
+		_get_errno :: proc() -> ^int ---
+	}
+
+	EDOM   :: 33
+	EILSEQ :: 84
+	ERANGE :: 34
+}
+
+when ODIN_OS == .FreeBSD {
+	@(private="file")
+	@(default_calling_convention="c")
+	foreign libc {
+		@(link_name="__error")
 		_get_errno :: proc() -> ^int ---
 	}
 


### PR DESCRIPTION
Although the FreeBSD link matches Darwin, its EILSEQ still matches Linux.

Confirmed with the following program:

```odin
package main
import "core:c/libc"

main :: proc() {
	libc.printf("%d\n", libc.errno()^) // 0
	_ = libc.fopen("nonexistent file", "r")
	libc.printf("%d\n", libc.errno()^) // 2
}
```

on Linux:

	Odin: dev-2022-10:075040ae
	OS:   Manjaro Linux, Linux 5.10.147-1-MANJARO
	CPU:  Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
	RAM:  15953 MiB

and FreeBSD:

	Odin: dev-2022-10:075040ae
	OS:   FreeBSD: Unknown
	CPU:  Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
	RAM:  990 MiB

FreeBSD uname -r: 13.0-RELEASE