### PR TITLE
Fix signature for `objc_allocateClassPair` and add `objc_registerClassPair` to enable Objective-C subclassing

### DIFF
--- a/core/runtime/procs_darwin.odin
+++ b/core/runtime/procs_darwin.odin
@@ -12,7 +12,7 @@ objc_SEL :: ^intrinsics.objc_selector
 foreign Foundation {
 	objc_lookUpClass :: proc "c" (name: cstring) -> objc_Class ---
 	sel_registerName :: proc "c" (name: cstring) -> objc_SEL ---
-	objc_allocateClassPair :: proc "c" (superclass: objc_Class, name: cstring, extraBytes: uint) ---
+	objc_allocateClassPair :: proc "c" (superclass: objc_Class, name: cstring, extraBytes: uint) -> objc_Class ---
 
 	objc_msgSend        :: proc "c" (self: objc_id, op: objc_SEL, #c_vararg args: ..any) ---
 	objc_msgSend_fpret  :: proc "c" (self: objc_id, op: objc_SEL, #c_vararg args: ..any) -> f64 ---

--- a/vendor/darwin/Foundation/objc.odin
+++ b/vendor/darwin/Foundation/objc.odin
@@ -11,6 +11,7 @@ foreign Foundation {
 	objc_lookUpClass       :: proc "c" (name: cstring) -> Class ---
 	sel_registerName       :: proc "c" (name: cstring) -> SEL ---
     objc_allocateClassPair :: proc "c" (superclass : Class, name : cstring, extraBytes : c.size_t) -> Class ---
+	objc_registerClassPair :: proc "c" (cls : Class) ---
 
 	class_addMethod :: proc "c" (cls: Class, name: SEL, imp: IMP, types: cstring) -> BOOL ---
 	class_getInstanceMethod :: proc "c" (cls: Class, name: SEL) -> Method ---

--- a/vendor/darwin/Foundation/objc.odin
+++ b/vendor/darwin/Foundation/objc.odin
@@ -10,7 +10,7 @@ IMP :: proc "c" (object: id, sel: SEL, #c_vararg args: ..any) -> id
 foreign Foundation {
 	objc_lookUpClass       :: proc "c" (name: cstring) -> Class ---
 	sel_registerName       :: proc "c" (name: cstring) -> SEL ---
-	objc_allocateClassPair :: proc "c" (superclass: Class, name: cstring, extraBytes: uint) -> Class ---
+    objc_allocateClassPair :: proc "c" (superclass : Class, name : cstring, extraBytes : c.size_t) -> Class ---
 
 	class_addMethod :: proc "c" (cls: Class, name: SEL, imp: IMP, types: cstring) -> BOOL ---
 	class_getInstanceMethod :: proc "c" (cls: Class, name: SEL) -> Method ---

--- a/vendor/darwin/Foundation/objc.odin
+++ b/vendor/darwin/Foundation/objc.odin
@@ -10,7 +10,7 @@ IMP :: proc "c" (object: id, sel: SEL, #c_vararg args: ..any) -> id
 foreign Foundation {
 	objc_lookUpClass       :: proc "c" (name: cstring) -> Class ---
 	sel_registerName       :: proc "c" (name: cstring) -> SEL ---
-	objc_allocateClassPair :: proc "c" (superclass: Class, name: cstring, extraBytes: uint) ---
+	objc_allocateClassPair :: proc "c" (superclass: Class, name: cstring, extraBytes: uint) -> Class ---
 
 	class_addMethod :: proc "c" (cls: Class, name: SEL, imp: IMP, types: cstring) -> BOOL ---
 	class_getInstanceMethod :: proc "c" (cls: Class, name: SEL) -> Method ---

--- a/vendor/darwin/Foundation/objc.odin
+++ b/vendor/darwin/Foundation/objc.odin
@@ -10,7 +10,7 @@ IMP :: proc "c" (object: id, sel: SEL, #c_vararg args: ..any) -> id
 foreign Foundation {
 	objc_lookUpClass       :: proc "c" (name: cstring) -> Class ---
 	sel_registerName       :: proc "c" (name: cstring) -> SEL ---
-    objc_allocateClassPair :: proc "c" (superclass : Class, name : cstring, extraBytes : c.size_t) -> Class ---
+	objc_allocateClassPair :: proc "c" (superclass : Class, name : cstring, extraBytes : c.size_t) -> Class ---
 	objc_registerClassPair :: proc "c" (cls : Class) ---
 
 	class_addMethod :: proc "c" (cls: Class, name: SEL, imp: IMP, types: cstring) -> BOOL ---


### PR DESCRIPTION
# Overview

1. Fixes signature for foreign `objc_allocateClassPair` proc.
2. Adds foreign  `objc_registerClassPair` proc.

These changes make it possible to create Objective-C subclasses.

## 1. Fix `objc_allocateClassPair`

`objc_allocateClassPair :: proc "c" (superclass : Class, name : cstring, extraBytes : uint) -> ---`
should be
`objc_allocateClassPair :: proc "c" (superclass : Class, name : cstring, extraBytes : c.size_t) -> Class ---`
to match [Apple's implementation](https://developer.apple.com/documentation/objectivec/1418559-objc_allocateclasspair?language=objc):
```C
Class objc_allocateClassPair(Class superclass, const char *name, size_t extraBytes);
```

Note that I used `c.size_t` in `vendor/darwin/Foundation/objc.odin` because it was already importing `core:c` but preserved it as `uint` in `core/runtime/procs_darwin.odin` because I wasn't sure if I should make that depend on `core:c`.

## 2. Add `objc_registerClassPair`

`objc_registerClassPair :: proc "c" (cls : Class) ---` is based on [this](https://developer.apple.com/documentation/objectivec/1418603-objc_registerclasspair?language=objc):
```C
void objc_registerClassPair(Class cls);
```

## Objective-C Subclassing Example

These changes make it possible to create subclasses of Objective-C classes as shown:

```Odin
package main

@require foreign import "system:Cocoa.framework"

import "core:fmt"
import "core:intrinsics"
import "core:runtime"

import NS "vendor:darwin/Foundation"

on_test :: proc "c" (self : NS.id, cmd: NS.SEL, someArg: i32) {
    context = runtime.default_context();
    fmt.printf("Test Called with: %d\n", someArg)
}

@(objc_class="CustomView")
CustomView :: struct {using _: NS.View}

main :: proc () {
    nsViewClass := intrinsics.objc_find_class("NSView")
    newClass := NS.objc_allocateClassPair(nsViewClass, "CustomView", 0)

    testSel := intrinsics.objc_find_selector("test")
    NS.class_addMethod(newClass, testSel, cast(NS.IMP)on_test, "v@:i");

    NS.objc_registerClassPair(newClass)

    allocedClass := intrinsics.objc_send(^CustomView, cast(^CustomView)newClass, "alloc")
    fmt.printf("Alloced: %v \n", allocedClass)
    initedClass := intrinsics.objc_send(^CustomView, allocedClass, "init")
    fmt.printf("InitedClass: %v \n", initedClass)
    isFlipped := intrinsics.objc_send(bool, initedClass, "isFlipped")
    fmt.printf("Class: %v IsFlipped: %v\n", initedClass, isFlipped)
    intrinsics.objc_send(nil, initedClass, "test", u32(5))
}
```