### PR TITLE
fix missing wasm memory case

### DIFF
--- a/vendor/wasm/js/memory.odin
+++ b/vendor/wasm/js/memory.odin
@@ -21,7 +21,7 @@ page_allocator :: proc() -> mem.Allocator {
 	                  old_memory: rawptr, old_size: int,
 	                  location := #caller_location) -> ([]byte, mem.Allocator_Error) {
 		switch mode {
-		case .Alloc:
+		case .Alloc, .Alloc_Non_Zeroed:
 			assert(size % PAGE_SIZE == 0)
 			return page_alloc(size/PAGE_SIZE)
 		case .Resize, .Free, .Free_All, .Query_Info:


### PR DESCRIPTION
This got left out from the WASM page_allocator, and prevents compilation.