### PR TITLE
Handle freeing nil in scratch allocator

### DIFF
--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -217,6 +217,9 @@ scratch_allocator_proc :: proc(allocator_data: rawptr, mode: Allocator_Mode,
 		return ptr, err
 
 	case .Free:
+		if old_memory == nil {
+			return nil, nil
+		}
 		start := uintptr(raw_data(s.data))
 		end := start + uintptr(len(s.data))
 		old_ptr := uintptr(old_memory)


### PR DESCRIPTION
Handle old_memory being nil in the scratch allocator, the same way the other allocators also allow freeing nil.

This would result in a failed realloc in some weird cases, like a scratch allocator being backed by another scratch allocator.