### PR TITLE
Implement os open for wasi_wasm32 target

### DIFF
--- a/core/os/os_wasi.odin
+++ b/core/os/os_wasi.odin
@@ -58,7 +58,7 @@ open :: proc(path: string, mode: int = O_RDONLY, perm: int = 0) -> (Handle, Errn
 		oflags += {.TRUNC}
 	}
 
-	rights: wasi.rights_t = {.FD_SEEK}
+	rights: wasi.rights_t = {.FD_SEEK, .FD_FILESTAT_GET}
 	switch mode & (O_RDONLY|O_WRONLY|O_RDWR) {
 	case O_RDONLY: rights += {.FD_READ}
 	case O_WRONLY: rights += {.FD_WRITE}

--- a/core/os/os_wasi.odin
+++ b/core/os/os_wasi.odin
@@ -24,7 +24,7 @@ O_CLOEXEC  :: 0x80000
 stdin:  Handle = 0
 stdout: Handle = 1
 stderr: Handle = 2
-default_dir: Handle = 3
+current_dir: Handle = 3
 
 write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 	iovs := wasi.ciovec_t(data)
@@ -75,7 +75,7 @@ open :: proc(path: string, mode: int = O_RDONLY, perm: int = 0) -> (Handle, Errn
 	if mode & O_SYNC == O_SYNC {
 		fdflags += {.SYNC}
 	}
-	fd, err := wasi.path_open(wasi.fd_t(default_dir),{.SYMLINK_FOLLOW},path,oflags,rights,{},fdflags)
+	fd, err := wasi.path_open(wasi.fd_t(current_dir),{.SYMLINK_FOLLOW},path,oflags,rights,{},fdflags)
 	return Handle(fd), Errno(err)
 }
 close :: proc(fd: Handle) -> Errno {

--- a/core/time/time_wasi.odin
+++ b/core/time/time_wasi.odin
@@ -22,3 +22,5 @@ _tick_now :: proc "contextless" () -> Tick {
 	return {}
 }
 
+_yield :: proc "contextless" () {
+}


### PR DESCRIPTION
Implements open for wasi using open_path with the file descriptor of the first preopened directory by default (assigned to `current_dir`). Also adds a stub of _yield to time_wasi because core:os won't compile for wasi without it.