### PR TITLE
don't suggest u8 slice cast to string for u8 slice literal

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -1998,7 +1998,7 @@ void check_assignment_error_suggestion(CheckerContext *c, Operand *o, Type *type
 		error_line("\tSuggestion: a string may be transmuted to %s\n", b);
 		error_line("\t            This is an UNSAFE operation as string data is assumed to be immutable, \n");
 		error_line("\t            whereas slices in general are assumed to be mutable.\n");
-	} else if (is_type_u8_slice(src) && are_types_identical(dst, t_string)) {
+	} else if (is_type_u8_slice(src) && are_types_identical(dst, t_string) && o->expr->kind != Ast_CompoundLit) {
 		error_line("\tSuggestion: the expression may be casted to %s\n", b);
 	}
 }
@@ -2039,7 +2039,7 @@ void check_cast_error_suggestion(CheckerContext *c, Operand *o, Type *type) {
 		}
 	} else if (are_types_identical(src, t_string) && is_type_u8_slice(dst)) {
 		error_line("\tSuggestion: a string may be transmuted to %s\n", b);
-	} else if (is_type_u8_slice(src) && are_types_identical(dst, t_string)) {
+	} else if (is_type_u8_slice(src) && are_types_identical(dst, t_string) && o->expr->kind != Ast_CompoundLit) {
 		error_line("\tSuggestion: the expression may be casted to %s\n", b);
 	}
 }


### PR DESCRIPTION
Before this PR, when a u8 slice literal was cast to string, the compiler would erroneously suggest that the literal be cast to string. This PR tightens the message to display only when the operand is a non-literal u8 slice. The error messages displayed when the following code is compiled reflect this:
```
f :: proc () -> []u8 {
    return {100, 100}
}

main :: proc() {
    a : []u8 = {100, 100}
    
    b : string = a
    c : string = f()
    d : string = []u8{100, 100}
}
```
```
/Users/jasper/git/Odin/test.odin(12:15) Cannot assign value 'a' of type '[]u8' to 'string' in variable declaration
	Suggestion: the expression may be casted to string
/Users/jasper/git/Odin/test.odin(13:18) Cannot assign value 'f()' of type '[]u8' to 'string' in variable declaration
	Suggestion: the expression may be casted to string
/Users/jasper/git/Odin/test.odin(14:18) Cannot assign value '[]u8{100, 100}' of type '[]u8' to 'string' in variable declaration
``` 
Note that the suggestion is only displayed in the first two cases where `a` and `f()` could be correctly cast to `string`.