### PR TITLE
fix #2129 Segfault in compiler when void function used for its return value

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1257,6 +1257,9 @@ bool is_type_typed(Type *t) {
 }
 bool is_type_untyped(Type *t) {
 	t = base_type(t);
+	if (t == nullptr) {
+		return false;
+	}
 	if (t->kind == Type_Basic) {
 		return (t->Basic.flags & BasicFlag_Untyped) != 0;
 	}


### PR DESCRIPTION
Before this PR, `is_type_untyped` would not check if the type passed to it was null, resulting in a segfault in situations such as #2129. The function now returns `false` when passed a null type.

Below is the compiler message displayed when the code from #2129 is run:
```
/git/Odin% ./odin build test.odin -file                       
/home/jasper/git/Odin/test.odin(6:9) 'f()' call does not return a value and cannot be used as a value
/home/jasper/git/Odin/test.odin(1:2) Undefined entry point procedure 'main'
```
Note the lack of a segfault.