### PR TITLE
Add -minimum-os-version flag

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -298,17 +298,17 @@ struct BuildContext {
 	bool   ignore_microsoft_magic;
 	bool   linker_map_file;
 
-	bool use_separate_modules;
-	bool threaded_checker;
+	bool   use_separate_modules;
+	bool   threaded_checker;
 
-	bool show_debug_messages;
+	bool   show_debug_messages;
 	
-	bool copy_file_contents;
+	bool   copy_file_contents;
 
-	bool disallow_rtti;
+	bool   disallow_rtti;
 
 	RelocMode reloc_mode;
-	bool disable_red_zone;
+	bool   disable_red_zone;
 
 
 	u32 cmd_doc_flags;
@@ -326,7 +326,7 @@ struct BuildContext {
 	BlockingMutex target_features_mutex;
 	StringSet target_features_set;
 	String target_features_string;
-
+	String minimum_os_version_string;
 };
 
 gb_global BuildContext build_context = {0};


### PR DESCRIPTION
Allow for Darwin targets to specify the minimum OS version: e.g. -minimum-os-version:12.0.0