### PR TITLE
fix wprintf return value

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -258,7 +258,7 @@ wprintf :: proc(w: io.Writer, fmt: string, args: ..any) -> int {
 	was_prev_index := false
 
 	loop: for i := 0; i < end; /**/ {
-		fi = Info{writer = w, good_arg_index = true, reordered = fi.reordered}
+		fi = Info{writer = w, good_arg_index = true, reordered = fi.reordered, n = fi.n}
 
 		prev_i := i
 		for i < end && !(fmt[i] == '%' || fmt[i] == '{' || fmt[i] == '}') {


### PR DESCRIPTION
Currently `fmt.wprintf` returns the wrong number of bytes written, because `fi.n` continuously initialized to 0 at the top of the loop.