### PR TITLE
Fix behavior of fmt_string() to not truncate strings to width

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -975,7 +975,7 @@ fmt_string :: proc(fi: ^Info, s: string, verb: rune) {
 				}
 			}
 			else {
-				io.write_string(fi.writer, s[:fi.width], &fi.n)
+				io.write_string(fi.writer, s, &fi.n)
 			}
 		}
 		else


### PR DESCRIPTION

Should now behave like libc printf, and treat `width` as a _minimum_ amount to print.