### PR TITLE
fix #2130 Assertion failure in compiler on cast of scalar to non-square matrix

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -821,11 +821,12 @@ i64 check_distance_between_types(CheckerContext *c, Operand *operand, Type *type
 		if (are_types_identical(src, dst)) {
 			return 5;
 		}
-
-		Type *dst_elem = base_array_type(dst);
-		i64 distance = check_distance_between_types(c, operand, dst_elem);
-		if (distance >= 0) {
-			return distance + 7;
+		if (dst->Matrix.row_count == dst->Matrix.column_count) {
+			Type *dst_elem = base_array_type(dst);
+			i64 distance = check_distance_between_types(c, operand, dst_elem);
+			if (distance >= 0) {
+				return distance + 7;
+			}
 		}
 	}
 


### PR DESCRIPTION
Before this PR, the type checker would fail to err on scalars cast to non-square matrices, resulting in an assertion failure. Now, on the failure case provided in #2130, for example, the following error message is displayed:
`Cannot cast '2' as 'matrix[3, 2]int' from 'untyped integer'`