### PR TITLE
terminate read if we read EOF

### DIFF
--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -404,6 +404,9 @@ read :: proc(fd: Handle, data: []u8) -> (int, Errno) {
 		if bytes_read == -1 {
 			return bytes_read_total, 1
 		}
+		if bytes_read == 0 {
+			break
+		}
 		bytes_read_total += bytes_read
 	}
 


### PR DESCRIPTION
On OSX, read returns 0 if you hit EOF.
This prevents a non-recoverable hot-loop if your buffer has extra space, but there's nothing left to read from the file.