### PR TITLE
make a bunch of stuff contextless

### DIFF
--- a/core/bufio/lookahead_reader.odin
+++ b/core/bufio/lookahead_reader.odin
@@ -13,14 +13,14 @@ Loadahead_Reader :: struct {
 	n:   int,
 }
 
-lookahead_reader_init :: proc(lr: ^Loadahead_Reader, r: io.Reader, buf: []byte) -> ^Loadahead_Reader {
+lookahead_reader_init :: proc "contextless" (lr: ^Loadahead_Reader, r: io.Reader, buf: []byte) -> ^Loadahead_Reader {
 	lr.r = r
 	lr.buf = buf
 	lr.n = 0
 	return lr
 }
 
-lookahead_reader_buffer :: proc(lr: ^Loadahead_Reader) -> []byte {
+lookahead_reader_buffer :: proc "contextless" (lr: ^Loadahead_Reader) -> []byte {
 	return lr.buf[:lr.n]
 }
 
@@ -64,7 +64,7 @@ lookahead_reader_peek_all :: proc(lr: ^Loadahead_Reader) -> ([]byte, io.Error) {
 
 
 // lookahead_reader_consume drops the first n populated bytes from the Lookahead_Reader.
-lookahead_reader_consume :: proc(lr: ^Loadahead_Reader, n: int) -> io.Error {
+lookahead_reader_consume :: proc "contextless" (lr: ^Loadahead_Reader, n: int) -> io.Error {
 	switch {
 	case n == 0:
 		return nil
@@ -78,6 +78,6 @@ lookahead_reader_consume :: proc(lr: ^Loadahead_Reader, n: int) -> io.Error {
 	return nil
 }
 
-lookahead_reader_consume_all :: proc(lr: ^Loadahead_Reader) -> io.Error {
+lookahead_reader_consume_all :: proc "contextless" (lr: ^Loadahead_Reader) -> io.Error {
 	return lookahead_reader_consume(lr, lr.n)
 }

--- a/core/bufio/read_writer.odin
+++ b/core/bufio/read_writer.odin
@@ -9,11 +9,11 @@ Read_Writer :: struct {
 }
 
 
-read_writer_init :: proc(rw: ^Read_Writer, r: ^Reader, w: ^Writer) {
+read_writer_init :: proc "contextless" (rw: ^Read_Writer, r: ^Reader, w: ^Writer) {
 	rw.r, rw.w = r, w
 }
 
-read_writer_to_stream :: proc(rw: ^Read_Writer) -> (s: io.Stream) {
+read_writer_to_stream :: proc "contextless" (rw: ^Read_Writer) -> (s: io.Stream) {
 	s.stream_data = rw
 	s.stream_vtable = &_read_writer_vtable
 	return

--- a/core/bufio/reader.odin
+++ b/core/bufio/reader.odin
@@ -37,7 +37,7 @@ reader_init :: proc(b: ^Reader, rd: io.Reader, size: int = DEFAULT_BUF_SIZE, all
 	b.buf = make([]byte, size, allocator)
 }
 
-reader_init_with_buf :: proc(b: ^Reader, rd: io.Reader, buf: []byte) {
+reader_init_with_buf :: proc "contextless" (b: ^Reader, rd: io.Reader, buf: []byte) {
 	reader_reset(b, rd)
 	b.buf_allocator = {}
 	b.buf = buf
@@ -49,11 +49,11 @@ reader_destroy :: proc(b: ^Reader) {
 	b^ = {}
 }
 
-reader_size :: proc(b: ^Reader) -> int {
+reader_size :: proc "contextless" (b: ^Reader) -> int {
 	return len(b.buf)
 }
 
-reader_reset :: proc(b: ^Reader, r: io.Reader) {
+reader_reset :: proc "contextless" (b: ^Reader, r: io.Reader) {
 	b.rd = r
 	b.r, b.w = 0, 0
 	b.err = nil
@@ -97,7 +97,7 @@ _reader_read_new_chunk :: proc(b: ^Reader) -> io.Error {
 }
 
 @(private)
-_reader_consume_err :: proc(b: ^Reader) -> io.Error {
+_reader_consume_err :: proc "contextless" (b: ^Reader) -> io.Error {
 	err := b.err
 	b.err = nil
 	return err
@@ -139,7 +139,7 @@ reader_peek :: proc(b: ^Reader, n: int) -> (data: []byte, err: io.Error) {
 }
 
 // reader_buffered returns the number of bytes that can be read from the current buffer
-reader_buffered :: proc(b: ^Reader) -> int {
+reader_buffered :: proc "contextless" (b: ^Reader) -> int {
 	return b.w - b.r
 }
 
@@ -240,7 +240,7 @@ reader_read_byte :: proc(b: ^Reader) -> (byte, io.Error) {
 }
 
 // reader_unread_byte unreads the last byte. Only the most recently read byte can be unread
-reader_unread_byte :: proc(b: ^Reader) -> io.Error {
+reader_unread_byte :: proc "contextless" (b: ^Reader) -> io.Error {
 	if b.last_byte < 0 || b.r == 0 && b.w > 0 {
 		return .Invalid_Unread
 	}
@@ -285,7 +285,7 @@ reader_read_rune :: proc(b: ^Reader) -> (r: rune, size: int, err: io.Error) {
 }
 
 // reader_unread_rune unreads the last rune. Only the most recently read rune can be unread
-reader_unread_rune :: proc(b: ^Reader) -> io.Error {
+reader_unread_rune :: proc "contextless" (b: ^Reader) -> io.Error {
 	if b.last_rune_size < 0 || b.r < b.last_rune_size {
 		return .Invalid_Unread
 	}
@@ -351,7 +351,7 @@ reader_write_to :: proc(b: ^Reader, w: io.Writer) -> (n: i64, err: io.Error) {
 
 
 // reader_to_stream converts a Reader into an io.Stream
-reader_to_stream :: proc(b: ^Reader) -> (s: io.Stream) {
+reader_to_stream :: proc "contextless" (b: ^Reader) -> (s: io.Stream) {
 	s.stream_data = b
 	s.stream_vtable = &_reader_vtable
 	return

--- a/core/bufio/scanner.odin
+++ b/core/bufio/scanner.odin
@@ -67,7 +67,7 @@ scanner_destroy :: proc(s: ^Scanner) {
 
 
 // Returns the first non-EOF error that was encountered by the scanner
-scanner_error :: proc(s: ^Scanner) -> Scanner_Error {
+scanner_error :: proc "contextless" (s: ^Scanner) -> Scanner_Error {
 	switch s._err {
 	case .EOF, nil:
 		return nil
@@ -79,7 +79,7 @@ scanner_error :: proc(s: ^Scanner) -> Scanner_Error {
 // The underlying array may point to data that may be overwritten
 // by another call to scanner_scan.
 // Treat the returned value as if it is immutable.
-scanner_bytes :: proc(s: ^Scanner) -> []byte {
+scanner_bytes :: proc "contextless" (s: ^Scanner) -> []byte {
 	return s.token
 }
 
@@ -87,13 +87,13 @@ scanner_bytes :: proc(s: ^Scanner) -> []byte {
 // The underlying array may point to data that may be overwritten
 // by another call to scanner_scan.
 // Treat the returned value as if it is immutable.
-scanner_text :: proc(s: ^Scanner) -> string {
+scanner_text :: proc "contextless" (s: ^Scanner) -> string {
 	return string(s.token)
 }
 
 // scanner_scan advances the scanner
 scanner_scan :: proc(s: ^Scanner) -> bool {
-	set_err :: proc(s: ^Scanner, err: Scanner_Error) {
+	set_err :: proc "contextless" (s: ^Scanner, err: Scanner_Error) {
 		switch s._err {
 		case nil, .EOF:
 			s._err = err
@@ -229,14 +229,14 @@ scanner_scan :: proc(s: ^Scanner) -> bool {
 	}
 }
 
-scan_bytes :: proc(data: []byte, at_eof: bool) -> (advance: int, token: []byte, err: Scanner_Error, final_token: bool) {
+scan_bytes :: proc "contextless" (data: []byte, at_eof: bool) -> (advance: int, token: []byte, err: Scanner_Error, final_token: bool) {
 	if at_eof && len(data) == 0 {
 		return
 	}
 	return 1, data[0:1], nil, false
 }
 
-scan_runes :: proc(data: []byte, at_eof: bool) -> (advance: int, token: []byte, err: Scanner_Error, final_token: bool) {
+scan_runes :: proc "contextless" (data: []byte, at_eof: bool) -> (advance: int, token: []byte, err: Scanner_Error, final_token: bool) {
 	if at_eof && len(data) == 0 {
 		return
 	}
@@ -265,7 +265,7 @@ scan_runes :: proc(data: []byte, at_eof: bool) -> (advance: int, token: []byte, 
 	return
 }
 
-scan_words :: proc(data: []byte, at_eof: bool) -> (advance: int, token: []byte, err: Scanner_Error, final_token: bool) {
+scan_words :: proc "contextless" (data: []byte, at_eof: bool) -> (advance: int, token: []byte, err: Scanner_Error, final_token: bool) {
 	is_space :: proc "contextless" (r:  rune) -> bool {
 		switch r {
 		// lower ones

--- a/core/bufio/writer.odin
+++ b/core/bufio/writer.odin
@@ -27,7 +27,7 @@ writer_init :: proc(b: ^Writer, wr: io.Writer, size: int = DEFAULT_BUF_SIZE, all
 	b.buf = make([]byte, size, allocator)
 }
 
-writer_init_with_buf :: proc(b: ^Writer, wr: io.Writer, buf: []byte) {
+writer_init_with_buf :: proc "contextless" (b: ^Writer, wr: io.Writer, buf: []byte) {
 	writer_reset(b, wr)
 	b.buf_allocator = {}
 	b.buf = buf
@@ -40,11 +40,11 @@ writer_destroy :: proc(b: ^Writer) {
 }
 
 // writer_size returns the size of underlying buffer in bytes
-writer_size :: proc(b: ^Writer) -> int {
+writer_size :: proc "contextless" (b: ^Writer) -> int {
 	return len(b.buf)
 }
 
-writer_reset :: proc(b: ^Writer, w: io.Writer) {
+writer_reset :: proc "contextless" (b: ^Writer, w: io.Writer) {
 	b.wr = w
 	b.n = 0
 	b.err = nil
@@ -77,12 +77,12 @@ writer_flush :: proc(b: ^Writer) -> io.Error {
 }
 
 // writer_available returns how many bytes are unused in the buffer
-writer_available :: proc(b: ^Writer) -> int {
+writer_available :: proc "contextless" (b: ^Writer) -> int {
 	return len(b.buf) - b.n
 }
 
 // writer_buffered returns the number of bytes that have been writted into the current buffer
-writer_buffered :: proc(b: ^Writer) -> int {
+writer_buffered :: proc "contextless" (b: ^Writer) -> int {
 	return b.n
 }
 
@@ -221,7 +221,7 @@ writer_read_from :: proc(b: ^Writer, r: io.Reader) -> (n: i64, err: io.Error) {
 
 
 // writer_to_stream converts a Writer into an io.Stream
-writer_to_stream :: proc(b: ^Writer) -> (s: io.Stream) {
+writer_to_stream :: proc "contextless" (b: ^Writer) -> (s: io.Stream) {
 	s.stream_data = b
 	s.stream_vtable = &_writer_vtable
 	return

--- a/core/bytes/buffer.odin
+++ b/core/bytes/buffer.odin
@@ -48,30 +48,30 @@ buffer_destroy :: proc(b: ^Buffer) {
 	buffer_reset(b)
 }
 
-buffer_to_bytes :: proc(b: ^Buffer) -> []byte {
+buffer_to_bytes :: proc "contextless" (b: ^Buffer) -> []byte {
 	return b.buf[b.off:]
 }
 
-buffer_to_string :: proc(b: ^Buffer) -> string {
+buffer_to_string :: proc "contextless" (b: ^Buffer) -> string {
 	if b == nil {
 		return "<nil>"
 	}
 	return string(b.buf[b.off:])
 }
 
-buffer_is_empty :: proc(b: ^Buffer) -> bool {
+buffer_is_empty :: proc "contextless" (b: ^Buffer) -> bool {
 	return len(b.buf) <= b.off
 }
 
-buffer_length :: proc(b: ^Buffer) -> int {
+buffer_length :: proc "contextless" (b: ^Buffer) -> int {
 	return len(b.buf) - b.off
 }
 
-buffer_capacity :: proc(b: ^Buffer) -> int {
+buffer_capacity :: proc "contextless" (b: ^Buffer) -> int {
 	return cap(b.buf)
 }
 
-buffer_reset :: proc(b: ^Buffer) {
+buffer_reset :: proc "contextless" (b: ^Buffer) {
 	clear(&b.buf)
 	b.off = 0
 	b.last_read = .Invalid
@@ -201,7 +201,7 @@ buffer_write_rune :: proc(b: ^Buffer, r: rune) -> (n: int, err: io.Error) {
 	return
 }
 
-buffer_next :: proc(b: ^Buffer, n: int) -> []byte {
+buffer_next :: proc "contextless" (b: ^Buffer, n: int) -> []byte {
 	n := n
 	b.last_read = .Invalid
 	m := buffer_length(b)
@@ -216,7 +216,7 @@ buffer_next :: proc(b: ^Buffer, n: int) -> []byte {
 	return data
 }
 
-buffer_read :: proc(b: ^Buffer, p: []byte) -> (n: int, err: io.Error) {
+buffer_read :: proc "contextless" (b: ^Buffer, p: []byte) -> (n: int, err: io.Error) {
 	b.last_read = .Invalid
 	if buffer_is_empty(b) {
 		buffer_reset(b)
@@ -233,11 +233,11 @@ buffer_read :: proc(b: ^Buffer, p: []byte) -> (n: int, err: io.Error) {
 	return
 }
 
-buffer_read_ptr :: proc(b: ^Buffer, ptr: rawptr, size: int) -> (n: int, err: io.Error) {
+buffer_read_ptr :: proc "contextless" (b: ^Buffer, ptr: rawptr, size: int) -> (n: int, err: io.Error) {
 	return buffer_read(b, ([^]byte)(ptr)[:size])
 }
 
-buffer_read_at :: proc(b: ^Buffer, p: []byte, offset: int) -> (n: int, err: io.Error) {
+buffer_read_at :: proc "contextless" (b: ^Buffer, p: []byte, offset: int) -> (n: int, err: io.Error) {
 	b.last_read = .Invalid
 
 	if uint(offset) >= len(b.buf) {
@@ -252,7 +252,7 @@ buffer_read_at :: proc(b: ^Buffer, p: []byte, offset: int) -> (n: int, err: io.E
 }
 
 
-buffer_read_byte :: proc(b: ^Buffer) -> (byte, io.Error) {
+buffer_read_byte :: proc "contextless" (b: ^Buffer) -> (byte, io.Error) {
 	if buffer_is_empty(b) {
 		buffer_reset(b)
 		return 0, .EOF
@@ -263,7 +263,7 @@ buffer_read_byte :: proc(b: ^Buffer) -> (byte, io.Error) {
 	return c, nil
 }
 
-buffer_read_rune :: proc(b: ^Buffer) -> (r: rune, size: int, err: io.Error) {
+buffer_read_rune :: proc "contextless" (b: ^Buffer) -> (r: rune, size: int, err: io.Error) {
 	if buffer_is_empty(b) {
 		buffer_reset(b)
 		return 0, 0, .EOF
@@ -280,7 +280,7 @@ buffer_read_rune :: proc(b: ^Buffer) -> (r: rune, size: int, err: io.Error) {
 	return
 }
 
-buffer_unread_byte :: proc(b: ^Buffer) -> io.Error {
+buffer_unread_byte :: proc "contextless" (b: ^Buffer) -> io.Error {
 	if b.last_read == .Invalid {
 		return .Invalid_Unread
 	}
@@ -291,7 +291,7 @@ buffer_unread_byte :: proc(b: ^Buffer) -> io.Error {
 	return nil
 }
 
-buffer_unread_rune :: proc(b: ^Buffer) -> io.Error {
+buffer_unread_rune :: proc "contextless" (b: ^Buffer) -> io.Error {
 	if b.last_read <= .Invalid {
 		return .Invalid_Unread
 	}
@@ -303,7 +303,7 @@ buffer_unread_rune :: proc(b: ^Buffer) -> io.Error {
 }
 
 
-buffer_read_bytes :: proc(b: ^Buffer, delim: byte) -> (line: []byte, err: io.Error) {
+buffer_read_bytes :: proc "contextless" (b: ^Buffer, delim: byte) -> (line: []byte, err: io.Error) {
 	i := index_byte(b.buf[b.off:], delim)
 	end := b.off + i + 1
 	if i < 0 {
@@ -316,7 +316,7 @@ buffer_read_bytes :: proc(b: ^Buffer, delim: byte) -> (line: []byte, err: io.Err
 	return
 }
 
-buffer_read_string :: proc(b: ^Buffer, delim: byte) -> (line: string, err: io.Error) {
+buffer_read_string :: proc "contextless" (b: ^Buffer, delim: byte) -> (line: string, err: io.Error) {
 	slice: []byte
 	slice, err = buffer_read_bytes(b, delim)
 	return string(slice), err
@@ -369,7 +369,7 @@ buffer_read_from :: proc(b: ^Buffer, r: io.Reader) -> (n: i64, err: io.Error) #n
 }
 
 
-buffer_to_stream :: proc(b: ^Buffer) -> (s: io.Stream) {
+buffer_to_stream :: proc "contextless" (b: ^Buffer) -> (s: io.Stream) {
 	s.stream_data = b
 	s.stream_vtable = &_buffer_vtable
 	return

--- a/core/bytes/bytes.odin
+++ b/core/bytes/bytes.odin
@@ -17,7 +17,7 @@ clone_safe :: proc(s: []byte, allocator := context.allocator, loc := #caller_loc
 }
 
 ptr_from_slice :: ptr_from_bytes
-ptr_from_bytes :: proc(str: []byte) -> ^byte {
+ptr_from_bytes :: proc "contextless" (str: []byte) -> ^byte {
 	d := transmute(mem.Raw_String)str
 	return d.data
 }
@@ -39,11 +39,11 @@ truncate_to_rune :: proc(str: []byte, r: rune) -> []byte {
 
 // Compares two strings, returning a value representing which one comes first lexiographically.
 // -1 for `a`; 1 for `b`, or 0 if they are equal.
-compare :: proc(lhs, rhs: []byte) -> int {
+compare :: proc "contextless" (lhs, rhs: []byte) -> int {
 	return mem.compare(lhs, rhs)
 }
 
-contains_rune :: proc(s: []byte, r: rune) -> int {
+contains_rune :: proc "contextless" (s: []byte, r: rune) -> int {
 	for c, offset in string(s) {
 		if c == r {
 			return offset
@@ -52,25 +52,25 @@ contains_rune :: proc(s: []byte, r: rune) -> int {
 	return -1
 }
 
-contains :: proc(s, substr: []byte) -> bool {
+contains :: proc "contextless" (s, substr: []byte) -> bool {
 	return index(s, substr) >= 0
 }
 
-contains_any :: proc(s, chars: []byte) -> bool {
+contains_any :: proc "contextless" (s, chars: []byte) -> bool {
 	return index_any(s, chars) >= 0
 }
 
 
-rune_count :: proc(s: []byte) -> int {
+rune_count :: proc "contextless" (s: []byte) -> int {
 	return utf8.rune_count(s)
 }
 
 
-equal :: proc(a, b: []byte) -> bool {
+equal :: proc "contextless" (a, b: []byte) -> bool {
 	return string(a) == string(b)
 }
 
-equal_fold :: proc(u, v: []byte) -> bool {
+equal_fold :: proc "contextless" (u, v: []byte) -> bool {
 	s, t := string(u), string(v)
 	loop: for s != "" && t != "" {
 		sr, tr: rune
@@ -113,11 +113,11 @@ equal_fold :: proc(u, v: []byte) -> bool {
 	return s == t
 }
 
-has_prefix :: proc(s, prefix: []byte) -> bool {
+has_prefix :: proc "contextless" (s, prefix: []byte) -> bool {
 	return len(s) >= len(prefix) && string(s[0:len(prefix)]) == string(prefix)
 }
 
-has_suffix :: proc(s, suffix: []byte) -> bool {
+has_suffix :: proc "contextless" (s, suffix: []byte) -> bool {
 	return len(s) >= len(suffix) && string(s[len(s)-len(suffix):]) == string(suffix)
 }
 
@@ -262,7 +262,7 @@ split_after_n :: proc(s, sep: []byte, n: int, allocator := context.allocator) ->
 
 
 @private
-_split_iterator :: proc(s: ^[]byte, sep: []byte, sep_save: int) -> (res: []byte, ok: bool) {
+_split_iterator :: proc "contextless" (s: ^[]byte, sep: []byte, sep_save: int) -> (res: []byte, ok: bool) {
 	if len(sep) == 0 {
 		res = s[:]
 		ok = true
@@ -285,16 +285,16 @@ _split_iterator :: proc(s: ^[]byte, sep: []byte, sep_save: int) -> (res: []byte,
 }
 
 
-split_iterator :: proc(s: ^[]byte, sep: []byte) -> ([]byte, bool) {
+split_iterator :: proc "contextless" (s: ^[]byte, sep: []byte) -> ([]byte, bool) {
 	return _split_iterator(s, sep, 0)
 }
 
-split_after_iterator :: proc(s: ^[]byte, sep: []byte) -> ([]byte, bool) {
+split_after_iterator :: proc "contextless" (s: ^[]byte, sep: []byte) -> ([]byte, bool) {
 	return _split_iterator(s, sep, len(sep))
 }
 
 
-index_byte :: proc(s: []byte, c: byte) -> int {
+index_byte :: proc "contextless" (s: []byte, c: byte) -> int {
 	for i := 0; i < len(s); i += 1 {
 		if s[i] == c {
 			return i
@@ -304,7 +304,7 @@ index_byte :: proc(s: []byte, c: byte) -> int {
 }
 
 // Returns -1 if c is not present
-last_index_byte :: proc(s: []byte, c: byte) -> int {
+last_index_byte :: proc "contextless" (s: []byte, c: byte) -> int {
 	for i := len(s)-1; i >= 0; i -= 1 {
 		if s[i] == c {
 			return i
@@ -317,8 +317,8 @@ last_index_byte :: proc(s: []byte, c: byte) -> int {
 
 @private PRIME_RABIN_KARP :: 16777619
 
-index :: proc(s, substr: []byte) -> int {
-	hash_str_rabin_karp :: proc(s: []byte) -> (hash: u32 = 0, pow: u32 = 1) {
+index :: proc "contextless" (s, substr: []byte) -> int {
+	hash_str_rabin_karp :: proc "contextless" (s: []byte) -> (hash: u32 = 0, pow: u32 = 1) {
 		for i := 0; i < len(s); i += 1 {
 			hash = hash*PRIME_RABIN_KARP + u32(s[i])
 		}
@@ -367,8 +367,8 @@ index :: proc(s, substr: []byte) -> int {
 	return -1
 }
 
-last_index :: proc(s, substr: []byte) -> int {
-	hash_str_rabin_karp_reverse :: proc(s: []byte) -> (hash: u32 = 0, pow: u32 = 1) {
+last_index :: proc "contextless" (s, substr: []byte) -> int {
+	hash_str_rabin_karp_reverse :: proc "contextless" (s: []byte) -> (hash: u32 = 0, pow: u32 = 1) {
 		for i := len(s) - 1; i >= 0; i -= 1 {
 			hash = hash*PRIME_RABIN_KARP + u32(s[i])
 		}
@@ -415,7 +415,7 @@ last_index :: proc(s, substr: []byte) -> int {
 	return -1
 }
 
-index_any :: proc(s, chars: []byte) -> int {
+index_any :: proc "contextless" (s, chars: []byte) -> int {
 	if chars == nil {
 		return -1
 	}
@@ -431,7 +431,7 @@ index_any :: proc(s, chars: []byte) -> int {
 	return -1
 }
 
-last_index_any :: proc(s, chars: []byte) -> int {
+last_index_any :: proc "contextless" (s, chars: []byte) -> int {
 	if chars == nil {
 		return -1
 	}
@@ -448,7 +448,7 @@ last_index_any :: proc(s, chars: []byte) -> int {
 	return -1
 }
 
-count :: proc(s, substr: []byte) -> int {
+count :: proc "contextless" (s, substr: []byte) -> int {
 	if len(substr) == 0 { // special case
 		return rune_count(s) + 1
 	}
@@ -556,14 +556,14 @@ remove_all :: proc(s, key: []byte, allocator := context.allocator) -> (output: [
 @(private) _ascii_space := [256]u8{'\t' = 1, '\n' = 1, '\v' = 1, '\f' = 1, '\r' = 1, ' ' = 1}
 
 
-is_ascii_space :: proc(r: rune) -> bool {
+is_ascii_space :: proc "contextless" (r: rune) -> bool {
 	if r < utf8.RUNE_SELF {
 		return _ascii_space[u8(r)] != 0
 	}
 	return false
 }
 
-is_space :: proc(r: rune) -> bool {
+is_space :: proc "contextless" (r: rune) -> bool {
 	if r < 0x2000 {
 		switch r {
 		case '\t', '\n', '\v', '\f', '\r', ' ', 0x85, 0xa0, 0x1680:
@@ -581,11 +581,18 @@ is_space :: proc(r: rune) -> bool {
 	return false
 }
 
-is_null :: proc(r: rune) -> bool {
+is_null :: proc "contextless" (r: rune) -> bool {
 	return r == 0x0000
 }
 
-index_proc :: proc(s: []byte, p: proc(rune) -> bool, truth := true) -> int {
+
+index_proc :: proc {
+	_index_proc_contextless,
+	_index_proc_odin,
+}
+
+@(private)
+_index_proc_odin :: proc "odin" (s: []byte, p: proc "odin" (rune) -> bool, truth := true) -> int {
 	for r, i in string(s) {
 		if p(r) == truth {
 			return i
@@ -594,7 +601,24 @@ index_proc :: proc(s: []byte, p: proc(rune) -> bool, truth := true) -> int {
 	return -1
 }
 
-index_proc_with_state :: proc(s: []byte, p: proc(rawptr, rune) -> bool, state: rawptr, truth := true) -> int {
+@(private)
+_index_proc_contextless :: proc "contextless" (s: []byte, p: proc "contextless" (rune) -> bool, truth := true) -> int {
+	for r, i in string(s) {
+		if p(r) == truth {
+			return i
+		}
+	}
+	return -1
+}
+
+
+index_proc_with_state :: proc {
+	_index_proc_with_state_odin,
+	_index_proc_with_state_contextless,
+}
+
+@(private)
+_index_proc_with_state_odin :: proc "odin" (s: []byte, p: proc "odin" (rawptr, rune) -> bool, state: rawptr, truth := true) -> int {
 	for r, i in string(s) {
 		if p(state, r) == truth {
 			return i
@@ -603,7 +627,24 @@ index_proc_with_state :: proc(s: []byte, p: proc(rawptr, rune) -> bool, state: r
 	return -1
 }
 
-last_index_proc :: proc(s: []byte, p: proc(rune) -> bool, truth := true) -> int {
+@(private)
+_index_proc_with_state_contextless :: proc "contextless" (s: []byte, p: proc "contextless" (rawptr, rune) -> bool, state: rawptr, truth := true) -> int {
+	for r, i in string(s) {
+		if p(state, r) == truth {
+			return i
+		}
+	}
+	return -1
+}
+
+
+last_index_proc :: proc {
+	_last_index_proc_odin,
+	_last_index_proc_contextless,
+}
+
+@(private)
+_last_index_proc_odin :: proc "odin" (s: []byte, p: proc "odin" (rune) -> bool, truth := true) -> int {
 	// TODO(bill): Probably use Rabin-Karp Search
 	for i := len(s); i > 0; {
 		r, size := utf8.decode_last_rune(s[:i])
@@ -615,7 +656,27 @@ last_index_proc :: proc(s: []byte, p: proc(rune) -> bool, truth := true) -> int 
 	return -1
 }
 
-last_index_proc_with_state :: proc(s: []byte, p: proc(rawptr, rune) -> bool, state: rawptr, truth := true) -> int {
+@(private)
+_last_index_proc_contextless :: proc "contextless" (s: []byte, p: proc "contextless" (rune) -> bool, truth := true) -> int {
+	// TODO(bill): Probably use Rabin-Karp Search
+	for i := len(s); i > 0; {
+		r, size := utf8.decode_last_rune(s[:i])
+		i -= size
+		if p(r) == truth {
+			return i
+		}
+	}
+	return -1
+}
+
+
+last_index_proc_with_state :: proc {
+	_last_index_proc_with_state_odin,
+	_last_index_proc_with_state_contextless,
+}
+
+@(private)
+_last_index_proc_with_state_odin :: proc "odin" (s: []byte, p: proc "odin" (rawptr, rune) -> bool, state: rawptr, truth := true) -> int {
 	// TODO(bill): Probably use Rabin-Karp Search
 	for i := len(s); i > 0; {
 		r, size := utf8.decode_last_rune(s[:i])
@@ -627,7 +688,27 @@ last_index_proc_with_state :: proc(s: []byte, p: proc(rawptr, rune) -> bool, sta
 	return -1
 }
 
-trim_left_proc :: proc(s: []byte, p: proc(rune) -> bool) -> []byte {
+@(private)
+_last_index_proc_with_state_contextless :: proc "contextless" (s: []byte, p: proc "contextless" (rawptr, rune) -> bool, state: rawptr, truth := true) -> int {
+	// TODO(bill): Probably use Rabin-Karp Search
+	for i := len(s); i > 0; {
+		r, size := utf8.decode_last_rune(s[:i])
+		i -= size
+		if p(state, r) == truth {
+			return i
+		}
+	}
+	return -1
+}
+
+
+trim_left_proc :: proc {
+	_trim_left_proc_odin,
+	_trim_left_proc_contextless,
+}
+
+@(private)
+_trim_left_proc_odin :: proc "odin" (s: []byte, p: proc "odin" (rune) -> bool) -> []byte {
 	i := index_proc(s, p, false)
 	if i == -1 {
 		return nil
@@ -635,8 +716,16 @@ trim_left_proc :: proc(s: []byte, p: proc(rune) -> bool) -> []byte {
 	return s[i:]
 }
 
+@(private)
+_trim_left_proc_contextless :: proc "contextless" (s: []byte, p: proc "contextless" (rune) -> bool) -> []byte {
+	i := index_proc(s, p, false)
+	if i == -1 {
+		return nil
+	}
+	return s[i:]
+}
 
-index_rune :: proc(s: []byte, r: rune) -> int {
+index_rune :: proc "contextless" (s: []byte, r: rune) -> int {
 	switch {
 	case u32(r) < utf8.RUNE_SELF:
 		return index_byte(s, byte(r))
@@ -658,7 +747,13 @@ index_rune :: proc(s: []byte, r: rune) -> int {
 }
 
 
-trim_left_proc_with_state :: proc(s: []byte, p: proc(rawptr, rune) -> bool, state: rawptr) -> []byte {
+trim_left_proc_with_state :: proc {
+	_trim_left_proc_with_state_odin,
+	_trim_left_proc_with_state_contextless,
+}
+
+@(private)
+_trim_left_proc_with_state_odin :: proc "odin" (s: []byte, p: proc "odin" (rawptr, rune) -> bool, state: rawptr) -> []byte {
 	i := index_proc_with_state(s, p, state, false)
 	if i == -1 {
 		return nil
@@ -666,7 +761,23 @@ trim_left_proc_with_state :: proc(s: []byte, p: proc(rawptr, rune) -> bool, stat
 	return s[i:]
 }
 
-trim_right_proc :: proc(s: []byte, p: proc(rune) -> bool) -> []byte {
+@(private)
+_trim_left_proc_with_state_contextless :: proc "contextless" (s: []byte, p: proc "contextless" (rawptr, rune) -> bool, state: rawptr) -> []byte {
+	i := index_proc_with_state(s, p, state, false)
+	if i == -1 {
+		return nil
+	}
+	return s[i:]
+}
+
+
+trim_right_proc :: proc {
+	_trim_right_proc_odin,
+	_trim_right_proc_contextless,
+}
+
+@(private)
+_trim_right_proc_odin :: proc "odin" (s: []byte, p: proc "odin" (rune) -> bool) -> []byte {
 	i := last_index_proc(s, p, false)
 	if i >= 0 && s[i] >= utf8.RUNE_SELF {
 		_, w := utf8.decode_rune(s[i:])
@@ -677,8 +788,9 @@ trim_right_proc :: proc(s: []byte, p: proc(rune) -> bool) -> []byte {
 	return s[0:i]
 }
 
-trim_right_proc_with_state :: proc(s: []byte, p: proc(rawptr, rune) -> bool, state: rawptr) -> []byte {
-	i := last_index_proc_with_state(s, p, state, false)
+@(private)
+_trim_right_proc_contextless :: proc "contextless" (s: []byte, p: proc "contextless" (rune) -> bool) -> []byte {
+	i := last_index_proc(s, p, false)
 	if i >= 0 && s[i] >= utf8.RUNE_SELF {
 		_, w := utf8.decode_rune(s[i:])
 		i += w
@@ -689,7 +801,36 @@ trim_right_proc_with_state :: proc(s: []byte, p: proc(rawptr, rune) -> bool, sta
 }
 
 
-is_in_cutset :: proc(state: rawptr, r: rune) -> bool {
+trim_right_proc_with_state :: proc {
+	_trim_right_proc_with_state_odin,
+	_trim_right_proc_with_state_contextless,
+}
+
+@(private)
+_trim_right_proc_with_state_odin :: proc "odin" (s: []byte, p: proc "odin" (rawptr, rune) -> bool, state: rawptr) -> []byte {
+	i := last_index_proc_with_state(s, p, state, false)
+	if i >= 0 && s[i] >= utf8.RUNE_SELF {
+		_, w := utf8.decode_rune(s[i:])
+		i += w
+	} else {
+		i += 1
+	}
+	return s[0:i]
+}
+
+@(private)
+_trim_right_proc_with_state_contextless :: proc "contextless" (s: []byte, p: proc "contextless" (rawptr, rune) -> bool, state: rawptr) -> []byte {
+	i := last_index_proc_with_state(s, p, state, false)
+	if i >= 0 && s[i] >= utf8.RUNE_SELF {
+		_, w := utf8.decode_rune(s[i:])
+		i += w
+	} else {
+		i += 1
+	}
+	return s[0:i]
+}
+
+is_in_cutset :: proc "contextless" (state: rawptr, r: rune) -> bool {
 	if state == nil {
 		return false
 	}
@@ -703,7 +844,7 @@ is_in_cutset :: proc(state: rawptr, r: rune) -> bool {
 }
 
 
-trim_left :: proc(s: []byte, cutset: []byte) -> []byte {
+trim_left :: proc "contextless" (s: []byte, cutset: []byte) -> []byte {
 	if s == nil || cutset == nil {
 		return s
 	}
@@ -711,7 +852,7 @@ trim_left :: proc(s: []byte, cutset: []byte) -> []byte {
 	return trim_left_proc_with_state(s, is_in_cutset, &state)
 }
 
-trim_right :: proc(s: []byte, cutset: []byte) -> []byte {
+trim_right :: proc "contextless" (s: []byte, cutset: []byte) -> []byte {
 	if s == nil || cutset == nil {
 		return s
 	}
@@ -719,43 +860,43 @@ trim_right :: proc(s: []byte, cutset: []byte) -> []byte {
 	return trim_right_proc_with_state(s, is_in_cutset, &state)
 }
 
-trim :: proc(s: []byte, cutset: []byte) -> []byte {
+trim :: proc "contextless" (s: []byte, cutset: []byte) -> []byte {
 	return trim_right(trim_left(s, cutset), cutset)
 }
 
-trim_left_space :: proc(s: []byte) -> []byte {
+trim_left_space :: proc "contextless" (s: []byte) -> []byte {
 	return trim_left_proc(s, is_space)
 }
 
-trim_right_space :: proc(s: []byte) -> []byte {
+trim_right_space :: proc "contextless" (s: []byte) -> []byte {
 	return trim_right_proc(s, is_space)
 }
 
-trim_space :: proc(s: []byte) -> []byte {
+trim_space :: proc "contextless" (s: []byte) -> []byte {
 	return trim_right_space(trim_left_space(s))
 }
 
 
-trim_left_null :: proc(s: []byte) -> []byte {
+trim_left_null :: proc "contextless" (s: []byte) -> []byte {
 	return trim_left_proc(s, is_null)
 }
 
-trim_right_null :: proc(s: []byte) -> []byte {
+trim_right_null :: proc "contextless" (s: []byte) -> []byte {
 	return trim_right_proc(s, is_null)
 }
 
-trim_null :: proc(s: []byte) -> []byte {
+trim_null :: proc "contextless" (s: []byte) -> []byte {
 	return trim_right_null(trim_left_null(s))
 }
 
-trim_prefix :: proc(s, prefix: []byte) -> []byte {
+trim_prefix :: proc "contextless" (s, prefix: []byte) -> []byte {
 	if has_prefix(s, prefix) {
 		return s[len(prefix):]
 	}
 	return s
 }
 
-trim_suffix :: proc(s, suffix: []byte) -> []byte {
+trim_suffix :: proc "contextless" (s, suffix: []byte) -> []byte {
 	if has_suffix(s, suffix) {
 		return s[:len(s)-len(suffix)]
 	}
@@ -843,7 +984,7 @@ split_multi :: proc(s: []byte, substrs: [][]byte, skip_empty := false, allocator
 
 
 
-split_multi_iterator :: proc(s: ^[]byte, substrs: [][]byte, skip_empty := false) -> ([]byte, bool) #no_bounds_check {
+split_multi_iterator :: proc "contextless" (s: ^[]byte, substrs: [][]byte, skip_empty := false) -> ([]byte, bool) #no_bounds_check {
 	if s == nil || s^ == nil || len(substrs) <= 0 {
 		return nil, false
 	}
@@ -988,7 +1129,7 @@ expand_tabs :: proc(s: []byte, tab_size: int, allocator := context.allocator) ->
 	return buffer_to_bytes(&b)
 }
 
-partition :: proc(str, sep: []byte) -> (head, match, tail: []byte) {
+partition :: proc "contextless" (str, sep: []byte) -> (head, match, tail: []byte) {
 	i := index(str, sep)
 	if i == -1 {
 		head = str
@@ -1141,7 +1282,13 @@ fields :: proc(s: []byte, allocator := context.allocator) -> [][]byte #no_bounds
 //
 // fields_proc makes no guarantee about the order in which it calls f(ch)
 // it assumes that `f` always returns the same value for a given ch
-fields_proc :: proc(s: []byte, f: proc(rune) -> bool, allocator := context.allocator) -> [][]byte #no_bounds_check {
+fields_proc :: proc {
+	_fields_proc_odin,
+	_fields_proc_contextless,
+}
+
+@(private)
+_fields_proc_callable :: proc(s: []byte, f: $F, allocator := context.allocator) -> [][]byte #no_bounds_check {
 	subslices := make([dynamic][]byte, 0, 32, allocator)
 
 	start, end := -1, -1
@@ -1166,4 +1313,14 @@ fields_proc :: proc(s: []byte, f: proc(rune) -> bool, allocator := context.alloc
 	}
 
 	return subslices[:]
+}
+
+@(private)
+_fields_proc_odin :: proc(s: []byte, f: proc "odin" (rune) -> bool, allocator := context.allocator) -> [][]byte {
+	return _fields_proc_callable(s, f, allocator)
+}
+
+@(private)
+_fields_proc_contextless :: proc(s: []byte, f: proc "contextless" (rune) -> bool, allocator := context.allocator) -> [][]byte {
+	return _fields_proc_callable(s, f, allocator)
 }

--- a/core/bytes/reader.odin
+++ b/core/bytes/reader.odin
@@ -9,30 +9,30 @@ Reader :: struct {
 	prev_rune: int,    // previous reading index of rune or < 0
 }
 
-reader_init :: proc(r: ^Reader, s: []byte) {
+reader_init :: proc "contextless" (r: ^Reader, s: []byte) {
 	r.s = s
 	r.i = 0
 	r.prev_rune = -1
 }
 
-reader_to_stream :: proc(r: ^Reader) -> (s: io.Stream) {
+reader_to_stream :: proc "contextless" (r: ^Reader) -> (s: io.Stream) {
 	s.stream_data = r
 	s.stream_vtable = &_reader_vtable
 	return
 }
 
-reader_length :: proc(r: ^Reader) -> int {
+reader_length :: proc "contextless" (r: ^Reader) -> int {
 	if r.i >= i64(len(r.s)) {
 		return 0
 	}
 	return int(i64(len(r.s)) - r.i)
 }
 
-reader_size :: proc(r: ^Reader) -> i64 {
+reader_size :: proc "contextless" (r: ^Reader) -> i64 {
 	return i64(len(r.s))
 }
 
-reader_read :: proc(r: ^Reader, p: []byte) -> (n: int, err: io.Error) {
+reader_read :: proc "contextless" (r: ^Reader, p: []byte) -> (n: int, err: io.Error) {
 	if r.i >= i64(len(r.s)) {
 		return 0, .EOF
 	}
@@ -41,7 +41,7 @@ reader_read :: proc(r: ^Reader, p: []byte) -> (n: int, err: io.Error) {
 	r.i += i64(n)
 	return
 }
-reader_read_at :: proc(r: ^Reader, p: []byte, off: i64) -> (n: int, err: io.Error) {
+reader_read_at :: proc "contextless" (r: ^Reader, p: []byte, off: i64) -> (n: int, err: io.Error) {
 	if off < 0 {
 		return 0, .Invalid_Offset
 	}
@@ -54,7 +54,7 @@ reader_read_at :: proc(r: ^Reader, p: []byte, off: i64) -> (n: int, err: io.Erro
 	}
 	return
 }
-reader_read_byte :: proc(r: ^Reader) -> (byte, io.Error) {
+reader_read_byte :: proc "contextless" (r: ^Reader) -> (byte, io.Error) {
 	r.prev_rune = -1
 	if r.i >= i64(len(r.s)) {
 		return 0, .EOF
@@ -63,7 +63,7 @@ reader_read_byte :: proc(r: ^Reader) -> (byte, io.Error) {
 	r.i += 1
 	return b, nil
 }
-reader_unread_byte :: proc(r: ^Reader) -> io.Error {
+reader_unread_byte :: proc "contextless" (r: ^Reader) -> io.Error {
 	if r.i <= 0 {
 		return .Invalid_Unread
 	}
@@ -71,7 +71,7 @@ reader_unread_byte :: proc(r: ^Reader) -> io.Error {
 	r.i -= 1
 	return nil
 }
-reader_read_rune :: proc(r: ^Reader) -> (ch: rune, size: int, err: io.Error) {
+reader_read_rune :: proc "contextless" (r: ^Reader) -> (ch: rune, size: int, err: io.Error) {
 	if r.i >= i64(len(r.s)) {
 		r.prev_rune = -1
 		return 0, 0, .EOF
@@ -85,7 +85,7 @@ reader_read_rune :: proc(r: ^Reader) -> (ch: rune, size: int, err: io.Error) {
 	r.i += i64(size)
 	return
 }
-reader_unread_rune :: proc(r: ^Reader) -> io.Error {
+reader_unread_rune :: proc "contextless" (r: ^Reader) -> io.Error {
 	if r.i <= 0 {
 		return .Invalid_Unread
 	}
@@ -96,7 +96,7 @@ reader_unread_rune :: proc(r: ^Reader) -> io.Error {
 	r.prev_rune = -1
 	return nil
 }
-reader_seek :: proc(r: ^Reader, offset: i64, whence: io.Seek_From) -> (i64, io.Error) {
+reader_seek :: proc "contextless" (r: ^Reader, offset: i64, whence: io.Seek_From) -> (i64, io.Error) {
 	r.prev_rune = -1
 	abs: i64
 	switch whence {

--- a/core/container/bit_array/bit_array.odin
+++ b/core/container/bit_array/bit_array.odin
@@ -35,7 +35,7 @@ Bit_Array_Iterator :: struct {
 	Out:
 		- it:   ^Bit_Array_Iterator - the iterator that holds iteration state
 */
-make_iterator :: proc (ba: ^Bit_Array) -> (it: Bit_Array_Iterator) {
+make_iterator :: proc "contextless" (ba: ^Bit_Array) -> (it: Bit_Array_Iterator) {
 	return Bit_Array_Iterator { array = ba }
 }
 
@@ -49,7 +49,7 @@ make_iterator :: proc (ba: ^Bit_Array) -> (it: Bit_Array_Iterator) {
 		- ok:	  bool - `true` if the iterator returned a valid index,
 			  `false` if there were no more bits
 */
-iterate_by_all :: proc (it: ^Bit_Array_Iterator) -> (set: bool, index: int, ok: bool) {
+iterate_by_all :: proc "contextless" (it: ^Bit_Array_Iterator) -> (set: bool, index: int, ok: bool) {
 	index = it.word_idx * NUM_BITS + int(it.bit_idx) + it.array.bias
 	if index > it.array.max_index { return false, 0, false }
 
@@ -74,7 +74,7 @@ iterate_by_all :: proc (it: ^Bit_Array_Iterator) -> (set: bool, index: int, ok: 
 		- ok:	  bool - `true` if the iterator returned a valid index,
 			  `false` if there were no more bits set
 */
-iterate_by_set :: proc (it: ^Bit_Array_Iterator) -> (index: int, ok: bool) {
+iterate_by_set :: proc "contextless" (it: ^Bit_Array_Iterator) -> (index: int, ok: bool) {
 	return iterate_internal_(it, true)
 }
 
@@ -87,12 +87,12 @@ iterate_by_set :: proc (it: ^Bit_Array_Iterator) -> (index: int, ok: bool) {
 		- ok:	  bool - `true` if the iterator returned a valid index,
 			  `false` if there were no more unset bits
 */
-iterate_by_unset:: proc (it: ^Bit_Array_Iterator) -> (index: int, ok: bool) {
+iterate_by_unset:: proc "contextless" (it: ^Bit_Array_Iterator) -> (index: int, ok: bool) {
 	return iterate_internal_(it, false)
 }
 
 @(private="file")
-iterate_internal_ :: proc (it: ^Bit_Array_Iterator, $ITERATE_SET_BITS: bool) -> (index: int, ok: bool) {
+iterate_internal_ :: proc "contextless" (it: ^Bit_Array_Iterator, $ITERATE_SET_BITS: bool) -> (index: int, ok: bool) {
 	word := it.array.bits[it.word_idx] if len(it.array.bits) > it.word_idx else 0
 	when ! ITERATE_SET_BITS { word = ~word }
 
@@ -233,7 +233,7 @@ create :: proc(max_index: int, min_index := 0, allocator := context.allocator) -
 /*
 	Sets all bits to `false`.
 */
-clear :: proc(ba: ^Bit_Array) {
+clear :: proc "contextless" (ba: ^Bit_Array) {
 	if ba == nil { return }
 	mem.zero_slice(ba.bits[:])
 }

--- a/core/container/intrusive/list/intrusive_list.odin
+++ b/core/container/intrusive/list/intrusive_list.odin
@@ -23,7 +23,7 @@ Node :: struct {
 	next, prev: ^Node,
 }
 
-push_front :: proc(list: ^List, node: ^Node) {
+push_front :: proc "contextless" (list: ^List, node: ^Node) {
 	if list.head != nil {
 		list.head.prev = node
 		node.prev, node.next = nil, list.head
@@ -34,7 +34,7 @@ push_front :: proc(list: ^List, node: ^Node) {
 	}
 }
 
-push_back :: proc(list: ^List, node: ^Node) {
+push_back :: proc "contextless" (list: ^List, node: ^Node) {
 	if list.tail != nil {
 		list.tail.next = node
 		node.prev, node.next = list.tail, nil
@@ -45,7 +45,7 @@ push_back :: proc(list: ^List, node: ^Node) {
 	}
 }
 
-remove :: proc(list: ^List, node: ^Node) {
+remove :: proc "contextless" (list: ^List, node: ^Node) {
 	if node != nil {
 		if node.next != nil {
 			node.next.prev = node.prev
@@ -84,11 +84,11 @@ remove_by_proc :: proc(list: ^List, to_erase: proc(^Node) -> bool) {
 }
 
 
-is_empty :: proc(list: ^List) -> bool {
+is_empty :: proc "contextless" (list: ^List) -> bool {
 	return list.head == nil
 }
 
-pop_front :: proc(list: ^List) -> ^Node {
+pop_front :: proc "contextless" (list: ^List) -> ^Node {
 	link := list.head
 	if link == nil {
 		return nil
@@ -108,7 +108,7 @@ pop_front :: proc(list: ^List) -> ^Node {
 	return link
 
 }
-pop_back :: proc(list: ^List) -> ^Node {
+pop_back :: proc "contextless" (list: ^List) -> ^Node {
 	link := list.tail
 	if link == nil {
 		return nil
@@ -134,25 +134,25 @@ Iterator :: struct($T: typeid) {
 	offset: uintptr,
 }
 
-iterator_head :: proc(list: List, $T: typeid, $field_name: string) -> Iterator(T)
+iterator_head :: proc "contextless" (list: List, $T: typeid, $field_name: string) -> Iterator(T)
 	where intrinsics.type_has_field(T, field_name),
 	      intrinsics.type_field_type(T, field_name) == Node {
 	return {list.head, offset_of_by_string(T, field_name)}
 }
 
-iterator_tail :: proc(list: List, $T: typeid, $field_name: string) -> Iterator(T)
+iterator_tail :: proc "contextless" (list: List, $T: typeid, $field_name: string) -> Iterator(T)
 	where intrinsics.type_has_field(T, field_name),
 	      intrinsics.type_field_type(T, field_name) == Node {
 	return {list.tail, offset_of_by_string(T, field_name)}
 }
 
-iterator_from_node :: proc(node: ^Node, $T: typeid, $field_name: string) -> Iterator(T)
+iterator_from_node :: proc "contextless" (node: ^Node, $T: typeid, $field_name: string) -> Iterator(T)
 	where intrinsics.type_has_field(T, field_name),
 	      intrinsics.type_field_type(T, field_name) == Node {
 	return {node, offset_of_by_string(T, field_name)}
 }
 
-iterate_next :: proc(it: ^Iterator($T)) -> (ptr: ^T, ok: bool) {
+iterate_next :: proc "contextless" (it: ^Iterator($T)) -> (ptr: ^T, ok: bool) {
 	node := it.curr
 	if node == nil {
 		return nil, false
@@ -162,7 +162,7 @@ iterate_next :: proc(it: ^Iterator($T)) -> (ptr: ^T, ok: bool) {
 	return (^T)(uintptr(node) - it.offset), true
 }
 
-iterate_prev :: proc(it: ^Iterator($T)) -> (ptr: ^T, ok: bool) {
+iterate_prev :: proc "contextless" (it: ^Iterator($T)) -> (ptr: ^T, ok: bool) {
 	node := it.curr
 	if node == nil {
 		return nil, false

--- a/core/container/lru/lru_cache.odin
+++ b/core/container/lru/lru_cache.odin
@@ -119,7 +119,7 @@ peek :: proc(c: ^$C/Cache($Key, $Value), key: Key) -> (value: Value, ok: bool) #
 }
 
 // exists checks for the existence of a value from a given key without updating the recent usage.
-exists :: proc(c: ^$C/Cache($Key, $Value), key: Key) -> bool {
+exists :: proc "contextless" (c: ^$C/Cache($Key, $Value), key: Key) -> bool {
 	return key in c.entries
 }
 
@@ -166,7 +166,7 @@ _call_on_remove :: proc(c: ^$C/Cache($Key, $Value), node: ^Node(Key, Value)) {
 }
 
 @(private)
-_push_front_node :: proc(c: ^$C/Cache($Key, $Value), e: ^Node(Key, Value)) {
+_push_front_node :: proc "contextless" (c: ^$C/Cache($Key, $Value), e: ^Node(Key, Value)) {
 	if c.head != nil {
 		e.next = c.head
 		e.next.prev = e
@@ -179,7 +179,7 @@ _push_front_node :: proc(c: ^$C/Cache($Key, $Value), e: ^Node(Key, Value)) {
 }
 
 @(private)
-_pop_node :: proc(c: ^$C/Cache($Key, $Value), e: ^Node(Key, Value)) {
+_pop_node :: proc "contextless" (c: ^$C/Cache($Key, $Value), e: ^Node(Key, Value)) {
 	if e == nil {
 		return
 	}

--- a/core/container/priority_queue/priority_queue.odin
+++ b/core/container/priority_queue/priority_queue.odin
@@ -44,13 +44,13 @@ destroy :: proc(pq: ^$Q/Priority_Queue($T)) {
 reserve :: proc(pq: ^$Q/Priority_Queue($T), capacity: int) {
 	builtin.reserve(&pq.queue, capacity)
 }
-clear :: proc(pq: ^$Q/Priority_Queue($T)) {
+clear :: proc "contextless" (pq: ^$Q/Priority_Queue($T)) {
 	builtin.clear(&pq.queue)
 }
-len :: proc(pq: $Q/Priority_Queue($T)) -> int {
+len :: proc "contextless" (pq: $Q/Priority_Queue($T)) -> int {
 	return builtin.len(pq.queue)
 }
-cap :: proc(pq: $Q/Priority_Queue($T)) -> int {
+cap :: proc "contextless" (pq: $Q/Priority_Queue($T)) -> int {
 	return builtin.cap(pq.queue)
 }
 

--- a/core/container/queue/queue.odin
+++ b/core/container/queue/queue.odin
@@ -40,17 +40,17 @@ destroy :: proc(q: ^$Q/Queue($T)) {
 }
 
 // The length of the queue
-len :: proc(q: $Q/Queue($T)) -> int {
+len :: proc "contextless" (q: $Q/Queue($T)) -> int {
 	return int(q.len)
 }
 
 // The current capacity of the queue
-cap :: proc(q: $Q/Queue($T)) -> int {
+cap :: proc "contextless" (q: $Q/Queue($T)) -> int {
 	return builtin.len(q.data)
 }
 
 // Remaining space in the queue (cap-len)
-space :: proc(q: $Q/Queue($T)) -> int {
+space :: proc "contextless" (q: $Q/Queue($T)) -> int {
 	return builtin.len(q.data) - int(q.len)
 }
 
@@ -70,18 +70,18 @@ get :: proc(q: ^$Q/Queue($T), #any_int i: int, loc := #caller_location) -> T {
 	return q.data[idx]
 }
 
-front :: proc(q: ^$Q/Queue($T)) -> T {
+front :: proc "contextless" (q: ^$Q/Queue($T)) -> T {
 	return q.data[q.offset]
 }
-front_ptr :: proc(q: ^$Q/Queue($T)) -> ^T {
+front_ptr :: proc "contextless" (q: ^$Q/Queue($T)) -> ^T {
 	return &q.data[q.offset]
 }
 
-back :: proc(q: ^$Q/Queue($T)) -> T {
+back :: proc "contextless" (q: ^$Q/Queue($T)) -> T {
 	idx := (q.offset+uint(q.len))%builtin.len(q.data)
 	return q.data[idx]
 }
-back_ptr :: proc(q: ^$Q/Queue($T)) -> ^T {
+back_ptr :: proc "contextless" (q: ^$Q/Queue($T)) -> ^T {
 	idx := (q.offset+uint(q.len))%builtin.len(q.data)
 	return &q.data[idx]
 }
@@ -218,7 +218,7 @@ append :: proc{push_back, push_back_elems}
 
 
 // Clear the contents of the queue
-clear :: proc(q: ^$Q/Queue($T)) {
+clear :: proc "contextless" (q: ^$Q/Queue($T)) {
 	q.len = 0
 	q.offset = 0
 }

--- a/core/container/topological_sort/topological_sort.odin
+++ b/core/container/topological_sort/topological_sort.odin
@@ -20,7 +20,7 @@ Sorter :: struct(K: typeid) where intrinsics.type_is_valid_map_key(K)  {
 }
 
 @(private="file")
-make_relations :: proc(sorter: ^$S/Sorter($K)) -> (r: Relations(K)) {
+make_relations :: proc "contextless" (sorter: ^$S/Sorter($K)) -> (r: Relations(K)) {
 	r.dependents.allocator = sorter.dependents_allocator
 	return
 }

--- a/core/encoding/endian/endian.odin
+++ b/core/encoding/endian/endian.odin
@@ -7,7 +7,7 @@ Byte_Order :: enum u8 {
 
 PLATFORM_BYTE_ORDER :: Byte_Order.Little when ODIN_ENDIAN == .Little else Byte_Order.Big
 
-get_u16 :: proc(b: []byte, order: Byte_Order) -> (v: u16, ok: bool) {
+get_u16 :: proc "contextless" (b: []byte, order: Byte_Order) -> (v: u16, ok: bool) {
 	if len(b) < 2 {
 		return 0, false
 	}
@@ -18,7 +18,7 @@ get_u16 :: proc(b: []byte, order: Byte_Order) -> (v: u16, ok: bool) {
 	}
 	return v, true
 }
-get_u32 :: proc(b: []byte, order: Byte_Order) -> (v: u32, ok: bool) {
+get_u32 :: proc "contextless" (b: []byte, order: Byte_Order) -> (v: u32, ok: bool) {
 	if len(b) < 4 {
 		return 0, false
 	}
@@ -30,7 +30,7 @@ get_u32 :: proc(b: []byte, order: Byte_Order) -> (v: u32, ok: bool) {
 	return v, true
 }
 
-get_u64 :: proc(b: []byte, order: Byte_Order) -> (v: u64, ok: bool) {
+get_u64 :: proc "contextless" (b: []byte, order: Byte_Order) -> (v: u64, ok: bool) {
 	if len(b) < 8 {
 		return 0, false
 	}
@@ -44,34 +44,34 @@ get_u64 :: proc(b: []byte, order: Byte_Order) -> (v: u64, ok: bool) {
 	return v, true
 }
 
-get_i16 :: proc(b: []byte, order: Byte_Order) -> (i16, bool) {
+get_i16 :: proc "contextless" (b: []byte, order: Byte_Order) -> (i16, bool) {
 	v, ok := get_u16(b, order)
 	return i16(v), ok
 }
-get_i32 :: proc(b: []byte, order: Byte_Order) -> (i32, bool) {
+get_i32 :: proc "contextless" (b: []byte, order: Byte_Order) -> (i32, bool) {
 	v, ok := get_u32(b, order)
 	return i32(v), ok
 }
-get_i64 :: proc(b: []byte, order: Byte_Order) -> (i64, bool) {
+get_i64 :: proc "contextless" (b: []byte, order: Byte_Order) -> (i64, bool) {
 	v, ok := get_u64(b, order)
 	return i64(v), ok
 }
 
-get_f16 :: proc(b: []byte, order: Byte_Order) -> (f16, bool) {
+get_f16 :: proc "contextless" (b: []byte, order: Byte_Order) -> (f16, bool) {
 	v, ok := get_u16(b, order)
 	return transmute(f16)v, ok
 }
-get_f32 :: proc(b: []byte, order: Byte_Order) -> (f32, bool) {
+get_f32 :: proc "contextless" (b: []byte, order: Byte_Order) -> (f32, bool) {
 	v, ok := get_u32(b, order)
 	return transmute(f32)v, ok
 }
-get_f64 :: proc(b: []byte, order: Byte_Order) -> (f64, bool) {
+get_f64 :: proc "contextless" (b: []byte, order: Byte_Order) -> (f64, bool) {
 	v, ok := get_u64(b, order)
 	return transmute(f64)v, ok
 }
 
 
-put_u16 :: proc(b: []byte, order: Byte_Order, v: u16) -> bool {
+put_u16 :: proc "contextless" (b: []byte, order: Byte_Order, v: u16) -> bool {
 	if len(b) < 2 {
 		return false
 	}
@@ -84,7 +84,7 @@ put_u16 :: proc(b: []byte, order: Byte_Order, v: u16) -> bool {
 	}
 	return true
 }
-put_u32 :: proc(b: []byte, order: Byte_Order, v: u32) -> bool {
+put_u32 :: proc "contextless" (b: []byte, order: Byte_Order, v: u32) -> bool {
 	if len(b) < 4 {
 		return false
 	}
@@ -101,7 +101,7 @@ put_u32 :: proc(b: []byte, order: Byte_Order, v: u32) -> bool {
 	}
 	return true
 }
-put_u64 :: proc(b: []byte, order: Byte_Order, v: u64) -> bool {
+put_u64 :: proc "contextless" (b: []byte, order: Byte_Order, v: u64) -> bool {
 	if len(b) < 8 {
 		return false
 	}
@@ -127,27 +127,27 @@ put_u64 :: proc(b: []byte, order: Byte_Order, v: u64) -> bool {
 	return true
 }
 
-put_i16 :: proc(b: []byte, order: Byte_Order, v: i16) -> bool {
+put_i16 :: proc "contextless" (b: []byte, order: Byte_Order, v: i16) -> bool {
 	return put_u16(b, order, u16(v))
 }
 
-put_i32 :: proc(b: []byte, order: Byte_Order, v: i32) -> bool {
+put_i32 :: proc "contextless" (b: []byte, order: Byte_Order, v: i32) -> bool {
 	return put_u32(b, order, u32(v))
 }
 
-put_i64 :: proc(b: []byte, order: Byte_Order, v: i64) -> bool {
+put_i64 :: proc "contextless" (b: []byte, order: Byte_Order, v: i64) -> bool {
 	return put_u64(b, order, u64(v))
 }
 
 
-put_f16 :: proc(b: []byte, order: Byte_Order, v: f16) -> bool {
+put_f16 :: proc "contextless" (b: []byte, order: Byte_Order, v: f16) -> bool {
 	return put_u16(b, order, transmute(u16)v)
 }
 
-put_f32 :: proc(b: []byte, order: Byte_Order, v: f32) -> bool {
+put_f32 :: proc "contextless" (b: []byte, order: Byte_Order, v: f32) -> bool {
 	return put_u32(b, order, transmute(u32)v)
 }
 
-put_f64 :: proc(b: []byte, order: Byte_Order, v: f64) -> bool {
+put_f64 :: proc "contextless" (b: []byte, order: Byte_Order, v: f64) -> bool {
 	return put_u64(b, order, transmute(u64)v)
 }

--- a/core/hash/crc.odin
+++ b/core/hash/crc.odin
@@ -1,7 +1,7 @@
 package hash
 
 @(optimization_mode="speed")
-crc64_ecma_182 :: proc(data: []byte, seed := u64(0)) -> (result: u64) #no_bounds_check {
+crc64_ecma_182 :: proc "contextless" (data: []byte, seed := u64(0)) -> (result: u64) #no_bounds_check {
 	result = seed
 	#no_bounds_check for b in data {
 		result = result<<8 ~ _crc64_table_ecma_182[((result>>56) ~ u64(b)) & 0xff]
@@ -15,7 +15,7 @@ crc64_ecma_182 :: proc(data: []byte, seed := u64(0)) -> (result: u64) #no_bounds
 	Based on Mark Adler's v1.4 implementation in C under the ZLIB license.
 */
 @(optimization_mode="speed")
-crc64_xz :: proc(data: []byte, seed := u64(0)) -> u64 #no_bounds_check {
+crc64_xz :: proc "contextless" (data: []byte, seed := u64(0)) -> u64 #no_bounds_check {
 	data := data
 	result := ~u64le(seed)
 
@@ -53,7 +53,7 @@ crc64_xz :: proc(data: []byte, seed := u64(0)) -> u64 #no_bounds_check {
 	Generator polynomial: x^64 + x^4 + x^3 + x + 1
 */
 @(optimization_mode="speed")
-crc64_iso_3306 :: proc(data: []byte, seed := u64(0)) -> u64 #no_bounds_check {
+crc64_iso_3306 :: proc "contextless" (data: []byte, seed := u64(0)) -> u64 #no_bounds_check {
 
 	result := seed
 
@@ -70,7 +70,7 @@ crc64_iso_3306 :: proc(data: []byte, seed := u64(0)) -> u64 #no_bounds_check {
 	return result
 }
 
-crc64_iso_3306_inverse :: proc(data: []byte, seed := u64(0)) -> u64 {
+crc64_iso_3306_inverse :: proc "contextless" (data: []byte, seed := u64(0)) -> u64 {
 	result := #force_inline crc64_iso_3306(data, ~seed)
 	return ~result
 }

--- a/core/hash/crc32.odin
+++ b/core/hash/crc32.odin
@@ -3,7 +3,7 @@ package hash
 import "core:intrinsics"
 
 @(optimization_mode="speed")
-crc32 :: proc(data: []byte, seed := u32(0)) -> u32 #no_bounds_check {
+crc32 :: proc "contextless" (data: []byte, seed := u32(0)) -> u32 #no_bounds_check {
 	crc := ~seed
 	buffer := raw_data(data)
 	length := len(data)

--- a/core/hash/hash.odin
+++ b/core/hash/hash.odin
@@ -4,7 +4,7 @@ import "core:mem"
 import "core:intrinsics"
 
 @(optimization_mode="speed")
-adler32 :: proc(data: []byte, seed := u32(1)) -> u32 #no_bounds_check {
+adler32 :: proc "contextless" (data: []byte, seed := u32(1)) -> u32 #no_bounds_check {
 
 	ADLER_CONST :: 65521
 
@@ -47,7 +47,7 @@ adler32 :: proc(data: []byte, seed := u32(1)) -> u32 #no_bounds_check {
 }
 
 @(optimization_mode="speed")
-djb2 :: proc(data: []byte, seed := u32(5381)) -> u32 {
+djb2 :: proc "contextless" (data: []byte, seed := u32(5381)) -> u32 {
 	hash: u32 = seed
 	for b in data {
 		hash = (hash << 5) + hash + u32(b) // hash * 33 + u32(b)
@@ -55,7 +55,7 @@ djb2 :: proc(data: []byte, seed := u32(5381)) -> u32 {
 	return hash
 }
 
-djbx33a :: proc(data: []byte, seed := u32(5381)) -> (result: [16]byte) #no_bounds_check {
+djbx33a :: proc "contextless" (data: []byte, seed := u32(5381)) -> (result: [16]byte) #no_bounds_check {
 	state := [4]u32{seed, seed, seed, seed}
 	
 	s: u32 = 0
@@ -74,7 +74,7 @@ djbx33a :: proc(data: []byte, seed := u32(5381)) -> (result: [16]byte) #no_bound
 
 // If you have a choice, prefer fnv32a
 @(optimization_mode="speed")
-fnv32_no_a :: proc(data: []byte, seed := u32(0x811c9dc5)) -> u32 {
+fnv32_no_a :: proc "contextless" (data: []byte, seed := u32(0x811c9dc5)) -> u32 {
 	h: u32 = seed
 	for b in data {
 		h = (h * 0x01000193) ~ u32(b)
@@ -84,7 +84,7 @@ fnv32_no_a :: proc(data: []byte, seed := u32(0x811c9dc5)) -> u32 {
 
 // If you have a choice, prefer fnv64a
 @(optimization_mode="speed")
-fnv64_no_a :: proc(data: []byte, seed := u64(0xcbf29ce484222325)) -> u64 {
+fnv64_no_a :: proc "contextless" (data: []byte, seed := u64(0xcbf29ce484222325)) -> u64 {
 	h: u64 = seed
 	for b in data {
 		h = (h * 0x100000001b3) ~ u64(b)
@@ -93,7 +93,7 @@ fnv64_no_a :: proc(data: []byte, seed := u64(0xcbf29ce484222325)) -> u64 {
 }
 
 @(optimization_mode="speed")
-fnv32a :: proc(data: []byte, seed := u32(0x811c9dc5)) -> u32 {
+fnv32a :: proc "contextless" (data: []byte, seed := u32(0x811c9dc5)) -> u32 {
 	h: u32 = seed
 	for b in data {
 		h = (h ~ u32(b)) * 0x01000193
@@ -102,7 +102,7 @@ fnv32a :: proc(data: []byte, seed := u32(0x811c9dc5)) -> u32 {
 }
 
 @(optimization_mode="speed")
-fnv64a :: proc(data: []byte, seed := u64(0xcbf29ce484222325)) -> u64 {
+fnv64a :: proc "contextless" (data: []byte, seed := u64(0xcbf29ce484222325)) -> u64 {
 	h: u64 = seed
 	for b in data {
 		h = (h ~ u64(b)) * 0x100000001b3
@@ -111,7 +111,7 @@ fnv64a :: proc(data: []byte, seed := u64(0xcbf29ce484222325)) -> u64 {
 }
 
 @(optimization_mode="speed")
-jenkins :: proc(data: []byte, seed := u32(0)) -> u32 {
+jenkins :: proc "contextless" (data: []byte, seed := u32(0)) -> u32 {
 	hash: u32 = seed
 	for b in data {
 		hash += u32(b)
@@ -125,7 +125,7 @@ jenkins :: proc(data: []byte, seed := u32(0)) -> u32 {
 }
 
 @(optimization_mode="speed")
-murmur32 :: proc(data: []byte, seed := u32(0)) -> u32 {
+murmur32 :: proc "contextless" (data: []byte, seed := u32(0)) -> u32 {
 	c1_32: u32 : 0xcc9e2d51
 	c2_32: u32 : 0x1b873593
 
@@ -176,7 +176,7 @@ murmur32 :: proc(data: []byte, seed := u32(0)) -> u32 {
 
 // See https://github.com/aappleby/smhasher/blob/master/src/MurmurHash2.cpp#L96
 @(optimization_mode="speed")
-murmur64a :: proc(data: []byte, seed := u64(0x9747b28c)) -> u64 {
+murmur64a :: proc "contextless" (data: []byte, seed := u64(0x9747b28c)) -> u64 {
 	m :: 0xc6a4a7935bd1e995
 	r :: 47
 
@@ -217,7 +217,7 @@ murmur64a :: proc(data: []byte, seed := u64(0x9747b28c)) -> u64 {
 
 // See https://github.com/aappleby/smhasher/blob/master/src/MurmurHash2.cpp#L140
 @(optimization_mode="speed")
-murmur64b :: proc(data: []byte, seed := u64(0x9747b28c)) -> u64 {
+murmur64b :: proc "contextless" (data: []byte, seed := u64(0x9747b28c)) -> u64 {
 	m :: 0x5bd1e995
 	r :: 24
 
@@ -285,7 +285,7 @@ murmur64b :: proc(data: []byte, seed := u64(0x9747b28c)) -> u64 {
 }
 
 @(optimization_mode="speed")
-sdbm :: proc(data: []byte, seed := u32(0)) -> u32 {
+sdbm :: proc "contextless" (data: []byte, seed := u32(0)) -> u32 {
 	hash: u32 = seed
 	for b in data {
 		hash = u32(b) + (hash<<6) + (hash<<16) - hash

--- a/core/hash/mini.odin
+++ b/core/hash/mini.odin
@@ -1,6 +1,6 @@
 package hash
 
-ginger_hash8 :: proc(x: u8) -> u8 {
+ginger_hash8 :: proc "contextless" (x: u8) -> u8 {
 	h := x * 251
 	h += ~(x << 3)
 	h ~=  (x >> 1)
@@ -11,7 +11,7 @@ ginger_hash8 :: proc(x: u8) -> u8 {
 }
 
 
-ginger_hash16 :: proc(x: u16) -> u16 {
+ginger_hash16 :: proc "contextless" (x: u16) -> u16 {
 	z := (x << 8) | (x >> 8)
 	h := z
 	h += ~(z << 5)
@@ -24,14 +24,14 @@ ginger_hash16 :: proc(x: u16) -> u16 {
 }
 
 
-ginger8 :: proc(data: []byte) -> u8 {
+ginger8 :: proc "contextless" (data: []byte) -> u8 {
 	h := ginger_hash8(0)
 	for b in data {
 		h ~= ginger_hash8(b)
 	}
 	return h
 }
-ginger16 :: proc(data: []byte) -> u16 {
+ginger16 :: proc "contextless" (data: []byte) -> u16 {
 	h := ginger_hash16(0)
 	for b in data {
 		h ~= ginger_hash16(u16(b))

--- a/core/hash/xxhash/common.odin
+++ b/core/hash/xxhash/common.odin
@@ -68,17 +68,17 @@ when !XXH_DISABLE_PREFETCH {
 
 
 @(optimization_mode="speed")
-XXH_rotl32 :: #force_inline proc(x, r: u32) -> (res: u32) {
+XXH_rotl32 :: #force_inline proc "contextless" (x, r: u32) -> (res: u32) {
 	return ((x << r) | (x >> (32 - r)))
 }
 
 @(optimization_mode="speed")
-XXH_rotl64 :: #force_inline proc(x, r: u64) -> (res: u64) {
+XXH_rotl64 :: #force_inline proc "contextless" (x, r: u64) -> (res: u64) {
 	return ((x << r) | (x >> (64 - r)))
 }
 
 @(optimization_mode="speed")
-XXH32_read32 :: #force_inline proc(buf: []u8, alignment := Alignment.Unaligned) -> (res: u32) {
+XXH32_read32 :: #force_inline proc "contextless" (buf: []u8, alignment := Alignment.Unaligned) -> (res: u32) {
 	if XXH_FORCE_MEMORY_ACCESS == 2 || alignment == .Aligned {
 		#no_bounds_check b := (^u32le)(&buf[0])^
 		return u32(b)
@@ -90,7 +90,7 @@ XXH32_read32 :: #force_inline proc(buf: []u8, alignment := Alignment.Unaligned) 
 }
 
 @(optimization_mode="speed")
-XXH64_read64 :: #force_inline proc(buf: []u8, alignment := Alignment.Unaligned) -> (res: u64) {
+XXH64_read64 :: #force_inline proc "contextless" (buf: []u8, alignment := Alignment.Unaligned) -> (res: u64) {
 	if XXH_FORCE_MEMORY_ACCESS == 2 || alignment == .Aligned {
 		#no_bounds_check b := (^u64le)(&buf[0])^
 		return u64(b)

--- a/core/hash/xxhash/streaming.odin
+++ b/core/hash/xxhash/streaming.odin
@@ -89,7 +89,7 @@ XXH3_128_digest :: proc(state: ^XXH3_state) -> (hash: XXH3_128_hash) {
 
 /*======   Canonical representation   ======*/
 
-XXH3_128_canonical_from_hash :: proc(hash: XXH128_hash_t) -> (canonical: XXH128_canonical) {
+XXH3_128_canonical_from_hash :: proc "contextless" (hash: XXH128_hash_t) -> (canonical: XXH128_canonical) {
 	#assert(size_of(XXH128_canonical) == size_of(XXH128_hash_t))
 
 	t := hash
@@ -102,7 +102,7 @@ XXH3_128_canonical_from_hash :: proc(hash: XXH128_hash_t) -> (canonical: XXH128_
 	return
 }
 
-XXH3_128_hash_from_canonical :: proc(src: ^XXH128_canonical) -> (hash: u128) {
+XXH3_128_hash_from_canonical :: proc "contextless" (src: ^XXH128_canonical) -> (hash: u128) {
 	h := XXH128_hash_t{}
 
 	high := (^u64be)(&src.digest[0])^
@@ -115,7 +115,7 @@ XXH3_128_hash_from_canonical :: proc(src: ^XXH128_canonical) -> (hash: u128) {
 
 /* ===   XXH3 streaming   === */
 
-XXH3_init_state :: proc(state: ^XXH3_state) {
+XXH3_init_state :: proc "contextless" (state: ^XXH3_state) {
 	state.seed = 0
 }
 

--- a/core/hash/xxhash/xxhash_3.odin
+++ b/core/hash/xxhash/xxhash_3.odin
@@ -112,13 +112,13 @@ XXH128_canonical :: struct {
 	@return The low 64 bits of the product XOR'd by the high 64 bits.
 */
 @(optimization_mode="speed")
-XXH_mul_64_to_128_fold_64 :: #force_inline proc(lhs, rhs: xxh_u64) -> (res: xxh_u64) {
+XXH_mul_64_to_128_fold_64 :: #force_inline proc "contextless" (lhs, rhs: xxh_u64) -> (res: xxh_u64) {
 	t := u128(lhs) * u128(rhs)
 	return u64(t & 0xFFFFFFFFFFFFFFFF) ~ u64(t >> 64)
 }
 
 @(optimization_mode="speed")
-XXH_xorshift_64 :: #force_inline proc(v: xxh_u64, auto_cast shift: uint) -> (res: xxh_u64) {
+XXH_xorshift_64 :: #force_inline proc "contextless" (v: xxh_u64, auto_cast shift: uint) -> (res: xxh_u64) {
 	return v ~ (v >> shift)
 }
 
@@ -126,7 +126,7 @@ XXH_xorshift_64 :: #force_inline proc(v: xxh_u64, auto_cast shift: uint) -> (res
 	This is a fast avalanche stage, suitable when input bits are already partially mixed
 */
 @(optimization_mode="speed")
-XXH3_avalanche :: #force_inline proc(h64: xxh_u64) -> (res: xxh_u64) {
+XXH3_avalanche :: #force_inline proc "contextless" (h64: xxh_u64) -> (res: xxh_u64) {
 	res = XXH_xorshift_64(h64, 37)
 	res *= 0x165667919E3779F9
 	res = XXH_xorshift_64(res, 32)
@@ -138,7 +138,7 @@ XXH3_avalanche :: #force_inline proc(h64: xxh_u64) -> (res: xxh_u64) {
 	preferable when input has not been previously mixed
 */
 @(optimization_mode="speed")
-XXH3_rrmxmx :: #force_inline proc(h64, length: xxh_u64) -> (res: xxh_u64) {
+XXH3_rrmxmx :: #force_inline proc "contextless" (h64, length: xxh_u64) -> (res: xxh_u64) {
 	/* this mix is inspired by Pelle Evensen's rrmxmx */
 	res = h64
 	res ~= XXH_rotl64(res, 49) ~ XXH_rotl64(res, 24)
@@ -446,7 +446,7 @@ XXH3_hashLong_128b_withSeed :: #force_no_inline proc(input: []u8, seed: xxh_u64,
 	return XXH3_hashLong_128b_withSeed_internal(input, seed, secret, XXH3_accumulate_512, XXH3_scramble_accumulator , XXH3_init_custom_secret)
 }
 
-XXH3_hashLong128_f :: #type proc(input: []u8, seed: xxh_u64, secret: []u8)  -> (res: XXH3_128_hash)
+XXH3_hashLong128_f :: #type proc(input: []u8, seed: xxh_u64, secret: []u8) -> (res: XXH3_128_hash)
 
 @(optimization_mode="speed")
 XXH3_128bits_internal :: #force_inline proc(
@@ -700,7 +700,7 @@ XXH_ACC_NB               :: (XXH_STRIPE_LEN / size_of(xxh_u64))
 XXH_SECRET_LASTACC_START :: 7 /* not aligned on 8, last secret is different from acc & scrambler */
 
 @(optimization_mode="speed")
-XXH_writeLE64 :: #force_inline proc(dst: []u8, v64: u64le) {
+XXH_writeLE64 :: #force_inline proc "contextless" (dst: []u8, v64: u64le) {
 	v := v64
 	mem_copy(raw_data(dst), &v, size_of(v64))
 }
@@ -921,7 +921,7 @@ XXH3_hashLong_64b_withSeed :: #force_no_inline proc(input: []u8, seed: xxh_u64, 
 }
 
 
-XXH3_hashLong64_f :: #type proc(input: []u8, seed: xxh_u64, secret: []u8)  -> (res: xxh_u64)
+XXH3_hashLong64_f :: #type proc(input: []u8, seed: xxh_u64, secret: []u8) -> (res: xxh_u64)
 
 @(optimization_mode="speed")
 XXH3_64bits_internal :: proc(input: []u8, seed: xxh_u64, secret: []u8, f_hashLong: XXH3_hashLong64_f) -> (hash: xxh_u64) {

--- a/core/hash/xxhash/xxhash_64.odin
+++ b/core/hash/xxhash/xxhash_64.odin
@@ -41,7 +41,7 @@ XXH_PRIME64_4 :: 0x85EBCA77C2B2AE63 /*!< 0b1000010111101011110010100111011111000
 XXH_PRIME64_5 :: 0x27D4EB2F165667C5 /*!< 0b0010011111010100111010110010111100010110010101100110011111000101 */
 
 @(optimization_mode="speed")
-XXH64_round :: proc(acc, input: xxh_u64) -> (res: xxh_u64) {
+XXH64_round :: proc "contextless" (acc, input: xxh_u64) -> (res: xxh_u64) {
 	acc := acc
 
 	acc += input * XXH_PRIME64_2
@@ -51,14 +51,14 @@ XXH64_round :: proc(acc, input: xxh_u64) -> (res: xxh_u64) {
 }
 
 @(optimization_mode="speed")
-XXH64_mergeRound :: proc(acc, val: xxh_u64) -> (res: xxh_u64) {
+XXH64_mergeRound :: proc "contextless" (acc, val: xxh_u64) -> (res: xxh_u64) {
 	res  = acc ~ XXH64_round(0, val)
 	res  = res * XXH_PRIME64_1 + XXH_PRIME64_4
 	return res
 }
 
 @(optimization_mode="speed")
-XXH64_avalanche :: proc(h64: xxh_u64) -> (res: xxh_u64) {
+XXH64_avalanche :: proc "contextless" (h64: xxh_u64) -> (res: xxh_u64) {
 	res = h64
 	res ~= res >> 33
 	res *= XXH_PRIME64_2
@@ -69,7 +69,7 @@ XXH64_avalanche :: proc(h64: xxh_u64) -> (res: xxh_u64) {
 }
 
 @(optimization_mode="speed")
-XXH64_finalize :: proc(h64: xxh_u64, buf: []u8, alignment: Alignment) -> (res: xxh_u64) {
+XXH64_finalize :: proc "contextless" (h64: xxh_u64, buf: []u8, alignment: Alignment) -> (res: xxh_u64) {
 	buf := buf
 	length := len(buf) & 31
 	res = h64
@@ -101,7 +101,7 @@ XXH64_finalize :: proc(h64: xxh_u64, buf: []u8, alignment: Alignment) -> (res: x
 }
 
 @(optimization_mode="speed")
-XXH64_endian_align :: proc(input: []u8, seed := XXH64_DEFAULT_SEED, alignment := Alignment.Unaligned) -> (res: xxh_u64) {
+XXH64_endian_align :: proc "contextless" (input: []u8, seed := XXH64_DEFAULT_SEED, alignment := Alignment.Unaligned) -> (res: xxh_u64) {
 	buf    := input
 	length := len(buf)
 
@@ -131,7 +131,7 @@ XXH64_endian_align :: proc(input: []u8, seed := XXH64_DEFAULT_SEED, alignment :=
 	return XXH64_finalize(res, buf, alignment)
 }
 
-XXH64 :: proc(input: []u8, seed := XXH64_DEFAULT_SEED) -> (digest: XXH64_hash) {
+XXH64 :: proc "contextless" (input: []u8, seed := XXH64_DEFAULT_SEED) -> (digest: XXH64_hash) {
 	when false {
 		/*
 			Simple version, good for code maintenance, but unfortunately slow for small inputs.
@@ -177,7 +177,7 @@ XXH64_copy_state :: proc(dest, src: ^XXH64_state) {
 	mem_copy(dest, src, size_of(XXH64_state))
 }
 
-XXH64_reset_state :: proc(state_ptr: ^XXH64_state, seed := XXH64_DEFAULT_SEED) -> (err: Error) {
+XXH64_reset_state :: proc "contextless" (state_ptr: ^XXH64_state, seed := XXH64_DEFAULT_SEED) -> (err: Error) {
 	state := XXH64_state{}
 
 	state.v1 = seed + XXH_PRIME64_1 + XXH_PRIME64_2
@@ -192,7 +192,7 @@ XXH64_reset_state :: proc(state_ptr: ^XXH64_state, seed := XXH64_DEFAULT_SEED) -
 }
 
 @(optimization_mode="speed")
-XXH64_update :: proc(state: ^XXH64_state, input: []u8) -> (err: Error) {
+XXH64_update :: proc "contextless" (state: ^XXH64_state, input: []u8) -> (err: Error) {
 	buf    := input
 	length := len(buf)
 
@@ -246,7 +246,7 @@ XXH64_update :: proc(state: ^XXH64_state, input: []u8) -> (err: Error) {
 }
 
 @(optimization_mode="speed")
-XXH64_digest :: proc(state: ^XXH64_state) -> (res: XXH64_hash) {
+XXH64_digest :: proc "contextless" (state: ^XXH64_state) -> (res: XXH64_hash) {
 	if state.total_len >= 32 {
 		v1 := state.v1
 		v2 := state.v2
@@ -282,14 +282,14 @@ XXH64_digest :: proc(state: ^XXH64_state) -> (res: XXH64_hash) {
 	The following functions allow transformation of hash values to and from their
 	canonical format.
 */
-XXH64_canonical_from_hash :: proc(hash: XXH64_hash) -> (canonical: XXH64_canonical) {
+XXH64_canonical_from_hash :: proc "contextless" (hash: XXH64_hash) -> (canonical: XXH64_canonical) {
 	#assert(size_of(XXH64_canonical) == size_of(XXH64_hash))
 	h := u64be(hash)
 	mem_copy(&canonical, &h, size_of(canonical))
 	return
 }
 
-XXH64_hash_from_canonical :: proc(canonical: ^XXH64_canonical) -> (hash: XXH64_hash) {
+XXH64_hash_from_canonical :: proc "contextless" (canonical: ^XXH64_canonical) -> (hash: XXH64_hash) {
 	h := (^u64be)(&canonical.digest)^
 	return XXH64_hash(h)
 }

--- a/core/io/conv.odin
+++ b/core/io/conv.odin
@@ -1,13 +1,13 @@
 package io
 
-to_reader :: proc(s: Stream) -> (r: Reader, ok: bool = true) #optional_ok {
+to_reader :: proc "contextless" (s: Stream) -> (r: Reader, ok: bool = true) #optional_ok {
 	r.stream = s
 	if s.stream_vtable == nil || s.impl_read == nil {
 		ok = false
 	}
 	return
 }
-to_writer :: proc(s: Stream) -> (w: Writer, ok: bool = true) #optional_ok {
+to_writer :: proc "contextless" (s: Stream) -> (w: Writer, ok: bool = true) #optional_ok {
 	w.stream = s
 	if s.stream_vtable == nil || s.impl_write == nil {
 		ok = false
@@ -15,21 +15,21 @@ to_writer :: proc(s: Stream) -> (w: Writer, ok: bool = true) #optional_ok {
 	return
 }
 
-to_closer :: proc(s: Stream) -> (c: Closer, ok: bool = true) #optional_ok {
+to_closer :: proc "contextless" (s: Stream) -> (c: Closer, ok: bool = true) #optional_ok {
 	c.stream = s
 	if s.stream_vtable == nil || s.impl_close == nil {
 		ok = false
 	}
 	return
 }
-to_flusher :: proc(s: Stream) -> (f: Flusher, ok: bool = true) #optional_ok {
+to_flusher :: proc "contextless" (s: Stream) -> (f: Flusher, ok: bool = true) #optional_ok {
 	f.stream = s
 	if s.stream_vtable == nil || s.impl_flush == nil {
 		ok = false
 	}
 	return
 }
-to_seeker :: proc(s: Stream) -> (seeker: Seeker, ok: bool = true) #optional_ok {
+to_seeker :: proc "contextless" (s: Stream) -> (seeker: Seeker, ok: bool = true) #optional_ok {
 	seeker.stream = s
 	if s.stream_vtable == nil || s.impl_seek == nil {
 		ok = false
@@ -37,42 +37,42 @@ to_seeker :: proc(s: Stream) -> (seeker: Seeker, ok: bool = true) #optional_ok {
 	return
 }
 
-to_read_writer :: proc(s: Stream) -> (r: Read_Writer, ok: bool = true) #optional_ok {
+to_read_writer :: proc "contextless" (s: Stream) -> (r: Read_Writer, ok: bool = true) #optional_ok {
 	r.stream = s
 	if s.stream_vtable == nil || s.impl_read == nil || s.impl_write == nil {
 		ok = false
 	}
 	return
 }
-to_read_closer :: proc(s: Stream) -> (r: Read_Closer, ok: bool = true) #optional_ok {
+to_read_closer :: proc "contextless" (s: Stream) -> (r: Read_Closer, ok: bool = true) #optional_ok {
 	r.stream = s
 	if s.stream_vtable == nil || s.impl_read == nil || s.impl_close == nil {
 		ok = false
 	}
 	return
 }
-to_read_write_closer :: proc(s: Stream) -> (r: Read_Write_Closer, ok: bool = true) #optional_ok {
+to_read_write_closer :: proc "contextless" (s: Stream) -> (r: Read_Write_Closer, ok: bool = true) #optional_ok {
 	r.stream = s
 	if s.stream_vtable == nil || s.impl_read == nil || s.impl_write == nil || s.impl_close == nil {
 		ok = false
 	}
 	return
 }
-to_read_write_seeker :: proc(s: Stream) -> (r: Read_Write_Seeker, ok: bool = true) #optional_ok {
+to_read_write_seeker :: proc "contextless" (s: Stream) -> (r: Read_Write_Seeker, ok: bool = true) #optional_ok {
 	r.stream = s
 	if s.stream_vtable == nil || s.impl_read == nil || s.impl_write == nil || s.impl_seek == nil {
 		ok = false
 	}
 	return
 }
-to_write_flusher :: proc(s: Stream) -> (w: Write_Flusher, ok: bool = true) #optional_ok {
+to_write_flusher :: proc "contextless" (s: Stream) -> (w: Write_Flusher, ok: bool = true) #optional_ok {
 	w.stream = s
 	if s.stream_vtable == nil || s.impl_write == nil || s.impl_flush == nil {
 		ok = false
 	}
 	return
 }
-to_write_flush_closer :: proc(s: Stream) -> (w: Write_Flush_Closer, ok: bool = true) #optional_ok {
+to_write_flush_closer :: proc "contextless" (s: Stream) -> (w: Write_Flush_Closer, ok: bool = true) #optional_ok {
 	w.stream = s
 	if s.stream_vtable == nil || s.impl_write == nil || s.impl_flush == nil || s.impl_close == nil {
 		ok = false
@@ -80,42 +80,42 @@ to_write_flush_closer :: proc(s: Stream) -> (w: Write_Flush_Closer, ok: bool = t
 	return
 }
 
-to_reader_at :: proc(s: Stream) -> (r: Reader_At, ok: bool = true) #optional_ok {
+to_reader_at :: proc "contextless" (s: Stream) -> (r: Reader_At, ok: bool = true) #optional_ok {
 	r.stream = s
 	if s.stream_vtable == nil || s.impl_read_at == nil {
 		ok = false
 	}
 	return
 }
-to_writer_at :: proc(s: Stream) -> (w: Writer_At, ok: bool = true) #optional_ok {
+to_writer_at :: proc "contextless" (s: Stream) -> (w: Writer_At, ok: bool = true) #optional_ok {
 	w.stream = s
 	if s.stream_vtable == nil || s.impl_write_at == nil {
 		ok = false
 	}
 	return
 }
-to_reader_from :: proc(s: Stream) -> (r: Reader_From, ok: bool = true) #optional_ok {
+to_reader_from :: proc "contextless" (s: Stream) -> (r: Reader_From, ok: bool = true) #optional_ok {
 	r.stream = s
 	if s.stream_vtable == nil || s.impl_read_from == nil {
 		ok = false
 	}
 	return
 }
-to_writer_to :: proc(s: Stream) -> (w: Writer_To, ok: bool = true) #optional_ok {
+to_writer_to :: proc "contextless" (s: Stream) -> (w: Writer_To, ok: bool = true) #optional_ok {
 	w.stream = s
 	if s.stream_vtable == nil || s.impl_write_to == nil {
 		ok = false
 	}
 	return
 }
-to_write_closer :: proc(s: Stream) -> (w: Write_Closer, ok: bool = true) #optional_ok {
+to_write_closer :: proc "contextless" (s: Stream) -> (w: Write_Closer, ok: bool = true) #optional_ok {
 	w.stream = s
 	if s.stream_vtable == nil || s.impl_write == nil || s.impl_close == nil {
 		ok = false
 	}
 	return
 }
-to_write_seeker :: proc(s: Stream) -> (w: Write_Seeker, ok: bool = true) #optional_ok {
+to_write_seeker :: proc "contextless" (s: Stream) -> (w: Write_Seeker, ok: bool = true) #optional_ok {
 	w.stream = s
 	if s.stream_vtable == nil || s.impl_write == nil || s.impl_seek == nil {
 		ok = false

--- a/core/math/bits/bits.odin
+++ b/core/math/bits/bits.odin
@@ -37,68 +37,68 @@ overflowing_sub :: intrinsics.overflow_sub
 overflowing_mul :: intrinsics.overflow_mul
 
 
-log2 :: proc(x: $T) -> T where intrinsics.type_is_integer(T), intrinsics.type_is_unsigned(T) {
+log2 :: proc "contextless" (x: $T) -> T where intrinsics.type_is_integer(T), intrinsics.type_is_unsigned(T) {
 	return (8*size_of(T)-1) - count_leading_zeros(x)
 }
 
-rotate_left8 :: proc(x: u8,  k: int) -> u8 {
+rotate_left8 :: proc "contextless" (x: u8,  k: int) -> u8 {
 	n :: 8
 	s := uint(k) & (n-1)
 	return x <<s | x>>(n-s)
 }
-rotate_left16 :: proc(x: u16, k: int) -> u16 {
+rotate_left16 :: proc "contextless" (x: u16, k: int) -> u16 {
 	n :: 16
 	s := uint(k) & (n-1)
 	return x <<s | x>>(n-s)
 }
-rotate_left32 :: proc(x: u32, k: int) -> u32 {
+rotate_left32 :: proc "contextless" (x: u32, k: int) -> u32 {
 	n :: 32
 	s := uint(k) & (n-1)
 	return x <<s | x>>(n-s)
 }
-rotate_left64 :: proc(x: u64, k: int) -> u64 {
+rotate_left64 :: proc "contextless" (x: u64, k: int) -> u64 {
 	n :: 64
 	s := uint(k) & (n-1)
 	return x <<s | x>>(n-s)
 }
 
-rotate_left :: proc(x: uint, k: int) -> uint {
+rotate_left :: proc "contextless" (x: uint, k: int) -> uint {
 	n :: 8*size_of(uint)
 	s := uint(k) & (n-1)
 	return x <<s | x>>(n-s)
 }
 
-from_be_u8   :: proc(i:   u8) ->   u8 { return i }
-from_be_u16  :: proc(i:  u16) ->  u16 { when ODIN_ENDIAN == .Big { return i } else { return byte_swap(i) } }
-from_be_u32  :: proc(i:  u32) ->  u32 { when ODIN_ENDIAN == .Big { return i } else { return byte_swap(i) } }
-from_be_u64  :: proc(i:  u64) ->  u64 { when ODIN_ENDIAN == .Big { return i } else { return byte_swap(i) } }
-from_be_uint :: proc(i: uint) -> uint { when ODIN_ENDIAN == .Big { return i } else { return byte_swap(i) } }
+from_be_u8   :: proc "contextless" (i:   u8) ->   u8 { return i }
+from_be_u16  :: proc "contextless" (i:  u16) ->  u16 { when ODIN_ENDIAN == .Big { return i } else { return byte_swap(i) } }
+from_be_u32  :: proc "contextless" (i:  u32) ->  u32 { when ODIN_ENDIAN == .Big { return i } else { return byte_swap(i) } }
+from_be_u64  :: proc "contextless" (i:  u64) ->  u64 { when ODIN_ENDIAN == .Big { return i } else { return byte_swap(i) } }
+from_be_uint :: proc "contextless" (i: uint) -> uint { when ODIN_ENDIAN == .Big { return i } else { return byte_swap(i) } }
 
-from_le_u8   :: proc(i:   u8) ->   u8 { return i }
-from_le_u16  :: proc(i:  u16) ->  u16 { when ODIN_ENDIAN == .Little { return i } else { return byte_swap(i) } }
-from_le_u32  :: proc(i:  u32) ->  u32 { when ODIN_ENDIAN == .Little { return i } else { return byte_swap(i) } }
-from_le_u64  :: proc(i:  u64) ->  u64 { when ODIN_ENDIAN == .Little { return i } else { return byte_swap(i) } }
-from_le_uint :: proc(i: uint) -> uint { when ODIN_ENDIAN == .Little { return i } else { return byte_swap(i) } }
+from_le_u8   :: proc "contextless" (i:   u8) ->   u8 { return i }
+from_le_u16  :: proc "contextless" (i:  u16) ->  u16 { when ODIN_ENDIAN == .Little { return i } else { return byte_swap(i) } }
+from_le_u32  :: proc "contextless" (i:  u32) ->  u32 { when ODIN_ENDIAN == .Little { return i } else { return byte_swap(i) } }
+from_le_u64  :: proc "contextless" (i:  u64) ->  u64 { when ODIN_ENDIAN == .Little { return i } else { return byte_swap(i) } }
+from_le_uint :: proc "contextless" (i: uint) -> uint { when ODIN_ENDIAN == .Little { return i } else { return byte_swap(i) } }
 
-to_be_u8   :: proc(i:   u8) ->   u8 { return i }
-to_be_u16  :: proc(i:  u16) ->  u16 { when ODIN_ENDIAN == .Big { return i } else { return byte_swap(i) } }
-to_be_u32  :: proc(i:  u32) ->  u32 { when ODIN_ENDIAN == .Big { return i } else { return byte_swap(i) } }
-to_be_u64  :: proc(i:  u64) ->  u64 { when ODIN_ENDIAN == .Big { return i } else { return byte_swap(i) } }
-to_be_uint :: proc(i: uint) -> uint { when ODIN_ENDIAN == .Big { return i } else { return byte_swap(i) } }
-
-
-to_le_u8   :: proc(i:   u8) ->   u8 { return i }
-to_le_u16  :: proc(i:  u16) ->  u16 { when ODIN_ENDIAN == .Little { return i } else { return byte_swap(i) } }
-to_le_u32  :: proc(i:  u32) ->  u32 { when ODIN_ENDIAN == .Little { return i } else { return byte_swap(i) } }
-to_le_u64  :: proc(i:  u64) ->  u64 { when ODIN_ENDIAN == .Little { return i } else { return byte_swap(i) } }
-to_le_uint :: proc(i: uint) -> uint { when ODIN_ENDIAN == .Little { return i } else { return byte_swap(i) } }
+to_be_u8   :: proc "contextless" (i:   u8) ->   u8 { return i }
+to_be_u16  :: proc "contextless" (i:  u16) ->  u16 { when ODIN_ENDIAN == .Big { return i } else { return byte_swap(i) } }
+to_be_u32  :: proc "contextless" (i:  u32) ->  u32 { when ODIN_ENDIAN == .Big { return i } else { return byte_swap(i) } }
+to_be_u64  :: proc "contextless" (i:  u64) ->  u64 { when ODIN_ENDIAN == .Big { return i } else { return byte_swap(i) } }
+to_be_uint :: proc "contextless" (i: uint) -> uint { when ODIN_ENDIAN == .Big { return i } else { return byte_swap(i) } }
 
 
+to_le_u8   :: proc "contextless" (i:   u8) ->   u8 { return i }
+to_le_u16  :: proc "contextless" (i:  u16) ->  u16 { when ODIN_ENDIAN == .Little { return i } else { return byte_swap(i) } }
+to_le_u32  :: proc "contextless" (i:  u32) ->  u32 { when ODIN_ENDIAN == .Little { return i } else { return byte_swap(i) } }
+to_le_u64  :: proc "contextless" (i:  u64) ->  u64 { when ODIN_ENDIAN == .Little { return i } else { return byte_swap(i) } }
+to_le_uint :: proc "contextless" (i: uint) -> uint { when ODIN_ENDIAN == .Little { return i } else { return byte_swap(i) } }
 
-len_u8 :: proc(x: u8) -> int {
+
+
+len_u8 :: proc "contextless" (x: u8) -> int {
 	return int(len_u8_table[x])
 }
-len_u16 :: proc(x: u16) -> (n: int) {
+len_u16 :: proc "contextless" (x: u16) -> (n: int) {
 	x := x
 	if x >= 1<<8 {
 		x >>= 8
@@ -106,7 +106,7 @@ len_u16 :: proc(x: u16) -> (n: int) {
 	}
 	return n + int(len_u8_table[x])
 }
-len_u32 :: proc(x: u32) -> (n: int) {
+len_u32 :: proc "contextless" (x: u32) -> (n: int) {
 	x := x
 	if x >= 1<<16 {
 		x >>= 16
@@ -118,7 +118,7 @@ len_u32 :: proc(x: u32) -> (n: int) {
 	}
 	return n + int(len_u8_table[x])
 }
-len_u64 :: proc(x: u64) -> (n: int) {
+len_u64 :: proc "contextless" (x: u64) -> (n: int) {
 	x := x
 	if x >= 1<<32 {
 		x >>= 32
@@ -134,7 +134,7 @@ len_u64 :: proc(x: u64) -> (n: int) {
 	}
 	return n + int(len_u8_table[x])
 }
-len_uint :: proc(x: uint) -> (n: int) {
+len_uint :: proc "contextless" (x: uint) -> (n: int) {
 	when size_of(uint) == size_of(u64) {
 		return len_u64(u64(x))
 	} else {
@@ -146,21 +146,21 @@ len_uint :: proc(x: uint) -> (n: int) {
 len :: proc{len_u8, len_u16, len_u32, len_u64, len_uint}
 
 
-add_u32 :: proc(x, y, carry: u32) -> (sum, carry_out: u32) {
+add_u32 :: proc "contextless" (x, y, carry: u32) -> (sum, carry_out: u32) {
 	tmp_carry, tmp_carry2: bool
 	sum, tmp_carry = intrinsics.overflow_add(x, y)
 	sum, tmp_carry2 = intrinsics.overflow_add(sum, carry)
 	carry_out = u32(tmp_carry | tmp_carry2)
 	return
 }
-add_u64 :: proc(x, y, carry: u64) -> (sum, carry_out: u64) {
+add_u64 :: proc "contextless" (x, y, carry: u64) -> (sum, carry_out: u64) {
 	tmp_carry, tmp_carry2: bool
 	sum, tmp_carry = intrinsics.overflow_add(x, y)
 	sum, tmp_carry2 = intrinsics.overflow_add(sum, carry)
 	carry_out = u64(tmp_carry | tmp_carry2)
 	return
 }
-add_uint :: proc(x, y, carry: uint) -> (sum, carry_out: uint) {
+add_uint :: proc "contextless" (x, y, carry: uint) -> (sum, carry_out: uint) {
 	when size_of(uint) == size_of(u64) {
 		a, b := add_u64(u64(x), u64(y), u64(carry))
 	} else {
@@ -172,21 +172,21 @@ add_uint :: proc(x, y, carry: uint) -> (sum, carry_out: uint) {
 add :: proc{add_u32, add_u64, add_uint}
 
 
-sub_u32 :: proc(x, y, borrow: u32) -> (diff, borrow_out: u32) {
+sub_u32 :: proc "contextless" (x, y, borrow: u32) -> (diff, borrow_out: u32) {
 	tmp_borrow, tmp_borrow2: bool
 	diff, tmp_borrow = intrinsics.overflow_sub(x, y)
 	diff, tmp_borrow2 = intrinsics.overflow_sub(diff, borrow)
 	borrow_out = u32(tmp_borrow | tmp_borrow2)
 	return
 }
-sub_u64 :: proc(x, y, borrow: u64) -> (diff, borrow_out: u64) {
+sub_u64 :: proc "contextless" (x, y, borrow: u64) -> (diff, borrow_out: u64) {
 	tmp_borrow, tmp_borrow2: bool
 	diff, tmp_borrow = intrinsics.overflow_sub(x, y)
 	diff, tmp_borrow2 = intrinsics.overflow_sub(diff, borrow)
 	borrow_out = u64(tmp_borrow | tmp_borrow2)
 	return
 }
-sub_uint :: proc(x, y, borrow: uint) -> (diff, borrow_out: uint) {
+sub_uint :: proc "contextless" (x, y, borrow: uint) -> (diff, borrow_out: uint) {
 	when size_of(uint) == size_of(u64) {
 		a, b := sub_u64(u64(x), u64(y), u64(borrow))
 	} else {
@@ -198,18 +198,18 @@ sub_uint :: proc(x, y, borrow: uint) -> (diff, borrow_out: uint) {
 sub :: proc{sub_u32, sub_u64, sub_uint}
 
 
-mul_u32 :: proc(x, y: u32) -> (hi, lo: u32) {
+mul_u32 :: proc "contextless" (x, y: u32) -> (hi, lo: u32) {
 	z := u64(x) * u64(y)
 	hi, lo = u32(z>>32), u32(z)
 	return
 }
-mul_u64 :: proc(x, y: u64) -> (hi, lo: u64) {
+mul_u64 :: proc "contextless" (x, y: u64) -> (hi, lo: u64) {
 	prod_wide := u128(x) * u128(y)
 	hi, lo = u64(prod_wide>>64), u64(prod_wide)
 	return
 }
 
-mul_uint :: proc(x, y: uint) -> (hi, lo: uint) {
+mul_uint :: proc "contextless" (x, y: uint) -> (hi, lo: uint) {
 	when size_of(uint) == size_of(u32) {
 		a, b := mul_u32(u32(x), u32(y))
 	} else {
@@ -286,16 +286,16 @@ div :: proc{div_u32, div_u64, div_uint}
 
 
 
-is_power_of_two_u8   :: proc(i:   u8) -> bool { return i > 0 && (i & (i-1)) == 0 }
-is_power_of_two_i8   :: proc(i:   i8) -> bool { return i > 0 && (i & (i-1)) == 0 }
-is_power_of_two_u16  :: proc(i:  u16) -> bool { return i > 0 && (i & (i-1)) == 0 }
-is_power_of_two_i16  :: proc(i:  i16) -> bool { return i > 0 && (i & (i-1)) == 0 }
-is_power_of_two_u32  :: proc(i:  u32) -> bool { return i > 0 && (i & (i-1)) == 0 }
-is_power_of_two_i32  :: proc(i:  i32) -> bool { return i > 0 && (i & (i-1)) == 0 }
-is_power_of_two_u64  :: proc(i:  u64) -> bool { return i > 0 && (i & (i-1)) == 0 }
-is_power_of_two_i64  :: proc(i:  i64) -> bool { return i > 0 && (i & (i-1)) == 0 }
-is_power_of_two_uint :: proc(i: uint) -> bool { return i > 0 && (i & (i-1)) == 0 }
-is_power_of_two_int  :: proc(i:  int) -> bool { return i > 0 && (i & (i-1)) == 0 }
+is_power_of_two_u8   :: proc "contextless" (i:   u8) -> bool { return i > 0 && (i & (i-1)) == 0 }
+is_power_of_two_i8   :: proc "contextless" (i:   i8) -> bool { return i > 0 && (i & (i-1)) == 0 }
+is_power_of_two_u16  :: proc "contextless" (i:  u16) -> bool { return i > 0 && (i & (i-1)) == 0 }
+is_power_of_two_i16  :: proc "contextless" (i:  i16) -> bool { return i > 0 && (i & (i-1)) == 0 }
+is_power_of_two_u32  :: proc "contextless" (i:  u32) -> bool { return i > 0 && (i & (i-1)) == 0 }
+is_power_of_two_i32  :: proc "contextless" (i:  i32) -> bool { return i > 0 && (i & (i-1)) == 0 }
+is_power_of_two_u64  :: proc "contextless" (i:  u64) -> bool { return i > 0 && (i & (i-1)) == 0 }
+is_power_of_two_i64  :: proc "contextless" (i:  i64) -> bool { return i > 0 && (i & (i-1)) == 0 }
+is_power_of_two_uint :: proc "contextless" (i: uint) -> bool { return i > 0 && (i & (i-1)) == 0 }
+is_power_of_two_int  :: proc "contextless" (i:  int) -> bool { return i > 0 && (i & (i-1)) == 0 }
 
 is_power_of_two :: proc{
 	is_power_of_two_u8,   is_power_of_two_i8,
@@ -320,44 +320,44 @@ len_u8_table := [256]u8{
 }
 
 
-bitfield_extract_u8   :: proc(value:   u8, offset, bits: uint) ->   u8 { return (value >> offset) &   u8(1<<bits - 1) }
-bitfield_extract_u16  :: proc(value:  u16, offset, bits: uint) ->  u16 { return (value >> offset) &  u16(1<<bits - 1) }
-bitfield_extract_u32  :: proc(value:  u32, offset, bits: uint) ->  u32 { return (value >> offset) &  u32(1<<bits - 1) }
-bitfield_extract_u64  :: proc(value:  u64, offset, bits: uint) ->  u64 { return (value >> offset) &  u64(1<<bits - 1) }
-bitfield_extract_u128 :: proc(value: u128, offset, bits: uint) -> u128 { return (value >> offset) & u128(1<<bits - 1) }
-bitfield_extract_uint :: proc(value: uint, offset, bits: uint) -> uint { return (value >> offset) & uint(1<<bits - 1) }
+bitfield_extract_u8   :: proc "contextless" (value:   u8, offset, bits: uint) ->   u8 { return (value >> offset) &   u8(1<<bits - 1) }
+bitfield_extract_u16  :: proc "contextless" (value:  u16, offset, bits: uint) ->  u16 { return (value >> offset) &  u16(1<<bits - 1) }
+bitfield_extract_u32  :: proc "contextless" (value:  u32, offset, bits: uint) ->  u32 { return (value >> offset) &  u32(1<<bits - 1) }
+bitfield_extract_u64  :: proc "contextless" (value:  u64, offset, bits: uint) ->  u64 { return (value >> offset) &  u64(1<<bits - 1) }
+bitfield_extract_u128 :: proc "contextless" (value: u128, offset, bits: uint) -> u128 { return (value >> offset) & u128(1<<bits - 1) }
+bitfield_extract_uint :: proc "contextless" (value: uint, offset, bits: uint) -> uint { return (value >> offset) & uint(1<<bits - 1) }
 
-bitfield_extract_i8 :: proc(value: i8, offset, bits: uint) -> i8 {
+bitfield_extract_i8 :: proc "contextless" (value: i8, offset, bits: uint) -> i8 {
 	v := (u8(value) >> offset) & u8(1<<bits - 1)
 	m := u8(1<<(bits-1))
 	r := (v~m) - m
 	return i8(r)
 }
-bitfield_extract_i16 :: proc(value: i16, offset, bits: uint) -> i16 {
+bitfield_extract_i16 :: proc "contextless" (value: i16, offset, bits: uint) -> i16 {
 	v := (u16(value) >> offset) & u16(1<<bits - 1)
 	m := u16(1<<(bits-1))
 	r := (v~m) - m
 	return i16(r)
 }
-bitfield_extract_i32 :: proc(value: i32, offset, bits: uint) -> i32 {
+bitfield_extract_i32 :: proc "contextless" (value: i32, offset, bits: uint) -> i32 {
 	v := (u32(value) >> offset) & u32(1<<bits - 1)
 	m := u32(1<<(bits-1))
 	r := (v~m) - m
 	return i32(r)
 }
-bitfield_extract_i64 :: proc(value: i64, offset, bits: uint) -> i64 {
+bitfield_extract_i64 :: proc "contextless" (value: i64, offset, bits: uint) -> i64 {
 	v := (u64(value) >> offset) & u64(1<<bits - 1)
 	m := u64(1<<(bits-1))
 	r := (v~m) - m
 	return i64(r)
 }
-bitfield_extract_i128 :: proc(value: i128, offset, bits: uint) -> i128 {
+bitfield_extract_i128 :: proc "contextless" (value: i128, offset, bits: uint) -> i128 {
 	v := (u128(value) >> offset) & u128(1<<bits - 1)
 	m := u128(1<<(bits-1))
 	r := (v~m) - m
 	return i128(r)
 }
-bitfield_extract_int :: proc(value: int, offset, bits: uint) -> int {
+bitfield_extract_int :: proc "contextless" (value: int, offset, bits: uint) -> int {
 	v := (uint(value) >> offset) & uint(1<<bits - 1)
 	m := uint(1<<(bits-1))
 	r := (v~m) - m
@@ -381,52 +381,52 @@ bitfield_extract :: proc{
 }
 
 
-bitfield_insert_u8 :: proc(base, insert: u8, offset, bits: uint) -> u8 {
+bitfield_insert_u8 :: proc "contextless" (base, insert: u8, offset, bits: uint) -> u8 {
 	mask := u8(1<<bits - 1)
 	return (base &~ (mask<<offset)) | ((insert&mask) << offset)
 }
-bitfield_insert_u16 :: proc(base, insert: u16, offset, bits: uint) -> u16 {
+bitfield_insert_u16 :: proc "contextless" (base, insert: u16, offset, bits: uint) -> u16 {
 	mask := u16(1<<bits - 1)
 	return (base &~ (mask<<offset)) | ((insert&mask) << offset)
 }
-bitfield_insert_u32 :: proc(base, insert: u32, offset, bits: uint) -> u32 {
+bitfield_insert_u32 :: proc "contextless" (base, insert: u32, offset, bits: uint) -> u32 {
 	mask := u32(1<<bits - 1)
 	return (base &~ (mask<<offset)) | ((insert&mask) << offset)
 }
-bitfield_insert_u64 :: proc(base, insert: u64, offset, bits: uint) -> u64 {
+bitfield_insert_u64 :: proc "contextless" (base, insert: u64, offset, bits: uint) -> u64 {
 	mask := u64(1<<bits - 1)
 	return (base &~ (mask<<offset)) | ((insert&mask) << offset)
 }
-bitfield_insert_u128 :: proc(base, insert: u128, offset, bits: uint) -> u128 {
+bitfield_insert_u128 :: proc "contextless" (base, insert: u128, offset, bits: uint) -> u128 {
 	mask := u128(1<<bits - 1)
 	return (base &~ (mask<<offset)) | ((insert&mask) << offset)
 }
-bitfield_insert_uint :: proc(base, insert: uint, offset, bits: uint) -> uint {
+bitfield_insert_uint :: proc "contextless" (base, insert: uint, offset, bits: uint) -> uint {
 	mask := uint(1<<bits - 1)
 	return (base &~ (mask<<offset)) | ((insert&mask) << offset)
 }
 
-bitfield_insert_i8 :: proc(base, insert: i8, offset, bits: uint) -> i8 {
+bitfield_insert_i8 :: proc "contextless" (base, insert: i8, offset, bits: uint) -> i8 {
 	mask := i8(1<<bits - 1)
 	return (base &~ (mask<<offset)) | ((insert&mask) << offset)
 }
-bitfield_insert_i16 :: proc(base, insert: i16, offset, bits: uint) -> i16 {
+bitfield_insert_i16 :: proc "contextless" (base, insert: i16, offset, bits: uint) -> i16 {
 	mask := i16(1<<bits - 1)
 	return (base &~ (mask<<offset)) | ((insert&mask) << offset)
 }
-bitfield_insert_i32 :: proc(base, insert: i32, offset, bits: uint) -> i32 {
+bitfield_insert_i32 :: proc "contextless" (base, insert: i32, offset, bits: uint) -> i32 {
 	mask := i32(1<<bits - 1)
 	return (base &~ (mask<<offset)) | ((insert&mask) << offset)
 }
-bitfield_insert_i64 :: proc(base, insert: i64, offset, bits: uint) -> i64 {
+bitfield_insert_i64 :: proc "contextless" (base, insert: i64, offset, bits: uint) -> i64 {
 	mask := i64(1<<bits - 1)
 	return (base &~ (mask<<offset)) | ((insert&mask) << offset)
 }
-bitfield_insert_i128 :: proc(base, insert: i128, offset, bits: uint) -> i128 {
+bitfield_insert_i128 :: proc "contextless" (base, insert: i128, offset, bits: uint) -> i128 {
 	mask := i128(1<<bits - 1)
 	return (base &~ (mask<<offset)) | ((insert&mask) << offset)
 }
-bitfield_insert_int :: proc(base, insert: int, offset, bits: uint) -> int {
+bitfield_insert_int :: proc "contextless" (base, insert: int, offset, bits: uint) -> int {
 	mask := int(1<<bits - 1)
 	return (base &~ (mask<<offset)) | ((insert&mask) << offset)
 }

--- a/core/math/ease/ease.odin
+++ b/core/math/ease/ease.odin
@@ -475,7 +475,7 @@ flux_update :: proc(flux: ^Flux_Map($T), dt: f64) where intrinsics.type_is_float
 
 // stop a specific key inside the map
 // returns true when it successfully removed the key
-flux_stop :: proc(flux: ^Flux_Map($T), key: ^T) -> bool where intrinsics.type_is_float(T) {
+flux_stop :: proc "contextless" (flux: ^Flux_Map($T), key: ^T) -> bool where intrinsics.type_is_float(T) {
 	if key in flux.values {
 		delete_key(&flux.values, key)
 		return true
@@ -486,7 +486,7 @@ flux_stop :: proc(flux: ^Flux_Map($T), key: ^T) -> bool where intrinsics.type_is
 
 // returns the amount of time left for the tween animation, if the key exists in the map
 // returns 0 if the tween doesnt exist on the map
-flux_tween_time_left :: proc(flux: Flux_Map($T), key: ^T) -> f64 {
+flux_tween_time_left :: proc "contextless" (flux: Flux_Map($T), key: ^T) -> f64 {
 	if tween, ok := flux.values[key]; ok {
 		return ((1 - tween.progress) * tween.rate) + tween.delay
 	} else {

--- a/core/math/fixed/fixed.odin
+++ b/core/math/fixed/fixed.odin
@@ -28,7 +28,7 @@ Fixed32_32 :: distinct Fixed(i64, 32)
 Fixed52_12 :: distinct Fixed(i64, 12)
 
 
-init_from_f64 :: proc(x: ^$T/Fixed($Backing, $Fraction_Width), val: f64) {
+init_from_f64 :: proc "contextless" (x: ^$T/Fixed($Backing, $Fraction_Width), val: f64) {
 	i, f := math.modf(val)
 	x.i  = Backing(f * (1<<Fraction_Width))
 	x.i &= 1<<Fraction_Width - 1
@@ -36,61 +36,61 @@ init_from_f64 :: proc(x: ^$T/Fixed($Backing, $Fraction_Width), val: f64) {
 }
 
 
-init_from_parts :: proc(x: ^$T/Fixed($Backing, $Fraction_Width), integer, fraction: Backing) {
+init_from_parts :: proc "contextless" (x: ^$T/Fixed($Backing, $Fraction_Width), integer, fraction: Backing) {
 	i, f := math.modf(val)
 	x.i  = fraction
 	x.i &= 1<<Fraction_Width - 1
 	x.i |= integer
 }
 
-to_f64 :: proc(x: $T/Fixed($Backing, $Fraction_Width)) -> f64 {
+to_f64 :: proc "contextless" (x: $T/Fixed($Backing, $Fraction_Width)) -> f64 {
 	res := f64(x.i >> Fraction_Width)
 	res += f64(x.i & (1<<Fraction_Width-1)) / f64(1<<Fraction_Width)
 	return res
 }
 
 
-add :: proc(x, y: $T/Fixed) -> T {
+add :: proc "contextless" (x, y: $T/Fixed) -> T {
 	return {x.i + y.i}
 }
-sub :: proc(x, y: $T/Fixed) -> T {
+sub :: proc "contextless" (x, y: $T/Fixed) -> T {
 	return {x.i - y.i}
 }
 
-mul :: proc(x, y: $T/Fixed($Backing, $Fraction_Width)) -> (z: T) {
+mul :: proc "contextless" (x, y: $T/Fixed($Backing, $Fraction_Width)) -> (z: T) {
 	z.i = intrinsics.fixed_point_mul(x.i, y.i, Fraction_Width)
 	return
 }
-mul_sat :: proc(x, y: $T/Fixed($Backing, $Fraction_Width)) -> (z: T) {
+mul_sat :: proc "contextless" (x, y: $T/Fixed($Backing, $Fraction_Width)) -> (z: T) {
 	z.i = intrinsics.fixed_point_mul_sat(x.i, y.i, Fraction_Width)
 	return
 }
 
-div :: proc(x, y: $T/Fixed($Backing, $Fraction_Width)) -> (z: T) {
+div :: proc "contextless" (x, y: $T/Fixed($Backing, $Fraction_Width)) -> (z: T) {
 	z.i = intrinsics.fixed_point_div(x.i, y.i, Fraction_Width)
 	return
 }
-div_sat :: proc(x, y: $T/Fixed($Backing, $Fraction_Width)) -> (z: T) {
+div_sat :: proc "contextless" (x, y: $T/Fixed($Backing, $Fraction_Width)) -> (z: T) {
 	z.i = intrinsics.fixed_point_div_sat(x.i, y.i, Fraction_Width)
 	return
 }
 
 
-floor :: proc(x: $T/Fixed($Backing, $Fraction_Width)) -> Backing {
+floor :: proc "contextless" (x: $T/Fixed($Backing, $Fraction_Width)) -> Backing {
 	return x.i >> Fraction_Width
 }
-ceil :: proc(x: $T/Fixed($Backing, $Fraction_Width)) -> Backing {
+ceil :: proc "contextless" (x: $T/Fixed($Backing, $Fraction_Width)) -> Backing {
 	Integer :: 8*size_of(Backing) - Fraction_Width
 	return (x.i + (1 << Integer-1)) >> Fraction_Width
 }
-round :: proc(x: $T/Fixed($Backing, $Fraction_Width)) -> Backing {
+round :: proc "contextless" (x: $T/Fixed($Backing, $Fraction_Width)) -> Backing {
 	Integer :: 8*size_of(Backing) - Fraction_Width
 	return (x.i + (1 << (Integer - 1))) >> Fraction_Width
 }
 
 
 
-append :: proc(dst: []byte, x: $T/Fixed($Backing, $Fraction_Width)) -> string {
+append :: proc "contextless" (dst: []byte, x: $T/Fixed($Backing, $Fraction_Width)) -> string {
 	x := x
 	buf: [48]byte
 	i := 0

--- a/core/math/linalg/extended.odin
+++ b/core/math/linalg/extended.odin
@@ -3,7 +3,7 @@ package linalg
 import "core:builtin"
 import "core:math"
 
-radians :: proc(degrees: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
+radians :: proc "contextless" (degrees: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = degrees * RAD_PER_DEG
@@ -13,7 +13,7 @@ radians :: proc(degrees: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
 	}
 	return
 }
-degrees :: proc(radians: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
+degrees :: proc "contextless" (radians: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = radians * DEG_PER_RAD
@@ -24,7 +24,7 @@ degrees :: proc(radians: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
 	return
 }
 
-min_double :: proc(a, b: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
+min_double :: proc "contextless" (a, b: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = builtin.min(a[i], b[i])
@@ -35,7 +35,7 @@ min_double :: proc(a, b: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
 	return
 }
 
-min_single :: proc(a: $T) -> (out: ELEM_TYPE(T)) where IS_NUMERIC(ELEM_TYPE(T)) {
+min_single :: proc "contextless" (a: $T) -> (out: ELEM_TYPE(T)) where IS_NUMERIC(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		N :: len(T)
 
@@ -55,13 +55,13 @@ min_single :: proc(a: $T) -> (out: ELEM_TYPE(T)) where IS_NUMERIC(ELEM_TYPE(T)) 
 	return
 }
 
-min_triple :: proc(a, b, c: $T) -> T where IS_NUMERIC(ELEM_TYPE(T)) {
+min_triple :: proc "contextless" (a, b, c: $T) -> T where IS_NUMERIC(ELEM_TYPE(T)) {
 	return min_double(a, min_double(b, c))
 }
 
 min :: proc{min_single, min_double, min_triple}
 
-max_double :: proc(a, b: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
+max_double :: proc "contextless" (a, b: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = builtin.max(a[i], b[i])
@@ -72,7 +72,7 @@ max_double :: proc(a, b: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
 	return
 }
 
-max_single :: proc(a: $T) -> (out: ELEM_TYPE(T)) where IS_NUMERIC(ELEM_TYPE(T)) {
+max_single :: proc "contextless" (a: $T) -> (out: ELEM_TYPE(T)) where IS_NUMERIC(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		N :: len(T)
 
@@ -94,13 +94,13 @@ max_single :: proc(a: $T) -> (out: ELEM_TYPE(T)) where IS_NUMERIC(ELEM_TYPE(T)) 
 	return
 }
 
-max_triple :: proc(a, b, c: $T) -> T where IS_NUMERIC(ELEM_TYPE(T)) {
+max_triple :: proc "contextless" (a, b, c: $T) -> T where IS_NUMERIC(ELEM_TYPE(T)) {
 	return max_double(a, max_double(b, c))
 }
 
 max :: proc{max_single, max_double, max_triple}
 
-abs :: proc(a: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
+abs :: proc "contextless" (a: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = auto_cast builtin.abs(a[i])
@@ -111,7 +111,7 @@ abs :: proc(a: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
 	return
 }
 
-sign :: proc(a: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
+sign :: proc "contextless" (a: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = #force_inline math.sign(a[i])
@@ -122,7 +122,7 @@ sign :: proc(a: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
 	return
 }
 
-clamp :: proc(x, a, b: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
+clamp :: proc "contextless" (x, a, b: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = builtin.clamp(x[i], a[i], b[i])
@@ -134,11 +134,11 @@ clamp :: proc(x, a, b: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
 }
 
 
-saturate :: proc(x: $T) -> T where IS_FLOAT(ELEM_TYPE(T)) {
+saturate :: proc "contextless" (x: $T) -> T where IS_FLOAT(ELEM_TYPE(T)) {
 	return clamp(x, 0.0, 1.0)
 }
 
-lerp :: proc(a, b, t: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+lerp :: proc "contextless" (a, b, t: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = a[i]*(1-t[i]) + b[i]*t[i]
@@ -148,7 +148,7 @@ lerp :: proc(a, b, t: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	}
 	return
 }
-mix :: proc(a, b, t: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+mix :: proc "contextless" (a, b, t: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = a[i]*(1-t[i]) + b[i]*t[i]
@@ -159,11 +159,11 @@ mix :: proc(a, b, t: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	return
 }
 
-unlerp :: proc(a, b, x: $T) -> T where IS_FLOAT(ELEM_TYPE(T)) {
+unlerp :: proc "contextless" (a, b, x: $T) -> T where IS_FLOAT(ELEM_TYPE(T)) {
 	return (x - a) / (b - a)
 }
 
-step :: proc(e, x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+step :: proc "contextless" (e, x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = x[i] < e[i] ? 0.0 : 1.0
@@ -174,18 +174,18 @@ step :: proc(e, x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	return
 }
 
-smoothstep :: proc(e0, e1, x: $T) -> T where IS_FLOAT(ELEM_TYPE(T)) {
+smoothstep :: proc "contextless" (e0, e1, x: $T) -> T where IS_FLOAT(ELEM_TYPE(T)) {
 	t := saturate(unlerp(e0, e1, x))
 	return t * t * (3.0 - 2.0 * t)
 }
 
-smootherstep :: proc(e0, e1, x: $T) -> T where IS_FLOAT(ELEM_TYPE(T)) {
+smootherstep :: proc "contextless" (e0, e1, x: $T) -> T where IS_FLOAT(ELEM_TYPE(T)) {
 	t := saturate(unlerp(e0, e1, x))
 	return t * t * t * (t * (6*t - 15) + 10)
 }
 
 
-sqrt :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+sqrt :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = math.sqrt(x[i])
@@ -196,7 +196,7 @@ sqrt :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	return
 }
 
-inverse_sqrt :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+inverse_sqrt :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = 1.0/math.sqrt(x[i])
@@ -207,7 +207,7 @@ inverse_sqrt :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	return
 }
 
-cos :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+cos :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = math.cos(x[i])
@@ -218,7 +218,7 @@ cos :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	return
 }
 
-sin :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+sin :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = math.sin(x[i])
@@ -229,7 +229,7 @@ sin :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	return
 }
 
-tan :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+tan :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = math.tan(x[i])
@@ -240,7 +240,7 @@ tan :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	return
 }
 
-acos :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+acos :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = math.acos(x[i])
@@ -251,7 +251,7 @@ acos :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	return
 }
 
-asin :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+asin :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = math.asin(x[i])
@@ -262,7 +262,7 @@ asin :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	return
 }
 
-atan :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+atan :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = math.atan(x[i])
@@ -272,7 +272,7 @@ atan :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	}
 	return
 }
-atan2 :: proc(y, x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+atan2 :: proc "contextless" (y, x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = math.atan2(y[i], x[i])
@@ -284,7 +284,7 @@ atan2 :: proc(y, x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 }
 
 
-ln :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+ln :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = math.ln(x[i])
@@ -295,7 +295,7 @@ ln :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	return
 }
 
-log2 :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+log2 :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = INVLN2 * math.ln(x[i])
@@ -306,7 +306,7 @@ log2 :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	return
 }
 
-log10 :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+log10 :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = INVLN10 * math.ln(x[i])
@@ -317,7 +317,7 @@ log10 :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	return
 }
 
-log :: proc(x, b: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+log :: proc "contextless" (x, b: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = math.ln(x[i]) / math.ln(cast(ELEM_TYPE(T))b[i])
@@ -328,7 +328,7 @@ log :: proc(x, b: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	return
 }
 
-exp :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+exp :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = math.exp(x[i])
@@ -339,7 +339,7 @@ exp :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	return
 }
 
-exp2 :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+exp2 :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = math.exp(LN2 * x[i])
@@ -350,7 +350,7 @@ exp2 :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	return
 }
 
-exp10 :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+exp10 :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = math.exp(LN10 * x[i])
@@ -361,7 +361,7 @@ exp10 :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	return
 }
 
-pow :: proc(x, e: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+pow :: proc "contextless" (x, e: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = math.pow(x[i], e[i])
@@ -373,7 +373,7 @@ pow :: proc(x, e: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 }
 
 
-ceil :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+ceil :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = #force_inline math.ceil(x[i])
@@ -384,7 +384,7 @@ ceil :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	return
 }
 
-floor :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+floor :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = #force_inline math.floor(x[i])
@@ -395,7 +395,7 @@ floor :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	return
 }
 
-round :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
+round :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	when IS_ARRAY(T) {
 		for i in 0..<len(T) {
 			out[i] = #force_inline math.round(x[i])
@@ -406,30 +406,30 @@ round :: proc(x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 	return
 }
 
-fract :: proc(x: $T) -> T where IS_FLOAT(ELEM_TYPE(T)) {
+fract :: proc "contextless" (x: $T) -> T where IS_FLOAT(ELEM_TYPE(T)) {
 	f := #force_inline floor(x)
 	return x - f
 }
 
-mod :: proc(x, m: $T) -> T where IS_FLOAT(ELEM_TYPE(T)) {
+mod :: proc "contextless" (x, m: $T) -> T where IS_FLOAT(ELEM_TYPE(T)) {
 	f := #force_inline floor(x / m)
 	return x - f * m
 }
 
 
-face_forward :: proc(N, I, N_ref: $T) -> (out: T) where IS_ARRAY(T), IS_FLOAT(ELEM_TYPE(T)) {
+face_forward :: proc "contextless" (N, I, N_ref: $T) -> (out: T) where IS_ARRAY(T), IS_FLOAT(ELEM_TYPE(T)) {
 	return dot(N_ref, I) < 0 ? N : -N
 }
 
-distance :: proc(p0, p1: $V/[$N]$E) -> E where IS_NUMERIC(E) {
+distance :: proc "contextless" (p0, p1: $V/[$N]$E) -> E where IS_NUMERIC(E) {
 	return length(p1 - p0)
 }
 
-reflect :: proc(I, N: $T) -> (out: T) where IS_ARRAY(T), IS_FLOAT(ELEM_TYPE(T)) {
+reflect :: proc "contextless" (I, N: $T) -> (out: T) where IS_ARRAY(T), IS_FLOAT(ELEM_TYPE(T)) {
 	b := N * (2 * dot(N, I))
 	return I - b
 }
-refract :: proc(I, N: $T) -> (out: T) where IS_ARRAY(T), IS_FLOAT(ELEM_TYPE(T)) {
+refract :: proc "contextless" (I, N: $T) -> (out: T) where IS_ARRAY(T), IS_FLOAT(ELEM_TYPE(T)) {
 	dv := dot(N, I)
 	k := 1 - eta*eta - (1 - dv*dv)
 	a := I * eta
@@ -440,33 +440,33 @@ refract :: proc(I, N: $T) -> (out: T) where IS_ARRAY(T), IS_FLOAT(ELEM_TYPE(T)) 
 
 
 
-is_nan_single :: proc(x: $T) -> bool where IS_FLOAT(T) {
+is_nan_single :: proc "contextless" (x: $T) -> bool where IS_FLOAT(T) {
 	return #force_inline math.is_nan(x)
 }
 
-is_nan_array :: proc(x: $A/[$N]$T) -> (out: [N]bool) where IS_FLOAT(T) {
+is_nan_array :: proc "contextless" (x: $A/[$N]$T) -> (out: [N]bool) where IS_FLOAT(T) {
 	for i in 0..<N {
 		out[i] = #force_inline is_nan(x[i])
 	}
 	return
 }
 
-is_inf_single :: proc(x: $T) -> bool where IS_FLOAT(T) {
+is_inf_single :: proc "contextless" (x: $T) -> bool where IS_FLOAT(T) {
 	return #force_inline math.is_inf(x)
 }
 
-is_inf_array :: proc(x: $A/[$N]$T) -> (out: [N]bool) where IS_FLOAT(T) {
+is_inf_array :: proc "contextless" (x: $A/[$N]$T) -> (out: [N]bool) where IS_FLOAT(T) {
 	for i in 0..<N {
 		out[i] = #force_inline is_inf(x[i])
 	}
 	return
 }
 
-classify_single :: proc(x: $T) -> math.Float_Class where IS_FLOAT(T) {
+classify_single :: proc "contextless" (x: $T) -> math.Float_Class where IS_FLOAT(T) {
 	return #force_inline math.classify(x)
 }
 
-classify_array :: proc(x: $A/[$N]$T) -> (out: [N]math.Float_Class) where IS_FLOAT(T) {
+classify_array :: proc "contextless" (x: $A/[$N]$T) -> (out: [N]math.Float_Class) where IS_FLOAT(T) {
 	for i in 0..<N {
 		out[i] = #force_inline classify_single(x[i])
 	}
@@ -478,44 +478,44 @@ is_inf :: proc{is_inf_single, is_inf_array}
 classify :: proc{classify_single, classify_array}
 
 
-less_than_single          :: proc(x, y: $T) -> (out: bool) where !IS_ARRAY(T), IS_FLOAT(T) { return x < y }
-less_than_equal_single    :: proc(x, y: $T) -> (out: bool) where !IS_ARRAY(T), IS_FLOAT(T) { return x <= y }
-greater_than_single       :: proc(x, y: $T) -> (out: bool) where !IS_ARRAY(T), IS_FLOAT(T) { return x > y }
-greater_than_equal_single :: proc(x, y: $T) -> (out: bool) where !IS_ARRAY(T), IS_FLOAT(T) { return x >= y }
-equal_single              :: proc(x, y: $T) -> (out: bool) where !IS_ARRAY(T), IS_FLOAT(T) { return x == y }
-not_equal_single          :: proc(x, y: $T) -> (out: bool) where !IS_ARRAY(T), IS_FLOAT(T) { return x != y }
+less_than_single          :: proc "contextless" (x, y: $T) -> (out: bool) where !IS_ARRAY(T), IS_FLOAT(T) { return x < y }
+less_than_equal_single    :: proc "contextless" (x, y: $T) -> (out: bool) where !IS_ARRAY(T), IS_FLOAT(T) { return x <= y }
+greater_than_single       :: proc "contextless" (x, y: $T) -> (out: bool) where !IS_ARRAY(T), IS_FLOAT(T) { return x > y }
+greater_than_equal_single :: proc "contextless" (x, y: $T) -> (out: bool) where !IS_ARRAY(T), IS_FLOAT(T) { return x >= y }
+equal_single              :: proc "contextless" (x, y: $T) -> (out: bool) where !IS_ARRAY(T), IS_FLOAT(T) { return x == y }
+not_equal_single          :: proc "contextless" (x, y: $T) -> (out: bool) where !IS_ARRAY(T), IS_FLOAT(T) { return x != y }
 
-less_than_array :: proc(x, y: $A/[$N]$T) -> (out: [N]bool) where IS_ARRAY(A), IS_FLOAT(ELEM_TYPE(A)) {
+less_than_array :: proc "contextless" (x, y: $A/[$N]$T) -> (out: [N]bool) where IS_ARRAY(A), IS_FLOAT(ELEM_TYPE(A)) {
 	for i in 0..<N {
 		out[i] = x[i] < y[i]
 	}
 	return
 }
-less_than_equal_array :: proc(x, y: $A/[$N]$T) -> (out: [N]bool) where IS_ARRAY(A), IS_FLOAT(ELEM_TYPE(A)) {
+less_than_equal_array :: proc "contextless" (x, y: $A/[$N]$T) -> (out: [N]bool) where IS_ARRAY(A), IS_FLOAT(ELEM_TYPE(A)) {
 	for i in 0..<N {
 		out[i] = x[i] <= y[i]
 	}
 	return
 }
-greater_than_array :: proc(x, y: $A/[$N]$T) -> (out: [N]bool) where IS_ARRAY(A), IS_FLOAT(ELEM_TYPE(A)) {
+greater_than_array :: proc "contextless" (x, y: $A/[$N]$T) -> (out: [N]bool) where IS_ARRAY(A), IS_FLOAT(ELEM_TYPE(A)) {
 	for i in 0..<N {
 		out[i] = x[i] > y[i]
 	}
 	return
 }
-greater_than_equal_array :: proc(x, y: $A/[$N]$T) -> (out: [N]bool) where IS_ARRAY(A), IS_FLOAT(ELEM_TYPE(A)) {
+greater_than_equal_array :: proc "contextless" (x, y: $A/[$N]$T) -> (out: [N]bool) where IS_ARRAY(A), IS_FLOAT(ELEM_TYPE(A)) {
 	for i in 0..<N {
 		out[i] = x[i] >= y[i]
 	}
 	return
 }
-equal_array :: proc(x, y: $A/[$N]$T) -> (out: [N]bool) where IS_ARRAY(A), IS_FLOAT(ELEM_TYPE(A)) {
+equal_array :: proc "contextless" (x, y: $A/[$N]$T) -> (out: [N]bool) where IS_ARRAY(A), IS_FLOAT(ELEM_TYPE(A)) {
 	for i in 0..<N {
 		out[i] = x[i] == y[i]
 	}
 	return
 }
-not_equal_array :: proc(x, y: $A/[$N]$T) -> (out: [N]bool) where IS_ARRAY(A), IS_FLOAT(ELEM_TYPE(A)) {
+not_equal_array :: proc "contextless" (x, y: $A/[$N]$T) -> (out: [N]bool) where IS_ARRAY(A), IS_FLOAT(ELEM_TYPE(A)) {
 	for i in 0..<N {
 		out[i] = x[i] != y[i]
 	}
@@ -529,7 +529,7 @@ greater_than_equal :: proc{greater_than_equal_single, greater_than_equal_array}
 equal              :: proc{equal_single, equal_array}
 not_equal          :: proc{not_equal_single, not_equal_array}
 
-any :: proc(x: $A/[$N]bool) -> (out: bool) {
+any :: proc "contextless" (x: $A/[$N]bool) -> (out: bool) {
 	for e in x {
 		if x {
 			return true
@@ -537,7 +537,7 @@ any :: proc(x: $A/[$N]bool) -> (out: bool) {
 	}
 	return false
 }
-all :: proc(x: $A/[$N]bool) -> (out: bool) {
+all :: proc "contextless" (x: $A/[$N]bool) -> (out: bool) {
 	for e in x {
 		if !e {
 			return false
@@ -545,7 +545,7 @@ all :: proc(x: $A/[$N]bool) -> (out: bool) {
 	}
 	return true
 }
-not :: proc(x: $A/[$N]bool) -> (out: A) {
+not :: proc "contextless" (x: $A/[$N]bool) -> (out: A) {
 	for e, i in x {
 		out[i] = !e
 	}

--- a/core/math/linalg/general.odin
+++ b/core/math/linalg/general.odin
@@ -38,23 +38,23 @@ DEG_PER_RAD :: 360.0/TAU
 @private ELEM_TYPE :: intrinsics.type_elem_type
 
 
-scalar_dot :: proc(a, b: $T) -> T where IS_FLOAT(T), !IS_ARRAY(T) {
+scalar_dot :: proc "contextless" (a, b: $T) -> T where IS_FLOAT(T), !IS_ARRAY(T) {
 	return a * b
 }
 
-vector_dot :: proc(a, b: $T/[$N]$E) -> (c: E) where IS_NUMERIC(E) #no_bounds_check {
+vector_dot :: proc "contextless" (a, b: $T/[$N]$E) -> (c: E) where IS_NUMERIC(E) #no_bounds_check {
 	for i in 0..<N {
 		c += a[i] * b[i]
 	}
 	return
 }
-quaternion64_dot :: proc(a, b: $T/quaternion64) -> (c: f16) {
+quaternion64_dot :: proc "contextless" (a, b: $T/quaternion64) -> (c: f16) {
 	return a.w*a.w + a.x*b.x + a.y*b.y + a.z*b.z
 }
-quaternion128_dot :: proc(a, b: $T/quaternion128) -> (c: f32) {
+quaternion128_dot :: proc "contextless" (a, b: $T/quaternion128) -> (c: f32) {
 	return a.w*a.w + a.x*b.x + a.y*b.y + a.z*b.z
 }
-quaternion256_dot :: proc(a, b: $T/quaternion256) -> (c: f64) {
+quaternion256_dot :: proc "contextless" (a, b: $T/quaternion256) -> (c: f64) {
 	return a.w*a.w + a.x*b.x + a.y*b.y + a.z*b.z
 }
 
@@ -63,27 +63,27 @@ dot :: proc{scalar_dot, vector_dot, quaternion64_dot, quaternion128_dot, quatern
 inner_product :: dot
 outer_product :: builtin.outer_product
 
-quaternion_inverse :: proc(q: $Q) -> Q where IS_QUATERNION(Q) {
+quaternion_inverse :: proc "contextless" (q: $Q) -> Q where IS_QUATERNION(Q) {
 	return conj(q) * quaternion(1.0/dot(q, q), 0, 0, 0)
 }
 
 
-scalar_cross :: proc(a, b: $T) -> T where IS_FLOAT(T), !IS_ARRAY(T) {
+scalar_cross :: proc "contextless" (a, b: $T) -> T where IS_FLOAT(T), !IS_ARRAY(T) {
 	return a * b
 }
 
-vector_cross2 :: proc(a, b: $T/[2]$E) -> E where IS_NUMERIC(E) {
+vector_cross2 :: proc "contextless" (a, b: $T/[2]$E) -> E where IS_NUMERIC(E) {
 	return a[0]*b[1] - b[0]*a[1]
 }
 
-vector_cross3 :: proc(a, b: $T/[3]$E) -> (c: T) where IS_NUMERIC(E) {
+vector_cross3 :: proc "contextless" (a, b: $T/[3]$E) -> (c: T) where IS_NUMERIC(E) {
 	c[0] = a[1]*b[2] - b[1]*a[2]
 	c[1] = a[2]*b[0] - b[2]*a[0]
 	c[2] = a[0]*b[1] - b[0]*a[1]
 	return
 }
 
-quaternion_cross :: proc(q1, q2: $Q) -> (q3: Q) where IS_QUATERNION(Q) {
+quaternion_cross :: proc "contextless" (q1, q2: $Q) -> (q3: Q) where IS_QUATERNION(Q) {
 	q3.x = q1.w * q2.x + q1.x * q2.w + q1.y * q2.z - q1.z * q2.y
 	q3.y = q1.w * q2.y + q1.y * q2.w + q1.z * q2.x - q1.x * q2.z
 	q3.z = q1.w * q2.z + q1.z * q2.w + q1.x * q2.y - q1.y * q2.x
@@ -94,49 +94,49 @@ quaternion_cross :: proc(q1, q2: $Q) -> (q3: Q) where IS_QUATERNION(Q) {
 vector_cross :: proc{scalar_cross, vector_cross2, vector_cross3}
 cross :: proc{scalar_cross, vector_cross2, vector_cross3, quaternion_cross}
 
-vector_normalize :: proc(v: $T/[$N]$E) -> T where IS_FLOAT(E) {
+vector_normalize :: proc "contextless" (v: $T/[$N]$E) -> T where IS_FLOAT(E) {
 	return v / length(v)
 }
-quaternion_normalize :: proc(q: $Q) -> Q where IS_QUATERNION(Q) {
+quaternion_normalize :: proc "contextless" (q: $Q) -> Q where IS_QUATERNION(Q) {
 	return q/abs(q)
 }
 normalize :: proc{vector_normalize, quaternion_normalize}
 
-vector_normalize0 :: proc(v: $T/[$N]$E) -> T where IS_FLOAT(E) {
+vector_normalize0 :: proc "contextless" (v: $T/[$N]$E) -> T where IS_FLOAT(E) {
 	m := length(v)
 	return 0 if m == 0 else v/m
 }
-quaternion_normalize0 :: proc(q: $Q) -> Q  where IS_QUATERNION(Q) {
+quaternion_normalize0 :: proc "contextless" (q: $Q) -> Q  where IS_QUATERNION(Q) {
 	m := abs(q)
 	return 0 if m == 0 else q/m
 }
 normalize0 :: proc{vector_normalize0, quaternion_normalize0}
 
 
-vector_length :: proc(v: $T/[$N]$E) -> E where IS_FLOAT(E) {
+vector_length :: proc "contextless" (v: $T/[$N]$E) -> E where IS_FLOAT(E) {
 	return math.sqrt(dot(v, v))
 }
 
-vector_length2 :: proc(v: $T/[$N]$E) -> E where IS_NUMERIC(E) {
+vector_length2 :: proc "contextless" (v: $T/[$N]$E) -> E where IS_NUMERIC(E) {
 	return dot(v, v)
 }
 
-quaternion_length :: proc(q: $Q) -> Q where IS_QUATERNION(Q) {
+quaternion_length :: proc "contextless" (q: $Q) -> Q where IS_QUATERNION(Q) {
 	return abs(q)
 }
 
-quaternion_length2 :: proc(q: $Q) -> Q where IS_QUATERNION(Q) {
+quaternion_length2 :: proc "contextless" (q: $Q) -> Q where IS_QUATERNION(Q) {
 	return dot(q, q)
 }
 
-scalar_triple_product :: proc(a, b, c: $T/[$N]$E) -> E where IS_NUMERIC(E) {
+scalar_triple_product :: proc "contextless" (a, b, c: $T/[$N]$E) -> E where IS_NUMERIC(E) {
 	// a . (b x c)
 	// b . (c x a)
 	// c . (a x b)
 	return dot(a, cross(b, c))
 }
 
-vector_triple_product :: proc(a, b, c: $T/[$N]$E) -> T where IS_NUMERIC(E) {
+vector_triple_product :: proc "contextless" (a, b, c: $T/[$N]$E) -> T where IS_NUMERIC(E) {
 	// a x (b x c)
 	// (a . c)b - (a . b)c
 	return cross(a, cross(b, c))
@@ -146,11 +146,11 @@ vector_triple_product :: proc(a, b, c: $T/[$N]$E) -> T where IS_NUMERIC(E) {
 length :: proc{vector_length, quaternion_length}
 length2 :: proc{vector_length2, quaternion_length2}
 
-projection :: proc(x, normal: $T/[$N]$E) -> T where IS_NUMERIC(E) {
+projection :: proc "contextless" (x, normal: $T/[$N]$E) -> T where IS_NUMERIC(E) {
 	return dot(x, normal) / dot(normal, normal) * normal
 }
 
-identity :: proc($T: typeid/[$N][N]$E) -> (m: T) #no_bounds_check {
+identity :: proc "contextless" ($T: typeid/[$N][N]$E) -> (m: T) #no_bounds_check {
 	for i in 0..<N {
 		m[i][i] = E(1)
 	}
@@ -160,32 +160,32 @@ identity :: proc($T: typeid/[$N][N]$E) -> (m: T) #no_bounds_check {
 trace :: builtin.matrix_trace
 transpose :: builtin.transpose
 
-matrix_mul :: proc(a, b: $M/matrix[$N, N]$E) -> (c: M)
+matrix_mul :: proc "contextless" (a, b: $M/matrix[$N, N]$E) -> (c: M)
 	where !IS_ARRAY(E), IS_NUMERIC(E) #no_bounds_check {
 	return a * b
 }
 
-matrix_comp_mul :: proc(a, b: $M/matrix[$I, $J]$E) -> (c: M)
+matrix_comp_mul :: proc "contextless" (a, b: $M/matrix[$I, $J]$E) -> (c: M)
 	where !IS_ARRAY(E), IS_NUMERIC(E) #no_bounds_check {
 	return hadamard_product(a, b)
 }
 
-matrix_mul_differ :: proc(a: $A/matrix[$I, $J]$E, b: $B/matrix[J, $K]E) -> (c: matrix[I, K]E)
+matrix_mul_differ :: proc "contextless" (a: $A/matrix[$I, $J]$E, b: $B/matrix[J, $K]E) -> (c: matrix[I, K]E)
 	where !IS_ARRAY(E), IS_NUMERIC(E), I != K #no_bounds_check {
 	return a * b
 }
 
 
-matrix_mul_vector :: proc(a: $A/matrix[$I, $J]$E, b: $B/[J]E) -> (c: B)
+matrix_mul_vector :: proc "contextless" (a: $A/matrix[$I, $J]$E, b: $B/[J]E) -> (c: B)
 	where !IS_ARRAY(E), IS_NUMERIC(E) #no_bounds_check {
 	return a * b
 }
 
-quaternion_mul_quaternion :: proc(q1, q2: $Q) -> Q where IS_QUATERNION(Q) {
+quaternion_mul_quaternion :: proc "contextless" (q1, q2: $Q) -> Q where IS_QUATERNION(Q) {
 	return q1 * q2
 }
 
-quaternion64_mul_vector3 :: proc(q: $Q/quaternion64, v: $V/[3]$F/f16) -> V {
+quaternion64_mul_vector3 :: proc "contextless" (q: $Q/quaternion64, v: $V/[3]$F/f16) -> V {
 	Raw_Quaternion :: struct {xyz: [3]f16, r: f16}
 
 	q := transmute(Raw_Quaternion)q
@@ -194,7 +194,7 @@ quaternion64_mul_vector3 :: proc(q: $Q/quaternion64, v: $V/[3]$F/f16) -> V {
 	t := cross(2*q.xyz, v)
 	return V(v + q.r*t + cross(q.xyz, t))
 }
-quaternion128_mul_vector3 :: proc(q: $Q/quaternion128, v: $V/[3]$F/f32) -> V {
+quaternion128_mul_vector3 :: proc "contextless" (q: $Q/quaternion128, v: $V/[3]$F/f32) -> V {
 	Raw_Quaternion :: struct {xyz: [3]f32, r: f32}
 
 	q := transmute(Raw_Quaternion)q
@@ -203,7 +203,7 @@ quaternion128_mul_vector3 :: proc(q: $Q/quaternion128, v: $V/[3]$F/f32) -> V {
 	t := cross(2*q.xyz, v)
 	return V(v + q.r*t + cross(q.xyz, t))
 }
-quaternion256_mul_vector3 :: proc(q: $Q/quaternion256, v: $V/[3]$F/f64) -> V {
+quaternion256_mul_vector3 :: proc "contextless" (q: $Q/quaternion256, v: $V/[3]$F/f64) -> V {
 	Raw_Quaternion :: struct {xyz: [3]f64, r: f64}
 
 	q := transmute(Raw_Quaternion)q
@@ -224,10 +224,10 @@ mul :: proc{
 	quaternion_mul_quaternion,
 }
 
-vector_to_ptr :: proc(v: ^$V/[$N]$E) -> ^E where IS_NUMERIC(E), N > 0 #no_bounds_check {
+vector_to_ptr :: proc "contextless" (v: ^$V/[$N]$E) -> ^E where IS_NUMERIC(E), N > 0 #no_bounds_check {
 	return &v[0]
 }
-matrix_to_ptr :: proc(m: ^$A/matrix[$I, $J]$E) -> ^E where IS_NUMERIC(E), I > 0, J > 0 #no_bounds_check {
+matrix_to_ptr :: proc "contextless" (m: ^$A/matrix[$I, $J]$E) -> ^E where IS_NUMERIC(E), I > 0, J > 0 #no_bounds_check {
 	return &m[0, 0]
 }
 

--- a/core/math/linalg/specific.odin
+++ b/core/math/linalg/specific.odin
@@ -130,11 +130,11 @@ VECTOR3F64_Y_AXIS :: Vector3f64{0, 1, 0}
 VECTOR3F64_Z_AXIS :: Vector3f64{0, 0, 1}
 
 
-vector2_orthogonal :: proc(v: $V/[2]$E) -> V where !IS_ARRAY(E), IS_FLOAT(E) {
+vector2_orthogonal :: proc "contextless" (v: $V/[2]$E) -> V where !IS_ARRAY(E), IS_FLOAT(E) {
 	return {-v.y, v.x}
 }
 
-vector3_orthogonal :: proc(v: $V/[3]$E) -> V where !IS_ARRAY(E), IS_FLOAT(E) {
+vector3_orthogonal :: proc "contextless" (v: $V/[3]$E) -> V where !IS_ARRAY(E), IS_FLOAT(E) {
 	x := abs(v.x)
 	y := abs(v.y)
 	z := abs(v.z)
@@ -160,21 +160,21 @@ orthogonal :: proc{vector2_orthogonal, vector3_orthogonal}
 
 
 
-vector4_srgb_to_linear_f16 :: proc(col: Vector4f16) -> Vector4f16 {
+vector4_srgb_to_linear_f16 :: proc "contextless" (col: Vector4f16) -> Vector4f16 {
 	r := math.pow(col.x, 2.2)
 	g := math.pow(col.y, 2.2)
 	b := math.pow(col.z, 2.2)
 	a := col.w
 	return {r, g, b, a}
 }
-vector4_srgb_to_linear_f32 :: proc(col: Vector4f32) -> Vector4f32 {
+vector4_srgb_to_linear_f32 :: proc "contextless" (col: Vector4f32) -> Vector4f32 {
 	r := math.pow(col.x, 2.2)
 	g := math.pow(col.y, 2.2)
 	b := math.pow(col.z, 2.2)
 	a := col.w
 	return {r, g, b, a}
 }
-vector4_srgb_to_linear_f64 :: proc(col: Vector4f64) -> Vector4f64 {
+vector4_srgb_to_linear_f64 :: proc "contextless" (col: Vector4f64) -> Vector4f64 {
 	r := math.pow(col.x, 2.2)
 	g := math.pow(col.y, 2.2)
 	b := math.pow(col.z, 2.2)
@@ -188,7 +188,7 @@ vector4_srgb_to_linear :: proc{
 }
 
 
-vector4_linear_to_srgb_f16 :: proc(col: Vector4f16) -> Vector4f16 {
+vector4_linear_to_srgb_f16 :: proc "contextless" (col: Vector4f16) -> Vector4f16 {
 	a :: 2.51
 	b :: 0.03
 	c :: 2.43
@@ -209,7 +209,7 @@ vector4_linear_to_srgb_f16 :: proc(col: Vector4f16) -> Vector4f16 {
 
 	return {x, y, z, col.w}
 }
-vector4_linear_to_srgb_f32 :: proc(col: Vector4f32) -> Vector4f32 {
+vector4_linear_to_srgb_f32 :: proc "contextless" (col: Vector4f32) -> Vector4f32 {
 	a :: 2.51
 	b :: 0.03
 	c :: 2.43
@@ -230,7 +230,7 @@ vector4_linear_to_srgb_f32 :: proc(col: Vector4f32) -> Vector4f32 {
 
 	return {x, y, z, col.w}
 }
-vector4_linear_to_srgb_f64 :: proc(col: Vector4f64) -> Vector4f64 {
+vector4_linear_to_srgb_f64 :: proc "contextless" (col: Vector4f64) -> Vector4f64 {
 	a :: 2.51
 	b :: 0.03
 	c :: 2.43
@@ -258,8 +258,8 @@ vector4_linear_to_srgb :: proc{
 }
 
 
-vector4_hsl_to_rgb_f16 :: proc(h, s, l: f16, a: f16 = 1) -> Vector4f16 {
-	hue_to_rgb :: proc(p, q, t: f16) -> f16 {
+vector4_hsl_to_rgb_f16 :: proc "contextless" (h, s, l: f16, a: f16 = 1) -> Vector4f16 {
+	hue_to_rgb :: proc "contextless" (p, q, t: f16) -> f16 {
 		t := t
 		if t < 0 { t += 1 }
 		if t > 1 { t -= 1 }
@@ -285,8 +285,8 @@ vector4_hsl_to_rgb_f16 :: proc(h, s, l: f16, a: f16 = 1) -> Vector4f16 {
 	}
 	return {r, g, b, a}
 }
-vector4_hsl_to_rgb_f32 :: proc(h, s, l: f32, a: f32 = 1) -> Vector4f32 {
-	hue_to_rgb :: proc(p, q, t: f32) -> f32 {
+vector4_hsl_to_rgb_f32 :: proc "contextless" (h, s, l: f32, a: f32 = 1) -> Vector4f32 {
+	hue_to_rgb :: proc "contextless" (p, q, t: f32) -> f32 {
 		t := t
 		if t < 0 { t += 1 }
 		if t > 1 { t -= 1 }
@@ -312,8 +312,8 @@ vector4_hsl_to_rgb_f32 :: proc(h, s, l: f32, a: f32 = 1) -> Vector4f32 {
 	}
 	return {r, g, b, a}
 }
-vector4_hsl_to_rgb_f64 :: proc(h, s, l: f64, a: f64 = 1) -> Vector4f64 {
-	hue_to_rgb :: proc(p, q, t: f64) -> f64 {
+vector4_hsl_to_rgb_f64 :: proc "contextless" (h, s, l: f64, a: f64 = 1) -> Vector4f64 {
+	hue_to_rgb :: proc "contextless" (p, q, t: f64) -> f64 {
 		t := t
 		if t < 0 { t += 1 }
 		if t > 1 { t -= 1 }
@@ -346,7 +346,7 @@ vector4_hsl_to_rgb :: proc{
 }
 
 
-vector4_rgb_to_hsl_f16 :: proc(col: Vector4f16) -> Vector4f16 {
+vector4_rgb_to_hsl_f16 :: proc "contextless" (col: Vector4f16) -> Vector4f16 {
 	r := col.x
 	g := col.y
 	b := col.z
@@ -375,7 +375,7 @@ vector4_rgb_to_hsl_f16 :: proc(col: Vector4f16) -> Vector4f16 {
 
 	return {h, s, l, a}
 }
-vector4_rgb_to_hsl_f32 :: proc(col: Vector4f32) -> Vector4f32 {
+vector4_rgb_to_hsl_f32 :: proc "contextless" (col: Vector4f32) -> Vector4f32 {
 	r := col.x
 	g := col.y
 	b := col.z
@@ -404,7 +404,7 @@ vector4_rgb_to_hsl_f32 :: proc(col: Vector4f32) -> Vector4f32 {
 
 	return {h, s, l, a}
 }
-vector4_rgb_to_hsl_f64 :: proc(col: Vector4f64) -> Vector4f64 {
+vector4_rgb_to_hsl_f64 :: proc "contextless" (col: Vector4f64) -> Vector4f64 {
 	r := col.x
 	g := col.y
 	b := col.z
@@ -441,7 +441,7 @@ vector4_rgb_to_hsl :: proc{
 
 
 
-quaternion_angle_axis_f16 :: proc(angle_radians: f16, axis: Vector3f16) -> (q: Quaternionf16) {
+quaternion_angle_axis_f16 :: proc "contextless" (angle_radians: f16, axis: Vector3f16) -> (q: Quaternionf16) {
 	t := angle_radians*0.5
 	v := normalize(axis) * math.sin(t)
 	q.x = v.x
@@ -450,7 +450,7 @@ quaternion_angle_axis_f16 :: proc(angle_radians: f16, axis: Vector3f16) -> (q: Q
 	q.w = math.cos(t)
 	return
 }
-quaternion_angle_axis_f32 :: proc(angle_radians: f32, axis: Vector3f32) -> (q: Quaternionf32) {
+quaternion_angle_axis_f32 :: proc "contextless" (angle_radians: f32, axis: Vector3f32) -> (q: Quaternionf32) {
 	t := angle_radians*0.5
 	v := normalize(axis) * math.sin(t)
 	q.x = v.x
@@ -459,7 +459,7 @@ quaternion_angle_axis_f32 :: proc(angle_radians: f32, axis: Vector3f32) -> (q: Q
 	q.w = math.cos(t)
 	return
 }
-quaternion_angle_axis_f64 :: proc(angle_radians: f64, axis: Vector3f64) -> (q: Quaternionf64) {
+quaternion_angle_axis_f64 :: proc "contextless" (angle_radians: f64, axis: Vector3f64) -> (q: Quaternionf64) {
 	t := angle_radians*0.5
 	v := normalize(axis) * math.sin(t)
 	q.x = v.x
@@ -474,21 +474,21 @@ quaternion_angle_axis :: proc{
 	quaternion_angle_axis_f64,
 }
 
-angle_from_quaternion_f16 :: proc(q: Quaternionf16) -> f16 {
+angle_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> f16 {
 	if abs(q.w) > math.SQRT_THREE*0.5 {
 		return math.asin(math.sqrt(q.x*q.x + q.y*q.y + q.z*q.z)) * 2
 	}
 
 	return math.acos(q.w) * 2
 }
-angle_from_quaternion_f32 :: proc(q: Quaternionf32) -> f32 {
+angle_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> f32 {
 	if abs(q.w) > math.SQRT_THREE*0.5 {
 		return math.asin(math.sqrt(q.x*q.x + q.y*q.y + q.z*q.z)) * 2
 	}
 
 	return math.acos(q.w) * 2
 }
-angle_from_quaternion_f64 :: proc(q: Quaternionf64) -> f64 {
+angle_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> f64 {
 	if abs(q.w) > math.SQRT_THREE*0.5 {
 		return math.asin(math.sqrt(q.x*q.x + q.y*q.y + q.z*q.z)) * 2
 	}
@@ -501,7 +501,7 @@ angle_from_quaternion :: proc{
 	angle_from_quaternion_f64,
 }
 
-axis_from_quaternion_f16 :: proc(q: Quaternionf16) -> Vector3f16 {
+axis_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> Vector3f16 {
 	t1 := 1 - q.w*q.w
 	if t1 < 0 {
 		return {0, 0, 1}
@@ -509,7 +509,7 @@ axis_from_quaternion_f16 :: proc(q: Quaternionf16) -> Vector3f16 {
 	t2 := 1.0 / math.sqrt(t1)
 	return {q.x*t2, q.y*t2, q.z*t2}
 }
-axis_from_quaternion_f32 :: proc(q: Quaternionf32) -> Vector3f32 {
+axis_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> Vector3f32 {
 	t1 := 1 - q.w*q.w
 	if t1 < 0 {
 		return {0, 0, 1}
@@ -517,7 +517,7 @@ axis_from_quaternion_f32 :: proc(q: Quaternionf32) -> Vector3f32 {
 	t2 := 1.0 / math.sqrt(t1)
 	return {q.x*t2, q.y*t2, q.z*t2}
 }
-axis_from_quaternion_f64 :: proc(q: Quaternionf64) -> Vector3f64 {
+axis_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> Vector3f64 {
 	t1 := 1 - q.w*q.w
 	if t1 < 0 {
 		return {0, 0, 1}
@@ -532,17 +532,17 @@ axis_from_quaternion :: proc{
 }
 
 
-angle_axis_from_quaternion_f16 :: proc(q: Quaternionf16) -> (angle: f16, axis: Vector3f16) {
+angle_axis_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> (angle: f16, axis: Vector3f16) {
 	angle = angle_from_quaternion(q)
 	axis  = axis_from_quaternion(q)
 	return
 }
-angle_axis_from_quaternion_f32 :: proc(q: Quaternionf32) -> (angle: f32, axis: Vector3f32) {
+angle_axis_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> (angle: f32, axis: Vector3f32) {
 	angle = angle_from_quaternion(q)
 	axis  = axis_from_quaternion(q)
 	return
 }
-angle_axis_from_quaternion_f64 :: proc(q: Quaternionf64) -> (angle: f64, axis: Vector3f64) {
+angle_axis_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> (angle: f64, axis: Vector3f64) {
 	angle = angle_from_quaternion(q)
 	axis  = axis_from_quaternion(q)
 	return
@@ -554,7 +554,7 @@ angle_axis_from_quaternion :: proc {
 }
 
 
-quaternion_from_forward_and_up_f16 :: proc(forward, up: Vector3f16) -> Quaternionf16 {
+quaternion_from_forward_and_up_f16 :: proc "contextless" (forward, up: Vector3f16) -> Quaternionf16 {
 	f := normalize(forward)
 	s := normalize(cross(f, up))
 	u := cross(s, f)
@@ -597,7 +597,7 @@ quaternion_from_forward_and_up_f16 :: proc(forward, up: Vector3f16) -> Quaternio
 
 	return normalize(q)
 }
-quaternion_from_forward_and_up_f32 :: proc(forward, up: Vector3f32) -> Quaternionf32 {
+quaternion_from_forward_and_up_f32 :: proc "contextless" (forward, up: Vector3f32) -> Quaternionf32 {
 	f := normalize(forward)
 	s := normalize(cross(f, up))
 	u := cross(s, f)
@@ -640,7 +640,7 @@ quaternion_from_forward_and_up_f32 :: proc(forward, up: Vector3f32) -> Quaternio
 
 	return normalize(q)
 }
-quaternion_from_forward_and_up_f64 :: proc(forward, up: Vector3f64) -> Quaternionf64 {
+quaternion_from_forward_and_up_f64 :: proc "contextless" (forward, up: Vector3f64) -> Quaternionf64 {
 	f := normalize(forward)
 	s := normalize(cross(f, up))
 	u := cross(s, f)
@@ -689,13 +689,13 @@ quaternion_from_forward_and_up :: proc{
 	quaternion_from_forward_and_up_f64,
 }
 
-quaternion_look_at_f16 :: proc(eye, centre: Vector3f16, up: Vector3f16) -> Quaternionf16 {
+quaternion_look_at_f16 :: proc "contextless" (eye, centre: Vector3f16, up: Vector3f16) -> Quaternionf16 {
 	return quaternion_from_matrix3(matrix3_look_at(eye, centre, up))
 }
-quaternion_look_at_f32 :: proc(eye, centre: Vector3f32, up: Vector3f32) -> Quaternionf32 {
+quaternion_look_at_f32 :: proc "contextless" (eye, centre: Vector3f32, up: Vector3f32) -> Quaternionf32 {
 	return quaternion_from_matrix3(matrix3_look_at(eye, centre, up))
 }
-quaternion_look_at_f64 :: proc(eye, centre: Vector3f64, up: Vector3f64) -> Quaternionf64 {
+quaternion_look_at_f64 :: proc "contextless" (eye, centre: Vector3f64, up: Vector3f64) -> Quaternionf64 {
 	return quaternion_from_matrix3(matrix3_look_at(eye, centre, up))
 }
 quaternion_look_at :: proc{
@@ -706,21 +706,21 @@ quaternion_look_at :: proc{
 
 
 
-quaternion_nlerp_f16 :: proc(a, b: Quaternionf16, t: f16) -> (c: Quaternionf16) {
+quaternion_nlerp_f16 :: proc "contextless" (a, b: Quaternionf16, t: f16) -> (c: Quaternionf16) {
 	c.x = a.x + (b.x-a.x)*t
 	c.y = a.y + (b.y-a.y)*t
 	c.z = a.z + (b.z-a.z)*t
 	c.w = a.w + (b.w-a.w)*t
 	return normalize(c)
 }
-quaternion_nlerp_f32 :: proc(a, b: Quaternionf32, t: f32) -> (c: Quaternionf32) {
+quaternion_nlerp_f32 :: proc "contextless" (a, b: Quaternionf32, t: f32) -> (c: Quaternionf32) {
 	c.x = a.x + (b.x-a.x)*t
 	c.y = a.y + (b.y-a.y)*t
 	c.z = a.z + (b.z-a.z)*t
 	c.w = a.w + (b.w-a.w)*t
 	return normalize(c)
 }
-quaternion_nlerp_f64 :: proc(a, b: Quaternionf64, t: f64) -> (c: Quaternionf64) {
+quaternion_nlerp_f64 :: proc "contextless" (a, b: Quaternionf64, t: f64) -> (c: Quaternionf64) {
 	c.x = a.x + (b.x-a.x)*t
 	c.y = a.y + (b.y-a.y)*t
 	c.z = a.z + (b.z-a.z)*t
@@ -734,7 +734,7 @@ quaternion_nlerp :: proc{
 }
 
 
-quaternion_slerp_f16 :: proc(x, y: Quaternionf16, t: f16) -> (q: Quaternionf16) {
+quaternion_slerp_f16 :: proc "contextless" (x, y: Quaternionf16, t: f16) -> (q: Quaternionf16) {
 	a, b := x, y
 	cos_angle := dot(a, b)
 	if cos_angle < 0 {
@@ -761,7 +761,7 @@ quaternion_slerp_f16 :: proc(x, y: Quaternionf16, t: f16) -> (q: Quaternionf16) 
 	q.w = factor_a * a.w + factor_b * b.w
 	return
 }
-quaternion_slerp_f32 :: proc(x, y: Quaternionf32, t: f32) -> (q: Quaternionf32) {
+quaternion_slerp_f32 :: proc "contextless" (x, y: Quaternionf32, t: f32) -> (q: Quaternionf32) {
 	a, b := x, y
 	cos_angle := dot(a, b)
 	if cos_angle < 0 {
@@ -788,7 +788,7 @@ quaternion_slerp_f32 :: proc(x, y: Quaternionf32, t: f32) -> (q: Quaternionf32) 
 	q.w = factor_a * a.w + factor_b * b.w
 	return
 }
-quaternion_slerp_f64 :: proc(x, y: Quaternionf64, t: f64) -> (q: Quaternionf64) {
+quaternion_slerp_f64 :: proc "contextless" (x, y: Quaternionf64, t: f64) -> (q: Quaternionf64) {
 	a, b := x, y
 	cos_angle := dot(a, b)
 	if cos_angle < 0 {
@@ -822,15 +822,15 @@ quaternion_slerp :: proc{
 }
 
 
-quaternion_squad_f16 :: proc(q1, q2, s1, s2: Quaternionf16, h: f16) -> Quaternionf16 {
+quaternion_squad_f16 :: proc "contextless" (q1, q2, s1, s2: Quaternionf16, h: f16) -> Quaternionf16 {
 	slerp :: quaternion_slerp
 	return slerp(slerp(q1, q2, h), slerp(s1, s2, h), 2 * (1 - h) * h)
 }
-quaternion_squad_f32 :: proc(q1, q2, s1, s2: Quaternionf32, h: f32) -> Quaternionf32 {
+quaternion_squad_f32 :: proc "contextless" (q1, q2, s1, s2: Quaternionf32, h: f32) -> Quaternionf32 {
 	slerp :: quaternion_slerp
 	return slerp(slerp(q1, q2, h), slerp(s1, s2, h), 2 * (1 - h) * h)
 }
-quaternion_squad_f64 :: proc(q1, q2, s1, s2: Quaternionf64, h: f64) -> Quaternionf64 {
+quaternion_squad_f64 :: proc "contextless" (q1, q2, s1, s2: Quaternionf64, h: f64) -> Quaternionf64 {
 	slerp :: quaternion_slerp
 	return slerp(slerp(q1, q2, h), slerp(s1, s2, h), 2 * (1 - h) * h)
 }
@@ -841,21 +841,21 @@ quaternion_squad :: proc{
 }
 
 
-quaternion_from_matrix4_f16 :: proc(m: Matrix4f16) -> (q: Quaternionf16) {
+quaternion_from_matrix4_f16 :: proc "contextless" (m: Matrix4f16) -> (q: Quaternionf16) {
 	m3: Matrix3f16 = ---
 	m3[0, 0], m3[1, 0], m3[2, 0] = m[0, 0], m[1, 0], m[2, 0]
 	m3[0, 1], m3[1, 1], m3[2, 1] = m[0, 1], m[1, 1], m[2, 1]
 	m3[0, 2], m3[1, 2], m3[2, 2] = m[0, 2], m[1, 2], m[2, 2]
 	return quaternion_from_matrix3(m3)
 }
-quaternion_from_matrix4_f32 :: proc(m: Matrix4f32) -> (q: Quaternionf32) {
+quaternion_from_matrix4_f32 :: proc "contextless" (m: Matrix4f32) -> (q: Quaternionf32) {
 	m3: Matrix3f32 = ---
 	m3[0, 0], m3[1, 0], m3[2, 0] = m[0, 0], m[1, 0], m[2, 0]
 	m3[0, 1], m3[1, 1], m3[2, 1] = m[0, 1], m[1, 1], m[2, 1]
 	m3[0, 2], m3[1, 2], m3[2, 2] = m[0, 2], m[1, 2], m[2, 2]
 	return quaternion_from_matrix3(m3)
 }
-quaternion_from_matrix4_f64 :: proc(m: Matrix4f64) -> (q: Quaternionf64) {
+quaternion_from_matrix4_f64 :: proc "contextless" (m: Matrix4f64) -> (q: Quaternionf64) {
 	m3: Matrix3f64 = ---
 	m3[0, 0], m3[1, 0], m3[2, 0] = m[0, 0], m[1, 0], m[2, 0]
 	m3[0, 1], m3[1, 1], m3[2, 1] = m[0, 1], m[1, 1], m[2, 1]
@@ -869,7 +869,7 @@ quaternion_from_matrix4 :: proc{
 }
 
 
-quaternion_from_matrix3_f16 :: proc(m: Matrix3f16) -> (q: Quaternionf16) {
+quaternion_from_matrix3_f16 :: proc "contextless" (m: Matrix3f16) -> (q: Quaternionf16) {
 	four_x_squared_minus_1 := m[0, 0] - m[1, 1] - m[2, 2]
 	four_y_squared_minus_1 := m[1, 1] - m[0, 0] - m[2, 2]
 	four_z_squared_minus_1 := m[2, 2] - m[0, 0] - m[1, 1]
@@ -918,7 +918,7 @@ quaternion_from_matrix3_f16 :: proc(m: Matrix3f16) -> (q: Quaternionf16) {
 	}
 	return
 }
-quaternion_from_matrix3_f32 :: proc(m: Matrix3f32) -> (q: Quaternionf32) {
+quaternion_from_matrix3_f32 :: proc "contextless" (m: Matrix3f32) -> (q: Quaternionf32) {
 	four_x_squared_minus_1 := m[0, 0] - m[1, 1] - m[2, 2]
 	four_y_squared_minus_1 := m[1, 1] - m[0, 0] - m[2, 2]
 	four_z_squared_minus_1 := m[2, 2] - m[0, 0] - m[1, 1]
@@ -967,7 +967,7 @@ quaternion_from_matrix3_f32 :: proc(m: Matrix3f32) -> (q: Quaternionf32) {
 	}
 	return
 }
-quaternion_from_matrix3_f64 :: proc(m: Matrix3f64) -> (q: Quaternionf64) {
+quaternion_from_matrix3_f64 :: proc "contextless" (m: Matrix3f64) -> (q: Quaternionf64) {
 	four_x_squared_minus_1 := m[0, 0] - m[1, 1] - m[2, 2]
 	four_y_squared_minus_1 := m[1, 1] - m[0, 0] - m[2, 2]
 	four_z_squared_minus_1 := m[2, 2] - m[0, 0] - m[1, 1]
@@ -1023,7 +1023,7 @@ quaternion_from_matrix3 :: proc{
 }
 
 
-quaternion_between_two_vector3_f16 :: proc(from, to: Vector3f16) -> (q: Quaternionf16) {
+quaternion_between_two_vector3_f16 :: proc "contextless" (from, to: Vector3f16) -> (q: Quaternionf16) {
 	x := normalize(from)
 	y := normalize(to)
 
@@ -1044,7 +1044,7 @@ quaternion_between_two_vector3_f16 :: proc(from, to: Vector3f16) -> (q: Quaterni
 	q.z = v.z
 	return normalize(q)
 }
-quaternion_between_two_vector3_f32 :: proc(from, to: Vector3f32) -> (q: Quaternionf32) {
+quaternion_between_two_vector3_f32 :: proc "contextless" (from, to: Vector3f32) -> (q: Quaternionf32) {
 	x := normalize(from)
 	y := normalize(to)
 
@@ -1065,7 +1065,7 @@ quaternion_between_two_vector3_f32 :: proc(from, to: Vector3f32) -> (q: Quaterni
 	q.z = v.z
 	return normalize(q)
 }
-quaternion_between_two_vector3_f64 :: proc(from, to: Vector3f64) -> (q: Quaternionf64) {
+quaternion_between_two_vector3_f64 :: proc "contextless" (from, to: Vector3f64) -> (q: Quaternionf64) {
 	x := normalize(from)
 	y := normalize(to)
 
@@ -1093,7 +1093,7 @@ quaternion_between_two_vector3 :: proc{
 }
 
 
-matrix2_inverse_transpose_f16 :: proc(m: Matrix2f16) -> (c: Matrix2f16) {
+matrix2_inverse_transpose_f16 :: proc "contextless" (m: Matrix2f16) -> (c: Matrix2f16) {
 	d := m[0, 0]*m[1, 1] - m[0, 1]*m[1, 0]
 	id := 1.0/d
 	c[0, 0] = +m[1, 1] * id
@@ -1102,7 +1102,7 @@ matrix2_inverse_transpose_f16 :: proc(m: Matrix2f16) -> (c: Matrix2f16) {
 	c[1, 1] = +m[0, 0] * id
 	return c
 }
-matrix2_inverse_transpose_f32 :: proc(m: Matrix2f32) -> (c: Matrix2f32) {
+matrix2_inverse_transpose_f32 :: proc "contextless" (m: Matrix2f32) -> (c: Matrix2f32) {
 	d := m[0, 0]*m[1, 1] - m[0, 1]*m[1, 0]
 	id := 1.0/d
 	c[0, 0] = +m[1, 1] * id
@@ -1111,7 +1111,7 @@ matrix2_inverse_transpose_f32 :: proc(m: Matrix2f32) -> (c: Matrix2f32) {
 	c[1, 1] = +m[0, 0] * id
 	return c
 }
-matrix2_inverse_transpose_f64 :: proc(m: Matrix2f64) -> (c: Matrix2f64) {
+matrix2_inverse_transpose_f64 :: proc "contextless" (m: Matrix2f64) -> (c: Matrix2f64) {
 	d := m[0, 0]*m[1, 1] - m[0, 1]*m[1, 0]
 	id := 1.0/d
 	c[0, 0] = +m[1, 1] * id
@@ -1127,13 +1127,13 @@ matrix2_inverse_transpose :: proc{
 }
 
 
-matrix2_determinant_f16 :: proc(m: Matrix2f16) -> f16 {
+matrix2_determinant_f16 :: proc "contextless" (m: Matrix2f16) -> f16 {
 	return m[0, 0]*m[1, 1] - m[0, 1]*m[1, 0]
 }
-matrix2_determinant_f32 :: proc(m: Matrix2f32) -> f32 {
+matrix2_determinant_f32 :: proc "contextless" (m: Matrix2f32) -> f32 {
 	return m[0, 0]*m[1, 1] - m[0, 1]*m[1, 0]
 }
-matrix2_determinant_f64 :: proc(m: Matrix2f64) -> f64 {
+matrix2_determinant_f64 :: proc "contextless" (m: Matrix2f64) -> f64 {
 	return m[0, 0]*m[1, 1] - m[0, 1]*m[1, 0]
 }
 matrix2_determinant :: proc{
@@ -1143,7 +1143,7 @@ matrix2_determinant :: proc{
 }
 
 
-matrix2_inverse_f16 :: proc(m: Matrix2f16) -> (c: Matrix2f16) {
+matrix2_inverse_f16 :: proc "contextless" (m: Matrix2f16) -> (c: Matrix2f16) {
 	d := m[0, 0]*m[1, 1] - m[0, 1]*m[1, 0]
 	id := 1.0/d
 	c[0, 0] = +m[1, 1] * id
@@ -1152,7 +1152,7 @@ matrix2_inverse_f16 :: proc(m: Matrix2f16) -> (c: Matrix2f16) {
 	c[1, 1] = +m[0, 0] * id
 	return c
 }
-matrix2_inverse_f32 :: proc(m: Matrix2f32) -> (c: Matrix2f32) {
+matrix2_inverse_f32 :: proc "contextless" (m: Matrix2f32) -> (c: Matrix2f32) {
 	d := m[0, 0]*m[1, 1] - m[0, 1]*m[1, 0]
 	id := 1.0/d
 	c[0, 0] = +m[1, 1] * id
@@ -1161,7 +1161,7 @@ matrix2_inverse_f32 :: proc(m: Matrix2f32) -> (c: Matrix2f32) {
 	c[1, 1] = +m[0, 0] * id
 	return c
 }
-matrix2_inverse_f64 :: proc(m: Matrix2f64) -> (c: Matrix2f64) {
+matrix2_inverse_f64 :: proc "contextless" (m: Matrix2f64) -> (c: Matrix2f64) {
 	d := m[0, 0]*m[1, 1] - m[0, 1]*m[1, 0]
 	id := 1.0/d
 	c[0, 0] = +m[1, 1] * id
@@ -1177,21 +1177,21 @@ matrix2_inverse :: proc{
 }
 
 
-matrix2_adjoint_f16 :: proc(m: Matrix2f16) -> (c: Matrix2f16) {
+matrix2_adjoint_f16 :: proc "contextless" (m: Matrix2f16) -> (c: Matrix2f16) {
 	c[0, 0] = +m[1, 1]
 	c[1, 0] = -m[0, 1]
 	c[0, 1] = -m[1, 0]
 	c[1, 1] = +m[0, 0]
 	return c
 }
-matrix2_adjoint_f32 :: proc(m: Matrix2f32) -> (c: Matrix2f32) {
+matrix2_adjoint_f32 :: proc "contextless" (m: Matrix2f32) -> (c: Matrix2f32) {
 	c[0, 0] = +m[1, 1]
 	c[1, 0] = -m[0, 1]
 	c[0, 1] = -m[1, 0]
 	c[1, 1] = +m[0, 0]
 	return c
 }
-matrix2_adjoint_f64 :: proc(m: Matrix2f64) -> (c: Matrix2f64) {
+matrix2_adjoint_f64 :: proc "contextless" (m: Matrix2f64) -> (c: Matrix2f64) {
 	c[0, 0] = +m[1, 1]
 	c[1, 0] = -m[0, 1]
 	c[0, 1] = -m[1, 0]
@@ -1205,7 +1205,7 @@ matrix2_adjoint :: proc{
 }
 
 
-matrix3_from_quaternion_f16 :: proc(q: Quaternionf16) -> (m: Matrix3f16) {
+matrix3_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> (m: Matrix3f16) {
 	qxx := q.x * q.x
 	qyy := q.y * q.y
 	qzz := q.z * q.z
@@ -1229,7 +1229,7 @@ matrix3_from_quaternion_f16 :: proc(q: Quaternionf16) -> (m: Matrix3f16) {
 	m[2, 2] = 1 - 2 * (qxx + qyy)
 	return m
 }
-matrix3_from_quaternion_f32 :: proc(q: Quaternionf32) -> (m: Matrix3f32) {
+matrix3_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> (m: Matrix3f32) {
 	qxx := q.x * q.x
 	qyy := q.y * q.y
 	qzz := q.z * q.z
@@ -1253,7 +1253,7 @@ matrix3_from_quaternion_f32 :: proc(q: Quaternionf32) -> (m: Matrix3f32) {
 	m[2, 2] = 1 - 2 * (qxx + qyy)
 	return m
 }
-matrix3_from_quaternion_f64 :: proc(q: Quaternionf64) -> (m: Matrix3f64) {
+matrix3_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> (m: Matrix3f64) {
 	qxx := q.x * q.x
 	qyy := q.y * q.y
 	qzz := q.z * q.z
@@ -1284,13 +1284,13 @@ matrix3_from_quaternion :: proc{
 }
 
 
-matrix3_inverse_f16 :: proc(m: Matrix3f16) -> Matrix3f16 {
+matrix3_inverse_f16 :: proc "contextless" (m: Matrix3f16) -> Matrix3f16 {
 	return transpose(matrix3_inverse_transpose(m))
 }
-matrix3_inverse_f32 :: proc(m: Matrix3f32) -> Matrix3f32 {
+matrix3_inverse_f32 :: proc "contextless" (m: Matrix3f32) -> Matrix3f32 {
 	return transpose(matrix3_inverse_transpose(m))
 }
-matrix3_inverse_f64 :: proc(m: Matrix3f64) -> Matrix3f64 {
+matrix3_inverse_f64 :: proc "contextless" (m: Matrix3f64) -> Matrix3f64 {
 	return transpose(matrix3_inverse_transpose(m))
 }
 matrix3_inverse :: proc{
@@ -1300,19 +1300,19 @@ matrix3_inverse :: proc{
 }
 
 
-matrix3_determinant_f16 :: proc(m: Matrix3f16) -> f16 {
+matrix3_determinant_f16 :: proc "contextless" (m: Matrix3f16) -> f16 {
 	a := +m[0, 0] * (m[1, 1] * m[2, 2] - m[1, 2] * m[2, 1])
 	b := -m[0, 1] * (m[1, 0] * m[2, 2] - m[1, 2] * m[2, 0])
 	c := +m[0, 2] * (m[1, 0] * m[2, 1] - m[1, 1] * m[2, 0])
 	return a + b + c
 }
-matrix3_determinant_f32 :: proc(m: Matrix3f32) -> f32 {
+matrix3_determinant_f32 :: proc "contextless" (m: Matrix3f32) -> f32 {
 	a := +m[0, 0] * (m[1, 1] * m[2, 2] - m[1, 2] * m[2, 1])
 	b := -m[0, 1] * (m[1, 0] * m[2, 2] - m[1, 2] * m[2, 0])
 	c := +m[0, 2] * (m[1, 0] * m[2, 1] - m[1, 1] * m[2, 0])
 	return a + b + c
 }
-matrix3_determinant_f64 :: proc(m: Matrix3f64) -> f64 {
+matrix3_determinant_f64 :: proc "contextless" (m: Matrix3f64) -> f64 {
 	a := +m[0, 0] * (m[1, 1] * m[2, 2] - m[1, 2] * m[2, 1])
 	b := -m[0, 1] * (m[1, 0] * m[2, 2] - m[1, 2] * m[2, 0])
 	c := +m[0, 2] * (m[1, 0] * m[2, 1] - m[1, 1] * m[2, 0])
@@ -1325,7 +1325,7 @@ matrix3_determinant :: proc{
 }
 
 
-matrix3_adjoint_f16 :: proc(m: Matrix3f16) -> (adjoint: Matrix3f16) {
+matrix3_adjoint_f16 :: proc "contextless" (m: Matrix3f16) -> (adjoint: Matrix3f16) {
 	adjoint[0, 0] = +(m[1, 1] * m[2, 2] - m[2, 1] * m[1, 2])
 	adjoint[0, 1] = -(m[1, 0] * m[2, 2] - m[2, 0] * m[1, 2])
 	adjoint[0, 2] = +(m[1, 0] * m[2, 1] - m[2, 0] * m[1, 1])
@@ -1337,7 +1337,7 @@ matrix3_adjoint_f16 :: proc(m: Matrix3f16) -> (adjoint: Matrix3f16) {
 	adjoint[2, 2] = +(m[0, 0] * m[1, 1] - m[1, 0] * m[0, 1])
 	return adjoint
 }
-matrix3_adjoint_f32 :: proc(m: Matrix3f32) -> (adjoint: Matrix3f32) {
+matrix3_adjoint_f32 :: proc "contextless" (m: Matrix3f32) -> (adjoint: Matrix3f32) {
 	adjoint[0, 0] = +(m[1, 1] * m[2, 2] - m[2, 1] * m[1, 2])
 	adjoint[0, 1] = -(m[1, 0] * m[2, 2] - m[2, 0] * m[1, 2])
 	adjoint[0, 2] = +(m[1, 0] * m[2, 1] - m[2, 0] * m[1, 1])
@@ -1349,7 +1349,7 @@ matrix3_adjoint_f32 :: proc(m: Matrix3f32) -> (adjoint: Matrix3f32) {
 	adjoint[2, 2] = +(m[0, 0] * m[1, 1] - m[1, 0] * m[0, 1])
 	return adjoint
 }
-matrix3_adjoint_f64 :: proc(m: Matrix3f64) -> (adjoint: Matrix3f64) {
+matrix3_adjoint_f64 :: proc "contextless" (m: Matrix3f64) -> (adjoint: Matrix3f64) {
 	adjoint[0, 0] = +(m[1, 1] * m[2, 2] - m[2, 1] * m[1, 2])
 	adjoint[0, 1] = -(m[1, 0] * m[2, 2] - m[2, 0] * m[1, 2])
 	adjoint[0, 2] = +(m[1, 0] * m[2, 1] - m[2, 0] * m[1, 1])
@@ -1369,13 +1369,13 @@ matrix3_adjoint :: proc{
 
 
 
-matrix3_inverse_transpose_f16 :: proc(m: Matrix3f16) -> (inverse_transpose: Matrix3f16) {
+matrix3_inverse_transpose_f16 :: proc "contextless" (m: Matrix3f16) -> (inverse_transpose: Matrix3f16) {
 	return builtin.inverse_transpose(m)
 }
-matrix3_inverse_transpose_f32 :: proc(m: Matrix3f32) -> (inverse_transpose: Matrix3f32) {
+matrix3_inverse_transpose_f32 :: proc "contextless" (m: Matrix3f32) -> (inverse_transpose: Matrix3f32) {
 	return builtin.inverse_transpose(m)
 }
-matrix3_inverse_transpose_f64 :: proc(m: Matrix3f64) -> (inverse_transpose: Matrix3f64) {
+matrix3_inverse_transpose_f64 :: proc "contextless" (m: Matrix3f64) -> (inverse_transpose: Matrix3f64) {
 	return builtin.inverse_transpose(m)
 }
 matrix3_inverse_transpose :: proc{
@@ -1385,19 +1385,19 @@ matrix3_inverse_transpose :: proc{
 }
 
 
-matrix3_scale_f16 :: proc(s: Vector3f16) -> (m: Matrix3f16) {
+matrix3_scale_f16 :: proc "contextless" (s: Vector3f16) -> (m: Matrix3f16) {
 	m[0, 0] = s[0]
 	m[1, 1] = s[1]
 	m[2, 2] = s[2]
 	return m
 }
-matrix3_scale_f32 :: proc(s: Vector3f32) -> (m: Matrix3f32) {
+matrix3_scale_f32 :: proc "contextless" (s: Vector3f32) -> (m: Matrix3f32) {
 	m[0, 0] = s[0]
 	m[1, 1] = s[1]
 	m[2, 2] = s[2]
 	return m
 }
-matrix3_scale_f64 :: proc(s: Vector3f64) -> (m: Matrix3f64) {
+matrix3_scale_f64 :: proc "contextless" (s: Vector3f64) -> (m: Matrix3f64) {
 	m[0, 0] = s[0]
 	m[1, 1] = s[1]
 	m[2, 2] = s[2]
@@ -1410,7 +1410,7 @@ matrix3_scale :: proc{
 }
 
 
-matrix3_rotate_f16 :: proc(angle_radians: f16, v: Vector3f16) -> (rot: Matrix3f16) {
+matrix3_rotate_f16 :: proc "contextless" (angle_radians: f16, v: Vector3f16) -> (rot: Matrix3f16) {
 	c := math.cos(angle_radians)
 	s := math.sin(angle_radians)
 
@@ -1431,7 +1431,7 @@ matrix3_rotate_f16 :: proc(angle_radians: f16, v: Vector3f16) -> (rot: Matrix3f1
 
 	return rot
 }
-matrix3_rotate_f32 :: proc(angle_radians: f32, v: Vector3f32) -> (rot: Matrix3f32) {
+matrix3_rotate_f32 :: proc "contextless" (angle_radians: f32, v: Vector3f32) -> (rot: Matrix3f32) {
 	c := math.cos(angle_radians)
 	s := math.sin(angle_radians)
 
@@ -1452,7 +1452,7 @@ matrix3_rotate_f32 :: proc(angle_radians: f32, v: Vector3f32) -> (rot: Matrix3f3
 
 	return rot
 }
-matrix3_rotate_f64 :: proc(angle_radians: f64, v: Vector3f64) -> (rot: Matrix3f64) {
+matrix3_rotate_f64 :: proc "contextless" (angle_radians: f64, v: Vector3f64) -> (rot: Matrix3f64) {
 	c := math.cos(angle_radians)
 	s := math.sin(angle_radians)
 
@@ -1480,7 +1480,7 @@ matrix3_rotate :: proc{
 }
 
 
-matrix3_look_at_f16 :: proc(eye, centre, up: Vector3f16) -> Matrix3f16 {
+matrix3_look_at_f16 :: proc "contextless" (eye, centre, up: Vector3f16) -> Matrix3f16 {
 	f := normalize(centre - eye)
 	s := normalize(cross(f, up))
 	u := cross(s, f)
@@ -1490,7 +1490,7 @@ matrix3_look_at_f16 :: proc(eye, centre, up: Vector3f16) -> Matrix3f16 {
 		-f.x, -f.y, -f.z,
 	}
 }
-matrix3_look_at_f32 :: proc(eye, centre, up: Vector3f32) -> Matrix3f32 {
+matrix3_look_at_f32 :: proc "contextless" (eye, centre, up: Vector3f32) -> Matrix3f32 {
 	f := normalize(centre - eye)
 	s := normalize(cross(f, up))
 	u := cross(s, f)
@@ -1500,7 +1500,7 @@ matrix3_look_at_f32 :: proc(eye, centre, up: Vector3f32) -> Matrix3f32 {
 		-f.x, -f.y, -f.z,
 	}
 }
-matrix3_look_at_f64 :: proc(eye, centre, up: Vector3f64) -> Matrix3f64 {
+matrix3_look_at_f64 :: proc "contextless" (eye, centre, up: Vector3f64) -> Matrix3f64 {
 	f := normalize(centre - eye)
 	s := normalize(cross(f, up))
 	u := cross(s, f)
@@ -1517,7 +1517,7 @@ matrix3_look_at :: proc{
 }
 
 
-matrix4_from_quaternion_f16 :: proc(q: Quaternionf16) -> (m: Matrix4f16) {
+matrix4_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> (m: Matrix4f16) {
 	qxx := q.x * q.x
 	qyy := q.y * q.y
 	qzz := q.z * q.z
@@ -1544,7 +1544,7 @@ matrix4_from_quaternion_f16 :: proc(q: Quaternionf16) -> (m: Matrix4f16) {
 
 	return m
 }
-matrix4_from_quaternion_f32 :: proc(q: Quaternionf32) -> (m: Matrix4f32) {
+matrix4_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> (m: Matrix4f32) {
 	qxx := q.x * q.x
 	qyy := q.y * q.y
 	qzz := q.z * q.z
@@ -1571,7 +1571,7 @@ matrix4_from_quaternion_f32 :: proc(q: Quaternionf32) -> (m: Matrix4f32) {
 
 	return m
 }
-matrix4_from_quaternion_f64 :: proc(q: Quaternionf64) -> (m: Matrix4f64) {
+matrix4_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> (m: Matrix4f64) {
 	qxx := q.x * q.x
 	qyy := q.y * q.y
 	qzz := q.z * q.z
@@ -1605,19 +1605,19 @@ matrix4_from_quaternion :: proc{
 }
 
 
-matrix4_from_trs_f16 :: proc(t: Vector3f16, r: Quaternionf16, s: Vector3f16) -> Matrix4f16 {
+matrix4_from_trs_f16 :: proc "contextless" (t: Vector3f16, r: Quaternionf16, s: Vector3f16) -> Matrix4f16 {
 	translation := matrix4_translate(t)
 	rotation := matrix4_from_quaternion(r)
 	scale := matrix4_scale(s)
 	return mul(translation, mul(rotation, scale))
 }
-matrix4_from_trs_f32 :: proc(t: Vector3f32, r: Quaternionf32, s: Vector3f32) -> Matrix4f32 {
+matrix4_from_trs_f32 :: proc "contextless" (t: Vector3f32, r: Quaternionf32, s: Vector3f32) -> Matrix4f32 {
 	translation := matrix4_translate(t)
 	rotation := matrix4_from_quaternion(r)
 	scale := matrix4_scale(s)
 	return mul(translation, mul(rotation, scale))
 }
-matrix4_from_trs_f64 :: proc(t: Vector3f64, r: Quaternionf64, s: Vector3f64) -> Matrix4f64 {
+matrix4_from_trs_f64 :: proc "contextless" (t: Vector3f64, r: Quaternionf64, s: Vector3f64) -> Matrix4f64 {
 	translation := matrix4_translate(t)
 	rotation := matrix4_from_quaternion(r)
 	scale := matrix4_scale(s)
@@ -1631,13 +1631,13 @@ matrix4_from_trs :: proc{
 
 
 
-matrix4_inverse_f16 :: proc(m: Matrix4f16) -> Matrix4f16 {
+matrix4_inverse_f16 :: proc "contextless" (m: Matrix4f16) -> Matrix4f16 {
 	return transpose(matrix4_inverse_transpose(m))
 }
-matrix4_inverse_f32 :: proc(m: Matrix4f32) -> Matrix4f32 {
+matrix4_inverse_f32 :: proc "contextless" (m: Matrix4f32) -> Matrix4f32 {
 	return transpose(matrix4_inverse_transpose(m))
 }
-matrix4_inverse_f64 :: proc(m: Matrix4f64) -> Matrix4f64 {
+matrix4_inverse_f64 :: proc "contextless" (m: Matrix4f64) -> Matrix4f64 {
 	return transpose(matrix4_inverse_transpose(m))
 }
 matrix4_inverse :: proc{
@@ -1647,7 +1647,7 @@ matrix4_inverse :: proc{
 }
 
 
-matrix4_minor_f16 :: proc(m: Matrix4f16, c, r: int) -> f16 {
+matrix4_minor_f16 :: proc "contextless" (m: Matrix4f16, c, r: int) -> f16 {
 	cut_down: Matrix3f16
 	for i in 0..<3 {
 		col := i if i < c else i+1
@@ -1658,7 +1658,7 @@ matrix4_minor_f16 :: proc(m: Matrix4f16, c, r: int) -> f16 {
 	}
 	return matrix3_determinant(cut_down)
 }
-matrix4_minor_f32 :: proc(m: Matrix4f32, c, r: int) -> f32 {
+matrix4_minor_f32 :: proc "contextless" (m: Matrix4f32, c, r: int) -> f32 {
 	cut_down: Matrix3f32
 	for i in 0..<3 {
 		col := i if i < c else i+1
@@ -1669,7 +1669,7 @@ matrix4_minor_f32 :: proc(m: Matrix4f32, c, r: int) -> f32 {
 	}
 	return matrix3_determinant(cut_down)
 }
-matrix4_minor_f64 :: proc(m: Matrix4f64, c, r: int) -> f64 {
+matrix4_minor_f64 :: proc "contextless" (m: Matrix4f64, c, r: int) -> f64 {
 	cut_down: Matrix3f64
 	for i in 0..<3 {
 		col := i if i < c else i+1
@@ -1687,19 +1687,19 @@ matrix4_minor :: proc{
 }
 
 
-matrix4_cofactor_f16 :: proc(m: Matrix4f16, c, r: int) -> f16 {
+matrix4_cofactor_f16 :: proc "contextless" (m: Matrix4f16, c, r: int) -> f16 {
 	sign, minor: f16
 	sign = 1 if (c + r) % 2 == 0 else -1
 	minor = matrix4_minor(m, c, r)
 	return sign * minor
 }
-matrix4_cofactor_f32 :: proc(m: Matrix4f32, c, r: int) -> f32 {
+matrix4_cofactor_f32 :: proc "contextless" (m: Matrix4f32, c, r: int) -> f32 {
 	sign, minor: f32
 	sign = 1 if (c + r) % 2 == 0 else -1
 	minor = matrix4_minor(m, c, r)
 	return sign * minor
 }
-matrix4_cofactor_f64 :: proc(m: Matrix4f64, c, r: int) -> f64 {
+matrix4_cofactor_f64 :: proc "contextless" (m: Matrix4f64, c, r: int) -> f64 {
 	sign, minor: f64
 	sign = 1 if (c + r) % 2 == 0 else -1
 	minor = matrix4_minor(m, c, r)
@@ -1712,7 +1712,7 @@ matrix4_cofactor :: proc{
 }
 
 
-matrix4_adjoint_f16 :: proc(m: Matrix4f16) -> (adjoint: Matrix4f16) {
+matrix4_adjoint_f16 :: proc "contextless" (m: Matrix4f16) -> (adjoint: Matrix4f16) {
 	for i in 0..<4 {
 		for j in 0..<4 {
 			adjoint[i][j] = matrix4_cofactor(m, i, j)
@@ -1720,7 +1720,7 @@ matrix4_adjoint_f16 :: proc(m: Matrix4f16) -> (adjoint: Matrix4f16) {
 	}
 	return
 }
-matrix4_adjoint_f32 :: proc(m: Matrix4f32) -> (adjoint: Matrix4f32) {
+matrix4_adjoint_f32 :: proc "contextless" (m: Matrix4f32) -> (adjoint: Matrix4f32) {
 	for i in 0..<4 {
 		for j in 0..<4 {
 			adjoint[i][j] = matrix4_cofactor(m, i, j)
@@ -1728,7 +1728,7 @@ matrix4_adjoint_f32 :: proc(m: Matrix4f32) -> (adjoint: Matrix4f32) {
 	}
 	return
 }
-matrix4_adjoint_f64 :: proc(m: Matrix4f64) -> (adjoint: Matrix4f64) {
+matrix4_adjoint_f64 :: proc "contextless" (m: Matrix4f64) -> (adjoint: Matrix4f64) {
 	for i in 0..<4 {
 		for j in 0..<4 {
 			adjoint[i][j] = matrix4_cofactor(m, i, j)
@@ -1743,21 +1743,21 @@ matrix4_adjoint :: proc{
 }
 
 
-matrix4_determinant_f16 :: proc(m: Matrix4f16) -> (determinant: f16) {
+matrix4_determinant_f16 :: proc "contextless" (m: Matrix4f16) -> (determinant: f16) {
 	adjoint := matrix4_adjoint(m)
 	for i in 0..<4 {
 		determinant += m[i][0] * adjoint[i][0]
 	}
 	return
 }
-matrix4_determinant_f32 :: proc(m: Matrix4f32) -> (determinant: f32) {
+matrix4_determinant_f32 :: proc "contextless" (m: Matrix4f32) -> (determinant: f32) {
 	adjoint := matrix4_adjoint(m)
 	for i in 0..<4 {
 		determinant += m[i][0] * adjoint[i][0]
 	}
 	return
 }
-matrix4_determinant_f64 :: proc(m: Matrix4f64) -> (determinant: f64) {
+matrix4_determinant_f64 :: proc "contextless" (m: Matrix4f64) -> (determinant: f64) {
 	adjoint := matrix4_adjoint(m)
 	for i in 0..<4 {
 		determinant += m[i][0] * adjoint[i][0]
@@ -1771,7 +1771,7 @@ matrix4_determinant :: proc{
 }
 
 
-matrix4_inverse_transpose_f16 :: proc(m: Matrix4f16) -> (inverse_transpose: Matrix4f16) {
+matrix4_inverse_transpose_f16 :: proc "contextless" (m: Matrix4f16) -> (inverse_transpose: Matrix4f16) {
 	adjoint := matrix4_adjoint(m)
 	determinant: f16 = 0
 	for i in 0..<4 {
@@ -1785,7 +1785,7 @@ matrix4_inverse_transpose_f16 :: proc(m: Matrix4f16) -> (inverse_transpose: Matr
 	}
 	return
 }
-matrix4_inverse_transpose_f32 :: proc(m: Matrix4f32) -> (inverse_transpose: Matrix4f32) {
+matrix4_inverse_transpose_f32 :: proc "contextless" (m: Matrix4f32) -> (inverse_transpose: Matrix4f32) {
 	adjoint := matrix4_adjoint(m)
 	determinant: f32 = 0
 	for i in 0..<4 {
@@ -1799,7 +1799,7 @@ matrix4_inverse_transpose_f32 :: proc(m: Matrix4f32) -> (inverse_transpose: Matr
 	}
 	return
 }
-matrix4_inverse_transpose_f64 :: proc(m: Matrix4f64) -> (inverse_transpose: Matrix4f64) {
+matrix4_inverse_transpose_f64 :: proc "contextless" (m: Matrix4f64) -> (inverse_transpose: Matrix4f64) {
 	adjoint := matrix4_adjoint(m)
 	determinant: f64 = 0
 	for i in 0..<4 {
@@ -1820,21 +1820,21 @@ matrix4_inverse_transpose :: proc{
 }
 
 
-matrix4_translate_f16 :: proc(v: Vector3f16) -> Matrix4f16 {
+matrix4_translate_f16 :: proc "contextless" (v: Vector3f16) -> Matrix4f16 {
 	m := MATRIX4F16_IDENTITY
 	m[3][0] = v[0]
 	m[3][1] = v[1]
 	m[3][2] = v[2]
 	return m
 }
-matrix4_translate_f32 :: proc(v: Vector3f32) -> Matrix4f32 {
+matrix4_translate_f32 :: proc "contextless" (v: Vector3f32) -> Matrix4f32 {
 	m := MATRIX4F32_IDENTITY
 	m[3][0] = v[0]
 	m[3][1] = v[1]
 	m[3][2] = v[2]
 	return m
 }
-matrix4_translate_f64 :: proc(v: Vector3f64) -> Matrix4f64 {
+matrix4_translate_f64 :: proc "contextless" (v: Vector3f64) -> Matrix4f64 {
 	m := MATRIX4F64_IDENTITY
 	m[3][0] = v[0]
 	m[3][1] = v[1]
@@ -1848,7 +1848,7 @@ matrix4_translate :: proc{
 }
 
 
-matrix4_rotate_f16 :: proc(angle_radians: f16, v: Vector3f16) -> Matrix4f16 {
+matrix4_rotate_f16 :: proc "contextless" (angle_radians: f16, v: Vector3f16) -> Matrix4f16 {
 	c := math.cos(angle_radians)
 	s := math.sin(angle_radians)
 
@@ -1874,7 +1874,7 @@ matrix4_rotate_f16 :: proc(angle_radians: f16, v: Vector3f16) -> Matrix4f16 {
 
 	return rot
 }
-matrix4_rotate_f32 :: proc(angle_radians: f32, v: Vector3f32) -> Matrix4f32 {
+matrix4_rotate_f32 :: proc "contextless" (angle_radians: f32, v: Vector3f32) -> Matrix4f32 {
 	c := math.cos(angle_radians)
 	s := math.sin(angle_radians)
 
@@ -1900,7 +1900,7 @@ matrix4_rotate_f32 :: proc(angle_radians: f32, v: Vector3f32) -> Matrix4f32 {
 
 	return rot
 }
-matrix4_rotate_f64 :: proc(angle_radians: f64, v: Vector3f64) -> Matrix4f64 {
+matrix4_rotate_f64 :: proc "contextless" (angle_radians: f64, v: Vector3f64) -> Matrix4f64 {
 	c := math.cos(angle_radians)
 	s := math.sin(angle_radians)
 
@@ -1933,21 +1933,21 @@ matrix4_rotate :: proc{
 }
 
 
-matrix4_scale_f16 :: proc(v: Vector3f16) -> (m: Matrix4f16) {
+matrix4_scale_f16 :: proc "contextless" (v: Vector3f16) -> (m: Matrix4f16) {
 	m[0][0] = v[0]
 	m[1][1] = v[1]
 	m[2][2] = v[2]
 	m[3][3] = 1
 	return
 }
-matrix4_scale_f32 :: proc(v: Vector3f32) -> (m: Matrix4f32) {
+matrix4_scale_f32 :: proc "contextless" (v: Vector3f32) -> (m: Matrix4f32) {
 	m[0][0] = v[0]
 	m[1][1] = v[1]
 	m[2][2] = v[2]
 	m[3][3] = 1
 	return
 }
-matrix4_scale_f64 :: proc(v: Vector3f64) -> (m: Matrix4f64) {
+matrix4_scale_f64 :: proc "contextless" (v: Vector3f64) -> (m: Matrix4f64) {
 	m[0][0] = v[0]
 	m[1][1] = v[1]
 	m[2][2] = v[2]
@@ -1961,7 +1961,7 @@ matrix4_scale :: proc{
 }
 
 
-matrix4_look_at_f16 :: proc(eye, centre, up: Vector3f16, flip_z_axis := true) -> (m: Matrix4f16) {
+matrix4_look_at_f16 :: proc "contextless" (eye, centre, up: Vector3f16, flip_z_axis := true) -> (m: Matrix4f16) {
 	f := normalize(centre - eye)
 	s := normalize(cross(f, up))
 	u := cross(s, f)
@@ -1975,7 +1975,7 @@ matrix4_look_at_f16 :: proc(eye, centre, up: Vector3f16, flip_z_axis := true) ->
 		   0,    0,    0, 1,
 	}
 }
-matrix4_look_at_f32 :: proc(eye, centre, up: Vector3f32, flip_z_axis := true) -> (m: Matrix4f32) {
+matrix4_look_at_f32 :: proc "contextless" (eye, centre, up: Vector3f32, flip_z_axis := true) -> (m: Matrix4f32) {
 	f := normalize(centre - eye)
 	s := normalize(cross(f, up))
 	u := cross(s, f)
@@ -1989,7 +1989,7 @@ matrix4_look_at_f32 :: proc(eye, centre, up: Vector3f32, flip_z_axis := true) ->
 		   0,    0,    0, 1,
 	}
 }
-matrix4_look_at_f64 :: proc(eye, centre, up: Vector3f64, flip_z_axis := true) -> (m: Matrix4f64) {
+matrix4_look_at_f64 :: proc "contextless" (eye, centre, up: Vector3f64, flip_z_axis := true) -> (m: Matrix4f64) {
 	f := normalize(centre - eye)
 	s := normalize(cross(f, up))
 	u := cross(s, f)
@@ -2010,7 +2010,7 @@ matrix4_look_at :: proc{
 }
 
 
-matrix4_look_at_from_fru_f16 :: proc(eye, f, r, u: Vector3f16, flip_z_axis := true) -> (m: Matrix4f16) {
+matrix4_look_at_from_fru_f16 :: proc "contextless" (eye, f, r, u: Vector3f16, flip_z_axis := true) -> (m: Matrix4f16) {
 	f, s, u := f, r, u
 	f = normalize(f)
 	s = normalize(s)
@@ -2024,7 +2024,7 @@ matrix4_look_at_from_fru_f16 :: proc(eye, f, r, u: Vector3f16, flip_z_axis := tr
 		   0,    0,    0, 1,
 	}
 }
-matrix4_look_at_from_fru_f32 :: proc(eye, f, r, u: Vector3f32, flip_z_axis := true) -> (m: Matrix4f32) {
+matrix4_look_at_from_fru_f32 :: proc "contextless" (eye, f, r, u: Vector3f32, flip_z_axis := true) -> (m: Matrix4f32) {
 	f, s, u := f, r, u
 	f = normalize(f)
 	s = normalize(s)
@@ -2038,7 +2038,7 @@ matrix4_look_at_from_fru_f32 :: proc(eye, f, r, u: Vector3f32, flip_z_axis := tr
 		   0,    0,    0, 1,
 	}
 }
-matrix4_look_at_from_fru_f64 :: proc(eye, f, r, u: Vector3f64, flip_z_axis := true) -> (m: Matrix4f64) {
+matrix4_look_at_from_fru_f64 :: proc "contextless" (eye, f, r, u: Vector3f64, flip_z_axis := true) -> (m: Matrix4f64) {
 	f, s, u := f, r, u
 	f = normalize(f)
 	s = normalize(s)
@@ -2059,7 +2059,7 @@ matrix4_look_at_from_fru :: proc{
 }
 
 
-matrix4_perspective_f16 :: proc(fovy, aspect, near, far: f16, flip_z_axis := true) -> (m: Matrix4f16) {
+matrix4_perspective_f16 :: proc "contextless" (fovy, aspect, near, far: f16, flip_z_axis := true) -> (m: Matrix4f16) {
 	tan_half_fovy := math.tan(0.5 * fovy)
 	m[0, 0] = 1 / (aspect*tan_half_fovy)
 	m[1, 1] = 1 / (tan_half_fovy)
@@ -2073,7 +2073,7 @@ matrix4_perspective_f16 :: proc(fovy, aspect, near, far: f16, flip_z_axis := tru
 
 	return
 }
-matrix4_perspective_f32 :: proc(fovy, aspect, near, far: f32, flip_z_axis := true) -> (m: Matrix4f32) {
+matrix4_perspective_f32 :: proc "contextless" (fovy, aspect, near, far: f32, flip_z_axis := true) -> (m: Matrix4f32) {
 	tan_half_fovy := math.tan(0.5 * fovy)
 	m[0, 0] = 1 / (aspect*tan_half_fovy)
 	m[1, 1] = 1 / (tan_half_fovy)
@@ -2087,7 +2087,7 @@ matrix4_perspective_f32 :: proc(fovy, aspect, near, far: f32, flip_z_axis := tru
 
 	return
 }
-matrix4_perspective_f64 :: proc(fovy, aspect, near, far: f64, flip_z_axis := true) -> (m: Matrix4f64) {
+matrix4_perspective_f64 :: proc "contextless" (fovy, aspect, near, far: f64, flip_z_axis := true) -> (m: Matrix4f64) {
 	tan_half_fovy := math.tan(0.5 * fovy)
 	m[0, 0] = 1 / (aspect*tan_half_fovy)
 	m[1, 1] = 1 / (tan_half_fovy)
@@ -2109,7 +2109,7 @@ matrix4_perspective :: proc{
 
 
 
-matrix_ortho3d_f16 :: proc(left, right, bottom, top, near, far: f16, flip_z_axis := true) -> (m: Matrix4f16) {
+matrix_ortho3d_f16 :: proc "contextless" (left, right, bottom, top, near, far: f16, flip_z_axis := true) -> (m: Matrix4f16) {
 	m[0, 0] = +2 / (right - left)
 	m[1, 1] = +2 / (top - bottom)
 	m[2, 2] = +2 / (far - near)
@@ -2124,7 +2124,7 @@ matrix_ortho3d_f16 :: proc(left, right, bottom, top, near, far: f16, flip_z_axis
 
 	return
 }
-matrix_ortho3d_f32 :: proc(left, right, bottom, top, near, far: f32, flip_z_axis := true) -> (m: Matrix4f32) {
+matrix_ortho3d_f32 :: proc "contextless" (left, right, bottom, top, near, far: f32, flip_z_axis := true) -> (m: Matrix4f32) {
 	m[0, 0] = +2 / (right - left)
 	m[1, 1] = +2 / (top - bottom)
 	m[2, 2] = +2 / (far - near)
@@ -2139,7 +2139,7 @@ matrix_ortho3d_f32 :: proc(left, right, bottom, top, near, far: f32, flip_z_axis
 
 	return
 }
-matrix_ortho3d_f64 :: proc(left, right, bottom, top, near, far: f64, flip_z_axis := true) -> (m: Matrix4f64) {
+matrix_ortho3d_f64 :: proc "contextless" (left, right, bottom, top, near, far: f64, flip_z_axis := true) -> (m: Matrix4f64) {
 	m[0, 0] = +2 / (right - left)
 	m[1, 1] = +2 / (top - bottom)
 	m[2, 2] = +2 / (far - near)
@@ -2162,7 +2162,7 @@ matrix_ortho3d :: proc{
 
 
 
-matrix4_infinite_perspective_f16 :: proc(fovy, aspect, near: f16, flip_z_axis := true) -> (m: Matrix4f16) {
+matrix4_infinite_perspective_f16 :: proc "contextless" (fovy, aspect, near: f16, flip_z_axis := true) -> (m: Matrix4f16) {
 	tan_half_fovy := math.tan(0.5 * fovy)
 	m[0, 0] = 1 / (aspect*tan_half_fovy)
 	m[1, 1] = 1 / (tan_half_fovy)
@@ -2176,7 +2176,7 @@ matrix4_infinite_perspective_f16 :: proc(fovy, aspect, near: f16, flip_z_axis :=
 
 	return
 }
-matrix4_infinite_perspective_f32 :: proc(fovy, aspect, near: f32, flip_z_axis := true) -> (m: Matrix4f32) {
+matrix4_infinite_perspective_f32 :: proc "contextless" (fovy, aspect, near: f32, flip_z_axis := true) -> (m: Matrix4f32) {
 	tan_half_fovy := math.tan(0.5 * fovy)
 	m[0, 0] = 1 / (aspect*tan_half_fovy)
 	m[1, 1] = 1 / (tan_half_fovy)
@@ -2190,7 +2190,7 @@ matrix4_infinite_perspective_f32 :: proc(fovy, aspect, near: f32, flip_z_axis :=
 
 	return
 }
-matrix4_infinite_perspective_f64 :: proc(fovy, aspect, near: f64, flip_z_axis := true) -> (m: Matrix4f64) {
+matrix4_infinite_perspective_f64 :: proc "contextless" (fovy, aspect, near: f64, flip_z_axis := true) -> (m: Matrix4f64) {
 	tan_half_fovy := math.tan(0.5 * fovy)
 	m[0, 0] = 1 / (aspect*tan_half_fovy)
 	m[1, 1] = 1 / (tan_half_fovy)
@@ -2212,17 +2212,17 @@ matrix4_infinite_perspective :: proc{
 
 
 
-matrix2_from_scalar_f16 :: proc(f: f16) -> (m: Matrix2f16) {
+matrix2_from_scalar_f16 :: proc "contextless" (f: f16) -> (m: Matrix2f16) {
 	m[0, 0], m[1, 0] = f, 0
 	m[0, 1], m[1, 1] = 0, f
 	return
 }
-matrix2_from_scalar_f32 :: proc(f: f32) -> (m: Matrix2f32) {
+matrix2_from_scalar_f32 :: proc "contextless" (f: f32) -> (m: Matrix2f32) {
 	m[0, 0], m[1, 0] = f, 0
 	m[0, 1], m[1, 1] = 0, f
 	return
 }
-matrix2_from_scalar_f64 :: proc(f: f64) -> (m: Matrix2f64) {
+matrix2_from_scalar_f64 :: proc "contextless" (f: f64) -> (m: Matrix2f64) {
 	m[0, 0], m[1, 0] = f, 0
 	m[0, 1], m[1, 1] = 0, f
 	return
@@ -2234,19 +2234,19 @@ matrix2_from_scalar :: proc{
 }
 
 
-matrix3_from_scalar_f16 :: proc(f: f16) -> (m: Matrix3f16) {
+matrix3_from_scalar_f16 :: proc "contextless" (f: f16) -> (m: Matrix3f16) {
 	m[0, 0], m[1, 0], m[2, 0] = f, 0, 0
 	m[0, 1], m[1, 1], m[2, 1] = 0, f, 0
 	m[0, 2], m[1, 2], m[2, 2] = 0, 0, f
 	return
 }
-matrix3_from_scalar_f32 :: proc(f: f32) -> (m: Matrix3f32) {
+matrix3_from_scalar_f32 :: proc "contextless" (f: f32) -> (m: Matrix3f32) {
 	m[0, 0], m[1, 0], m[2, 0] = f, 0, 0
 	m[0, 1], m[1, 1], m[2, 1] = 0, f, 0
 	m[0, 2], m[1, 2], m[2, 2] = 0, 0, f
 	return
 }
-matrix3_from_scalar_f64 :: proc(f: f64) -> (m: Matrix3f64) {
+matrix3_from_scalar_f64 :: proc "contextless" (f: f64) -> (m: Matrix3f64) {
 	m[0, 0], m[1, 0], m[2, 0] = f, 0, 0
 	m[0, 1], m[1, 1], m[2, 1] = 0, f, 0
 	m[0, 2], m[1, 2], m[2, 2] = 0, 0, f
@@ -2259,21 +2259,21 @@ matrix3_from_scalar :: proc{
 }
 
 
-matrix4_from_scalar_f16 :: proc(f: f16) -> (m: Matrix4f16) {
+matrix4_from_scalar_f16 :: proc "contextless" (f: f16) -> (m: Matrix4f16) {
 	m[0, 0], m[1, 0], m[2, 0], m[3, 0] = f, 0, 0, 0
 	m[0, 1], m[1, 1], m[2, 1], m[3, 1] = 0, f, 0, 0
 	m[0, 2], m[1, 2], m[2, 2], m[3, 2] = 0, 0, f, 0
 	m[0, 3], m[1, 3], m[2, 3], m[3, 3] = 0, 0, 0, f
 	return
 }
-matrix4_from_scalar_f32 :: proc(f: f32) -> (m: Matrix4f32) {
+matrix4_from_scalar_f32 :: proc "contextless" (f: f32) -> (m: Matrix4f32) {
 	m[0, 0], m[1, 0], m[2, 0], m[3, 0] = f, 0, 0, 0
 	m[0, 1], m[1, 1], m[2, 1], m[3, 1] = 0, f, 0, 0
 	m[0, 2], m[1, 2], m[2, 2], m[3, 2] = 0, 0, f, 0
 	m[0, 3], m[1, 3], m[2, 3], m[3, 3] = 0, 0, 0, f
 	return
 }
-matrix4_from_scalar_f64 :: proc(f: f64) -> (m: Matrix4f64) {
+matrix4_from_scalar_f64 :: proc "contextless" (f: f64) -> (m: Matrix4f64) {
 	m[0, 0], m[1, 0], m[2, 0], m[3, 0] = f, 0, 0, 0
 	m[0, 1], m[1, 1], m[2, 1], m[3, 1] = 0, f, 0, 0
 	m[0, 2], m[1, 2], m[2, 2], m[3, 2] = 0, 0, f, 0
@@ -2287,17 +2287,17 @@ matrix4_from_scalar :: proc{
 }
 
 
-matrix2_from_matrix3_f16 :: proc(m: Matrix3f16) -> (r: Matrix2f16) {
+matrix2_from_matrix3_f16 :: proc "contextless" (m: Matrix3f16) -> (r: Matrix2f16) {
 	r[0, 0], r[1, 0] = m[0, 0], m[1, 0]
 	r[0, 1], r[1, 1] = m[0, 1], m[1, 1]
 	return
 }
-matrix2_from_matrix3_f32 :: proc(m: Matrix3f32) -> (r: Matrix2f32) {
+matrix2_from_matrix3_f32 :: proc "contextless" (m: Matrix3f32) -> (r: Matrix2f32) {
 	r[0, 0], r[1, 0] = m[0, 0], m[1, 0]
 	r[0, 1], r[1, 1] = m[0, 1], m[1, 1]
 	return
 }
-matrix2_from_matrix3_f64 :: proc(m: Matrix3f64) -> (r: Matrix2f64) {
+matrix2_from_matrix3_f64 :: proc "contextless" (m: Matrix3f64) -> (r: Matrix2f64) {
 	r[0, 0], r[1, 0] = m[0, 0], m[1, 0]
 	r[0, 1], r[1, 1] = m[0, 1], m[1, 1]
 	return
@@ -2309,17 +2309,17 @@ matrix2_from_matrix3 :: proc{
 }
 
 
-matrix2_from_matrix4_f16 :: proc(m: Matrix4f16) -> (r: Matrix2f16) {
+matrix2_from_matrix4_f16 :: proc "contextless" (m: Matrix4f16) -> (r: Matrix2f16) {
 	r[0, 0], r[1, 0] = m[0, 0], m[1, 0]
 	r[0, 1], r[1, 1] = m[0, 1], m[1, 1]
 	return
 }
-matrix2_from_matrix4_f32 :: proc(m: Matrix4f32) -> (r: Matrix2f32) {
+matrix2_from_matrix4_f32 :: proc "contextless" (m: Matrix4f32) -> (r: Matrix2f32) {
 	r[0, 0], r[1, 0] = m[0, 0], m[1, 0]
 	r[0, 1], r[1, 1] = m[0, 1], m[1, 1]
 	return
 }
-matrix2_from_matrix4_f64 :: proc(m: Matrix4f64) -> (r: Matrix2f64) {
+matrix2_from_matrix4_f64 :: proc "contextless" (m: Matrix4f64) -> (r: Matrix2f64) {
 	r[0, 0], r[1, 0] = m[0, 0], m[1, 0]
 	r[0, 1], r[1, 1] = m[0, 1], m[1, 1]
 	return
@@ -2331,19 +2331,19 @@ matrix2_from_matrix4 :: proc{
 }
 
 
-matrix3_from_matrix2_f16 :: proc(m: Matrix2f16) -> (r: Matrix3f16) {
+matrix3_from_matrix2_f16 :: proc "contextless" (m: Matrix2f16) -> (r: Matrix3f16) {
 	r[0, 0], r[1, 0], r[2, 0] = m[0, 0], m[1, 0], 0
 	r[0, 1], r[1, 1], r[2, 1] = m[0, 1], m[1, 1], 0
 	r[0, 2], r[1, 2], r[2, 2] =       0,       0, 1
 	return
 }
-matrix3_from_matrix2_f32 :: proc(m: Matrix2f32) -> (r: Matrix3f32) {
+matrix3_from_matrix2_f32 :: proc "contextless" (m: Matrix2f32) -> (r: Matrix3f32) {
 	r[0, 0], r[1, 0], r[2, 0] = m[0, 0], m[1, 0], 0
 	r[0, 1], r[1, 1], r[2, 1] = m[0, 1], m[1, 1], 0
 	r[0, 2], r[1, 2], r[2, 2] =       0,       0, 1
 	return
 }
-matrix3_from_matrix2_f64 :: proc(m: Matrix2f64) -> (r: Matrix3f64) {
+matrix3_from_matrix2_f64 :: proc "contextless" (m: Matrix2f64) -> (r: Matrix3f64) {
 	r[0, 0], r[1, 0], r[2, 0] = m[0, 0], m[1, 0], 0
 	r[0, 1], r[1, 1], r[2, 1] = m[0, 1], m[1, 1], 0
 	r[0, 2], r[1, 2], r[2, 2] =       0,       0, 1
@@ -2356,19 +2356,19 @@ matrix3_from_matrix2 :: proc{
 }
 
 
-matrix3_from_matrix4_f16 :: proc(m: Matrix4f16) -> (r: Matrix3f16) {
+matrix3_from_matrix4_f16 :: proc "contextless" (m: Matrix4f16) -> (r: Matrix3f16) {
 	r[0, 0], r[1, 0], r[2, 0] = m[0, 0], m[1, 0], m[2, 0]
 	r[0, 1], r[1, 1], r[2, 1] = m[0, 1], m[1, 1], m[2, 1]
 	r[0, 2], r[1, 2], r[2, 2] = m[0, 2], m[1, 2], m[2, 2]
 	return
 }
-matrix3_from_matrix4_f32 :: proc(m: Matrix4f32) -> (r: Matrix3f32) {
+matrix3_from_matrix4_f32 :: proc "contextless" (m: Matrix4f32) -> (r: Matrix3f32) {
 	r[0, 0], r[1, 0], r[2, 0] = m[0, 0], m[1, 0], m[2, 0]
 	r[0, 1], r[1, 1], r[2, 1] = m[0, 1], m[1, 1], m[2, 1]
 	r[0, 2], r[1, 2], r[2, 2] = m[0, 2], m[1, 2], m[2, 2]
 	return
 }
-matrix3_from_matrix4_f64 :: proc(m: Matrix4f64) -> (r: Matrix3f64) {
+matrix3_from_matrix4_f64 :: proc "contextless" (m: Matrix4f64) -> (r: Matrix3f64) {
 	r[0, 0], r[1, 0], r[2, 0] = m[0, 0], m[1, 0], m[2, 0]
 	r[0, 1], r[1, 1], r[2, 1] = m[0, 1], m[1, 1], m[2, 1]
 	r[0, 2], r[1, 2], r[2, 2] = m[0, 2], m[1, 2], m[2, 2]
@@ -2381,21 +2381,21 @@ matrix3_from_matrix4 :: proc{
 }
 
 
-matrix4_from_matrix2_f16 :: proc(m: Matrix2f16) -> (r: Matrix4f16) {
+matrix4_from_matrix2_f16 :: proc "contextless" (m: Matrix2f16) -> (r: Matrix4f16) {
 	r[0, 0], r[1, 0], r[2, 0], r[3, 0] = m[0, 0], m[1, 0], 0, 0
 	r[0, 1], r[1, 1], r[2, 1], r[3, 1] = m[0, 1], m[1, 1], 0, 0
 	r[0, 2], r[1, 2], r[2, 2], r[3, 2] =       0,       0, 1, 0
 	r[0, 3], r[1, 3], r[2, 3], r[3, 3] =       0,       0, 0, 1
 	return
 }
-matrix4_from_matrix2_f32 :: proc(m: Matrix2f32) -> (r: Matrix4f32) {
+matrix4_from_matrix2_f32 :: proc "contextless" (m: Matrix2f32) -> (r: Matrix4f32) {
 	r[0, 0], r[1, 0], r[2, 0], r[3, 0] = m[0, 0], m[1, 0], 0, 0
 	r[0, 1], r[1, 1], r[2, 1], r[3, 1] = m[0, 1], m[1, 1], 0, 0
 	r[0, 2], r[1, 2], r[2, 2], r[3, 2] =       0,       0, 1, 0
 	r[0, 3], r[1, 3], r[2, 3], r[3, 3] =       0,       0, 0, 1
 	return
 }
-matrix4_from_matrix2_f64 :: proc(m: Matrix2f64) -> (r: Matrix4f64) {
+matrix4_from_matrix2_f64 :: proc "contextless" (m: Matrix2f64) -> (r: Matrix4f64) {
 	r[0, 0], r[1, 0], r[2, 0], r[3, 0] = m[0, 0], m[1, 0], 0, 0
 	r[0, 1], r[1, 1], r[2, 1], r[3, 1] = m[0, 1], m[1, 1], 0, 0
 	r[0, 2], r[1, 2], r[2, 2], r[3, 2] =       0,       0, 1, 0
@@ -2409,21 +2409,21 @@ matrix4_from_matrix2 :: proc{
 }
 
 
-matrix4_from_matrix3_f16 :: proc(m: Matrix3f16) -> (r: Matrix4f16) {
+matrix4_from_matrix3_f16 :: proc "contextless" (m: Matrix3f16) -> (r: Matrix4f16) {
 	r[0, 0], r[1, 0], r[2, 0], r[3, 0] = m[0, 0], m[1, 0], m[2, 0], 0
 	r[0, 1], r[1, 1], r[2, 1], r[3, 1] = m[0, 1], m[1, 1], m[2, 1], 0
 	r[0, 2], r[1, 2], r[2, 2], r[3, 2] = m[0, 2], m[1, 2], m[2, 2], 0
 	r[0, 3], r[1, 3], r[2, 3], r[3, 3] =       0,       0,       0, 1
 	return
 }
-matrix4_from_matrix3_f32 :: proc(m: Matrix3f32) -> (r: Matrix4f32) {
+matrix4_from_matrix3_f32 :: proc "contextless" (m: Matrix3f32) -> (r: Matrix4f32) {
 	r[0, 0], r[1, 0], r[2, 0], r[3, 0] = m[0, 0], m[1, 0], m[2, 0], 0
 	r[0, 1], r[1, 1], r[2, 1], r[3, 1] = m[0, 1], m[1, 1], m[2, 1], 0
 	r[0, 2], r[1, 2], r[2, 2], r[3, 2] = m[0, 2], m[1, 2], m[2, 2], 0
 	r[0, 3], r[1, 3], r[2, 3], r[3, 3] =       0,       0,       0, 1
 	return
 }
-matrix4_from_matrix3_f64 :: proc(m: Matrix3f64) -> (r: Matrix4f64) {
+matrix4_from_matrix3_f64 :: proc "contextless" (m: Matrix3f64) -> (r: Matrix4f64) {
 	r[0, 0], r[1, 0], r[2, 0], r[3, 0] = m[0, 0], m[1, 0], m[2, 0], 0
 	r[0, 1], r[1, 1], r[2, 1], r[3, 1] = m[0, 1], m[1, 1], m[2, 1], 0
 	r[0, 2], r[1, 2], r[2, 2], r[3, 2] = m[0, 2], m[1, 2], m[2, 2], 0
@@ -2437,15 +2437,15 @@ matrix4_from_matrix3 :: proc{
 }
 
 
-quaternion_from_scalar_f16 :: proc(f: f16) -> (q: Quaternionf16) {
+quaternion_from_scalar_f16 :: proc "contextless" (f: f16) -> (q: Quaternionf16) {
 	q.w = f
 	return
 }
-quaternion_from_scalar_f32 :: proc(f: f32) -> (q: Quaternionf32) {
+quaternion_from_scalar_f32 :: proc "contextless" (f: f32) -> (q: Quaternionf32) {
 	q.w = f
 	return
 }
-quaternion_from_scalar_f64 :: proc(f: f64) -> (q: Quaternionf64) {
+quaternion_from_scalar_f64 :: proc "contextless" (f: f64) -> (q: Quaternionf64) {
 	q.w = f
 	return
 }
@@ -2505,7 +2505,7 @@ to_quaternion :: proc{
 
 
 
-matrix2_orthonormalize_f16 :: proc(m: Matrix2f16) -> (r: Matrix2f16) {
+matrix2_orthonormalize_f16 :: proc "contextless" (m: Matrix2f16) -> (r: Matrix2f16) {
 	r[0] = normalize(m[0])
 
 	d0 := dot(r[0], r[1])
@@ -2514,7 +2514,7 @@ matrix2_orthonormalize_f16 :: proc(m: Matrix2f16) -> (r: Matrix2f16) {
 
 	return
 }
-matrix2_orthonormalize_f32 :: proc(m: Matrix2f32) -> (r: Matrix2f32) {
+matrix2_orthonormalize_f32 :: proc "contextless" (m: Matrix2f32) -> (r: Matrix2f32) {
 	r[0] = normalize(m[0])
 
 	d0 := dot(r[0], r[1])
@@ -2523,7 +2523,7 @@ matrix2_orthonormalize_f32 :: proc(m: Matrix2f32) -> (r: Matrix2f32) {
 
 	return
 }
-matrix2_orthonormalize_f64 :: proc(m: Matrix2f64) -> (r: Matrix2f64) {
+matrix2_orthonormalize_f64 :: proc "contextless" (m: Matrix2f64) -> (r: Matrix2f64) {
 	r[0] = normalize(m[0])
 
 	d0 := dot(r[0], r[1])
@@ -2539,7 +2539,7 @@ matrix2_orthonormalize :: proc{
 }
 
 
-matrix3_orthonormalize_f16 :: proc(m: Matrix3f16) -> (r: Matrix3f16) {
+matrix3_orthonormalize_f16 :: proc "contextless" (m: Matrix3f16) -> (r: Matrix3f16) {
 	r[0] = normalize(m[0])
 
 	d0 := dot(r[0], r[1])
@@ -2553,7 +2553,7 @@ matrix3_orthonormalize_f16 :: proc(m: Matrix3f16) -> (r: Matrix3f16) {
 
 	return
 }
-matrix3_orthonormalize_f32 :: proc(m: Matrix3f32) -> (r: Matrix3f32) {
+matrix3_orthonormalize_f32 :: proc "contextless" (m: Matrix3f32) -> (r: Matrix3f32) {
 	r[0] = normalize(m[0])
 
 	d0 := dot(r[0], r[1])
@@ -2567,7 +2567,7 @@ matrix3_orthonormalize_f32 :: proc(m: Matrix3f32) -> (r: Matrix3f32) {
 
 	return
 }
-matrix3_orthonormalize_f64 :: proc(m: Matrix3f64) -> (r: Matrix3f64) {
+matrix3_orthonormalize_f64 :: proc "contextless" (m: Matrix3f64) -> (r: Matrix3f64) {
 	r[0] = normalize(m[0])
 
 	d0 := dot(r[0], r[1])
@@ -2588,13 +2588,13 @@ matrix3_orthonormalize :: proc{
 }
 
 
-vector3_orthonormalize_f16 :: proc(x, y: Vector3f16) -> (z: Vector3f16) {
+vector3_orthonormalize_f16 :: proc "contextless" (x, y: Vector3f16) -> (z: Vector3f16) {
 	return normalize(x - y * dot(y, x))
 }
-vector3_orthonormalize_f32 :: proc(x, y: Vector3f32) -> (z: Vector3f32) {
+vector3_orthonormalize_f32 :: proc "contextless" (x, y: Vector3f32) -> (z: Vector3f32) {
 	return normalize(x - y * dot(y, x))
 }
-vector3_orthonormalize_f64 :: proc(x, y: Vector3f64) -> (z: Vector3f64) {
+vector3_orthonormalize_f64 :: proc "contextless" (x, y: Vector3f64) -> (z: Vector3f64) {
 	return normalize(x - y * dot(y, x))
 }
 vector3_orthonormalize :: proc{
@@ -2611,7 +2611,7 @@ orthonormalize :: proc{
 }
 
 
-matrix4_orientation_f16 :: proc(normal, up: Vector3f16) -> Matrix4f16 {
+matrix4_orientation_f16 :: proc "contextless" (normal, up: Vector3f16) -> Matrix4f16 {
 	if all(equal(normal, up)) {
 		return MATRIX4F16_IDENTITY
 	}
@@ -2621,7 +2621,7 @@ matrix4_orientation_f16 :: proc(normal, up: Vector3f16) -> Matrix4f16 {
 
 	return matrix4_rotate(angle, rotation_axis)
 }
-matrix4_orientation_f32 :: proc(normal, up: Vector3f32) -> Matrix4f32 {
+matrix4_orientation_f32 :: proc "contextless" (normal, up: Vector3f32) -> Matrix4f32 {
 	if all(equal(normal, up)) {
 		return MATRIX4F32_IDENTITY
 	}
@@ -2631,7 +2631,7 @@ matrix4_orientation_f32 :: proc(normal, up: Vector3f32) -> Matrix4f32 {
 
 	return matrix4_rotate(angle, rotation_axis)
 }
-matrix4_orientation_f64 :: proc(normal, up: Vector3f64) -> Matrix4f64 {
+matrix4_orientation_f64 :: proc "contextless" (normal, up: Vector3f64) -> Matrix4f64 {
 	if all(equal(normal, up)) {
 		return MATRIX4F64_IDENTITY
 	}
@@ -2648,7 +2648,7 @@ matrix4_orientation :: proc{
 }
 
 
-euclidean_from_polar_f16 :: proc(polar: Vector2f16) -> Vector3f16 {
+euclidean_from_polar_f16 :: proc "contextless" (polar: Vector2f16) -> Vector3f16 {
 	latitude, longitude := polar.x, polar.y
 	cx, sx := math.cos(latitude), math.sin(latitude)
 	cy, sy := math.cos(longitude), math.sin(longitude)
@@ -2659,7 +2659,7 @@ euclidean_from_polar_f16 :: proc(polar: Vector2f16) -> Vector3f16 {
 		cx*cy,
 	}
 }
-euclidean_from_polar_f32 :: proc(polar: Vector2f32) -> Vector3f32 {
+euclidean_from_polar_f32 :: proc "contextless" (polar: Vector2f32) -> Vector3f32 {
 	latitude, longitude := polar.x, polar.y
 	cx, sx := math.cos(latitude), math.sin(latitude)
 	cy, sy := math.cos(longitude), math.sin(longitude)
@@ -2670,7 +2670,7 @@ euclidean_from_polar_f32 :: proc(polar: Vector2f32) -> Vector3f32 {
 		cx*cy,
 	}
 }
-euclidean_from_polar_f64 :: proc(polar: Vector2f64) -> Vector3f64 {
+euclidean_from_polar_f64 :: proc "contextless" (polar: Vector2f64) -> Vector3f64 {
 	latitude, longitude := polar.x, polar.y
 	cx, sx := math.cos(latitude), math.sin(latitude)
 	cy, sy := math.cos(longitude), math.sin(longitude)
@@ -2688,7 +2688,7 @@ euclidean_from_polar :: proc{
 }
 
 
-polar_from_euclidean_f16 :: proc(euclidean: Vector3f16) -> Vector3f16 {
+polar_from_euclidean_f16 :: proc "contextless" (euclidean: Vector3f16) -> Vector3f16 {
 	n := length(euclidean)
 	tmp := euclidean / n
 
@@ -2700,7 +2700,7 @@ polar_from_euclidean_f16 :: proc(euclidean: Vector3f16) -> Vector3f16 {
 		xz_dist,
 	}
 }
-polar_from_euclidean_f32 :: proc(euclidean: Vector3f32) -> Vector3f32 {
+polar_from_euclidean_f32 :: proc "contextless" (euclidean: Vector3f32) -> Vector3f32 {
 	n := length(euclidean)
 	tmp := euclidean / n
 
@@ -2712,7 +2712,7 @@ polar_from_euclidean_f32 :: proc(euclidean: Vector3f32) -> Vector3f32 {
 		xz_dist,
 	}
 }
-polar_from_euclidean_f64 :: proc(euclidean: Vector3f64) -> Vector3f64 {
+polar_from_euclidean_f64 :: proc "contextless" (euclidean: Vector3f64) -> Vector3f64 {
 	n := length(euclidean)
 	tmp := euclidean / n
 

--- a/core/math/linalg/specific_euler_angles_f16.odin
+++ b/core/math/linalg/specific_euler_angles_f16.odin
@@ -2,7 +2,7 @@ package linalg
 
 import "core:math"
 
-euler_angles_from_matrix3_f16 :: proc(m: Matrix3f16, order: Euler_Angle_Order) -> (t1, t2, t3: f16) {
+euler_angles_from_matrix3_f16 :: proc "contextless" (m: Matrix3f16, order: Euler_Angle_Order) -> (t1, t2, t3: f16) {
 	switch order {
 	case .XYZ: t1, t2, t3 = euler_angles_xyz_from_matrix3(m)
 	case .XZY: t1, t2, t3 = euler_angles_xzy_from_matrix3(m)
@@ -19,7 +19,7 @@ euler_angles_from_matrix3_f16 :: proc(m: Matrix3f16, order: Euler_Angle_Order) -
 	}
 	return
 }
-euler_angles_from_matrix4_f16 :: proc(m: Matrix4f16, order: Euler_Angle_Order) -> (t1, t2, t3: f16) {
+euler_angles_from_matrix4_f16 :: proc "contextless" (m: Matrix4f16, order: Euler_Angle_Order) -> (t1, t2, t3: f16) {
 	switch order {
 	case .XYZ: t1, t2, t3 = euler_angles_xyz_from_matrix4(m)
 	case .XZY: t1, t2, t3 = euler_angles_xzy_from_matrix4(m)
@@ -36,7 +36,7 @@ euler_angles_from_matrix4_f16 :: proc(m: Matrix4f16, order: Euler_Angle_Order) -
 	}
 	return
 }
-euler_angles_from_quaternion_f16 :: proc(m: Quaternionf16, order: Euler_Angle_Order) -> (t1, t2, t3: f16) {
+euler_angles_from_quaternion_f16 :: proc "contextless" (m: Quaternionf16, order: Euler_Angle_Order) -> (t1, t2, t3: f16) {
 	switch order {
 	case .XYZ: t1, t2, t3 = euler_angles_xyz_from_quaternion(m)
 	case .XZY: t1, t2, t3 = euler_angles_xzy_from_quaternion(m)
@@ -54,7 +54,7 @@ euler_angles_from_quaternion_f16 :: proc(m: Quaternionf16, order: Euler_Angle_Or
 	return
 }
 
-matrix3_from_euler_angles_f16 :: proc(t1, t2, t3: f16, order: Euler_Angle_Order) -> (m: Matrix3f16) {
+matrix3_from_euler_angles_f16 :: proc "contextless" (t1, t2, t3: f16, order: Euler_Angle_Order) -> (m: Matrix3f16) {
 	switch order {
 	case .XYZ: return matrix3_from_euler_angles_xyz(t1, t2, t3) // m1, m2, m3 = X(t1), Y(t2), Z(t3);
 	case .XZY: return matrix3_from_euler_angles_xzy(t1, t2, t3) // m1, m2, m3 = X(t1), Z(t2), Y(t3);
@@ -71,7 +71,7 @@ matrix3_from_euler_angles_f16 :: proc(t1, t2, t3: f16, order: Euler_Angle_Order)
 	}
 	return
 }
-matrix4_from_euler_angles_f16 :: proc(t1, t2, t3: f16, order: Euler_Angle_Order) -> (m: Matrix4f16) {
+matrix4_from_euler_angles_f16 :: proc "contextless" (t1, t2, t3: f16, order: Euler_Angle_Order) -> (m: Matrix4f16) {
 	switch order {
 	case .XYZ: return matrix4_from_euler_angles_xyz(t1, t2, t3) // m1, m2, m3 = X(t1), Y(t2), Z(t3);
 	case .XZY: return matrix4_from_euler_angles_xzy(t1, t2, t3) // m1, m2, m3 = X(t1), Z(t2), Y(t3);
@@ -89,7 +89,7 @@ matrix4_from_euler_angles_f16 :: proc(t1, t2, t3: f16, order: Euler_Angle_Order)
 	return
 }
 
-quaternion_from_euler_angles_f16 :: proc(t1, t2, t3: f16, order: Euler_Angle_Order) -> Quaternionf16 {
+quaternion_from_euler_angles_f16 :: proc "contextless" (t1, t2, t3: f16, order: Euler_Angle_Order) -> Quaternionf16 {
 	X :: quaternion_from_euler_angle_x
 	Y :: quaternion_from_euler_angle_y
 	Z :: quaternion_from_euler_angle_z
@@ -117,17 +117,17 @@ quaternion_from_euler_angles_f16 :: proc(t1, t2, t3: f16, order: Euler_Angle_Ord
 
 // Quaternionf16s
 
-quaternion_from_euler_angle_x_f16 :: proc(angle_x: f16) -> (q: Quaternionf16) {
+quaternion_from_euler_angle_x_f16 :: proc "contextless" (angle_x: f16) -> (q: Quaternionf16) {
 	return quaternion_angle_axis_f16(angle_x, {1, 0, 0})
 }
-quaternion_from_euler_angle_y_f16 :: proc(angle_y: f16) -> (q: Quaternionf16) {
+quaternion_from_euler_angle_y_f16 :: proc "contextless" (angle_y: f16) -> (q: Quaternionf16) {
 	return quaternion_angle_axis_f16(angle_y, {0, 1, 0})
 }
-quaternion_from_euler_angle_z_f16 :: proc(angle_z: f16) -> (q: Quaternionf16) {
+quaternion_from_euler_angle_z_f16 :: proc "contextless" (angle_z: f16) -> (q: Quaternionf16) {
 	return quaternion_angle_axis_f16(angle_z, {0, 0, 1})
 }
 
-quaternion_from_pitch_yaw_roll_f16 :: proc(pitch, yaw, roll: f16) -> Quaternionf16 {
+quaternion_from_pitch_yaw_roll_f16 :: proc "contextless" (pitch, yaw, roll: f16) -> Quaternionf16 {
 	a, b, c := pitch, yaw, roll
 
 	ca, sa := math.cos(a*0.5), math.sin(a*0.5)
@@ -142,11 +142,11 @@ quaternion_from_pitch_yaw_roll_f16 :: proc(pitch, yaw, roll: f16) -> Quaternionf
 	return q
 }
 
-roll_from_quaternion_f16 :: proc(q: Quaternionf16) -> f16 {
+roll_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> f16 {
 	return math.atan2(2 * q.x*q.y + q.w*q.z, q.w*q.w + q.x*q.x - q.y*q.y - q.z*q.z)
 }
 
-pitch_from_quaternion_f16 :: proc(q: Quaternionf16) -> f16 {
+pitch_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> f16 {
 	y := 2 * (q.y*q.z + q.w*q.w)
 	x := q.w*q.w - q.x*q.x - q.y*q.y + q.z*q.z
 
@@ -157,52 +157,52 @@ pitch_from_quaternion_f16 :: proc(q: Quaternionf16) -> f16 {
 	return math.atan2(y, x)
 }
 
-yaw_from_quaternion_f16 :: proc(q: Quaternionf16) -> f16 {
+yaw_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> f16 {
 	return math.asin(clamp(-2 * (q.x*q.z - q.w*q.y), -1, 1))
 }
 
 
-pitch_yaw_roll_from_quaternion_f16 :: proc(q: Quaternionf16) -> (pitch, yaw, roll: f16) {
+pitch_yaw_roll_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> (pitch, yaw, roll: f16) {
 	pitch = pitch_from_quaternion(q)
 	yaw = yaw_from_quaternion(q)
 	roll = roll_from_quaternion(q)
 	return
 }
 
-euler_angles_xyz_from_quaternion_f16 :: proc(q: Quaternionf16) -> (t1, t2, t3: f16) {
+euler_angles_xyz_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> (t1, t2, t3: f16) {
 	return euler_angles_xyz_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_yxz_from_quaternion_f16 :: proc(q: Quaternionf16) -> (t1, t2, t3: f16) {
+euler_angles_yxz_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> (t1, t2, t3: f16) {
 	return euler_angles_yxz_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_xzx_from_quaternion_f16 :: proc(q: Quaternionf16) -> (t1, t2, t3: f16) {
+euler_angles_xzx_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> (t1, t2, t3: f16) {
 	return euler_angles_xzx_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_xyx_from_quaternion_f16 :: proc(q: Quaternionf16) -> (t1, t2, t3: f16) {
+euler_angles_xyx_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> (t1, t2, t3: f16) {
 	return euler_angles_xyx_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_yxy_from_quaternion_f16 :: proc(q: Quaternionf16) -> (t1, t2, t3: f16) {
+euler_angles_yxy_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> (t1, t2, t3: f16) {
 	return euler_angles_yxy_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_yzy_from_quaternion_f16 :: proc(q: Quaternionf16) -> (t1, t2, t3: f16) {
+euler_angles_yzy_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> (t1, t2, t3: f16) {
 	return euler_angles_yzy_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_zyz_from_quaternion_f16 :: proc(q: Quaternionf16) -> (t1, t2, t3: f16) {
+euler_angles_zyz_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> (t1, t2, t3: f16) {
 	return euler_angles_zyz_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_zxz_from_quaternion_f16 :: proc(q: Quaternionf16) -> (t1, t2, t3: f16) {
+euler_angles_zxz_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> (t1, t2, t3: f16) {
 	return euler_angles_zxz_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_xzy_from_quaternion_f16 :: proc(q: Quaternionf16) -> (t1, t2, t3: f16) {
+euler_angles_xzy_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> (t1, t2, t3: f16) {
 	return euler_angles_xzy_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_yzx_from_quaternion_f16 :: proc(q: Quaternionf16) -> (t1, t2, t3: f16) {
+euler_angles_yzx_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> (t1, t2, t3: f16) {
 	return euler_angles_yzx_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_zyx_from_quaternion_f16 :: proc(q: Quaternionf16) -> (t1, t2, t3: f16) {
+euler_angles_zyx_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> (t1, t2, t3: f16) {
 	return euler_angles_zyx_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_zxy_from_quaternion_f16 :: proc(q: Quaternionf16) -> (t1, t2, t3: f16) {
+euler_angles_zxy_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> (t1, t2, t3: f16) {
 	return euler_angles_zxy_from_matrix4(matrix4_from_quaternion(q))
 }
 
@@ -210,7 +210,7 @@ euler_angles_zxy_from_quaternion_f16 :: proc(q: Quaternionf16) -> (t1, t2, t3: f
 // Matrix3
 
 
-matrix3_from_euler_angle_x_f16 :: proc(angle_x: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angle_x_f16 :: proc "contextless" (angle_x: f16) -> (m: Matrix3f16) {
 	cos_x, sin_x := math.cos(angle_x), math.sin(angle_x)
 	m[0, 0] = 1
 	m[1, 1] = +cos_x
@@ -219,7 +219,7 @@ matrix3_from_euler_angle_x_f16 :: proc(angle_x: f16) -> (m: Matrix3f16) {
 	m[2, 2] = +cos_x
 	return
 }
-matrix3_from_euler_angle_y_f16 :: proc(angle_y: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angle_y_f16 :: proc "contextless" (angle_y: f16) -> (m: Matrix3f16) {
 	cos_y, sin_y := math.cos(angle_y), math.sin(angle_y)
 	m[0, 0] = +cos_y
 	m[0, 2] = -sin_y
@@ -228,7 +228,7 @@ matrix3_from_euler_angle_y_f16 :: proc(angle_y: f16) -> (m: Matrix3f16) {
 	m[2, 2] = +cos_y
 	return
 }
-matrix3_from_euler_angle_z_f16 :: proc(angle_z: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angle_z_f16 :: proc "contextless" (angle_z: f16) -> (m: Matrix3f16) {
 	cos_z, sin_z := math.cos(angle_z), math.sin(angle_z)
 	m[0, 0] = +cos_z
 	m[0, 1] = +sin_z
@@ -239,7 +239,7 @@ matrix3_from_euler_angle_z_f16 :: proc(angle_z: f16) -> (m: Matrix3f16) {
 }
 
 
-matrix3_from_derived_euler_angle_x_f16 :: proc(angle_x: f16, angular_velocity_x: f16) -> (m: Matrix3f16) {
+matrix3_from_derived_euler_angle_x_f16 :: proc "contextless" (angle_x: f16, angular_velocity_x: f16) -> (m: Matrix3f16) {
 	cos_x := math.cos(angle_x) * angular_velocity_x
 	sin_x := math.sin(angle_x) * angular_velocity_x
 	m[0, 0] = 1
@@ -249,7 +249,7 @@ matrix3_from_derived_euler_angle_x_f16 :: proc(angle_x: f16, angular_velocity_x:
 	m[2, 2] = +cos_x
 	return
 }
-matrix3_from_derived_euler_angle_y_f16 :: proc(angle_y: f16, angular_velocity_y: f16) -> (m: Matrix3f16) {
+matrix3_from_derived_euler_angle_y_f16 :: proc "contextless" (angle_y: f16, angular_velocity_y: f16) -> (m: Matrix3f16) {
 	cos_y := math.cos(angle_y) * angular_velocity_y
 	sin_y := math.sin(angle_y) * angular_velocity_y
 	m[0, 0] = +cos_y
@@ -259,7 +259,7 @@ matrix3_from_derived_euler_angle_y_f16 :: proc(angle_y: f16, angular_velocity_y:
 	m[2, 2] = +cos_y
 	return
 }
-matrix3_from_derived_euler_angle_z_f16 :: proc(angle_z: f16, angular_velocity_z: f16) -> (m: Matrix3f16) {
+matrix3_from_derived_euler_angle_z_f16 :: proc "contextless" (angle_z: f16, angular_velocity_z: f16) -> (m: Matrix3f16) {
 	cos_z := math.cos(angle_z) * angular_velocity_z
 	sin_z := math.sin(angle_z) * angular_velocity_z
 	m[0, 0] = +cos_z
@@ -271,7 +271,7 @@ matrix3_from_derived_euler_angle_z_f16 :: proc(angle_z: f16, angular_velocity_z:
 }
 
 
-matrix3_from_euler_angles_xy_f16 :: proc(angle_x, angle_y: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angles_xy_f16 :: proc "contextless" (angle_x, angle_y: f16) -> (m: Matrix3f16) {
 	cos_x, sin_x := math.cos(angle_x), math.sin(angle_x)
 	cos_y, sin_y := math.cos(angle_y), math.sin(angle_y)
 	m[0, 0] = cos_y
@@ -286,7 +286,7 @@ matrix3_from_euler_angles_xy_f16 :: proc(angle_x, angle_y: f16) -> (m: Matrix3f1
 }
 
 
-matrix3_from_euler_angles_yx_f16 :: proc(angle_y, angle_x: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angles_yx_f16 :: proc "contextless" (angle_y, angle_x: f16) -> (m: Matrix3f16) {
 	cos_x, sin_x := math.cos(angle_x), math.sin(angle_x)
 	cos_y, sin_y := math.cos(angle_y), math.sin(angle_y)
 	m[0, 0] = cos_y
@@ -300,21 +300,21 @@ matrix3_from_euler_angles_yx_f16 :: proc(angle_y, angle_x: f16) -> (m: Matrix3f1
 	return
 }
 
-matrix3_from_euler_angles_xz_f16 :: proc(angle_x, angle_z: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angles_xz_f16 :: proc "contextless" (angle_x, angle_z: f16) -> (m: Matrix3f16) {
 	return mul(matrix3_from_euler_angle_x(angle_x), matrix3_from_euler_angle_z(angle_z))
 }
-matrix3_from_euler_angles_zx_f16 :: proc(angle_z, angle_x: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angles_zx_f16 :: proc "contextless" (angle_z, angle_x: f16) -> (m: Matrix3f16) {
 	return mul(matrix3_from_euler_angle_z(angle_z), matrix3_from_euler_angle_x(angle_x))
 }
-matrix3_from_euler_angles_yz_f16 :: proc(angle_y, angle_z: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angles_yz_f16 :: proc "contextless" (angle_y, angle_z: f16) -> (m: Matrix3f16) {
 	return mul(matrix3_from_euler_angle_y(angle_y), matrix3_from_euler_angle_z(angle_z))
 }
-matrix3_from_euler_angles_zy_f16 :: proc(angle_z, angle_y: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angles_zy_f16 :: proc "contextless" (angle_z, angle_y: f16) -> (m: Matrix3f16) {
 	return mul(matrix3_from_euler_angle_z(angle_z), matrix3_from_euler_angle_y(angle_y))
 }
 
 
-matrix3_from_euler_angles_xyz_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angles_xyz_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix3f16) {
 	c1 := math.cos(-t1)
 	c2 := math.cos(-t2)
 	c3 := math.cos(-t3)
@@ -334,7 +334,7 @@ matrix3_from_euler_angles_xyz_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
 	return
 }
 
-matrix3_from_euler_angles_yxz_f16 :: proc(yaw, pitch, roll: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angles_yxz_f16 :: proc "contextless" (yaw, pitch, roll: f16) -> (m: Matrix3f16) {
 	ch := math.cos(yaw)
 	sh := math.sin(yaw)
 	cp := math.cos(pitch)
@@ -354,7 +354,7 @@ matrix3_from_euler_angles_yxz_f16 :: proc(yaw, pitch, roll: f16) -> (m: Matrix3f
 	return
 }
 
-matrix3_from_euler_angles_xzx_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angles_xzx_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix3f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -374,7 +374,7 @@ matrix3_from_euler_angles_xzx_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
 	return
 }
 
-matrix3_from_euler_angles_xyx_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angles_xyx_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix3f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -394,7 +394,7 @@ matrix3_from_euler_angles_xyx_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
 	return
 }
 
-matrix3_from_euler_angles_yxy_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angles_yxy_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix3f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -414,7 +414,7 @@ matrix3_from_euler_angles_yxy_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
 	return
 }
 
-matrix3_from_euler_angles_yzy_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angles_yzy_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix3f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -434,7 +434,7 @@ matrix3_from_euler_angles_yzy_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
 	return
 }
 
-matrix3_from_euler_angles_zyz_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angles_zyz_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix3f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -454,7 +454,7 @@ matrix3_from_euler_angles_zyz_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
 	return
 }
 
-matrix3_from_euler_angles_zxz_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angles_zxz_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix3f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -475,7 +475,7 @@ matrix3_from_euler_angles_zxz_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
 }
 
 
-matrix3_from_euler_angles_xzy_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angles_xzy_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix3f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -495,7 +495,7 @@ matrix3_from_euler_angles_xzy_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
 	return
 }
 
-matrix3_from_euler_angles_yzx_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angles_yzx_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix3f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -515,7 +515,7 @@ matrix3_from_euler_angles_yzx_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
 	return
 }
 
-matrix3_from_euler_angles_zyx_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angles_zyx_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix3f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -535,7 +535,7 @@ matrix3_from_euler_angles_zyx_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
 	return
 }
 
-matrix3_from_euler_angles_zxy_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
+matrix3_from_euler_angles_zxy_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix3f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -556,7 +556,7 @@ matrix3_from_euler_angles_zxy_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix3f16) {
 }
 
 
-matrix3_from_yaw_pitch_roll_f16 :: proc(yaw, pitch, roll: f16) -> (m: Matrix3f16) {
+matrix3_from_yaw_pitch_roll_f16 :: proc "contextless" (yaw, pitch, roll: f16) -> (m: Matrix3f16) {
 	ch := math.cos(yaw)
 	sh := math.sin(yaw)
 	cp := math.cos(pitch)
@@ -576,7 +576,7 @@ matrix3_from_yaw_pitch_roll_f16 :: proc(yaw, pitch, roll: f16) -> (m: Matrix3f16
 	return m
 }
 
-euler_angles_xyz_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
+euler_angles_xyz_from_matrix3_f16 :: proc "contextless" (m: Matrix3f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[1, 2], m[2, 2])
 	C2 := math.sqrt(m[0, 0]*m[0, 0] + m[0, 1]*m[0, 1])
 	T2 := math.atan2(-m[0, 2], C2)
@@ -589,7 +589,7 @@ euler_angles_xyz_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_yxz_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
+euler_angles_yxz_from_matrix3_f16 :: proc "contextless" (m: Matrix3f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[0, 2], m[2, 2])
 	C2 := math.sqrt(m[1, 0]*m[1, 0] + m[1, 1]*m[1, 1])
 	T2 := math.atan2(-m[1, 2], C2)
@@ -602,7 +602,7 @@ euler_angles_yxz_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_xzx_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
+euler_angles_xzx_from_matrix3_f16 :: proc "contextless" (m: Matrix3f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[2, 0], m[1, 0])
 	S2 := math.sqrt(m[0, 1]*m[0, 1] + m[0, 2]*m[0, 2])
 	T2 := math.atan2(S2, m[0, 0])
@@ -615,7 +615,7 @@ euler_angles_xzx_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_xyx_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
+euler_angles_xyx_from_matrix3_f16 :: proc "contextless" (m: Matrix3f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[1, 0], -m[2, 0])
 	S2 := math.sqrt(m[0, 1]*m[0, 1] + m[0, 2]*m[0, 2])
 	T2 := math.atan2(S2, m[0, 0])
@@ -628,7 +628,7 @@ euler_angles_xyx_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_yxy_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
+euler_angles_yxy_from_matrix3_f16 :: proc "contextless" (m: Matrix3f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[0, 1], m[2, 1])
 	S2 := math.sqrt(m[1, 0]*m[1, 0] + m[1, 2]*m[1, 2])
 	T2 := math.atan2(S2, m[1, 1])
@@ -641,7 +641,7 @@ euler_angles_yxy_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_yzy_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
+euler_angles_yzy_from_matrix3_f16 :: proc "contextless" (m: Matrix3f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[2, 1], -m[0, 1])
 	S2 := math.sqrt(m[1, 0]*m[1, 0] + m[1, 2]*m[1, 2])
 	T2 := math.atan2(S2, m[1, 1])
@@ -653,7 +653,7 @@ euler_angles_yzy_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
 	t3 = T3
 	return
 }
-euler_angles_zyz_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
+euler_angles_zyz_from_matrix3_f16 :: proc "contextless" (m: Matrix3f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[1, 2], m[0, 2])
 	S2 := math.sqrt(m[2, 0]*m[2, 0] + m[2, 1]*m[2, 1])
 	T2 := math.atan2(S2, m[2, 2])
@@ -666,7 +666,7 @@ euler_angles_zyz_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_zxz_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
+euler_angles_zxz_from_matrix3_f16 :: proc "contextless" (m: Matrix3f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[0, 2], -m[1, 2])
 	S2 := math.sqrt(m[2, 0]*m[2, 0] + m[2, 1]*m[2, 1])
 	T2 := math.atan2(S2, m[2, 2])
@@ -679,7 +679,7 @@ euler_angles_zxz_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_xzy_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
+euler_angles_xzy_from_matrix3_f16 :: proc "contextless" (m: Matrix3f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[2, 1], m[1, 1])
 	C2 := math.sqrt(m[0, 0]*m[0, 0] + m[0, 2]*m[0, 2])
 	T2 := math.atan2(-m[0, 1], C2)
@@ -692,7 +692,7 @@ euler_angles_xzy_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_yzx_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
+euler_angles_yzx_from_matrix3_f16 :: proc "contextless" (m: Matrix3f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(-m[2, 0], m[0, 0])
 	C2 := math.sqrt(m[1, 1]*m[1, 1] + m[1, 2]*m[1, 2])
 	T2 := math.atan2(m[1, 0], C2)
@@ -705,7 +705,7 @@ euler_angles_yzx_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_zyx_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
+euler_angles_zyx_from_matrix3_f16 :: proc "contextless" (m: Matrix3f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[1, 0], m[0, 0])
 	C2 := math.sqrt(m[2, 1]*m[2, 1] + m[2, 2]*m[2, 2])
 	T2 := math.atan2(-m[2, 0], C2)
@@ -718,7 +718,7 @@ euler_angles_zyx_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_zxy_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
+euler_angles_zxy_from_matrix3_f16 :: proc "contextless" (m: Matrix3f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(-m[0, 1], m[1, 1])
 	C2 := math.sqrt(m[2, 0]*m[2, 0] + m[2, 2]*m[2, 2])
 	T2 := math.atan2(m[2, 1], C2)
@@ -735,7 +735,7 @@ euler_angles_zxy_from_matrix3_f16 :: proc(m: Matrix3f16) -> (t1, t2, t3: f16) {
 // Matrix4
 
 
-matrix4_from_euler_angle_x_f16 :: proc(angle_x: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angle_x_f16 :: proc "contextless" (angle_x: f16) -> (m: Matrix4f16) {
 	cos_x, sin_x := math.cos(angle_x), math.sin(angle_x)
 	m[0, 0] = 1
 	m[1, 1] = +cos_x
@@ -745,7 +745,7 @@ matrix4_from_euler_angle_x_f16 :: proc(angle_x: f16) -> (m: Matrix4f16) {
 	m[3, 3] = 1
 	return
 }
-matrix4_from_euler_angle_y_f16 :: proc(angle_y: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angle_y_f16 :: proc "contextless" (angle_y: f16) -> (m: Matrix4f16) {
 	cos_y, sin_y := math.cos(angle_y), math.sin(angle_y)
 	m[0, 0] = +cos_y
 	m[0, 2] = -sin_y
@@ -755,7 +755,7 @@ matrix4_from_euler_angle_y_f16 :: proc(angle_y: f16) -> (m: Matrix4f16) {
 	m[3, 3] = 1
 	return
 }
-matrix4_from_euler_angle_z_f16 :: proc(angle_z: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angle_z_f16 :: proc "contextless" (angle_z: f16) -> (m: Matrix4f16) {
 	cos_z, sin_z := math.cos(angle_z), math.sin(angle_z)
 	m[0, 0] = +cos_z
 	m[0, 1] = +sin_z
@@ -767,7 +767,7 @@ matrix4_from_euler_angle_z_f16 :: proc(angle_z: f16) -> (m: Matrix4f16) {
 }
 
 
-matrix4_from_derived_euler_angle_x_f16 :: proc(angle_x: f16, angular_velocity_x: f16) -> (m: Matrix4f16) {
+matrix4_from_derived_euler_angle_x_f16 :: proc "contextless" (angle_x: f16, angular_velocity_x: f16) -> (m: Matrix4f16) {
 	cos_x := math.cos(angle_x) * angular_velocity_x
 	sin_x := math.sin(angle_x) * angular_velocity_x
 	m[0, 0] = 1
@@ -778,7 +778,7 @@ matrix4_from_derived_euler_angle_x_f16 :: proc(angle_x: f16, angular_velocity_x:
 	m[3, 3] = 1
 	return
 }
-matrix4_from_derived_euler_angle_y_f16 :: proc(angle_y: f16, angular_velocity_y: f16) -> (m: Matrix4f16) {
+matrix4_from_derived_euler_angle_y_f16 :: proc "contextless" (angle_y: f16, angular_velocity_y: f16) -> (m: Matrix4f16) {
 	cos_y := math.cos(angle_y) * angular_velocity_y
 	sin_y := math.sin(angle_y) * angular_velocity_y
 	m[0, 0] = +cos_y
@@ -789,7 +789,7 @@ matrix4_from_derived_euler_angle_y_f16 :: proc(angle_y: f16, angular_velocity_y:
 	m[3, 3] = 1
 	return
 }
-matrix4_from_derived_euler_angle_z_f16 :: proc(angle_z: f16, angular_velocity_z: f16) -> (m: Matrix4f16) {
+matrix4_from_derived_euler_angle_z_f16 :: proc "contextless" (angle_z: f16, angular_velocity_z: f16) -> (m: Matrix4f16) {
 	cos_z := math.cos(angle_z) * angular_velocity_z
 	sin_z := math.sin(angle_z) * angular_velocity_z
 	m[0, 0] = +cos_z
@@ -802,7 +802,7 @@ matrix4_from_derived_euler_angle_z_f16 :: proc(angle_z: f16, angular_velocity_z:
 }
 
 
-matrix4_from_euler_angles_xy_f16 :: proc(angle_x, angle_y: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angles_xy_f16 :: proc "contextless" (angle_x, angle_y: f16) -> (m: Matrix4f16) {
 	cos_x, sin_x := math.cos(angle_x), math.sin(angle_x)
 	cos_y, sin_y := math.cos(angle_y), math.sin(angle_y)
 	m[0, 0] = cos_y
@@ -818,7 +818,7 @@ matrix4_from_euler_angles_xy_f16 :: proc(angle_x, angle_y: f16) -> (m: Matrix4f1
 }
 
 
-matrix4_from_euler_angles_yx_f16 :: proc(angle_y, angle_x: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angles_yx_f16 :: proc "contextless" (angle_y, angle_x: f16) -> (m: Matrix4f16) {
 	cos_x, sin_x := math.cos(angle_x), math.sin(angle_x)
 	cos_y, sin_y := math.cos(angle_y), math.sin(angle_y)
 	m[0, 0] = cos_y
@@ -833,21 +833,21 @@ matrix4_from_euler_angles_yx_f16 :: proc(angle_y, angle_x: f16) -> (m: Matrix4f1
 	return
 }
 
-matrix4_from_euler_angles_xz_f16 :: proc(angle_x, angle_z: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angles_xz_f16 :: proc "contextless" (angle_x, angle_z: f16) -> (m: Matrix4f16) {
 	return mul(matrix4_from_euler_angle_x(angle_x), matrix4_from_euler_angle_z(angle_z))
 }
-matrix4_from_euler_angles_zx_f16 :: proc(angle_z, angle_x: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angles_zx_f16 :: proc "contextless" (angle_z, angle_x: f16) -> (m: Matrix4f16) {
 	return mul(matrix4_from_euler_angle_z(angle_z), matrix4_from_euler_angle_x(angle_x))
 }
-matrix4_from_euler_angles_yz_f16 :: proc(angle_y, angle_z: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angles_yz_f16 :: proc "contextless" (angle_y, angle_z: f16) -> (m: Matrix4f16) {
 	return mul(matrix4_from_euler_angle_y(angle_y), matrix4_from_euler_angle_z(angle_z))
 }
-matrix4_from_euler_angles_zy_f16 :: proc(angle_z, angle_y: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angles_zy_f16 :: proc "contextless" (angle_z, angle_y: f16) -> (m: Matrix4f16) {
 	return mul(matrix4_from_euler_angle_z(angle_z), matrix4_from_euler_angle_y(angle_y))
 }
 
 
-matrix4_from_euler_angles_xyz_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angles_xyz_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix4f16) {
 	c1 := math.cos(-t1)
 	c2 := math.cos(-t2)
 	c3 := math.cos(-t3)
@@ -874,7 +874,7 @@ matrix4_from_euler_angles_xyz_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
 	return
 }
 
-matrix4_from_euler_angles_yxz_f16 :: proc(yaw, pitch, roll: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angles_yxz_f16 :: proc "contextless" (yaw, pitch, roll: f16) -> (m: Matrix4f16) {
 	ch := math.cos(yaw)
 	sh := math.sin(yaw)
 	cp := math.cos(pitch)
@@ -901,7 +901,7 @@ matrix4_from_euler_angles_yxz_f16 :: proc(yaw, pitch, roll: f16) -> (m: Matrix4f
 	return
 }
 
-matrix4_from_euler_angles_xzx_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angles_xzx_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix4f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -928,7 +928,7 @@ matrix4_from_euler_angles_xzx_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
 	return
 }
 
-matrix4_from_euler_angles_xyx_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angles_xyx_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix4f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -955,7 +955,7 @@ matrix4_from_euler_angles_xyx_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
 	return
 }
 
-matrix4_from_euler_angles_yxy_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angles_yxy_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix4f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -982,7 +982,7 @@ matrix4_from_euler_angles_yxy_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
 	return
 }
 
-matrix4_from_euler_angles_yzy_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angles_yzy_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix4f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1009,7 +1009,7 @@ matrix4_from_euler_angles_yzy_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
 	return
 }
 
-matrix4_from_euler_angles_zyz_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angles_zyz_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix4f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1036,7 +1036,7 @@ matrix4_from_euler_angles_zyz_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
 	return
 }
 
-matrix4_from_euler_angles_zxz_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angles_zxz_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix4f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1064,7 +1064,7 @@ matrix4_from_euler_angles_zxz_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
 }
 
 
-matrix4_from_euler_angles_xzy_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angles_xzy_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix4f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1091,7 +1091,7 @@ matrix4_from_euler_angles_xzy_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
 	return
 }
 
-matrix4_from_euler_angles_yzx_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angles_yzx_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix4f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1118,7 +1118,7 @@ matrix4_from_euler_angles_yzx_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
 	return
 }
 
-matrix4_from_euler_angles_zyx_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angles_zyx_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix4f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1145,7 +1145,7 @@ matrix4_from_euler_angles_zyx_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
 	return
 }
 
-matrix4_from_euler_angles_zxy_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
+matrix4_from_euler_angles_zxy_f16 :: proc "contextless" (t1, t2, t3: f16) -> (m: Matrix4f16) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1173,7 +1173,7 @@ matrix4_from_euler_angles_zxy_f16 :: proc(t1, t2, t3: f16) -> (m: Matrix4f16) {
 }
 
 
-matrix4_from_yaw_pitch_roll_f16 :: proc(yaw, pitch, roll: f16) -> (m: Matrix4f16) {
+matrix4_from_yaw_pitch_roll_f16 :: proc "contextless" (yaw, pitch, roll: f16) -> (m: Matrix4f16) {
 	ch := math.cos(yaw)
 	sh := math.sin(yaw)
 	cp := math.cos(pitch)
@@ -1200,7 +1200,7 @@ matrix4_from_yaw_pitch_roll_f16 :: proc(yaw, pitch, roll: f16) -> (m: Matrix4f16
 	return m
 }
 
-euler_angles_xyz_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
+euler_angles_xyz_from_matrix4_f16 :: proc "contextless" (m: Matrix4f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[1, 2], m[2, 2])
 	C2 := math.sqrt(m[0, 0]*m[0, 0] + m[0, 1]*m[0, 1])
 	T2 := math.atan2(-m[0, 2], C2)
@@ -1213,7 +1213,7 @@ euler_angles_xyz_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_yxz_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
+euler_angles_yxz_from_matrix4_f16 :: proc "contextless" (m: Matrix4f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[0, 2], m[2, 2])
 	C2 := math.sqrt(m[1, 0]*m[1, 0] + m[1, 1]*m[1, 1])
 	T2 := math.atan2(-m[1, 2], C2)
@@ -1226,7 +1226,7 @@ euler_angles_yxz_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_xzx_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
+euler_angles_xzx_from_matrix4_f16 :: proc "contextless" (m: Matrix4f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[2, 0], m[1, 0])
 	S2 := math.sqrt(m[0, 1]*m[0, 1] + m[0, 2]*m[0, 2])
 	T2 := math.atan2(S2, m[0, 0])
@@ -1239,7 +1239,7 @@ euler_angles_xzx_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_xyx_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
+euler_angles_xyx_from_matrix4_f16 :: proc "contextless" (m: Matrix4f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[1, 0], -m[2, 0])
 	S2 := math.sqrt(m[0, 1]*m[0, 1] + m[0, 2]*m[0, 2])
 	T2 := math.atan2(S2, m[0, 0])
@@ -1252,7 +1252,7 @@ euler_angles_xyx_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_yxy_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
+euler_angles_yxy_from_matrix4_f16 :: proc "contextless" (m: Matrix4f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[0, 1], m[2, 1])
 	S2 := math.sqrt(m[1, 0]*m[1, 0] + m[1, 2]*m[1, 2])
 	T2 := math.atan2(S2, m[1, 1])
@@ -1265,7 +1265,7 @@ euler_angles_yxy_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_yzy_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
+euler_angles_yzy_from_matrix4_f16 :: proc "contextless" (m: Matrix4f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[2, 1], -m[0, 1])
 	S2 := math.sqrt(m[1, 0]*m[1, 0] + m[1, 2]*m[1, 2])
 	T2 := math.atan2(S2, m[1, 1])
@@ -1277,7 +1277,7 @@ euler_angles_yzy_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
 	t3 = T3
 	return
 }
-euler_angles_zyz_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
+euler_angles_zyz_from_matrix4_f16 :: proc "contextless" (m: Matrix4f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[1, 2], m[0, 2])
 	S2 := math.sqrt(m[2, 0]*m[2, 0] + m[2, 1]*m[2, 1])
 	T2 := math.atan2(S2, m[2, 2])
@@ -1290,7 +1290,7 @@ euler_angles_zyz_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_zxz_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
+euler_angles_zxz_from_matrix4_f16 :: proc "contextless" (m: Matrix4f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[0, 2], -m[1, 2])
 	S2 := math.sqrt(m[2, 0]*m[2, 0] + m[2, 1]*m[2, 1])
 	T2 := math.atan2(S2, m[2, 2])
@@ -1303,7 +1303,7 @@ euler_angles_zxz_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_xzy_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
+euler_angles_xzy_from_matrix4_f16 :: proc "contextless" (m: Matrix4f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[2, 1], m[1, 1])
 	C2 := math.sqrt(m[0, 0]*m[0, 0] + m[0, 2]*m[0, 2])
 	T2 := math.atan2(-m[0, 1], C2)
@@ -1316,7 +1316,7 @@ euler_angles_xzy_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_yzx_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
+euler_angles_yzx_from_matrix4_f16 :: proc "contextless" (m: Matrix4f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(-m[2, 0], m[0, 0])
 	C2 := math.sqrt(m[1, 1]*m[1, 1] + m[1, 2]*m[1, 2])
 	T2 := math.atan2(m[1, 0], C2)
@@ -1329,7 +1329,7 @@ euler_angles_yzx_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_zyx_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
+euler_angles_zyx_from_matrix4_f16 :: proc "contextless" (m: Matrix4f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(m[1, 0], m[0, 0])
 	C2 := math.sqrt(m[2, 1]*m[2, 1] + m[2, 2]*m[2, 2])
 	T2 := math.atan2(-m[2, 0], C2)
@@ -1342,7 +1342,7 @@ euler_angles_zyx_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
 	return
 }
 
-euler_angles_zxy_from_matrix4_f16 :: proc(m: Matrix4f16) -> (t1, t2, t3: f16) {
+euler_angles_zxy_from_matrix4_f16 :: proc "contextless" (m: Matrix4f16) -> (t1, t2, t3: f16) {
 	T1 := math.atan2(-m[0, 1], m[1, 1])
 	C2 := math.sqrt(m[2, 0]*m[2, 0] + m[2, 2]*m[2, 2])
 	T2 := math.atan2(m[2, 1], C2)

--- a/core/math/linalg/specific_euler_angles_f32.odin
+++ b/core/math/linalg/specific_euler_angles_f32.odin
@@ -2,7 +2,7 @@ package linalg
 
 import "core:math"
 
-euler_angles_from_matrix3_f32 :: proc(m: Matrix3f32, order: Euler_Angle_Order) -> (t1, t2, t3: f32) {
+euler_angles_from_matrix3_f32 :: proc "contextless" (m: Matrix3f32, order: Euler_Angle_Order) -> (t1, t2, t3: f32) {
 	switch order {
 	case .XYZ: t1, t2, t3 = euler_angles_xyz_from_matrix3(m)
 	case .XZY: t1, t2, t3 = euler_angles_xzy_from_matrix3(m)
@@ -19,7 +19,7 @@ euler_angles_from_matrix3_f32 :: proc(m: Matrix3f32, order: Euler_Angle_Order) -
 	}
 	return
 }
-euler_angles_from_matrix4_f32 :: proc(m: Matrix4f32, order: Euler_Angle_Order) -> (t1, t2, t3: f32) {
+euler_angles_from_matrix4_f32 :: proc "contextless" (m: Matrix4f32, order: Euler_Angle_Order) -> (t1, t2, t3: f32) {
 	switch order {
 	case .XYZ: t1, t2, t3 = euler_angles_xyz_from_matrix4(m)
 	case .XZY: t1, t2, t3 = euler_angles_xzy_from_matrix4(m)
@@ -36,7 +36,7 @@ euler_angles_from_matrix4_f32 :: proc(m: Matrix4f32, order: Euler_Angle_Order) -
 	}
 	return
 }
-euler_angles_from_quaternion_f32 :: proc(m: Quaternionf32, order: Euler_Angle_Order) -> (t1, t2, t3: f32) {
+euler_angles_from_quaternion_f32 :: proc "contextless" (m: Quaternionf32, order: Euler_Angle_Order) -> (t1, t2, t3: f32) {
 	switch order {
 	case .XYZ: t1, t2, t3 = euler_angles_xyz_from_quaternion(m)
 	case .XZY: t1, t2, t3 = euler_angles_xzy_from_quaternion(m)
@@ -54,7 +54,7 @@ euler_angles_from_quaternion_f32 :: proc(m: Quaternionf32, order: Euler_Angle_Or
 	return
 }
 
-matrix3_from_euler_angles_f32 :: proc(t1, t2, t3: f32, order: Euler_Angle_Order) -> (m: Matrix3f32) {
+matrix3_from_euler_angles_f32 :: proc "contextless" (t1, t2, t3: f32, order: Euler_Angle_Order) -> (m: Matrix3f32) {
 	switch order {
 	case .XYZ: return matrix3_from_euler_angles_xyz(t1, t2, t3) // m1, m2, m3 = X(t1), Y(t2), Z(t3);
 	case .XZY: return matrix3_from_euler_angles_xzy(t1, t2, t3) // m1, m2, m3 = X(t1), Z(t2), Y(t3);
@@ -71,7 +71,7 @@ matrix3_from_euler_angles_f32 :: proc(t1, t2, t3: f32, order: Euler_Angle_Order)
 	}
 	return
 }
-matrix4_from_euler_angles_f32 :: proc(t1, t2, t3: f32, order: Euler_Angle_Order) -> (m: Matrix4f32) {
+matrix4_from_euler_angles_f32 :: proc "contextless" (t1, t2, t3: f32, order: Euler_Angle_Order) -> (m: Matrix4f32) {
 	switch order {
 	case .XYZ: return matrix4_from_euler_angles_xyz(t1, t2, t3) // m1, m2, m3 = X(t1), Y(t2), Z(t3);
 	case .XZY: return matrix4_from_euler_angles_xzy(t1, t2, t3) // m1, m2, m3 = X(t1), Z(t2), Y(t3);
@@ -89,7 +89,7 @@ matrix4_from_euler_angles_f32 :: proc(t1, t2, t3: f32, order: Euler_Angle_Order)
 	return
 }
 
-quaternion_from_euler_angles_f32 :: proc(t1, t2, t3: f32, order: Euler_Angle_Order) -> Quaternionf32 {
+quaternion_from_euler_angles_f32 :: proc "contextless" (t1, t2, t3: f32, order: Euler_Angle_Order) -> Quaternionf32 {
 	X :: quaternion_from_euler_angle_x
 	Y :: quaternion_from_euler_angle_y
 	Z :: quaternion_from_euler_angle_z
@@ -117,17 +117,17 @@ quaternion_from_euler_angles_f32 :: proc(t1, t2, t3: f32, order: Euler_Angle_Ord
 
 // Quaternionf32s
 
-quaternion_from_euler_angle_x_f32 :: proc(angle_x: f32) -> (q: Quaternionf32) {
+quaternion_from_euler_angle_x_f32 :: proc "contextless" (angle_x: f32) -> (q: Quaternionf32) {
 	return quaternion_angle_axis_f32(angle_x, {1, 0, 0})
 }
-quaternion_from_euler_angle_y_f32 :: proc(angle_y: f32) -> (q: Quaternionf32) {
+quaternion_from_euler_angle_y_f32 :: proc "contextless" (angle_y: f32) -> (q: Quaternionf32) {
 	return quaternion_angle_axis_f32(angle_y, {0, 1, 0})
 }
-quaternion_from_euler_angle_z_f32 :: proc(angle_z: f32) -> (q: Quaternionf32) {
+quaternion_from_euler_angle_z_f32 :: proc "contextless" (angle_z: f32) -> (q: Quaternionf32) {
 	return quaternion_angle_axis_f32(angle_z, {0, 0, 1})
 }
 
-quaternion_from_pitch_yaw_roll_f32 :: proc(pitch, yaw, roll: f32) -> Quaternionf32 {
+quaternion_from_pitch_yaw_roll_f32 :: proc "contextless" (pitch, yaw, roll: f32) -> Quaternionf32 {
 	a, b, c := pitch, yaw, roll
 
 	ca, sa := math.cos(a*0.5), math.sin(a*0.5)
@@ -142,11 +142,11 @@ quaternion_from_pitch_yaw_roll_f32 :: proc(pitch, yaw, roll: f32) -> Quaternionf
 	return q
 }
 
-roll_from_quaternion_f32 :: proc(q: Quaternionf32) -> f32 {
+roll_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> f32 {
 	return math.atan2(2 * q.x*q.y + q.w*q.z, q.w*q.w + q.x*q.x - q.y*q.y - q.z*q.z)
 }
 
-pitch_from_quaternion_f32 :: proc(q: Quaternionf32) -> f32 {
+pitch_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> f32 {
 	y := 2 * (q.y*q.z + q.w*q.w)
 	x := q.w*q.w - q.x*q.x - q.y*q.y + q.z*q.z
 
@@ -157,52 +157,52 @@ pitch_from_quaternion_f32 :: proc(q: Quaternionf32) -> f32 {
 	return math.atan2(y, x)
 }
 
-yaw_from_quaternion_f32 :: proc(q: Quaternionf32) -> f32 {
+yaw_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> f32 {
 	return math.asin(clamp(-2 * (q.x*q.z - q.w*q.y), -1, 1))
 }
 
 
-pitch_yaw_roll_from_quaternion_f32 :: proc(q: Quaternionf32) -> (pitch, yaw, roll: f32) {
+pitch_yaw_roll_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> (pitch, yaw, roll: f32) {
 	pitch = pitch_from_quaternion(q)
 	yaw = yaw_from_quaternion(q)
 	roll = roll_from_quaternion(q)
 	return
 }
 
-euler_angles_xyz_from_quaternion_f32 :: proc(q: Quaternionf32) -> (t1, t2, t3: f32) {
+euler_angles_xyz_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> (t1, t2, t3: f32) {
 	return euler_angles_xyz_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_yxz_from_quaternion_f32 :: proc(q: Quaternionf32) -> (t1, t2, t3: f32) {
+euler_angles_yxz_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> (t1, t2, t3: f32) {
 	return euler_angles_yxz_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_xzx_from_quaternion_f32 :: proc(q: Quaternionf32) -> (t1, t2, t3: f32) {
+euler_angles_xzx_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> (t1, t2, t3: f32) {
 	return euler_angles_xzx_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_xyx_from_quaternion_f32 :: proc(q: Quaternionf32) -> (t1, t2, t3: f32) {
+euler_angles_xyx_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> (t1, t2, t3: f32) {
 	return euler_angles_xyx_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_yxy_from_quaternion_f32 :: proc(q: Quaternionf32) -> (t1, t2, t3: f32) {
+euler_angles_yxy_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> (t1, t2, t3: f32) {
 	return euler_angles_yxy_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_yzy_from_quaternion_f32 :: proc(q: Quaternionf32) -> (t1, t2, t3: f32) {
+euler_angles_yzy_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> (t1, t2, t3: f32) {
 	return euler_angles_yzy_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_zyz_from_quaternion_f32 :: proc(q: Quaternionf32) -> (t1, t2, t3: f32) {
+euler_angles_zyz_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> (t1, t2, t3: f32) {
 	return euler_angles_zyz_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_zxz_from_quaternion_f32 :: proc(q: Quaternionf32) -> (t1, t2, t3: f32) {
+euler_angles_zxz_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> (t1, t2, t3: f32) {
 	return euler_angles_zxz_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_xzy_from_quaternion_f32 :: proc(q: Quaternionf32) -> (t1, t2, t3: f32) {
+euler_angles_xzy_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> (t1, t2, t3: f32) {
 	return euler_angles_xzy_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_yzx_from_quaternion_f32 :: proc(q: Quaternionf32) -> (t1, t2, t3: f32) {
+euler_angles_yzx_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> (t1, t2, t3: f32) {
 	return euler_angles_yzx_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_zyx_from_quaternion_f32 :: proc(q: Quaternionf32) -> (t1, t2, t3: f32) {
+euler_angles_zyx_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> (t1, t2, t3: f32) {
 	return euler_angles_zyx_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_zxy_from_quaternion_f32 :: proc(q: Quaternionf32) -> (t1, t2, t3: f32) {
+euler_angles_zxy_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> (t1, t2, t3: f32) {
 	return euler_angles_zxy_from_matrix4(matrix4_from_quaternion(q))
 }
 
@@ -210,7 +210,7 @@ euler_angles_zxy_from_quaternion_f32 :: proc(q: Quaternionf32) -> (t1, t2, t3: f
 // Matrix3
 
 
-matrix3_from_euler_angle_x_f32 :: proc(angle_x: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angle_x_f32 :: proc "contextless" (angle_x: f32) -> (m: Matrix3f32) {
 	cos_x, sin_x := math.cos(angle_x), math.sin(angle_x)
 	m[0, 0] = 1
 	m[1, 1] = +cos_x
@@ -219,7 +219,7 @@ matrix3_from_euler_angle_x_f32 :: proc(angle_x: f32) -> (m: Matrix3f32) {
 	m[2, 2] = +cos_x
 	return
 }
-matrix3_from_euler_angle_y_f32 :: proc(angle_y: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angle_y_f32 :: proc "contextless" (angle_y: f32) -> (m: Matrix3f32) {
 	cos_y, sin_y := math.cos(angle_y), math.sin(angle_y)
 	m[0, 0] = +cos_y
 	m[0, 2] = -sin_y
@@ -228,7 +228,7 @@ matrix3_from_euler_angle_y_f32 :: proc(angle_y: f32) -> (m: Matrix3f32) {
 	m[2, 2] = +cos_y
 	return
 }
-matrix3_from_euler_angle_z_f32 :: proc(angle_z: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angle_z_f32 :: proc "contextless" (angle_z: f32) -> (m: Matrix3f32) {
 	cos_z, sin_z := math.cos(angle_z), math.sin(angle_z)
 	m[0, 0] = +cos_z
 	m[0, 1] = +sin_z
@@ -239,7 +239,7 @@ matrix3_from_euler_angle_z_f32 :: proc(angle_z: f32) -> (m: Matrix3f32) {
 }
 
 
-matrix3_from_derived_euler_angle_x_f32 :: proc(angle_x: f32, angular_velocity_x: f32) -> (m: Matrix3f32) {
+matrix3_from_derived_euler_angle_x_f32 :: proc "contextless" (angle_x: f32, angular_velocity_x: f32) -> (m: Matrix3f32) {
 	cos_x := math.cos(angle_x) * angular_velocity_x
 	sin_x := math.sin(angle_x) * angular_velocity_x
 	m[0, 0] = 1
@@ -249,7 +249,7 @@ matrix3_from_derived_euler_angle_x_f32 :: proc(angle_x: f32, angular_velocity_x:
 	m[2, 2] = +cos_x
 	return
 }
-matrix3_from_derived_euler_angle_y_f32 :: proc(angle_y: f32, angular_velocity_y: f32) -> (m: Matrix3f32) {
+matrix3_from_derived_euler_angle_y_f32 :: proc "contextless" (angle_y: f32, angular_velocity_y: f32) -> (m: Matrix3f32) {
 	cos_y := math.cos(angle_y) * angular_velocity_y
 	sin_y := math.sin(angle_y) * angular_velocity_y
 	m[0, 0] = +cos_y
@@ -259,7 +259,7 @@ matrix3_from_derived_euler_angle_y_f32 :: proc(angle_y: f32, angular_velocity_y:
 	m[2, 2] = +cos_y
 	return
 }
-matrix3_from_derived_euler_angle_z_f32 :: proc(angle_z: f32, angular_velocity_z: f32) -> (m: Matrix3f32) {
+matrix3_from_derived_euler_angle_z_f32 :: proc "contextless" (angle_z: f32, angular_velocity_z: f32) -> (m: Matrix3f32) {
 	cos_z := math.cos(angle_z) * angular_velocity_z
 	sin_z := math.sin(angle_z) * angular_velocity_z
 	m[0, 0] = +cos_z
@@ -271,7 +271,7 @@ matrix3_from_derived_euler_angle_z_f32 :: proc(angle_z: f32, angular_velocity_z:
 }
 
 
-matrix3_from_euler_angles_xy_f32 :: proc(angle_x, angle_y: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angles_xy_f32 :: proc "contextless" (angle_x, angle_y: f32) -> (m: Matrix3f32) {
 	cos_x, sin_x := math.cos(angle_x), math.sin(angle_x)
 	cos_y, sin_y := math.cos(angle_y), math.sin(angle_y)
 	m[0, 0] = cos_y
@@ -286,7 +286,7 @@ matrix3_from_euler_angles_xy_f32 :: proc(angle_x, angle_y: f32) -> (m: Matrix3f3
 }
 
 
-matrix3_from_euler_angles_yx_f32 :: proc(angle_y, angle_x: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angles_yx_f32 :: proc "contextless" (angle_y, angle_x: f32) -> (m: Matrix3f32) {
 	cos_x, sin_x := math.cos(angle_x), math.sin(angle_x)
 	cos_y, sin_y := math.cos(angle_y), math.sin(angle_y)
 	m[0, 0] = cos_y
@@ -303,18 +303,18 @@ matrix3_from_euler_angles_yx_f32 :: proc(angle_y, angle_x: f32) -> (m: Matrix3f3
 matrix3_from_euler_angles_xz_f32 :: proc(angle_x, angle_z: f32) -> (m: Matrix3f32) {
 	return mul(matrix3_from_euler_angle_x(angle_x), matrix3_from_euler_angle_z(angle_z))
 }
-matrix3_from_euler_angles_zx_f32 :: proc(angle_z, angle_x: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angles_zx_f32 :: proc "contextless" (angle_z, angle_x: f32) -> (m: Matrix3f32) {
 	return mul(matrix3_from_euler_angle_z(angle_z), matrix3_from_euler_angle_x(angle_x))
 }
-matrix3_from_euler_angles_yz_f32 :: proc(angle_y, angle_z: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angles_yz_f32 :: proc "contextless" (angle_y, angle_z: f32) -> (m: Matrix3f32) {
 	return mul(matrix3_from_euler_angle_y(angle_y), matrix3_from_euler_angle_z(angle_z))
 }
-matrix3_from_euler_angles_zy_f32 :: proc(angle_z, angle_y: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angles_zy_f32 :: proc "contextless" (angle_z, angle_y: f32) -> (m: Matrix3f32) {
 	return mul(matrix3_from_euler_angle_z(angle_z), matrix3_from_euler_angle_y(angle_y))
 }
 
 
-matrix3_from_euler_angles_xyz_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angles_xyz_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix3f32) {
 	c1 := math.cos(-t1)
 	c2 := math.cos(-t2)
 	c3 := math.cos(-t3)
@@ -334,7 +334,7 @@ matrix3_from_euler_angles_xyz_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
 	return
 }
 
-matrix3_from_euler_angles_yxz_f32 :: proc(yaw, pitch, roll: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angles_yxz_f32 :: proc "contextless" (yaw, pitch, roll: f32) -> (m: Matrix3f32) {
 	ch := math.cos(yaw)
 	sh := math.sin(yaw)
 	cp := math.cos(pitch)
@@ -354,7 +354,7 @@ matrix3_from_euler_angles_yxz_f32 :: proc(yaw, pitch, roll: f32) -> (m: Matrix3f
 	return
 }
 
-matrix3_from_euler_angles_xzx_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angles_xzx_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix3f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -374,7 +374,7 @@ matrix3_from_euler_angles_xzx_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
 	return
 }
 
-matrix3_from_euler_angles_xyx_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angles_xyx_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix3f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -394,7 +394,7 @@ matrix3_from_euler_angles_xyx_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
 	return
 }
 
-matrix3_from_euler_angles_yxy_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angles_yxy_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix3f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -414,7 +414,7 @@ matrix3_from_euler_angles_yxy_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
 	return
 }
 
-matrix3_from_euler_angles_yzy_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angles_yzy_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix3f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -434,7 +434,7 @@ matrix3_from_euler_angles_yzy_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
 	return
 }
 
-matrix3_from_euler_angles_zyz_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angles_zyz_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix3f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -454,7 +454,7 @@ matrix3_from_euler_angles_zyz_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
 	return
 }
 
-matrix3_from_euler_angles_zxz_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angles_zxz_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix3f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -475,7 +475,7 @@ matrix3_from_euler_angles_zxz_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
 }
 
 
-matrix3_from_euler_angles_xzy_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angles_xzy_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix3f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -495,7 +495,7 @@ matrix3_from_euler_angles_xzy_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
 	return
 }
 
-matrix3_from_euler_angles_yzx_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angles_yzx_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix3f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -515,7 +515,7 @@ matrix3_from_euler_angles_yzx_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
 	return
 }
 
-matrix3_from_euler_angles_zyx_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angles_zyx_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix3f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -535,7 +535,7 @@ matrix3_from_euler_angles_zyx_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
 	return
 }
 
-matrix3_from_euler_angles_zxy_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
+matrix3_from_euler_angles_zxy_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix3f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -556,7 +556,7 @@ matrix3_from_euler_angles_zxy_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix3f32) {
 }
 
 
-matrix3_from_yaw_pitch_roll_f32 :: proc(yaw, pitch, roll: f32) -> (m: Matrix3f32) {
+matrix3_from_yaw_pitch_roll_f32 :: proc "contextless" (yaw, pitch, roll: f32) -> (m: Matrix3f32) {
 	ch := math.cos(yaw)
 	sh := math.sin(yaw)
 	cp := math.cos(pitch)
@@ -576,7 +576,7 @@ matrix3_from_yaw_pitch_roll_f32 :: proc(yaw, pitch, roll: f32) -> (m: Matrix3f32
 	return m
 }
 
-euler_angles_xyz_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
+euler_angles_xyz_from_matrix3_f32 :: proc "contextless" (m: Matrix3f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[1, 2], m[2, 2])
 	C2 := math.sqrt(m[0, 0]*m[0, 0] + m[0, 1]*m[0, 1])
 	T2 := math.atan2(-m[0, 2], C2)
@@ -589,7 +589,7 @@ euler_angles_xyz_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_yxz_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
+euler_angles_yxz_from_matrix3_f32 :: proc "contextless" (m: Matrix3f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[0, 2], m[2, 2])
 	C2 := math.sqrt(m[1, 0]*m[1, 0] + m[1, 1]*m[1, 1])
 	T2 := math.atan2(-m[1, 2], C2)
@@ -602,7 +602,7 @@ euler_angles_yxz_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_xzx_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
+euler_angles_xzx_from_matrix3_f32 :: proc "contextless" (m: Matrix3f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[2, 0], m[1, 0])
 	S2 := math.sqrt(m[0, 1]*m[0, 1] + m[0, 2]*m[0, 2])
 	T2 := math.atan2(S2, m[0, 0])
@@ -615,7 +615,7 @@ euler_angles_xzx_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_xyx_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
+euler_angles_xyx_from_matrix3_f32 :: proc "contextless" (m: Matrix3f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[1, 0], -m[2, 0])
 	S2 := math.sqrt(m[0, 1]*m[0, 1] + m[0, 2]*m[0, 2])
 	T2 := math.atan2(S2, m[0, 0])
@@ -628,7 +628,7 @@ euler_angles_xyx_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_yxy_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
+euler_angles_yxy_from_matrix3_f32 :: proc "contextless" (m: Matrix3f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[0, 1], m[2, 1])
 	S2 := math.sqrt(m[1, 0]*m[1, 0] + m[1, 2]*m[1, 2])
 	T2 := math.atan2(S2, m[1, 1])
@@ -641,7 +641,7 @@ euler_angles_yxy_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_yzy_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
+euler_angles_yzy_from_matrix3_f32 :: proc "contextless" (m: Matrix3f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[2, 1], -m[0, 1])
 	S2 := math.sqrt(m[1, 0]*m[1, 0] + m[1, 2]*m[1, 2])
 	T2 := math.atan2(S2, m[1, 1])
@@ -653,7 +653,7 @@ euler_angles_yzy_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
 	t3 = T3
 	return
 }
-euler_angles_zyz_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
+euler_angles_zyz_from_matrix3_f32 :: proc "contextless" (m: Matrix3f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[1, 2], m[0, 2])
 	S2 := math.sqrt(m[2, 0]*m[2, 0] + m[2, 1]*m[2, 1])
 	T2 := math.atan2(S2, m[2, 2])
@@ -666,7 +666,7 @@ euler_angles_zyz_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_zxz_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
+euler_angles_zxz_from_matrix3_f32 :: proc "contextless" (m: Matrix3f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[0, 2], -m[1, 2])
 	S2 := math.sqrt(m[2, 0]*m[2, 0] + m[2, 1]*m[2, 1])
 	T2 := math.atan2(S2, m[2, 2])
@@ -679,7 +679,7 @@ euler_angles_zxz_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_xzy_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
+euler_angles_xzy_from_matrix3_f32 :: proc "contextless" (m: Matrix3f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[2, 1], m[1, 1])
 	C2 := math.sqrt(m[0, 0]*m[0, 0] + m[0, 2]*m[0, 2])
 	T2 := math.atan2(-m[0, 1], C2)
@@ -692,7 +692,7 @@ euler_angles_xzy_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_yzx_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
+euler_angles_yzx_from_matrix3_f32 :: proc "contextless" (m: Matrix3f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(-m[2, 0], m[0, 0])
 	C2 := math.sqrt(m[1, 1]*m[1, 1] + m[1, 2]*m[1, 2])
 	T2 := math.atan2(m[1, 0], C2)
@@ -705,7 +705,7 @@ euler_angles_yzx_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_zyx_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
+euler_angles_zyx_from_matrix3_f32 :: proc "contextless" (m: Matrix3f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[1, 0], m[0, 0])
 	C2 := math.sqrt(m[2, 1]*m[2, 1] + m[2, 2]*m[2, 2])
 	T2 := math.atan2(-m[2, 0], C2)
@@ -718,7 +718,7 @@ euler_angles_zyx_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_zxy_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
+euler_angles_zxy_from_matrix3_f32 :: proc "contextless" (m: Matrix3f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(-m[0, 1], m[1, 1])
 	C2 := math.sqrt(m[2, 0]*m[2, 0] + m[2, 2]*m[2, 2])
 	T2 := math.atan2(m[2, 1], C2)
@@ -735,7 +735,7 @@ euler_angles_zxy_from_matrix3_f32 :: proc(m: Matrix3f32) -> (t1, t2, t3: f32) {
 // Matrix4
 
 
-matrix4_from_euler_angle_x_f32 :: proc(angle_x: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angle_x_f32 :: proc "contextless" (angle_x: f32) -> (m: Matrix4f32) {
 	cos_x, sin_x := math.cos(angle_x), math.sin(angle_x)
 	m[0, 0] = 1
 	m[1, 1] = +cos_x
@@ -745,7 +745,7 @@ matrix4_from_euler_angle_x_f32 :: proc(angle_x: f32) -> (m: Matrix4f32) {
 	m[3, 3] = 1
 	return
 }
-matrix4_from_euler_angle_y_f32 :: proc(angle_y: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angle_y_f32 :: proc "contextless" (angle_y: f32) -> (m: Matrix4f32) {
 	cos_y, sin_y := math.cos(angle_y), math.sin(angle_y)
 	m[0, 0] = +cos_y
 	m[0, 2] = -sin_y
@@ -755,7 +755,7 @@ matrix4_from_euler_angle_y_f32 :: proc(angle_y: f32) -> (m: Matrix4f32) {
 	m[3, 3] = 1
 	return
 }
-matrix4_from_euler_angle_z_f32 :: proc(angle_z: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angle_z_f32 :: proc "contextless" (angle_z: f32) -> (m: Matrix4f32) {
 	cos_z, sin_z := math.cos(angle_z), math.sin(angle_z)
 	m[0, 0] = +cos_z
 	m[0, 1] = +sin_z
@@ -767,7 +767,7 @@ matrix4_from_euler_angle_z_f32 :: proc(angle_z: f32) -> (m: Matrix4f32) {
 }
 
 
-matrix4_from_derived_euler_angle_x_f32 :: proc(angle_x: f32, angular_velocity_x: f32) -> (m: Matrix4f32) {
+matrix4_from_derived_euler_angle_x_f32 :: proc "contextless" (angle_x: f32, angular_velocity_x: f32) -> (m: Matrix4f32) {
 	cos_x := math.cos(angle_x) * angular_velocity_x
 	sin_x := math.sin(angle_x) * angular_velocity_x
 	m[0, 0] = 1
@@ -778,7 +778,7 @@ matrix4_from_derived_euler_angle_x_f32 :: proc(angle_x: f32, angular_velocity_x:
 	m[3, 3] = 1
 	return
 }
-matrix4_from_derived_euler_angle_y_f32 :: proc(angle_y: f32, angular_velocity_y: f32) -> (m: Matrix4f32) {
+matrix4_from_derived_euler_angle_y_f32 :: proc "contextless" (angle_y: f32, angular_velocity_y: f32) -> (m: Matrix4f32) {
 	cos_y := math.cos(angle_y) * angular_velocity_y
 	sin_y := math.sin(angle_y) * angular_velocity_y
 	m[0, 0] = +cos_y
@@ -789,7 +789,7 @@ matrix4_from_derived_euler_angle_y_f32 :: proc(angle_y: f32, angular_velocity_y:
 	m[3, 3] = 1
 	return
 }
-matrix4_from_derived_euler_angle_z_f32 :: proc(angle_z: f32, angular_velocity_z: f32) -> (m: Matrix4f32) {
+matrix4_from_derived_euler_angle_z_f32 :: proc "contextless" (angle_z: f32, angular_velocity_z: f32) -> (m: Matrix4f32) {
 	cos_z := math.cos(angle_z) * angular_velocity_z
 	sin_z := math.sin(angle_z) * angular_velocity_z
 	m[0, 0] = +cos_z
@@ -802,7 +802,7 @@ matrix4_from_derived_euler_angle_z_f32 :: proc(angle_z: f32, angular_velocity_z:
 }
 
 
-matrix4_from_euler_angles_xy_f32 :: proc(angle_x, angle_y: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angles_xy_f32 :: proc "contextless" (angle_x, angle_y: f32) -> (m: Matrix4f32) {
 	cos_x, sin_x := math.cos(angle_x), math.sin(angle_x)
 	cos_y, sin_y := math.cos(angle_y), math.sin(angle_y)
 	m[0, 0] = cos_y
@@ -818,7 +818,7 @@ matrix4_from_euler_angles_xy_f32 :: proc(angle_x, angle_y: f32) -> (m: Matrix4f3
 }
 
 
-matrix4_from_euler_angles_yx_f32 :: proc(angle_y, angle_x: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angles_yx_f32 :: proc "contextless" (angle_y, angle_x: f32) -> (m: Matrix4f32) {
 	cos_x, sin_x := math.cos(angle_x), math.sin(angle_x)
 	cos_y, sin_y := math.cos(angle_y), math.sin(angle_y)
 	m[0, 0] = cos_y
@@ -833,21 +833,21 @@ matrix4_from_euler_angles_yx_f32 :: proc(angle_y, angle_x: f32) -> (m: Matrix4f3
 	return
 }
 
-matrix4_from_euler_angles_xz_f32 :: proc(angle_x, angle_z: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angles_xz_f32 :: proc "contextless" (angle_x, angle_z: f32) -> (m: Matrix4f32) {
 	return mul(matrix4_from_euler_angle_x(angle_x), matrix4_from_euler_angle_z(angle_z))
 }
-matrix4_from_euler_angles_zx_f32 :: proc(angle_z, angle_x: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angles_zx_f32 :: proc "contextless" (angle_z, angle_x: f32) -> (m: Matrix4f32) {
 	return mul(matrix4_from_euler_angle_z(angle_z), matrix4_from_euler_angle_x(angle_x))
 }
-matrix4_from_euler_angles_yz_f32 :: proc(angle_y, angle_z: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angles_yz_f32 :: proc "contextless" (angle_y, angle_z: f32) -> (m: Matrix4f32) {
 	return mul(matrix4_from_euler_angle_y(angle_y), matrix4_from_euler_angle_z(angle_z))
 }
-matrix4_from_euler_angles_zy_f32 :: proc(angle_z, angle_y: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angles_zy_f32 :: proc "contextless" (angle_z, angle_y: f32) -> (m: Matrix4f32) {
 	return mul(matrix4_from_euler_angle_z(angle_z), matrix4_from_euler_angle_y(angle_y))
 }
 
 
-matrix4_from_euler_angles_xyz_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angles_xyz_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix4f32) {
 	c1 := math.cos(-t1)
 	c2 := math.cos(-t2)
 	c3 := math.cos(-t3)
@@ -874,7 +874,7 @@ matrix4_from_euler_angles_xyz_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
 	return
 }
 
-matrix4_from_euler_angles_yxz_f32 :: proc(yaw, pitch, roll: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angles_yxz_f32 :: proc "contextless" (yaw, pitch, roll: f32) -> (m: Matrix4f32) {
 	ch := math.cos(yaw)
 	sh := math.sin(yaw)
 	cp := math.cos(pitch)
@@ -901,7 +901,7 @@ matrix4_from_euler_angles_yxz_f32 :: proc(yaw, pitch, roll: f32) -> (m: Matrix4f
 	return
 }
 
-matrix4_from_euler_angles_xzx_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angles_xzx_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix4f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -928,7 +928,7 @@ matrix4_from_euler_angles_xzx_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
 	return
 }
 
-matrix4_from_euler_angles_xyx_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angles_xyx_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix4f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -955,7 +955,7 @@ matrix4_from_euler_angles_xyx_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
 	return
 }
 
-matrix4_from_euler_angles_yxy_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angles_yxy_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix4f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -982,7 +982,7 @@ matrix4_from_euler_angles_yxy_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
 	return
 }
 
-matrix4_from_euler_angles_yzy_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angles_yzy_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix4f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1009,7 +1009,7 @@ matrix4_from_euler_angles_yzy_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
 	return
 }
 
-matrix4_from_euler_angles_zyz_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angles_zyz_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix4f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1036,7 +1036,7 @@ matrix4_from_euler_angles_zyz_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
 	return
 }
 
-matrix4_from_euler_angles_zxz_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angles_zxz_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix4f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1064,7 +1064,7 @@ matrix4_from_euler_angles_zxz_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
 }
 
 
-matrix4_from_euler_angles_xzy_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angles_xzy_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix4f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1091,7 +1091,7 @@ matrix4_from_euler_angles_xzy_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
 	return
 }
 
-matrix4_from_euler_angles_yzx_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angles_yzx_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix4f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1118,7 +1118,7 @@ matrix4_from_euler_angles_yzx_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
 	return
 }
 
-matrix4_from_euler_angles_zyx_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angles_zyx_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix4f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1145,7 +1145,7 @@ matrix4_from_euler_angles_zyx_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
 	return
 }
 
-matrix4_from_euler_angles_zxy_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
+matrix4_from_euler_angles_zxy_f32 :: proc "contextless" (t1, t2, t3: f32) -> (m: Matrix4f32) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1173,7 +1173,7 @@ matrix4_from_euler_angles_zxy_f32 :: proc(t1, t2, t3: f32) -> (m: Matrix4f32) {
 }
 
 
-matrix4_from_yaw_pitch_roll_f32 :: proc(yaw, pitch, roll: f32) -> (m: Matrix4f32) {
+matrix4_from_yaw_pitch_roll_f32 :: proc "contextless" (yaw, pitch, roll: f32) -> (m: Matrix4f32) {
 	ch := math.cos(yaw)
 	sh := math.sin(yaw)
 	cp := math.cos(pitch)
@@ -1200,7 +1200,7 @@ matrix4_from_yaw_pitch_roll_f32 :: proc(yaw, pitch, roll: f32) -> (m: Matrix4f32
 	return m
 }
 
-euler_angles_xyz_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
+euler_angles_xyz_from_matrix4_f32 :: proc "contextless" (m: Matrix4f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[1, 2], m[2, 2])
 	C2 := math.sqrt(m[0, 0]*m[0, 0] + m[0, 1]*m[0, 1])
 	T2 := math.atan2(-m[0, 2], C2)
@@ -1213,7 +1213,7 @@ euler_angles_xyz_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_yxz_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
+euler_angles_yxz_from_matrix4_f32 :: proc "contextless" (m: Matrix4f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[0, 2], m[2, 2])
 	C2 := math.sqrt(m[1, 0]*m[1, 0] + m[1, 1]*m[1, 1])
 	T2 := math.atan2(-m[1, 2], C2)
@@ -1226,7 +1226,7 @@ euler_angles_yxz_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_xzx_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
+euler_angles_xzx_from_matrix4_f32 :: proc "contextless" (m: Matrix4f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[2, 0], m[1, 0])
 	S2 := math.sqrt(m[0, 1]*m[0, 1] + m[0, 2]*m[0, 2])
 	T2 := math.atan2(S2, m[0, 0])
@@ -1239,7 +1239,7 @@ euler_angles_xzx_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_xyx_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
+euler_angles_xyx_from_matrix4_f32 :: proc "contextless" (m: Matrix4f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[1, 0], -m[2, 0])
 	S2 := math.sqrt(m[0, 1]*m[0, 1] + m[0, 2]*m[0, 2])
 	T2 := math.atan2(S2, m[0, 0])
@@ -1252,7 +1252,7 @@ euler_angles_xyx_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_yxy_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
+euler_angles_yxy_from_matrix4_f32 :: proc "contextless" (m: Matrix4f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[0, 1], m[2, 1])
 	S2 := math.sqrt(m[1, 0]*m[1, 0] + m[1, 2]*m[1, 2])
 	T2 := math.atan2(S2, m[1, 1])
@@ -1265,7 +1265,7 @@ euler_angles_yxy_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_yzy_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
+euler_angles_yzy_from_matrix4_f32 :: proc "contextless" (m: Matrix4f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[2, 1], -m[0, 1])
 	S2 := math.sqrt(m[1, 0]*m[1, 0] + m[1, 2]*m[1, 2])
 	T2 := math.atan2(S2, m[1, 1])
@@ -1277,7 +1277,7 @@ euler_angles_yzy_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
 	t3 = T3
 	return
 }
-euler_angles_zyz_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
+euler_angles_zyz_from_matrix4_f32 :: proc "contextless" (m: Matrix4f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[1, 2], m[0, 2])
 	S2 := math.sqrt(m[2, 0]*m[2, 0] + m[2, 1]*m[2, 1])
 	T2 := math.atan2(S2, m[2, 2])
@@ -1290,7 +1290,7 @@ euler_angles_zyz_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_zxz_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
+euler_angles_zxz_from_matrix4_f32 :: proc "contextless" (m: Matrix4f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[0, 2], -m[1, 2])
 	S2 := math.sqrt(m[2, 0]*m[2, 0] + m[2, 1]*m[2, 1])
 	T2 := math.atan2(S2, m[2, 2])
@@ -1303,7 +1303,7 @@ euler_angles_zxz_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_xzy_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
+euler_angles_xzy_from_matrix4_f32 :: proc "contextless" (m: Matrix4f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[2, 1], m[1, 1])
 	C2 := math.sqrt(m[0, 0]*m[0, 0] + m[0, 2]*m[0, 2])
 	T2 := math.atan2(-m[0, 1], C2)
@@ -1316,7 +1316,7 @@ euler_angles_xzy_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_yzx_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
+euler_angles_yzx_from_matrix4_f32 :: proc "contextless" (m: Matrix4f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(-m[2, 0], m[0, 0])
 	C2 := math.sqrt(m[1, 1]*m[1, 1] + m[1, 2]*m[1, 2])
 	T2 := math.atan2(m[1, 0], C2)
@@ -1329,7 +1329,7 @@ euler_angles_yzx_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_zyx_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
+euler_angles_zyx_from_matrix4_f32 :: proc "contextless" (m: Matrix4f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(m[1, 0], m[0, 0])
 	C2 := math.sqrt(m[2, 1]*m[2, 1] + m[2, 2]*m[2, 2])
 	T2 := math.atan2(-m[2, 0], C2)
@@ -1342,7 +1342,7 @@ euler_angles_zyx_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
 	return
 }
 
-euler_angles_zxy_from_matrix4_f32 :: proc(m: Matrix4f32) -> (t1, t2, t3: f32) {
+euler_angles_zxy_from_matrix4_f32 :: proc "contextless" (m: Matrix4f32) -> (t1, t2, t3: f32) {
 	T1 := math.atan2(-m[0, 1], m[1, 1])
 	C2 := math.sqrt(m[2, 0]*m[2, 0] + m[2, 2]*m[2, 2])
 	T2 := math.atan2(m[2, 1], C2)

--- a/core/math/linalg/specific_euler_angles_f64.odin
+++ b/core/math/linalg/specific_euler_angles_f64.odin
@@ -2,7 +2,7 @@ package linalg
 
 import "core:math"
 
-euler_angles_from_matrix3_f64 :: proc(m: Matrix3f64, order: Euler_Angle_Order) -> (t1, t2, t3: f64) {
+euler_angles_from_matrix3_f64 :: proc "contextless" (m: Matrix3f64, order: Euler_Angle_Order) -> (t1, t2, t3: f64) {
 	switch order {
 	case .XYZ: t1, t2, t3 = euler_angles_xyz_from_matrix3(m)
 	case .XZY: t1, t2, t3 = euler_angles_xzy_from_matrix3(m)
@@ -19,7 +19,7 @@ euler_angles_from_matrix3_f64 :: proc(m: Matrix3f64, order: Euler_Angle_Order) -
 	}
 	return
 }
-euler_angles_from_matrix4_f64 :: proc(m: Matrix4f64, order: Euler_Angle_Order) -> (t1, t2, t3: f64) {
+euler_angles_from_matrix4_f64 :: proc "contextless" (m: Matrix4f64, order: Euler_Angle_Order) -> (t1, t2, t3: f64) {
 	switch order {
 	case .XYZ: t1, t2, t3 = euler_angles_xyz_from_matrix4(m)
 	case .XZY: t1, t2, t3 = euler_angles_xzy_from_matrix4(m)
@@ -36,7 +36,7 @@ euler_angles_from_matrix4_f64 :: proc(m: Matrix4f64, order: Euler_Angle_Order) -
 	}
 	return
 }
-euler_angles_from_quaternion_f64 :: proc(m: Quaternionf64, order: Euler_Angle_Order) -> (t1, t2, t3: f64) {
+euler_angles_from_quaternion_f64 :: proc "contextless" (m: Quaternionf64, order: Euler_Angle_Order) -> (t1, t2, t3: f64) {
 	switch order {
 	case .XYZ: t1, t2, t3 = euler_angles_xyz_from_quaternion(m)
 	case .XZY: t1, t2, t3 = euler_angles_xzy_from_quaternion(m)
@@ -54,7 +54,7 @@ euler_angles_from_quaternion_f64 :: proc(m: Quaternionf64, order: Euler_Angle_Or
 	return
 }
 
-matrix3_from_euler_angles_f64 :: proc(t1, t2, t3: f64, order: Euler_Angle_Order) -> (m: Matrix3f64) {
+matrix3_from_euler_angles_f64 :: proc "contextless" (t1, t2, t3: f64, order: Euler_Angle_Order) -> (m: Matrix3f64) {
 	switch order {
 	case .XYZ: return matrix3_from_euler_angles_xyz(t1, t2, t3) // m1, m2, m3 = X(t1), Y(t2), Z(t3);
 	case .XZY: return matrix3_from_euler_angles_xzy(t1, t2, t3) // m1, m2, m3 = X(t1), Z(t2), Y(t3);
@@ -71,7 +71,7 @@ matrix3_from_euler_angles_f64 :: proc(t1, t2, t3: f64, order: Euler_Angle_Order)
 	}
 	return
 }
-matrix4_from_euler_angles_f64 :: proc(t1, t2, t3: f64, order: Euler_Angle_Order) -> (m: Matrix4f64) {
+matrix4_from_euler_angles_f64 :: proc "contextless" (t1, t2, t3: f64, order: Euler_Angle_Order) -> (m: Matrix4f64) {
 	switch order {
 	case .XYZ: return matrix4_from_euler_angles_xyz(t1, t2, t3) // m1, m2, m3 = X(t1), Y(t2), Z(t3);
 	case .XZY: return matrix4_from_euler_angles_xzy(t1, t2, t3) // m1, m2, m3 = X(t1), Z(t2), Y(t3);
@@ -89,7 +89,7 @@ matrix4_from_euler_angles_f64 :: proc(t1, t2, t3: f64, order: Euler_Angle_Order)
 	return
 }
 
-quaternion_from_euler_angles_f64 :: proc(t1, t2, t3: f64, order: Euler_Angle_Order) -> Quaternionf64 {
+quaternion_from_euler_angles_f64 :: proc "contextless" (t1, t2, t3: f64, order: Euler_Angle_Order) -> Quaternionf64 {
 	X :: quaternion_from_euler_angle_x
 	Y :: quaternion_from_euler_angle_y
 	Z :: quaternion_from_euler_angle_z
@@ -117,17 +117,17 @@ quaternion_from_euler_angles_f64 :: proc(t1, t2, t3: f64, order: Euler_Angle_Ord
 
 // Quaternionf64s
 
-quaternion_from_euler_angle_x_f64 :: proc(angle_x: f64) -> (q: Quaternionf64) {
+quaternion_from_euler_angle_x_f64 :: proc "contextless" (angle_x: f64) -> (q: Quaternionf64) {
 	return quaternion_angle_axis_f64(angle_x, {1, 0, 0})
 }
-quaternion_from_euler_angle_y_f64 :: proc(angle_y: f64) -> (q: Quaternionf64) {
+quaternion_from_euler_angle_y_f64 :: proc "contextless" (angle_y: f64) -> (q: Quaternionf64) {
 	return quaternion_angle_axis_f64(angle_y, {0, 1, 0})
 }
-quaternion_from_euler_angle_z_f64 :: proc(angle_z: f64) -> (q: Quaternionf64) {
+quaternion_from_euler_angle_z_f64 :: proc "contextless" (angle_z: f64) -> (q: Quaternionf64) {
 	return quaternion_angle_axis_f64(angle_z, {0, 0, 1})
 }
 
-quaternion_from_pitch_yaw_roll_f64 :: proc(pitch, yaw, roll: f64) -> Quaternionf64 {
+quaternion_from_pitch_yaw_roll_f64 :: proc "contextless" (pitch, yaw, roll: f64) -> Quaternionf64 {
 	a, b, c := pitch, yaw, roll
 
 	ca, sa := math.cos(a*0.5), math.sin(a*0.5)
@@ -142,11 +142,11 @@ quaternion_from_pitch_yaw_roll_f64 :: proc(pitch, yaw, roll: f64) -> Quaternionf
 	return q
 }
 
-roll_from_quaternion_f64 :: proc(q: Quaternionf64) -> f64 {
+roll_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> f64 {
 	return math.atan2(2 * q.x*q.y + q.w*q.z, q.w*q.w + q.x*q.x - q.y*q.y - q.z*q.z)
 }
 
-pitch_from_quaternion_f64 :: proc(q: Quaternionf64) -> f64 {
+pitch_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> f64 {
 	y := 2 * (q.y*q.z + q.w*q.w)
 	x := q.w*q.w - q.x*q.x - q.y*q.y + q.z*q.z
 
@@ -157,52 +157,52 @@ pitch_from_quaternion_f64 :: proc(q: Quaternionf64) -> f64 {
 	return math.atan2(y, x)
 }
 
-yaw_from_quaternion_f64 :: proc(q: Quaternionf64) -> f64 {
+yaw_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> f64 {
 	return math.asin(clamp(-2 * (q.x*q.z - q.w*q.y), -1, 1))
 }
 
 
-pitch_yaw_roll_from_quaternion_f64 :: proc(q: Quaternionf64) -> (pitch, yaw, roll: f64) {
+pitch_yaw_roll_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> (pitch, yaw, roll: f64) {
 	pitch = pitch_from_quaternion(q)
 	yaw = yaw_from_quaternion(q)
 	roll = roll_from_quaternion(q)
 	return
 }
 
-euler_angles_xyz_from_quaternion_f64 :: proc(q: Quaternionf64) -> (t1, t2, t3: f64) {
+euler_angles_xyz_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> (t1, t2, t3: f64) {
 	return euler_angles_xyz_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_yxz_from_quaternion_f64 :: proc(q: Quaternionf64) -> (t1, t2, t3: f64) {
+euler_angles_yxz_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> (t1, t2, t3: f64) {
 	return euler_angles_yxz_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_xzx_from_quaternion_f64 :: proc(q: Quaternionf64) -> (t1, t2, t3: f64) {
+euler_angles_xzx_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> (t1, t2, t3: f64) {
 	return euler_angles_xzx_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_xyx_from_quaternion_f64 :: proc(q: Quaternionf64) -> (t1, t2, t3: f64) {
+euler_angles_xyx_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> (t1, t2, t3: f64) {
 	return euler_angles_xyx_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_yxy_from_quaternion_f64 :: proc(q: Quaternionf64) -> (t1, t2, t3: f64) {
+euler_angles_yxy_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> (t1, t2, t3: f64) {
 	return euler_angles_yxy_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_yzy_from_quaternion_f64 :: proc(q: Quaternionf64) -> (t1, t2, t3: f64) {
+euler_angles_yzy_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> (t1, t2, t3: f64) {
 	return euler_angles_yzy_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_zyz_from_quaternion_f64 :: proc(q: Quaternionf64) -> (t1, t2, t3: f64) {
+euler_angles_zyz_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> (t1, t2, t3: f64) {
 	return euler_angles_zyz_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_zxz_from_quaternion_f64 :: proc(q: Quaternionf64) -> (t1, t2, t3: f64) {
+euler_angles_zxz_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> (t1, t2, t3: f64) {
 	return euler_angles_zxz_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_xzy_from_quaternion_f64 :: proc(q: Quaternionf64) -> (t1, t2, t3: f64) {
+euler_angles_xzy_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> (t1, t2, t3: f64) {
 	return euler_angles_xzy_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_yzx_from_quaternion_f64 :: proc(q: Quaternionf64) -> (t1, t2, t3: f64) {
+euler_angles_yzx_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> (t1, t2, t3: f64) {
 	return euler_angles_yzx_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_zyx_from_quaternion_f64 :: proc(q: Quaternionf64) -> (t1, t2, t3: f64) {
+euler_angles_zyx_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> (t1, t2, t3: f64) {
 	return euler_angles_zyx_from_matrix4(matrix4_from_quaternion(q))
 }
-euler_angles_zxy_from_quaternion_f64 :: proc(q: Quaternionf64) -> (t1, t2, t3: f64) {
+euler_angles_zxy_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> (t1, t2, t3: f64) {
 	return euler_angles_zxy_from_matrix4(matrix4_from_quaternion(q))
 }
 
@@ -210,7 +210,7 @@ euler_angles_zxy_from_quaternion_f64 :: proc(q: Quaternionf64) -> (t1, t2, t3: f
 // Matrix3
 
 
-matrix3_from_euler_angle_x_f64 :: proc(angle_x: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angle_x_f64 :: proc "contextless" (angle_x: f64) -> (m: Matrix3f64) {
 	cos_x, sin_x := math.cos(angle_x), math.sin(angle_x)
 	m[0, 0] = 1
 	m[1, 1] = +cos_x
@@ -219,7 +219,7 @@ matrix3_from_euler_angle_x_f64 :: proc(angle_x: f64) -> (m: Matrix3f64) {
 	m[2, 2] = +cos_x
 	return
 }
-matrix3_from_euler_angle_y_f64 :: proc(angle_y: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angle_y_f64 :: proc "contextless" (angle_y: f64) -> (m: Matrix3f64) {
 	cos_y, sin_y := math.cos(angle_y), math.sin(angle_y)
 	m[0, 0] = +cos_y
 	m[0, 2] = -sin_y
@@ -228,7 +228,7 @@ matrix3_from_euler_angle_y_f64 :: proc(angle_y: f64) -> (m: Matrix3f64) {
 	m[2, 2] = +cos_y
 	return
 }
-matrix3_from_euler_angle_z_f64 :: proc(angle_z: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angle_z_f64 :: proc "contextless" (angle_z: f64) -> (m: Matrix3f64) {
 	cos_z, sin_z := math.cos(angle_z), math.sin(angle_z)
 	m[0, 0] = +cos_z
 	m[0, 1] = +sin_z
@@ -239,7 +239,7 @@ matrix3_from_euler_angle_z_f64 :: proc(angle_z: f64) -> (m: Matrix3f64) {
 }
 
 
-matrix3_from_derived_euler_angle_x_f64 :: proc(angle_x: f64, angular_velocity_x: f64) -> (m: Matrix3f64) {
+matrix3_from_derived_euler_angle_x_f64 :: proc "contextless" (angle_x: f64, angular_velocity_x: f64) -> (m: Matrix3f64) {
 	cos_x := math.cos(angle_x) * angular_velocity_x
 	sin_x := math.sin(angle_x) * angular_velocity_x
 	m[0, 0] = 1
@@ -249,7 +249,7 @@ matrix3_from_derived_euler_angle_x_f64 :: proc(angle_x: f64, angular_velocity_x:
 	m[2, 2] = +cos_x
 	return
 }
-matrix3_from_derived_euler_angle_y_f64 :: proc(angle_y: f64, angular_velocity_y: f64) -> (m: Matrix3f64) {
+matrix3_from_derived_euler_angle_y_f64 :: proc "contextless" (angle_y: f64, angular_velocity_y: f64) -> (m: Matrix3f64) {
 	cos_y := math.cos(angle_y) * angular_velocity_y
 	sin_y := math.sin(angle_y) * angular_velocity_y
 	m[0, 0] = +cos_y
@@ -259,7 +259,7 @@ matrix3_from_derived_euler_angle_y_f64 :: proc(angle_y: f64, angular_velocity_y:
 	m[2, 2] = +cos_y
 	return
 }
-matrix3_from_derived_euler_angle_z_f64 :: proc(angle_z: f64, angular_velocity_z: f64) -> (m: Matrix3f64) {
+matrix3_from_derived_euler_angle_z_f64 :: proc "contextless" (angle_z: f64, angular_velocity_z: f64) -> (m: Matrix3f64) {
 	cos_z := math.cos(angle_z) * angular_velocity_z
 	sin_z := math.sin(angle_z) * angular_velocity_z
 	m[0, 0] = +cos_z
@@ -271,7 +271,7 @@ matrix3_from_derived_euler_angle_z_f64 :: proc(angle_z: f64, angular_velocity_z:
 }
 
 
-matrix3_from_euler_angles_xy_f64 :: proc(angle_x, angle_y: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angles_xy_f64 :: proc "contextless" (angle_x, angle_y: f64) -> (m: Matrix3f64) {
 	cos_x, sin_x := math.cos(angle_x), math.sin(angle_x)
 	cos_y, sin_y := math.cos(angle_y), math.sin(angle_y)
 	m[0, 0] = cos_y
@@ -286,7 +286,7 @@ matrix3_from_euler_angles_xy_f64 :: proc(angle_x, angle_y: f64) -> (m: Matrix3f6
 }
 
 
-matrix3_from_euler_angles_yx_f64 :: proc(angle_y, angle_x: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angles_yx_f64 :: proc "contextless" (angle_y, angle_x: f64) -> (m: Matrix3f64) {
 	cos_x, sin_x := math.cos(angle_x), math.sin(angle_x)
 	cos_y, sin_y := math.cos(angle_y), math.sin(angle_y)
 	m[0, 0] = cos_y
@@ -300,21 +300,21 @@ matrix3_from_euler_angles_yx_f64 :: proc(angle_y, angle_x: f64) -> (m: Matrix3f6
 	return
 }
 
-matrix3_from_euler_angles_xz_f64 :: proc(angle_x, angle_z: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angles_xz_f64 :: proc "contextless" (angle_x, angle_z: f64) -> (m: Matrix3f64) {
 	return mul(matrix3_from_euler_angle_x(angle_x), matrix3_from_euler_angle_z(angle_z))
 }
-matrix3_from_euler_angles_zx_f64 :: proc(angle_z, angle_x: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angles_zx_f64 :: proc "contextless" (angle_z, angle_x: f64) -> (m: Matrix3f64) {
 	return mul(matrix3_from_euler_angle_z(angle_z), matrix3_from_euler_angle_x(angle_x))
 }
-matrix3_from_euler_angles_yz_f64 :: proc(angle_y, angle_z: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angles_yz_f64 :: proc "contextless" (angle_y, angle_z: f64) -> (m: Matrix3f64) {
 	return mul(matrix3_from_euler_angle_y(angle_y), matrix3_from_euler_angle_z(angle_z))
 }
-matrix3_from_euler_angles_zy_f64 :: proc(angle_z, angle_y: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angles_zy_f64 :: proc "contextless" (angle_z, angle_y: f64) -> (m: Matrix3f64) {
 	return mul(matrix3_from_euler_angle_z(angle_z), matrix3_from_euler_angle_y(angle_y))
 }
 
 
-matrix3_from_euler_angles_xyz_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angles_xyz_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix3f64) {
 	c1 := math.cos(-t1)
 	c2 := math.cos(-t2)
 	c3 := math.cos(-t3)
@@ -334,7 +334,7 @@ matrix3_from_euler_angles_xyz_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
 	return
 }
 
-matrix3_from_euler_angles_yxz_f64 :: proc(yaw, pitch, roll: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angles_yxz_f64 :: proc "contextless" (yaw, pitch, roll: f64) -> (m: Matrix3f64) {
 	ch := math.cos(yaw)
 	sh := math.sin(yaw)
 	cp := math.cos(pitch)
@@ -354,7 +354,7 @@ matrix3_from_euler_angles_yxz_f64 :: proc(yaw, pitch, roll: f64) -> (m: Matrix3f
 	return
 }
 
-matrix3_from_euler_angles_xzx_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angles_xzx_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix3f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -374,7 +374,7 @@ matrix3_from_euler_angles_xzx_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
 	return
 }
 
-matrix3_from_euler_angles_xyx_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angles_xyx_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix3f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -394,7 +394,7 @@ matrix3_from_euler_angles_xyx_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
 	return
 }
 
-matrix3_from_euler_angles_yxy_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angles_yxy_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix3f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -414,7 +414,7 @@ matrix3_from_euler_angles_yxy_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
 	return
 }
 
-matrix3_from_euler_angles_yzy_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angles_yzy_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix3f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -434,7 +434,7 @@ matrix3_from_euler_angles_yzy_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
 	return
 }
 
-matrix3_from_euler_angles_zyz_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angles_zyz_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix3f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -454,7 +454,7 @@ matrix3_from_euler_angles_zyz_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
 	return
 }
 
-matrix3_from_euler_angles_zxz_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angles_zxz_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix3f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -475,7 +475,7 @@ matrix3_from_euler_angles_zxz_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
 }
 
 
-matrix3_from_euler_angles_xzy_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angles_xzy_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix3f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -495,7 +495,7 @@ matrix3_from_euler_angles_xzy_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
 	return
 }
 
-matrix3_from_euler_angles_yzx_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angles_yzx_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix3f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -515,7 +515,7 @@ matrix3_from_euler_angles_yzx_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
 	return
 }
 
-matrix3_from_euler_angles_zyx_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angles_zyx_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix3f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -535,7 +535,7 @@ matrix3_from_euler_angles_zyx_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
 	return
 }
 
-matrix3_from_euler_angles_zxy_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
+matrix3_from_euler_angles_zxy_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix3f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -556,7 +556,7 @@ matrix3_from_euler_angles_zxy_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix3f64) {
 }
 
 
-matrix3_from_yaw_pitch_roll_f64 :: proc(yaw, pitch, roll: f64) -> (m: Matrix3f64) {
+matrix3_from_yaw_pitch_roll_f64 :: proc "contextless" (yaw, pitch, roll: f64) -> (m: Matrix3f64) {
 	ch := math.cos(yaw)
 	sh := math.sin(yaw)
 	cp := math.cos(pitch)
@@ -576,7 +576,7 @@ matrix3_from_yaw_pitch_roll_f64 :: proc(yaw, pitch, roll: f64) -> (m: Matrix3f64
 	return m
 }
 
-euler_angles_xyz_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
+euler_angles_xyz_from_matrix3_f64 :: proc "contextless" (m: Matrix3f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[1, 2], m[2, 2])
 	C2 := math.sqrt(m[0, 0]*m[0, 0] + m[0, 1]*m[0, 1])
 	T2 := math.atan2(-m[0, 2], C2)
@@ -589,7 +589,7 @@ euler_angles_xyz_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_yxz_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
+euler_angles_yxz_from_matrix3_f64 :: proc "contextless" (m: Matrix3f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[0, 2], m[2, 2])
 	C2 := math.sqrt(m[1, 0]*m[1, 0] + m[1, 1]*m[1, 1])
 	T2 := math.atan2(-m[1, 2], C2)
@@ -602,7 +602,7 @@ euler_angles_yxz_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_xzx_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
+euler_angles_xzx_from_matrix3_f64 :: proc "contextless" (m: Matrix3f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[2, 0], m[1, 0])
 	S2 := math.sqrt(m[0, 1]*m[0, 1] + m[0, 2]*m[0, 2])
 	T2 := math.atan2(S2, m[0, 0])
@@ -615,7 +615,7 @@ euler_angles_xzx_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_xyx_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
+euler_angles_xyx_from_matrix3_f64 :: proc "contextless" (m: Matrix3f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[1, 0], -m[2, 0])
 	S2 := math.sqrt(m[0, 1]*m[0, 1] + m[0, 2]*m[0, 2])
 	T2 := math.atan2(S2, m[0, 0])
@@ -628,7 +628,7 @@ euler_angles_xyx_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_yxy_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
+euler_angles_yxy_from_matrix3_f64 :: proc "contextless" (m: Matrix3f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[0, 1], m[2, 1])
 	S2 := math.sqrt(m[1, 0]*m[1, 0] + m[1, 2]*m[1, 2])
 	T2 := math.atan2(S2, m[1, 1])
@@ -641,7 +641,7 @@ euler_angles_yxy_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_yzy_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
+euler_angles_yzy_from_matrix3_f64 :: proc "contextless" (m: Matrix3f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[2, 1], -m[0, 1])
 	S2 := math.sqrt(m[1, 0]*m[1, 0] + m[1, 2]*m[1, 2])
 	T2 := math.atan2(S2, m[1, 1])
@@ -653,7 +653,7 @@ euler_angles_yzy_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
 	t3 = T3
 	return
 }
-euler_angles_zyz_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
+euler_angles_zyz_from_matrix3_f64 :: proc "contextless" (m: Matrix3f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[1, 2], m[0, 2])
 	S2 := math.sqrt(m[2, 0]*m[2, 0] + m[2, 1]*m[2, 1])
 	T2 := math.atan2(S2, m[2, 2])
@@ -666,7 +666,7 @@ euler_angles_zyz_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_zxz_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
+euler_angles_zxz_from_matrix3_f64 :: proc "contextless" (m: Matrix3f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[0, 2], -m[1, 2])
 	S2 := math.sqrt(m[2, 0]*m[2, 0] + m[2, 1]*m[2, 1])
 	T2 := math.atan2(S2, m[2, 2])
@@ -679,7 +679,7 @@ euler_angles_zxz_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_xzy_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
+euler_angles_xzy_from_matrix3_f64 :: proc "contextless" (m: Matrix3f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[2, 1], m[1, 1])
 	C2 := math.sqrt(m[0, 0]*m[0, 0] + m[0, 2]*m[0, 2])
 	T2 := math.atan2(-m[0, 1], C2)
@@ -692,7 +692,7 @@ euler_angles_xzy_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_yzx_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
+euler_angles_yzx_from_matrix3_f64 :: proc "contextless" (m: Matrix3f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(-m[2, 0], m[0, 0])
 	C2 := math.sqrt(m[1, 1]*m[1, 1] + m[1, 2]*m[1, 2])
 	T2 := math.atan2(m[1, 0], C2)
@@ -705,7 +705,7 @@ euler_angles_yzx_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_zyx_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
+euler_angles_zyx_from_matrix3_f64 :: proc "contextless" (m: Matrix3f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[1, 0], m[0, 0])
 	C2 := math.sqrt(m[2, 1]*m[2, 1] + m[2, 2]*m[2, 2])
 	T2 := math.atan2(-m[2, 0], C2)
@@ -718,7 +718,7 @@ euler_angles_zyx_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_zxy_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
+euler_angles_zxy_from_matrix3_f64 :: proc "contextless" (m: Matrix3f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(-m[0, 1], m[1, 1])
 	C2 := math.sqrt(m[2, 0]*m[2, 0] + m[2, 2]*m[2, 2])
 	T2 := math.atan2(m[2, 1], C2)
@@ -735,7 +735,7 @@ euler_angles_zxy_from_matrix3_f64 :: proc(m: Matrix3f64) -> (t1, t2, t3: f64) {
 // Matrix4
 
 
-matrix4_from_euler_angle_x_f64 :: proc(angle_x: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angle_x_f64 :: proc "contextless" (angle_x: f64) -> (m: Matrix4f64) {
 	cos_x, sin_x := math.cos(angle_x), math.sin(angle_x)
 	m[0, 0] = 1
 	m[1, 1] = +cos_x
@@ -745,7 +745,7 @@ matrix4_from_euler_angle_x_f64 :: proc(angle_x: f64) -> (m: Matrix4f64) {
 	m[3, 3] = 1
 	return
 }
-matrix4_from_euler_angle_y_f64 :: proc(angle_y: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angle_y_f64 :: proc "contextless" (angle_y: f64) -> (m: Matrix4f64) {
 	cos_y, sin_y := math.cos(angle_y), math.sin(angle_y)
 	m[0, 0] = +cos_y
 	m[0, 2] = -sin_y
@@ -755,7 +755,7 @@ matrix4_from_euler_angle_y_f64 :: proc(angle_y: f64) -> (m: Matrix4f64) {
 	m[3, 3] = 1
 	return
 }
-matrix4_from_euler_angle_z_f64 :: proc(angle_z: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angle_z_f64 :: proc "contextless" (angle_z: f64) -> (m: Matrix4f64) {
 	cos_z, sin_z := math.cos(angle_z), math.sin(angle_z)
 	m[0, 0] = +cos_z
 	m[0, 1] = +sin_z
@@ -767,7 +767,7 @@ matrix4_from_euler_angle_z_f64 :: proc(angle_z: f64) -> (m: Matrix4f64) {
 }
 
 
-matrix4_from_derived_euler_angle_x_f64 :: proc(angle_x: f64, angular_velocity_x: f64) -> (m: Matrix4f64) {
+matrix4_from_derived_euler_angle_x_f64 :: proc "contextless" (angle_x: f64, angular_velocity_x: f64) -> (m: Matrix4f64) {
 	cos_x := math.cos(angle_x) * angular_velocity_x
 	sin_x := math.sin(angle_x) * angular_velocity_x
 	m[0, 0] = 1
@@ -778,7 +778,7 @@ matrix4_from_derived_euler_angle_x_f64 :: proc(angle_x: f64, angular_velocity_x:
 	m[3, 3] = 1
 	return
 }
-matrix4_from_derived_euler_angle_y_f64 :: proc(angle_y: f64, angular_velocity_y: f64) -> (m: Matrix4f64) {
+matrix4_from_derived_euler_angle_y_f64 :: proc "contextless" (angle_y: f64, angular_velocity_y: f64) -> (m: Matrix4f64) {
 	cos_y := math.cos(angle_y) * angular_velocity_y
 	sin_y := math.sin(angle_y) * angular_velocity_y
 	m[0, 0] = +cos_y
@@ -789,7 +789,7 @@ matrix4_from_derived_euler_angle_y_f64 :: proc(angle_y: f64, angular_velocity_y:
 	m[3, 3] = 1
 	return
 }
-matrix4_from_derived_euler_angle_z_f64 :: proc(angle_z: f64, angular_velocity_z: f64) -> (m: Matrix4f64) {
+matrix4_from_derived_euler_angle_z_f64 :: proc "contextless" (angle_z: f64, angular_velocity_z: f64) -> (m: Matrix4f64) {
 	cos_z := math.cos(angle_z) * angular_velocity_z
 	sin_z := math.sin(angle_z) * angular_velocity_z
 	m[0, 0] = +cos_z
@@ -802,7 +802,7 @@ matrix4_from_derived_euler_angle_z_f64 :: proc(angle_z: f64, angular_velocity_z:
 }
 
 
-matrix4_from_euler_angles_xy_f64 :: proc(angle_x, angle_y: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angles_xy_f64 :: proc "contextless" (angle_x, angle_y: f64) -> (m: Matrix4f64) {
 	cos_x, sin_x := math.cos(angle_x), math.sin(angle_x)
 	cos_y, sin_y := math.cos(angle_y), math.sin(angle_y)
 	m[0, 0] = cos_y
@@ -818,7 +818,7 @@ matrix4_from_euler_angles_xy_f64 :: proc(angle_x, angle_y: f64) -> (m: Matrix4f6
 }
 
 
-matrix4_from_euler_angles_yx_f64 :: proc(angle_y, angle_x: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angles_yx_f64 :: proc "contextless" (angle_y, angle_x: f64) -> (m: Matrix4f64) {
 	cos_x, sin_x := math.cos(angle_x), math.sin(angle_x)
 	cos_y, sin_y := math.cos(angle_y), math.sin(angle_y)
 	m[0, 0] = cos_y
@@ -833,21 +833,21 @@ matrix4_from_euler_angles_yx_f64 :: proc(angle_y, angle_x: f64) -> (m: Matrix4f6
 	return
 }
 
-matrix4_from_euler_angles_xz_f64 :: proc(angle_x, angle_z: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angles_xz_f64 :: proc "contextless" (angle_x, angle_z: f64) -> (m: Matrix4f64) {
 	return mul(matrix4_from_euler_angle_x(angle_x), matrix4_from_euler_angle_z(angle_z))
 }
-matrix4_from_euler_angles_zx_f64 :: proc(angle_z, angle_x: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angles_zx_f64 :: proc "contextless" (angle_z, angle_x: f64) -> (m: Matrix4f64) {
 	return mul(matrix4_from_euler_angle_z(angle_z), matrix4_from_euler_angle_x(angle_x))
 }
-matrix4_from_euler_angles_yz_f64 :: proc(angle_y, angle_z: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angles_yz_f64 :: proc "contextless" (angle_y, angle_z: f64) -> (m: Matrix4f64) {
 	return mul(matrix4_from_euler_angle_y(angle_y), matrix4_from_euler_angle_z(angle_z))
 }
-matrix4_from_euler_angles_zy_f64 :: proc(angle_z, angle_y: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angles_zy_f64 :: proc "contextless" (angle_z, angle_y: f64) -> (m: Matrix4f64) {
 	return mul(matrix4_from_euler_angle_z(angle_z), matrix4_from_euler_angle_y(angle_y))
 }
 
 
-matrix4_from_euler_angles_xyz_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angles_xyz_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix4f64) {
 	c1 := math.cos(-t1)
 	c2 := math.cos(-t2)
 	c3 := math.cos(-t3)
@@ -874,7 +874,7 @@ matrix4_from_euler_angles_xyz_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
 	return
 }
 
-matrix4_from_euler_angles_yxz_f64 :: proc(yaw, pitch, roll: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angles_yxz_f64 :: proc "contextless" (yaw, pitch, roll: f64) -> (m: Matrix4f64) {
 	ch := math.cos(yaw)
 	sh := math.sin(yaw)
 	cp := math.cos(pitch)
@@ -901,7 +901,7 @@ matrix4_from_euler_angles_yxz_f64 :: proc(yaw, pitch, roll: f64) -> (m: Matrix4f
 	return
 }
 
-matrix4_from_euler_angles_xzx_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angles_xzx_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix4f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -928,7 +928,7 @@ matrix4_from_euler_angles_xzx_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
 	return
 }
 
-matrix4_from_euler_angles_xyx_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angles_xyx_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix4f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -955,7 +955,7 @@ matrix4_from_euler_angles_xyx_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
 	return
 }
 
-matrix4_from_euler_angles_yxy_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angles_yxy_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix4f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -982,7 +982,7 @@ matrix4_from_euler_angles_yxy_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
 	return
 }
 
-matrix4_from_euler_angles_yzy_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angles_yzy_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix4f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1009,7 +1009,7 @@ matrix4_from_euler_angles_yzy_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
 	return
 }
 
-matrix4_from_euler_angles_zyz_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angles_zyz_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix4f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1036,7 +1036,7 @@ matrix4_from_euler_angles_zyz_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
 	return
 }
 
-matrix4_from_euler_angles_zxz_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angles_zxz_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix4f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1064,7 +1064,7 @@ matrix4_from_euler_angles_zxz_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
 }
 
 
-matrix4_from_euler_angles_xzy_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angles_xzy_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix4f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1091,7 +1091,7 @@ matrix4_from_euler_angles_xzy_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
 	return
 }
 
-matrix4_from_euler_angles_yzx_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angles_yzx_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix4f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1118,7 +1118,7 @@ matrix4_from_euler_angles_yzx_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
 	return
 }
 
-matrix4_from_euler_angles_zyx_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angles_zyx_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix4f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1145,7 +1145,7 @@ matrix4_from_euler_angles_zyx_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
 	return
 }
 
-matrix4_from_euler_angles_zxy_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
+matrix4_from_euler_angles_zxy_f64 :: proc "contextless" (t1, t2, t3: f64) -> (m: Matrix4f64) {
 	c1 := math.cos(t1)
 	s1 := math.sin(t1)
 	c2 := math.cos(t2)
@@ -1173,7 +1173,7 @@ matrix4_from_euler_angles_zxy_f64 :: proc(t1, t2, t3: f64) -> (m: Matrix4f64) {
 }
 
 
-matrix4_from_yaw_pitch_roll_f64 :: proc(yaw, pitch, roll: f64) -> (m: Matrix4f64) {
+matrix4_from_yaw_pitch_roll_f64 :: proc "contextless" (yaw, pitch, roll: f64) -> (m: Matrix4f64) {
 	ch := math.cos(yaw)
 	sh := math.sin(yaw)
 	cp := math.cos(pitch)
@@ -1200,7 +1200,7 @@ matrix4_from_yaw_pitch_roll_f64 :: proc(yaw, pitch, roll: f64) -> (m: Matrix4f64
 	return m
 }
 
-euler_angles_xyz_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
+euler_angles_xyz_from_matrix4_f64 :: proc "contextless" (m: Matrix4f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[1, 2], m[2, 2])
 	C2 := math.sqrt(m[0, 0]*m[0, 0] + m[0, 1]*m[0, 1])
 	T2 := math.atan2(-m[0, 2], C2)
@@ -1213,7 +1213,7 @@ euler_angles_xyz_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_yxz_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
+euler_angles_yxz_from_matrix4_f64 :: proc "contextless" (m: Matrix4f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[0, 2], m[2, 2])
 	C2 := math.sqrt(m[1, 0]*m[1, 0] + m[1, 1]*m[1, 1])
 	T2 := math.atan2(-m[1, 2], C2)
@@ -1226,7 +1226,7 @@ euler_angles_yxz_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_xzx_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
+euler_angles_xzx_from_matrix4_f64 :: proc "contextless" (m: Matrix4f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[2, 0], m[1, 0])
 	S2 := math.sqrt(m[0, 1]*m[0, 1] + m[0, 2]*m[0, 2])
 	T2 := math.atan2(S2, m[0, 0])
@@ -1239,7 +1239,7 @@ euler_angles_xzx_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_xyx_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
+euler_angles_xyx_from_matrix4_f64 :: proc "contextless" (m: Matrix4f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[1, 0], -m[2, 0])
 	S2 := math.sqrt(m[0, 1]*m[0, 1] + m[0, 2]*m[0, 2])
 	T2 := math.atan2(S2, m[0, 0])
@@ -1252,7 +1252,7 @@ euler_angles_xyx_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_yxy_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
+euler_angles_yxy_from_matrix4_f64 :: proc "contextless" (m: Matrix4f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[0, 1], m[2, 1])
 	S2 := math.sqrt(m[1, 0]*m[1, 0] + m[1, 2]*m[1, 2])
 	T2 := math.atan2(S2, m[1, 1])
@@ -1265,7 +1265,7 @@ euler_angles_yxy_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_yzy_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
+euler_angles_yzy_from_matrix4_f64 :: proc "contextless" (m: Matrix4f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[2, 1], -m[0, 1])
 	S2 := math.sqrt(m[1, 0]*m[1, 0] + m[1, 2]*m[1, 2])
 	T2 := math.atan2(S2, m[1, 1])
@@ -1277,7 +1277,7 @@ euler_angles_yzy_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
 	t3 = T3
 	return
 }
-euler_angles_zyz_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
+euler_angles_zyz_from_matrix4_f64 :: proc "contextless" (m: Matrix4f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[1, 2], m[0, 2])
 	S2 := math.sqrt(m[2, 0]*m[2, 0] + m[2, 1]*m[2, 1])
 	T2 := math.atan2(S2, m[2, 2])
@@ -1290,7 +1290,7 @@ euler_angles_zyz_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_zxz_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
+euler_angles_zxz_from_matrix4_f64 :: proc "contextless" (m: Matrix4f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[0, 2], -m[1, 2])
 	S2 := math.sqrt(m[2, 0]*m[2, 0] + m[2, 1]*m[2, 1])
 	T2 := math.atan2(S2, m[2, 2])
@@ -1303,7 +1303,7 @@ euler_angles_zxz_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_xzy_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
+euler_angles_xzy_from_matrix4_f64 :: proc "contextless" (m: Matrix4f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[2, 1], m[1, 1])
 	C2 := math.sqrt(m[0, 0]*m[0, 0] + m[0, 2]*m[0, 2])
 	T2 := math.atan2(-m[0, 1], C2)
@@ -1316,7 +1316,7 @@ euler_angles_xzy_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_yzx_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
+euler_angles_yzx_from_matrix4_f64 :: proc "contextless" (m: Matrix4f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(-m[2, 0], m[0, 0])
 	C2 := math.sqrt(m[1, 1]*m[1, 1] + m[1, 2]*m[1, 2])
 	T2 := math.atan2(m[1, 0], C2)
@@ -1329,7 +1329,7 @@ euler_angles_yzx_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_zyx_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
+euler_angles_zyx_from_matrix4_f64 :: proc "contextless" (m: Matrix4f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(m[1, 0], m[0, 0])
 	C2 := math.sqrt(m[2, 1]*m[2, 1] + m[2, 2]*m[2, 2])
 	T2 := math.atan2(-m[2, 0], C2)
@@ -1342,7 +1342,7 @@ euler_angles_zyx_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
 	return
 }
 
-euler_angles_zxy_from_matrix4_f64 :: proc(m: Matrix4f64) -> (t1, t2, t3: f64) {
+euler_angles_zxy_from_matrix4_f64 :: proc "contextless" (m: Matrix4f64) -> (t1, t2, t3: f64) {
 	T1 := math.atan2(-m[0, 1], m[1, 1])
 	C2 := math.sqrt(m[2, 0]*m[2, 0] + m[2, 2]*m[2, 2])
 	T2 := math.atan2(m[2, 1], C2)

--- a/core/math/linalg/swizzle.odin
+++ b/core/math/linalg/swizzle.odin
@@ -37,110 +37,110 @@ Vector4_Components :: enum u8 {
 	a = 3,
 }
 
-scalar_f32_swizzle1 :: proc(f: f32, c0: Scalar_Components) -> f32 {
+scalar_f32_swizzle1 :: proc "contextless" (f: f32, c0: Scalar_Components) -> f32 {
 	return f
 }
-scalar_f32_swizzle2 :: proc(f: f32, c0, c1: Scalar_Components) -> Vector2f32 {
+scalar_f32_swizzle2 :: proc "contextless" (f: f32, c0, c1: Scalar_Components) -> Vector2f32 {
 	return {f, f}
 }
-scalar_f32_swizzle3 :: proc(f: f32, c0, c1, c2: Scalar_Components) -> Vector3f32 {
+scalar_f32_swizzle3 :: proc "contextless" (f: f32, c0, c1, c2: Scalar_Components) -> Vector3f32 {
 	return {f, f, f}
 }
-scalar_f32_swizzle4 :: proc(f: f32, c0, c1, c2, c3: Scalar_Components) -> Vector4f32 {
+scalar_f32_swizzle4 :: proc "contextless" (f: f32, c0, c1, c2, c3: Scalar_Components) -> Vector4f32 {
 	return {f, f, f, f}
 }
 
-vector2f32_swizzle1 :: proc(v: Vector2f32, c0: Vector2_Components) -> f32 {
+vector2f32_swizzle1 :: proc "contextless" (v: Vector2f32, c0: Vector2_Components) -> f32 {
 	return v[c0]
 }
-vector2f32_swizzle2 :: proc(v: Vector2f32, c0, c1: Vector2_Components) -> Vector2f32 {
+vector2f32_swizzle2 :: proc "contextless" (v: Vector2f32, c0, c1: Vector2_Components) -> Vector2f32 {
 	return {v[c0], v[c1]}
 }
-vector2f32_swizzle3 :: proc(v: Vector2f32, c0, c1, c2: Vector2_Components) -> Vector3f32 {
+vector2f32_swizzle3 :: proc "contextless" (v: Vector2f32, c0, c1, c2: Vector2_Components) -> Vector3f32 {
 	return {v[c0], v[c1], v[c2]}
 }
-vector2f32_swizzle4 :: proc(v: Vector2f32, c0, c1, c2, c3: Vector2_Components) -> Vector4f32 {
+vector2f32_swizzle4 :: proc "contextless" (v: Vector2f32, c0, c1, c2, c3: Vector2_Components) -> Vector4f32 {
 	return {v[c0], v[c1], v[c2], v[c3]}
 }
 
 
-vector3f32_swizzle1 :: proc(v: Vector3f32, c0: Vector3_Components) -> f32 {
+vector3f32_swizzle1 :: proc "contextless" (v: Vector3f32, c0: Vector3_Components) -> f32 {
 	return v[c0]
 }
-vector3f32_swizzle2 :: proc(v: Vector3f32, c0, c1: Vector3_Components) -> Vector2f32 {
+vector3f32_swizzle2 :: proc "contextless" (v: Vector3f32, c0, c1: Vector3_Components) -> Vector2f32 {
 	return {v[c0], v[c1]}
 }
-vector3f32_swizzle3 :: proc(v: Vector3f32, c0, c1, c2: Vector3_Components) -> Vector3f32 {
+vector3f32_swizzle3 :: proc "contextless" (v: Vector3f32, c0, c1, c2: Vector3_Components) -> Vector3f32 {
 	return {v[c0], v[c1], v[c2]}
 }
-vector3f32_swizzle4 :: proc(v: Vector3f32, c0, c1, c2, c3: Vector3_Components) -> Vector4f32 {
+vector3f32_swizzle4 :: proc "contextless" (v: Vector3f32, c0, c1, c2, c3: Vector3_Components) -> Vector4f32 {
 	return {v[c0], v[c1], v[c2], v[c3]}
 }
 
-vector4f32_swizzle1 :: proc(v: Vector4f32, c0: Vector4_Components) -> f32 {
+vector4f32_swizzle1 :: proc "contextless" (v: Vector4f32, c0: Vector4_Components) -> f32 {
 	return v[c0]
 }
-vector4f32_swizzle2 :: proc(v: Vector4f32, c0, c1: Vector4_Components) -> Vector2f32 {
+vector4f32_swizzle2 :: proc "contextless" (v: Vector4f32, c0, c1: Vector4_Components) -> Vector2f32 {
 	return {v[c0], v[c1]}
 }
-vector4f32_swizzle3 :: proc(v: Vector4f32, c0, c1, c2: Vector4_Components) -> Vector3f32 {
+vector4f32_swizzle3 :: proc "contextless" (v: Vector4f32, c0, c1, c2: Vector4_Components) -> Vector3f32 {
 	return {v[c0], v[c1], v[c2]}
 }
-vector4f32_swizzle4 :: proc(v: Vector4f32, c0, c1, c2, c3: Vector4_Components) -> Vector4f32 {
+vector4f32_swizzle4 :: proc "contextless" (v: Vector4f32, c0, c1, c2, c3: Vector4_Components) -> Vector4f32 {
 	return {v[c0], v[c1], v[c2], v[c3]}
 }
 
 
-scalar_f64_swizzle1 :: proc(f: f64, c0: Scalar_Components) -> f64 {
+scalar_f64_swizzle1 :: proc "contextless" (f: f64, c0: Scalar_Components) -> f64 {
 	return f
 }
-scalar_f64_swizzle2 :: proc(f: f64, c0, c1: Scalar_Components) -> Vector2f64 {
+scalar_f64_swizzle2 :: proc "contextless" (f: f64, c0, c1: Scalar_Components) -> Vector2f64 {
 	return {f, f}
 }
-scalar_f64_swizzle3 :: proc(f: f64, c0, c1, c2: Scalar_Components) -> Vector3f64 {
+scalar_f64_swizzle3 :: proc "contextless" (f: f64, c0, c1, c2: Scalar_Components) -> Vector3f64 {
 	return {f, f, f}
 }
-scalar_f64_swizzle4 :: proc(f: f64, c0, c1, c2, c3: Scalar_Components) -> Vector4f64 {
+scalar_f64_swizzle4 :: proc "contextless" (f: f64, c0, c1, c2, c3: Scalar_Components) -> Vector4f64 {
 	return {f, f, f, f}
 }
 
-vector2f64_swizzle1 :: proc(v: Vector2f64, c0: Vector2_Components) -> f64 {
+vector2f64_swizzle1 :: proc "contextless" (v: Vector2f64, c0: Vector2_Components) -> f64 {
 	return v[c0]
 }
-vector2f64_swizzle2 :: proc(v: Vector2f64, c0, c1: Vector2_Components) -> Vector2f64 {
+vector2f64_swizzle2 :: proc "contextless" (v: Vector2f64, c0, c1: Vector2_Components) -> Vector2f64 {
 	return {v[c0], v[c1]}
 }
-vector2f64_swizzle3 :: proc(v: Vector2f64, c0, c1, c2: Vector2_Components) -> Vector3f64 {
+vector2f64_swizzle3 :: proc "contextless" (v: Vector2f64, c0, c1, c2: Vector2_Components) -> Vector3f64 {
 	return {v[c0], v[c1], v[c2]}
 }
-vector2f64_swizzle4 :: proc(v: Vector2f64, c0, c1, c2, c3: Vector2_Components) -> Vector4f64 {
+vector2f64_swizzle4 :: proc "contextless" (v: Vector2f64, c0, c1, c2, c3: Vector2_Components) -> Vector4f64 {
 	return {v[c0], v[c1], v[c2], v[c3]}
 }
 
 
-vector3f64_swizzle1 :: proc(v: Vector3f64, c0: Vector3_Components) -> f64 {
+vector3f64_swizzle1 :: proc "contextless" (v: Vector3f64, c0: Vector3_Components) -> f64 {
 	return v[c0]
 }
-vector3f64_swizzle2 :: proc(v: Vector3f64, c0, c1: Vector3_Components) -> Vector2f64 {
+vector3f64_swizzle2 :: proc "contextless" (v: Vector3f64, c0, c1: Vector3_Components) -> Vector2f64 {
 	return {v[c0], v[c1]}
 }
-vector3f64_swizzle3 :: proc(v: Vector3f64, c0, c1, c2: Vector3_Components) -> Vector3f64 {
+vector3f64_swizzle3 :: proc "contextless" (v: Vector3f64, c0, c1, c2: Vector3_Components) -> Vector3f64 {
 	return {v[c0], v[c1], v[c2]}
 }
-vector3f64_swizzle4 :: proc(v: Vector3f64, c0, c1, c2, c3: Vector3_Components) -> Vector4f64 {
+vector3f64_swizzle4 :: proc "contextless" (v: Vector3f64, c0, c1, c2, c3: Vector3_Components) -> Vector4f64 {
 	return {v[c0], v[c1], v[c2], v[c3]}
 }
 
-vector4f64_swizzle1 :: proc(v: Vector4f64, c0: Vector4_Components) -> f64 {
+vector4f64_swizzle1 :: proc "contextless" (v: Vector4f64, c0: Vector4_Components) -> f64 {
 	return v[c0]
 }
-vector4f64_swizzle2 :: proc(v: Vector4f64, c0, c1: Vector4_Components) -> Vector2f64 {
+vector4f64_swizzle2 :: proc "contextless" (v: Vector4f64, c0, c1: Vector4_Components) -> Vector2f64 {
 	return {v[c0], v[c1]}
 }
-vector4f64_swizzle3 :: proc(v: Vector4f64, c0, c1, c2: Vector4_Components) -> Vector3f64 {
+vector4f64_swizzle3 :: proc "contextless" (v: Vector4f64, c0, c1, c2: Vector4_Components) -> Vector3f64 {
 	return {v[c0], v[c1], v[c2]}
 }
-vector4f64_swizzle4 :: proc(v: Vector4f64, c0, c1, c2, c3: Vector4_Components) -> Vector4f64 {
+vector4f64_swizzle4 :: proc "contextless" (v: Vector4f64, c0, c1, c2, c3: Vector4_Components) -> Vector4f64 {
 	return {v[c0], v[c1], v[c2], v[c3]}
 }
 

--- a/core/math/noise/internal.odin
+++ b/core/math/noise/internal.odin
@@ -474,7 +474,7 @@ GRADIENTS_4D := [N_GRADS_4D * 4]f32{
 /*
 	2D Simplex noise base.
 */
-_internal_noise_2d_unskewed_base :: proc(seed: i64, coord: Vec2) -> (value: f32) {
+_internal_noise_2d_unskewed_base :: proc "contextless" (seed: i64, coord: Vec2) -> (value: f32) {
 	// Get base points and offsets.
 	base := [2]i64{fast_floor(coord.x), fast_floor(coord.y)}
 	i    := [2]f32{f32(coord.x - f64(base.x)), f32(coord.y - f64(base.y))}
@@ -521,7 +521,7 @@ _internal_noise_2d_unskewed_base :: proc(seed: i64, coord: Vec2) -> (value: f32)
 /*
 	Generate overlapping cubic lattices for 3D OpenSimplex2 noise.
 */
-_internal_noise_3d_unrotated_base :: proc(seed: i64, coord: Vec3) -> (value: f32) {
+_internal_noise_3d_unrotated_base :: proc "contextless" (seed: i64, coord: Vec3) -> (value: f32) {
 	seed := seed
 	// Get base points and offsets.
 	// xr, yr, zr := coord.x, coord.y, coord.z
@@ -607,7 +607,7 @@ _internal_noise_3d_unrotated_base :: proc(seed: i64, coord: Vec3) -> (value: f32
 /*
 	4D OpenSimplex2 noise base.
 */
-_internal_noise_4d_unskewed_base :: proc(seed: i64, coord: Vec4) -> (value: f32) {
+_internal_noise_4d_unskewed_base :: proc "contextless" (seed: i64, coord: Vec4) -> (value: f32) {
 	seed := seed
 
 	// Get base points and offsets
@@ -691,7 +691,7 @@ _internal_noise_4d_unskewed_base :: proc(seed: i64, coord: Vec4) -> (value: f32)
 	Utility functions
 */
 @(optimization_mode="speed")
-grad_2d :: proc(seed: i64, svp: [2]i64, delta: [2]f32) -> (value: f32) {
+grad_2d :: proc "contextless" (seed: i64, svp: [2]i64, delta: [2]f32) -> (value: f32) {
 	hash := seed ~ svp.x ~ svp.y
 	hash *= HASH_MULTIPLIER
 	hash ~= hash >> (64 - N_GRADS_2D_EXPONENT + 1)
@@ -701,7 +701,7 @@ grad_2d :: proc(seed: i64, svp: [2]i64, delta: [2]f32) -> (value: f32) {
 }
 
 @(optimization_mode="speed")
-grad_3d :: proc(seed: i64, rvp: [3]i64, delta: [3]f32) -> (value: f32) {
+grad_3d :: proc "contextless" (seed: i64, rvp: [3]i64, delta: [3]f32) -> (value: f32) {
 	hash := (seed ~ rvp.x) ~ (rvp.y ~ rvp.z)
 	hash *= HASH_MULTIPLIER
 	hash ~= hash >> (64 - N_GRADS_3D_EXPONENT + 2)
@@ -711,7 +711,7 @@ grad_3d :: proc(seed: i64, rvp: [3]i64, delta: [3]f32) -> (value: f32) {
 }
 
 @(optimization_mode="speed")
-grad_4d :: proc(seed: i64, svp: [4]i64, delta: [4]f32) -> (value: f32) {
+grad_4d :: proc "contextless" (seed: i64, svp: [4]i64, delta: [4]f32) -> (value: f32) {
 	hash := seed ~ (svp.x ~ svp.y) ~ (svp.z ~ svp.w)
 	hash *= HASH_MULTIPLIER
 	hash ~= hash >> (64 - N_GRADS_4D_EXPONENT + 2)
@@ -723,12 +723,12 @@ grad_4d :: proc(seed: i64, svp: [4]i64, delta: [4]f32) -> (value: f32) {
 grad :: proc {grad_2d, grad_3d, grad_4d}
 
 @(optimization_mode="speed")
-fast_floor :: proc(x: f64) -> (floored: i64) {
+fast_floor :: proc "contextless" (x: f64) -> (floored: i64) {
 	xi := i64(x)
 	return x < f64(xi) ? xi - 1 : xi
 }
 
 @(optimization_mode="speed")
-fast_round :: proc(x: f64) -> (rounded: i64) {
+fast_round :: proc "contextless" (x: f64) -> (rounded: i64) {
 	return x < 0 ? i64(x - 0.5) : i64(x + 0.5)
 }

--- a/core/math/noise/opensimplex2.odin
+++ b/core/math/noise/opensimplex2.odin
@@ -20,7 +20,7 @@ Vec4 :: [4]f64
 /*
 	2D Simplex noise, standard lattice orientation.
 */
-noise_2d :: proc(seed: i64, coord: Vec2) -> (value: f32) {
+noise_2d :: proc "contextless" (seed: i64, coord: Vec2) -> (value: f32) {
 	// Get points for A2* lattice
 	skew   := SKEW_2D * (coord.x + coord.y)
 	skewed := coord + skew
@@ -35,7 +35,7 @@ noise_2d :: proc(seed: i64, coord: Vec2) -> (value: f32) {
 	unless your map is centered around an equator. It's a subtle
 	difference, but the option is here to make it an easy choice.
 */
-noise_2d_improve_x :: proc(seed: i64, coord: Vec2) -> (value: f32) {
+noise_2d_improve_x :: proc "contextless" (seed: i64, coord: Vec2) -> (value: f32) {
 	// Skew transform and rotation baked into one.
 	xx := coord.x * ROOT_2_OVER_2
 	yy := coord.y * (ROOT_2_OVER_2 * (1 + 2 * SKEW_2D))
@@ -51,7 +51,7 @@ noise_2d_improve_x :: proc(seed: i64, coord: Vec2) -> (value: f32) {
 	If Z is vertical in world coordinates, call `noise_3d_improve_xz(x, y, Z)`.
 	For a time varied animation, call `noise_3d_improve_xz(x, y, T)`.
 */
-noise_3d_improve_xy :: proc(seed: i64, coord: Vec3) -> (value: f32) {
+noise_3d_improve_xy :: proc "contextless" (seed: i64, coord: Vec3) -> (value: f32) {
 	/*
 		Re-orient the cubic lattices without skewing, so Z points up the main lattice diagonal,
 		and the planes formed by XY are moved far out of alignment with the cube faces.
@@ -75,7 +75,7 @@ noise_3d_improve_xy :: proc(seed: i64, coord: Vec3) -> (value: f32) {
 	If Z is vertical in world coordinates, call `noise_3d_improve_xz(x, Z, y)` or use `noise_3d_improve_xy`.
 	For a time varied animation, call `noise_3d_improve_xz(x, T, y)` or use `noise_3d_improve_xy`.
 */
-noise_3d_improve_xz :: proc(seed: i64, coord: Vec3) -> (value: f32) {
+noise_3d_improve_xz :: proc "contextless" (seed: i64, coord: Vec3) -> (value: f32) {
 	/*
 		Re-orient the cubic lattices without skewing, so Y points up the main lattice diagonal,
 		and the planes formed by XZ are moved far out of alignment with the cube faces.
@@ -96,7 +96,7 @@ noise_3d_improve_xz :: proc(seed: i64, coord: Vec3) -> (value: f32) {
 	Use `noise_3d_improve_xy` or `noise_3d_improve_xz` instead, wherever appropriate.
 	They have less diagonal bias. This function's best use is as a fallback.
 */
-noise_3d_fallback :: proc(seed: i64, coord: Vec3) -> (value: f32) {
+noise_3d_fallback :: proc "contextless" (seed: i64, coord: Vec3) -> (value: f32) {
 	/*
 		Re-orient the cubic lattices via rotation, to produce a familiar look.
 		Orthonormal rotation. Not a skew transform.
@@ -114,7 +114,7 @@ noise_3d_fallback :: proc(seed: i64, coord: Vec3) -> (value: f32) {
 	Recommended for time-varied animations which texture a 3D object (W=time)
 	in a space where Z is vertical.
 */
-noise_4d_improve_xyz_improve_xy :: proc(seed: i64, coord: Vec4) -> (value: f32) {
+noise_4d_improve_xyz_improve_xy :: proc "contextless" (seed: i64, coord: Vec4) -> (value: f32) {
 	xy := coord.x + coord.y
 	s2 := xy * -0.21132486540518699998
 	zz := coord.z * 0.28867513459481294226
@@ -133,7 +133,7 @@ noise_4d_improve_xyz_improve_xy :: proc(seed: i64, coord: Vec4) -> (value: f32) 
 	Recommended for time-varied animations which texture a 3D object (W=time)
 	in a space where Y is vertical.
 */
-noise_4d_improve_xyz_improve_xz :: proc(seed: i64, coord: Vec4) -> (value: f32) {
+noise_4d_improve_xyz_improve_xz :: proc "contextless" (seed: i64, coord: Vec4) -> (value: f32) {
 	xz := coord.x + coord.z
 	s2 := xz * -0.21132486540518699998
 	yy := coord.y * 0.28867513459481294226
@@ -152,7 +152,7 @@ noise_4d_improve_xyz_improve_xz :: proc(seed: i64, coord: Vec4) -> (value: f32) 
 	Recommended for time-varied animations which texture a 3D object (W=time)
 	where there isn't a clear distinction between horizontal and vertical
 */
-noise_4d_improve_xyz :: proc(seed: i64, coord: Vec4) -> (value: f32) {
+noise_4d_improve_xyz :: proc "contextless" (seed: i64, coord: Vec4) -> (value: f32) {
 	xyz := coord.x + coord.y + coord.z
 	ww  := coord.w * 0.2236067977499788
 	s2  := xyz * -0.16666666666666666 + ww
@@ -164,7 +164,7 @@ noise_4d_improve_xyz :: proc(seed: i64, coord: Vec4) -> (value: f32) {
 /*
 	4D OpenSimplex2 noise, fallback lattice orientation.
 */
-noise_4d_fallback :: proc(seed: i64, coord: Vec4) -> (value: f32) {
+noise_4d_fallback :: proc "contextless" (seed: i64, coord: Vec4) -> (value: f32) {
 	// Get points for A4 lattice
 	skew := f64(SKEW_4D) * (coord.x + coord.y + coord.z + coord.w)
 	return _internal_noise_4d_unskewed_base(seed, coord + skew)

--- a/core/math/noise/opensimplex2.odin
+++ b/core/math/noise/opensimplex2.odin
@@ -20,7 +20,7 @@ Vec4 :: [4]f64
 /*
 	2D Simplex noise, standard lattice orientation.
 */
-noise_2d :: proc "contextless" (seed: i64, coord: Vec2) -> (value: f32) {
+noise_2d :: proc(seed: i64, coord: Vec2) -> (value: f32) {
 	// Get points for A2* lattice
 	skew   := SKEW_2D * (coord.x + coord.y)
 	skewed := coord + skew
@@ -35,7 +35,7 @@ noise_2d :: proc "contextless" (seed: i64, coord: Vec2) -> (value: f32) {
 	unless your map is centered around an equator. It's a subtle
 	difference, but the option is here to make it an easy choice.
 */
-noise_2d_improve_x :: proc "contextless" (seed: i64, coord: Vec2) -> (value: f32) {
+noise_2d_improve_x :: proc(seed: i64, coord: Vec2) -> (value: f32) {
 	// Skew transform and rotation baked into one.
 	xx := coord.x * ROOT_2_OVER_2
 	yy := coord.y * (ROOT_2_OVER_2 * (1 + 2 * SKEW_2D))
@@ -51,7 +51,7 @@ noise_2d_improve_x :: proc "contextless" (seed: i64, coord: Vec2) -> (value: f32
 	If Z is vertical in world coordinates, call `noise_3d_improve_xz(x, y, Z)`.
 	For a time varied animation, call `noise_3d_improve_xz(x, y, T)`.
 */
-noise_3d_improve_xy :: proc "contextless" (seed: i64, coord: Vec3) -> (value: f32) {
+noise_3d_improve_xy :: proc(seed: i64, coord: Vec3) -> (value: f32) {
 	/*
 		Re-orient the cubic lattices without skewing, so Z points up the main lattice diagonal,
 		and the planes formed by XY are moved far out of alignment with the cube faces.
@@ -75,7 +75,7 @@ noise_3d_improve_xy :: proc "contextless" (seed: i64, coord: Vec3) -> (value: f3
 	If Z is vertical in world coordinates, call `noise_3d_improve_xz(x, Z, y)` or use `noise_3d_improve_xy`.
 	For a time varied animation, call `noise_3d_improve_xz(x, T, y)` or use `noise_3d_improve_xy`.
 */
-noise_3d_improve_xz :: proc "contextless" (seed: i64, coord: Vec3) -> (value: f32) {
+noise_3d_improve_xz :: proc(seed: i64, coord: Vec3) -> (value: f32) {
 	/*
 		Re-orient the cubic lattices without skewing, so Y points up the main lattice diagonal,
 		and the planes formed by XZ are moved far out of alignment with the cube faces.
@@ -96,7 +96,7 @@ noise_3d_improve_xz :: proc "contextless" (seed: i64, coord: Vec3) -> (value: f3
 	Use `noise_3d_improve_xy` or `noise_3d_improve_xz` instead, wherever appropriate.
 	They have less diagonal bias. This function's best use is as a fallback.
 */
-noise_3d_fallback :: proc "contextless" (seed: i64, coord: Vec3) -> (value: f32) {
+noise_3d_fallback :: proc(seed: i64, coord: Vec3) -> (value: f32) {
 	/*
 		Re-orient the cubic lattices via rotation, to produce a familiar look.
 		Orthonormal rotation. Not a skew transform.
@@ -114,7 +114,7 @@ noise_3d_fallback :: proc "contextless" (seed: i64, coord: Vec3) -> (value: f32)
 	Recommended for time-varied animations which texture a 3D object (W=time)
 	in a space where Z is vertical.
 */
-noise_4d_improve_xyz_improve_xy :: proc "contextless" (seed: i64, coord: Vec4) -> (value: f32) {
+noise_4d_improve_xyz_improve_xy :: proc(seed: i64, coord: Vec4) -> (value: f32) {
 	xy := coord.x + coord.y
 	s2 := xy * -0.21132486540518699998
 	zz := coord.z * 0.28867513459481294226
@@ -133,7 +133,7 @@ noise_4d_improve_xyz_improve_xy :: proc "contextless" (seed: i64, coord: Vec4) -
 	Recommended for time-varied animations which texture a 3D object (W=time)
 	in a space where Y is vertical.
 */
-noise_4d_improve_xyz_improve_xz :: proc "contextless" (seed: i64, coord: Vec4) -> (value: f32) {
+noise_4d_improve_xyz_improve_xz :: proc(seed: i64, coord: Vec4) -> (value: f32) {
 	xz := coord.x + coord.z
 	s2 := xz * -0.21132486540518699998
 	yy := coord.y * 0.28867513459481294226
@@ -152,7 +152,7 @@ noise_4d_improve_xyz_improve_xz :: proc "contextless" (seed: i64, coord: Vec4) -
 	Recommended for time-varied animations which texture a 3D object (W=time)
 	where there isn't a clear distinction between horizontal and vertical
 */
-noise_4d_improve_xyz :: proc "contextless" (seed: i64, coord: Vec4) -> (value: f32) {
+noise_4d_improve_xyz :: proc(seed: i64, coord: Vec4) -> (value: f32) {
 	xyz := coord.x + coord.y + coord.z
 	ww  := coord.w * 0.2236067977499788
 	s2  := xyz * -0.16666666666666666 + ww
@@ -164,7 +164,7 @@ noise_4d_improve_xyz :: proc "contextless" (seed: i64, coord: Vec4) -> (value: f
 /*
 	4D OpenSimplex2 noise, fallback lattice orientation.
 */
-noise_4d_fallback :: proc "contextless" (seed: i64, coord: Vec4) -> (value: f32) {
+noise_4d_fallback :: proc(seed: i64, coord: Vec4) -> (value: f32) {
 	// Get points for A4 lattice
 	skew := f64(SKEW_4D) * (coord.x + coord.y + coord.z + coord.w)
 	return _internal_noise_4d_unskewed_base(seed, coord + skew)

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -9,7 +9,7 @@ nil_allocator_proc :: proc(allocator_data: rawptr, mode: Allocator_Mode,
 	return nil, nil
 }
 
-nil_allocator :: proc() -> Allocator {
+nil_allocator :: proc "contextless" () -> Allocator {
 	return Allocator{
 		procedure = nil_allocator_proc,
 		data = nil,
@@ -31,7 +31,7 @@ Arena_Temp_Memory :: struct {
 }
 
 
-arena_init :: proc(a: ^Arena, data: []byte) {
+arena_init :: proc "contextless" (a: ^Arena, data: []byte) {
 	a.data       = data
 	a.offset     = 0
 	a.peak_used  = 0
@@ -46,7 +46,7 @@ init_arena :: proc(a: ^Arena, data: []byte) {
 	a.temp_count = 0
 }
 
-arena_allocator :: proc(arena: ^Arena) -> Allocator {
+arena_allocator :: proc "contextless" (arena: ^Arena) -> Allocator {
 	return Allocator{
 		procedure = arena_allocator_proc,
 		data = arena,
@@ -100,7 +100,7 @@ arena_allocator_proc :: proc(allocator_data: rawptr, mode: Allocator_Mode,
 	return nil, nil
 }
 
-begin_arena_temp_memory :: proc(a: ^Arena) -> Arena_Temp_Memory {
+begin_arena_temp_memory :: proc "contextless" (a: ^Arena) -> Arena_Temp_Memory {
 	tmp: Arena_Temp_Memory
 	tmp.arena = a
 	tmp.prev_offset = a.offset
@@ -286,7 +286,7 @@ scratch_allocator_proc :: proc(allocator_data: rawptr, mode: Allocator_Mode,
 	return nil, nil
 }
 
-scratch_allocator :: proc(allocator: ^Scratch_Allocator) -> Allocator {
+scratch_allocator :: proc "contextless" (allocator: ^Scratch_Allocator) -> Allocator {
 	return Allocator{
 		procedure = scratch_allocator_proc,
 		data = allocator,
@@ -310,7 +310,7 @@ Stack :: struct {
 	peak_used: int,
 }
 
-stack_init :: proc(s: ^Stack, data: []byte) {
+stack_init :: proc "contextless" (s: ^Stack, data: []byte) {
 	s.data = data
 	s.prev_offset = 0
 	s.curr_offset = 0
@@ -318,14 +318,14 @@ stack_init :: proc(s: ^Stack, data: []byte) {
 }
 
 @(deprecated="prefer 'mem.stack_init'")
-init_stack :: proc(s: ^Stack, data: []byte) {
+init_stack :: proc "contextless" (s: ^Stack, data: []byte) {
 	s.data = data
 	s.prev_offset = 0
 	s.curr_offset = 0
 	s.peak_used = 0
 }
 
-stack_allocator :: proc(stack: ^Stack) -> Allocator {
+stack_allocator :: proc "contextless" (stack: ^Stack) -> Allocator {
 	return Allocator{
 		procedure = stack_allocator_proc,
 		data = stack,
@@ -477,20 +477,20 @@ Small_Stack :: struct {
 	peak_used: int,
 }
 
-small_stack_init :: proc(s: ^Small_Stack, data: []byte) {
+small_stack_init :: proc "contextless" (s: ^Small_Stack, data: []byte) {
 	s.data      = data
 	s.offset    = 0
 	s.peak_used = 0
 }
 
 @(deprecated="prefer 'small_stack_init'")
-init_small_stack :: proc(s: ^Small_Stack, data: []byte) {
+init_small_stack :: proc "contextless" (s: ^Small_Stack, data: []byte) {
 	s.data      = data
 	s.offset    = 0
 	s.peak_used = 0
 }
 
-small_stack_allocator :: proc(stack: ^Small_Stack) -> Allocator {
+small_stack_allocator :: proc "contextless" (stack: ^Small_Stack) -> Allocator {
 	return Allocator{
 		procedure = small_stack_allocator_proc,
 		data      = stack,
@@ -673,7 +673,7 @@ dynamic_pool_allocator_proc :: proc(allocator_data: rawptr, mode: Allocator_Mode
 }
 
 
-dynamic_pool_allocator :: proc(pool: ^Dynamic_Pool) -> Allocator {
+dynamic_pool_allocator :: proc "contextless" (pool: ^Dynamic_Pool) -> Allocator {
 	return Allocator{
 		procedure = dynamic_pool_allocator_proc,
 		data = pool,
@@ -836,7 +836,7 @@ panic_allocator_proc :: proc(allocator_data: rawptr, mode: Allocator_Mode,
 	return nil, nil
 }
 
-panic_allocator :: proc() -> Allocator {
+panic_allocator :: proc "contextless" () -> Allocator {
 	return Allocator{
 		procedure = panic_allocator_proc,
 		data = nil,
@@ -885,7 +885,7 @@ tracking_allocator_clear :: proc(t: ^Tracking_Allocator) {
 }
 
 
-tracking_allocator :: proc(data: ^Tracking_Allocator) -> Allocator {
+tracking_allocator :: proc "contextless" (data: ^Tracking_Allocator) -> Allocator {
 	return Allocator{
 		data = data,
 		procedure = tracking_allocator_proc,

--- a/core/mem/raw.odin
+++ b/core/mem/raw.odin
@@ -23,16 +23,3 @@ make_any :: proc "contextless" (data: rawptr, id: typeid) -> any {
 }
 
 raw_data :: builtin.raw_data
-
-
-Poly_Raw_Map_Entry :: struct($Key, $Value: typeid) {
-	hash:  uintptr,
-	next:  int,
-	key:   Key,
-	value: Value,	
-}
-
-Poly_Raw_Map :: struct($Key, $Value: typeid) {
-	hashes:  []int,
-	entries: [dynamic]Poly_Raw_Map_Entry(Key, Value),
-}

--- a/core/os/os2/stat_linux.odin
+++ b/core/os/os2/stat_linux.odin
@@ -40,13 +40,13 @@ S_ISGID :: 0o2000 // Set group id on execution
 S_ISVTX :: 0o1000 // Directory restrcted delete
 
 
-S_ISLNK  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFLNK  }
-S_ISREG  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFREG  }
-S_ISDIR  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFDIR  }
-S_ISCHR  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFCHR  }
-S_ISBLK  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFBLK  }
-S_ISFIFO :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFIFO  }
-S_ISSOCK :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFSOCK }
+S_ISLNK  :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFLNK  }
+S_ISREG  :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFREG  }
+S_ISDIR  :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFDIR  }
+S_ISCHR  :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFCHR  }
+S_ISBLK  :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFBLK  }
+S_ISFIFO :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFIFO  }
+S_ISSOCK :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFSOCK }
 
 F_OK :: 0 // Test for file existance
 X_OK :: 1 // Test for execute permission

--- a/core/os/os2/stat_windows.odin
+++ b/core/os/os2/stat_windows.odin
@@ -299,7 +299,7 @@ reserved_names := [?]string{
 	"LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
 }
 
-_is_reserved_name :: proc(path: string) -> bool {
+_is_reserved_name :: proc "contextless" (path: string) -> bool {
 	if len(path) == 0 {
 		return false
 	}
@@ -311,11 +311,11 @@ _is_reserved_name :: proc(path: string) -> bool {
 	return false
 }
 
-_is_UNC :: proc(path: string) -> bool {
+_is_UNC :: proc "contextless" (path: string) -> bool {
 	return _volume_name_len(path) > 2
 }
 
-_volume_name_len :: proc(path: string) -> int {
+_volume_name_len :: proc "contextless" (path: string) -> int {
 	if ODIN_OS == .Windows {
 		if len(path) < 2 {
 			return 0
@@ -354,7 +354,7 @@ _volume_name_len :: proc(path: string) -> int {
 }
 
 
-_is_abs :: proc(path: string) -> bool {
+_is_abs :: proc "contextless" (path: string) -> bool {
 	if _is_reserved_name(path) {
 		return true
 	}

--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -257,13 +257,13 @@ S_ISUID :: 0o4000 // Set user id on execution
 S_ISGID :: 0o2000 // Set group id on execution
 S_ISVTX :: 0o1000 // Directory restrcted delete
 
-S_ISLNK  :: #force_inline proc(m: u16) -> bool { return (m & S_IFMT) == S_IFLNK  }
-S_ISREG  :: #force_inline proc(m: u16) -> bool { return (m & S_IFMT) == S_IFREG  }
-S_ISDIR  :: #force_inline proc(m: u16) -> bool { return (m & S_IFMT) == S_IFDIR  }
-S_ISCHR  :: #force_inline proc(m: u16) -> bool { return (m & S_IFMT) == S_IFCHR  }
-S_ISBLK  :: #force_inline proc(m: u16) -> bool { return (m & S_IFMT) == S_IFBLK  }
-S_ISFIFO :: #force_inline proc(m: u16) -> bool { return (m & S_IFMT) == S_IFIFO  }
-S_ISSOCK :: #force_inline proc(m: u16) -> bool { return (m & S_IFMT) == S_IFSOCK }
+S_ISLNK  :: #force_inline proc "contextless" (m: u16) -> bool { return (m & S_IFMT) == S_IFLNK  }
+S_ISREG  :: #force_inline proc "contextless" (m: u16) -> bool { return (m & S_IFMT) == S_IFREG  }
+S_ISDIR  :: #force_inline proc "contextless" (m: u16) -> bool { return (m & S_IFMT) == S_IFDIR  }
+S_ISCHR  :: #force_inline proc "contextless" (m: u16) -> bool { return (m & S_IFMT) == S_IFCHR  }
+S_ISBLK  :: #force_inline proc "contextless" (m: u16) -> bool { return (m & S_IFMT) == S_IFBLK  }
+S_ISFIFO :: #force_inline proc "contextless" (m: u16) -> bool { return (m & S_IFMT) == S_IFIFO  }
+S_ISSOCK :: #force_inline proc "contextless" (m: u16) -> bool { return (m & S_IFMT) == S_IFSOCK }
 
 R_OK :: 4 // Test for read permission
 W_OK :: 2 // Test for write permission

--- a/core/os/os_freebsd.odin
+++ b/core/os/os_freebsd.odin
@@ -241,13 +241,13 @@ S_ISGID :: 0o2000 // Set group id on execution
 S_ISVTX :: 0o1000 // Directory restrcted delete
 
 
-S_ISLNK  :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFLNK  }
-S_ISREG  :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFREG  }
-S_ISDIR  :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFDIR  }
-S_ISCHR  :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFCHR  }
-S_ISBLK  :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFBLK  }
-S_ISFIFO :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFIFO  }
-S_ISSOCK :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFSOCK }
+S_ISLNK  :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFLNK  }
+S_ISREG  :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFREG  }
+S_ISDIR  :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFDIR  }
+S_ISCHR  :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFCHR  }
+S_ISBLK  :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFBLK  }
+S_ISFIFO :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFIFO  }
+S_ISSOCK :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFSOCK }
 
 F_OK :: 0 // Test for file existance
 X_OK :: 1 // Test for execute permission

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -253,13 +253,13 @@ S_ISGID :: 0o2000 // Set group id on execution
 S_ISVTX :: 0o1000 // Directory restrcted delete
 
 
-S_ISLNK  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFLNK  }
-S_ISREG  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFREG  }
-S_ISDIR  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFDIR  }
-S_ISCHR  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFCHR  }
-S_ISBLK  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFBLK  }
-S_ISFIFO :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFIFO  }
-S_ISSOCK :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFSOCK }
+S_ISLNK  :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFLNK  }
+S_ISREG  :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFREG  }
+S_ISDIR  :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFDIR  }
+S_ISCHR  :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFCHR  }
+S_ISBLK  :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFBLK  }
+S_ISFIFO :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFIFO  }
+S_ISSOCK :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFSOCK }
 
 F_OK :: 0 // Test for file existance
 X_OK :: 1 // Test for execute permission
@@ -270,11 +270,11 @@ AT_FDCWD            :: ~uintptr(99)	/* -100 */
 AT_REMOVEDIR        :: uintptr(0x200)
 AT_SYMLINK_NOFOLLOW :: uintptr(0x100)
 
-_unix_personality :: proc(persona: u64) -> int {
+_unix_personality :: proc "contextless" (persona: u64) -> int {
 	return int(intrinsics.syscall(unix.SYS_personality, uintptr(persona)))
 }
 
-_unix_fork :: proc() -> Pid {
+_unix_fork :: proc "contextless" () -> Pid {
 	when ODIN_ARCH != .arm64 {
 		res := int(intrinsics.syscall(unix.SYS_fork))
 	} else {
@@ -283,7 +283,7 @@ _unix_fork :: proc() -> Pid {
 	return -1 if res < 0 else Pid(res)
 }
 
-_unix_open :: proc(path: cstring, flags: int, mode: int = 0o000) -> Handle {
+_unix_open :: proc "contextless" (path: cstring, flags: int, mode: int = 0o000) -> Handle {
 	when ODIN_ARCH != .arm64 {
 		res := int(intrinsics.syscall(unix.SYS_open, uintptr(rawptr(path)), uintptr(flags), uintptr(mode)))
 	} else { // NOTE: arm64 does not have open
@@ -292,19 +292,19 @@ _unix_open :: proc(path: cstring, flags: int, mode: int = 0o000) -> Handle {
 	return -1 if res < 0 else Handle(res)
 }
 
-_unix_close :: proc(fd: Handle) -> int {
+_unix_close :: proc "contextless" (fd: Handle) -> int {
 	return int(intrinsics.syscall(unix.SYS_close, uintptr(fd)))
 }
 
-_unix_read :: proc(fd: Handle, buf: rawptr, size: uint) -> int {
+_unix_read :: proc "contextless" (fd: Handle, buf: rawptr, size: uint) -> int {
 	return int(intrinsics.syscall(unix.SYS_read, uintptr(fd), uintptr(buf), uintptr(size)))
 }
 
-_unix_write :: proc(fd: Handle, buf: rawptr, size: uint) -> int {
+_unix_write :: proc "contextless" (fd: Handle, buf: rawptr, size: uint) -> int {
 	return int(intrinsics.syscall(unix.SYS_write, uintptr(fd), uintptr(buf), uintptr(size)))
 }
 
-_unix_seek :: proc(fd: Handle, offset: i64, whence: int) -> i64 {
+_unix_seek :: proc "contextless" (fd: Handle, offset: i64, whence: int) -> i64 {
 	when ODIN_ARCH == .amd64 || ODIN_ARCH == .arm64 {
 		return i64(intrinsics.syscall(unix.SYS_lseek, uintptr(fd), uintptr(offset), uintptr(whence)))
 	} else {
@@ -316,7 +316,7 @@ _unix_seek :: proc(fd: Handle, offset: i64, whence: int) -> i64 {
 	}
 }
 
-_unix_stat :: proc(path: cstring, stat: ^OS_Stat) -> int {
+_unix_stat :: proc "contextless" (path: cstring, stat: ^OS_Stat) -> int {
 	when ODIN_ARCH == .amd64 {
 		return int(intrinsics.syscall(unix.SYS_stat, uintptr(rawptr(path)), uintptr(stat)))
 	} else when ODIN_ARCH != .arm64 {
@@ -326,7 +326,7 @@ _unix_stat :: proc(path: cstring, stat: ^OS_Stat) -> int {
 	}
 }
 
-_unix_fstat :: proc(fd: Handle, stat: ^OS_Stat) -> int {
+_unix_fstat :: proc "contextless" (fd: Handle, stat: ^OS_Stat) -> int {
 	when ODIN_ARCH == .amd64 || ODIN_ARCH == .arm64 {
 		return int(intrinsics.syscall(unix.SYS_fstat, uintptr(fd), uintptr(stat)))
 	} else {
@@ -334,7 +334,7 @@ _unix_fstat :: proc(fd: Handle, stat: ^OS_Stat) -> int {
 	}
 }
 
-_unix_lstat :: proc(path: cstring, stat: ^OS_Stat) -> int {
+_unix_lstat :: proc "contextless" (path: cstring, stat: ^OS_Stat) -> int {
 	when ODIN_ARCH == .amd64 {
 		return int(intrinsics.syscall(unix.SYS_lstat, uintptr(rawptr(path)), uintptr(stat)))
 	} else when ODIN_ARCH != .arm64 {
@@ -344,7 +344,7 @@ _unix_lstat :: proc(path: cstring, stat: ^OS_Stat) -> int {
 	}
 }
 
-_unix_readlink :: proc(path: cstring, buf: rawptr, bufsiz: uint) -> int {
+_unix_readlink :: proc "contextless" (path: cstring, buf: rawptr, bufsiz: uint) -> int {
 	when ODIN_ARCH != .arm64 {
 		return int(intrinsics.syscall(unix.SYS_readlink, uintptr(rawptr(path)), uintptr(buf), uintptr(bufsiz)))
 	} else { // NOTE: arm64 does not have readlink
@@ -352,7 +352,7 @@ _unix_readlink :: proc(path: cstring, buf: rawptr, bufsiz: uint) -> int {
 	}
 }
 
-_unix_access :: proc(path: cstring, mask: int) -> int {
+_unix_access :: proc "contextless" (path: cstring, mask: int) -> int {
 	when ODIN_ARCH != .arm64 {
 		return int(intrinsics.syscall(unix.SYS_access, uintptr(rawptr(path)), uintptr(mask)))
 	} else { // NOTE: arm64 does not have access
@@ -360,15 +360,15 @@ _unix_access :: proc(path: cstring, mask: int) -> int {
 	}
 }
 
-_unix_getcwd :: proc(buf: rawptr, size: uint) -> int {
+_unix_getcwd :: proc "contextless" (buf: rawptr, size: uint) -> int {
 	return int(intrinsics.syscall(unix.SYS_getcwd, uintptr(buf), uintptr(size)))
 }
 
-_unix_chdir :: proc(path: cstring) -> int {
+_unix_chdir :: proc "contextless" (path: cstring) -> int {
 	return int(intrinsics.syscall(unix.SYS_chdir, uintptr(rawptr(path))))
 }
 
-_unix_rename :: proc(old, new: cstring) -> int {
+_unix_rename :: proc "contextless" (old, new: cstring) -> int {
 	when ODIN_ARCH != .arm64 {
 		return int(intrinsics.syscall(unix.SYS_rename, uintptr(rawptr(old)), uintptr(rawptr(new))))
 	} else { // NOTE: arm64 does not have rename
@@ -376,7 +376,7 @@ _unix_rename :: proc(old, new: cstring) -> int {
 	}
 }
 
-_unix_unlink :: proc(path: cstring) -> int {
+_unix_unlink :: proc "contextless" (path: cstring) -> int {
 	when ODIN_ARCH != .arm64 {
 		return int(intrinsics.syscall(unix.SYS_unlink, uintptr(rawptr(path))))
 	} else { // NOTE: arm64 does not have unlink
@@ -384,7 +384,7 @@ _unix_unlink :: proc(path: cstring) -> int {
 	}
 }
 
-_unix_rmdir :: proc(path: cstring) -> int {
+_unix_rmdir :: proc "contextless" (path: cstring) -> int {
 	when ODIN_ARCH != .arm64 {
 		return int(intrinsics.syscall(unix.SYS_rmdir, uintptr(rawptr(path))))
 	} else { // NOTE: arm64 does not have rmdir
@@ -392,7 +392,7 @@ _unix_rmdir :: proc(path: cstring) -> int {
 	}
 }
 
-_unix_mkdir :: proc(path: cstring, mode: u32) -> int {
+_unix_mkdir :: proc "contextless" (path: cstring, mode: u32) -> int {
 	when ODIN_ARCH != .arm64 {
 		return int(intrinsics.syscall(unix.SYS_mkdir, uintptr(rawptr(path)), uintptr(mode)))
 	} else { // NOTE: arm64 does not have mkdir
@@ -427,13 +427,13 @@ foreign dl {
 	@(link_name="dlerror")          _unix_dlerror       :: proc() -> cstring ---
 }
 
-is_path_separator :: proc(r: rune) -> bool {
+is_path_separator :: proc "contextless" (r: rune) -> bool {
 	return r == '/'
 }
 
 // determine errno from syscall return value
 @private
-_get_errno :: proc(res: int) -> Errno {
+_get_errno :: proc "contextless" (res: int) -> Errno {
 	if res < 0 && res > -4096 {
 		return Errno(-res)
 	}
@@ -441,11 +441,11 @@ _get_errno :: proc(res: int) -> Errno {
 }
 
 // get errno from libc
-get_last_error :: proc() -> int {
+get_last_error :: proc "contextless" () -> int {
 	return __errno_location()^
 }
 
-personality :: proc(persona: u64) -> (Errno) {
+personality :: proc "contextless" (persona: u64) -> (Errno) {
 	res := _unix_personality(persona)
 	if res == -1 {
 		return _get_errno(res)
@@ -453,7 +453,7 @@ personality :: proc(persona: u64) -> (Errno) {
 	return ERROR_NONE
 }
 
-fork :: proc() -> (Pid, Errno) {
+fork :: proc "contextless" () -> (Pid, Errno) {
 	pid := _unix_fork()
 	if pid == -1 {
 		return -1, _get_errno(int(pid))
@@ -470,11 +470,11 @@ open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Err
 	return handle, ERROR_NONE
 }
 
-close :: proc(fd: Handle) -> Errno {
+close :: proc "contextless" (fd: Handle) -> Errno {
 	return _get_errno(_unix_close(fd))
 }
 
-read :: proc(fd: Handle, data: []byte) -> (int, Errno) {
+read :: proc "contextless" (fd: Handle, data: []byte) -> (int, Errno) {
 	bytes_read := _unix_read(fd, &data[0], c.size_t(len(data)))
 	if bytes_read < 0 {
 		return -1, _get_errno(bytes_read)
@@ -482,7 +482,7 @@ read :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 	return bytes_read, ERROR_NONE
 }
 
-write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
+write :: proc "contextless" (fd: Handle, data: []byte) -> (int, Errno) {
 	if len(data) == 0 {
 		return 0, ERROR_NONE
 	}
@@ -493,7 +493,7 @@ write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 	return int(bytes_written), ERROR_NONE
 }
 
-seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
+seek :: proc "contextless" (fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
 	res := _unix_seek(fd, offset, whence)
 	if res < 0 {
 		return -1, _get_errno(int(res))
@@ -502,13 +502,13 @@ seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
 }
 
 file_size :: proc(fd: Handle) -> (i64, Errno) {
-    // deliberately uninitialized; the syscall fills this buffer for us
-    s: OS_Stat = ---
-    result := _unix_fstat(fd, &s)
-    if result < 0 {
-        return 0, _get_errno(result)
-    }
-    return max(s.size, 0), ERROR_NONE
+	// deliberately uninitialized; the syscall fills this buffer for us
+	s: OS_Stat = ---
+	result := _unix_fstat(fd, &s)
+	if result < 0 {
+		return 0, _get_errno(result)
+	}
+	return max(s.size, 0), ERROR_NONE
 }
 
 rename :: proc(old_path, new_path: string) -> Errno {

--- a/core/os/os_openbsd.odin
+++ b/core/os/os_openbsd.odin
@@ -225,13 +225,13 @@ S_ISUID :: 0o4000 // Set user id on execution
 S_ISGID :: 0o2000 // Set group id on execution
 S_ISTXT :: 0o1000 // Sticky bit
 
-S_ISLNK  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFLNK  }
-S_ISREG  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFREG  }
-S_ISDIR  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFDIR  }
-S_ISCHR  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFCHR  }
-S_ISBLK  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFBLK  }
-S_ISFIFO :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFIFO  }
-S_ISSOCK :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFSOCK }
+S_ISLNK  :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFLNK  }
+S_ISREG  :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFREG  }
+S_ISDIR  :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFDIR  }
+S_ISCHR  :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFCHR  }
+S_ISBLK  :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFBLK  }
+S_ISFIFO :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFIFO  }
+S_ISSOCK :: #force_inline proc "contextless" (m: u32) -> bool { return (m & S_IFMT) == S_IFSOCK }
 
 F_OK :: 0x00 // Test for file existance
 X_OK :: 0x01 // Test for execute permission

--- a/core/os/stat_unix.odin
+++ b/core/os/stat_unix.odin
@@ -51,14 +51,14 @@ File_Info :: struct {
 */
 
 @private
-_make_time_from_unix_file_time :: proc(uft: Unix_File_Time) -> time.Time {
+_make_time_from_unix_file_time :: proc "contextless" (uft: Unix_File_Time) -> time.Time {
 	return time.Time{
 		_nsec = uft.nanoseconds + uft.seconds * 1_000_000_000,
 	}
 }
 
 @private
-_fill_file_info_from_stat :: proc(fi: ^File_Info, s: OS_Stat) {
+_fill_file_info_from_stat :: proc "contextless" (fi: ^File_Info, s: OS_Stat) {
 	fi.size = s.size
 	fi.mode = cast(File_Mode)s.mode
 	fi.is_dir = S_ISDIR(s.mode)
@@ -72,8 +72,8 @@ _fill_file_info_from_stat :: proc(fi: ^File_Info, s: OS_Stat) {
 
 
 @private
-path_base :: proc(path: string) -> string {
-	is_separator :: proc(c: byte) -> bool {
+path_base :: proc "contextless" (path: string) -> string {
+	is_separator :: proc "contextless" (c: byte) -> bool {
 		return c == '/'
 	}
 

--- a/core/path/filepath/match.odin
+++ b/core/path/filepath/match.odin
@@ -32,7 +32,7 @@ Match_Error :: enum {
 //
 // NOTE(bill): This is effectively the shell pattern matching system found
 //
-match :: proc(pattern, name: string) -> (matched: bool, err: Match_Error) {
+match :: proc "contextless" (pattern, name: string) -> (matched: bool, err: Match_Error) {
 	pattern, name := pattern, name
 	pattern_loop: for len(pattern) > 0 {
 		star: bool
@@ -77,7 +77,7 @@ match :: proc(pattern, name: string) -> (matched: bool, err: Match_Error) {
 
 
 @(private="file")
-scan_chunk :: proc(pattern: string) -> (star: bool, chunk, rest: string) {
+scan_chunk :: proc "contextless" (pattern: string) -> (star: bool, chunk, rest: string) {
 	pattern := pattern
 	for len(pattern) > 0 && pattern[0] == '*' {
 		pattern = pattern[1:]
@@ -109,7 +109,7 @@ scan_chunk :: proc(pattern: string) -> (star: bool, chunk, rest: string) {
 }
 
 @(private="file")
-match_chunk :: proc(chunk, s: string) -> (rest: string, ok: bool, err: Match_Error) {
+match_chunk :: proc "contextless" (chunk, s: string) -> (rest: string, ok: bool, err: Match_Error) {
 	chunk, s := chunk, s
 	for len(chunk) > 0 {
 		if len(s) == 0 {
@@ -182,7 +182,7 @@ match_chunk :: proc(chunk, s: string) -> (rest: string, ok: bool, err: Match_Err
 }
 
 @(private="file")
-get_escape :: proc(chunk: string) -> (r: rune, next_chunk: string, err: Match_Error) {
+get_escape :: proc "contextless" (chunk: string) -> (r: rune, next_chunk: string, err: Match_Error) {
 	if len(chunk) == 0 || chunk[0] == '-' || chunk[0] == ']' {
 		err = .Syntax_Error
 		return
@@ -312,7 +312,7 @@ _glob :: proc(dir, pattern: string, matches: ^[dynamic]string, allocator := cont
 }
 
 @(private)
-has_meta :: proc(path: string) -> bool {
+has_meta :: proc "contextless" (path: string) -> bool {
 	when ODIN_OS == .Windows {
 		CHARS :: `*?[`
 	} else {
@@ -322,7 +322,7 @@ has_meta :: proc(path: string) -> bool {
 }
 
 @(private)
-clean_glob_path :: proc(path: string) -> string {
+clean_glob_path :: proc "contextless" (path: string) -> string {
 	switch path {
 	case "":
 		return "."
@@ -334,7 +334,7 @@ clean_glob_path :: proc(path: string) -> string {
 
 
 @(private)
-clean_glob_path_windows :: proc(path: string, temp_buf: []byte) -> (prefix_len: int, cleaned: string) {
+clean_glob_path_windows :: proc "contextless" (path: string, temp_buf: []byte) -> (prefix_len: int, cleaned: string) {
 	vol_len := volume_name_len(path)
 	switch {
 	case path == "":

--- a/core/path/filepath/path.odin
+++ b/core/path/filepath/path.odin
@@ -7,7 +7,7 @@ import "core:strings"
 SEPARATOR_CHARS :: `/\`
 
 // is_separator checks whether the byte is a valid separator character
-is_separator :: proc(c: byte) -> bool {
+is_separator :: proc "contextless" (c: byte) -> bool {
 	switch c {
 	case '/':  return true
 	case '\\': return ODIN_OS == .Windows
@@ -16,11 +16,11 @@ is_separator :: proc(c: byte) -> bool {
 }
 
 @(private)
-is_slash :: proc(c: byte) -> bool {
+is_slash :: proc "contextless" (c: byte) -> bool {
 	return c == '\\' || c == '/'
 }
 
-split :: proc(path: string) -> (dir, file: string) {
+split :: proc "contextless" (path: string) -> (dir, file: string) {
 	vol := volume_name(path)
 	i := len(path) - 1
 	for i >= len(vol) && !is_separator(path[i]) {
@@ -29,11 +29,11 @@ split :: proc(path: string) -> (dir, file: string) {
 	return path[:i+1], path[i+1:]
 }
 
-volume_name :: proc(path: string) -> string {
+volume_name :: proc "contextless" (path: string) -> string {
 	return path[:volume_name_len(path)]
 }
 
-volume_name_len :: proc(path: string) -> int {
+volume_name_len :: proc "contextless" (path: string) -> int {
 	if ODIN_OS == .Windows {
 		if len(path) < 2 {
 			return 0
@@ -81,7 +81,7 @@ volume_name_len :: proc(path: string) -> int {
 
 	Returns "." if the path is an empty string.
 */
-base :: proc(path: string) -> string {
+base :: proc "contextless" (path: string) -> string {
 	if path == "" {
 		return "."
 	}
@@ -121,7 +121,7 @@ base :: proc(path: string) -> string {
 	Returns an empty string if there is no stem. e.g: '.gitignore'.
 	Returns an empty string if there's a trailing path separator.
 */
-stem :: proc(path: string) -> string {
+stem :: proc "contextless" (path: string) -> string {
 	if len(path) > 0 && is_separator(path[len(path) - 1]) {
 		// NOTE(tetra): Trailing separator
 		return ""
@@ -154,7 +154,7 @@ stem :: proc(path: string) -> string {
 	Returns an empty string if there is no stem. e.g: '.gitignore'.
 	Returns an empty string if there's a trailing path separator.
 */
-short_stem :: proc(path: string) -> string {
+short_stem :: proc "contextless" (path: string) -> string {
 	s := stem(path)
 	if i := strings.index_byte(s, '.'); i != -1 {
 		return s[:i]
@@ -177,7 +177,7 @@ short_stem :: proc(path: string) -> string {
 	Returns an empty string if there is no dot.
 	Returns an empty string if there is a trailing path separator.
 */
-ext :: proc(path: string) -> string {
+ext :: proc "contextless" (path: string) -> string {
 	for i := len(path)-1; i >= 0 && !is_separator(path[i]); i -= 1 {
 		if path[i] == '.' {
 			return path[i:]
@@ -200,7 +200,7 @@ ext :: proc(path: string) -> string {
 	Returns an empty string if there is no dot.
 	Returns an empty string if there is a trailing path separator.
 */
-long_ext :: proc(path: string) -> string {
+long_ext :: proc "contextless" (path: string) -> string {
 	if len(path) > 0 && is_separator(path[len(path) - 1]) {
 		// NOTE(tetra): Trailing separator
 		return ""

--- a/core/path/filepath/path_unix.odin
+++ b/core/path/filepath/path_unix.odin
@@ -13,11 +13,11 @@ SEPARATOR :: '/'
 SEPARATOR_STRING :: `/`
 LIST_SEPARATOR :: ':'
 
-is_reserved_name :: proc(path: string) -> bool {
+is_reserved_name :: proc "contextless" (path: string) -> bool {
 	return false
 }
 
-is_abs :: proc(path: string) -> bool {
+is_abs :: proc "contextless" (path: string) -> bool {
 	return strings.has_prefix(path, "/")
 }
 

--- a/core/path/filepath/path_windows.odin
+++ b/core/path/filepath/path_windows.odin
@@ -15,7 +15,7 @@ reserved_names := [?]string{
 	"LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
 }
 
-is_reserved_name :: proc(path: string) -> bool {
+is_reserved_name :: proc "contextless" (path: string) -> bool {
 	if len(path) == 0 {
 		return false
 	}
@@ -27,12 +27,12 @@ is_reserved_name :: proc(path: string) -> bool {
 	return false
 }
 
-is_UNC :: proc(path: string) -> bool {
+is_UNC :: proc "contextless" (path: string) -> bool {
 	return volume_name_len(path) > 2
 }
 
 
-is_abs :: proc(path: string) -> bool {
+is_abs :: proc "contextless" (path: string) -> bool {
 	if is_reserved_name(path) {
 		return true
 	}

--- a/core/path/slashpath/path.odin
+++ b/core/path/slashpath/path.odin
@@ -8,13 +8,13 @@ package slashpath
 import "core:strings"
 
 // is_separator checks whether the byte is a valid separator character
-is_separator :: proc(c: byte) -> bool {
+is_separator :: proc "contextless" (c: byte) -> bool {
 	return c == '/'
 }
 
 
 // is_abs checks whether the path is absolute
-is_abs :: proc(path: string) -> bool {
+is_abs :: proc "contextless" (path: string) -> bool {
 	return len(path) > 0 && path[0] == '/'
 }
 
@@ -66,7 +66,7 @@ dir :: proc(path: string, allocator := context.allocator) -> string {
 // separating it into a directory and file name component.
 // If there is no slash in path, it returns an empty dir and file set to path
 // The returned values have the property that path = dir+file
-split :: proc(path: string) -> (dir, file: string) {
+split :: proc "contextless" (path: string) -> (dir, file: string) {
 	i := strings.last_index(path, "/")
 	return path[:i+1], path[i+1:]
 }

--- a/core/runtime/core_builtin_soa.odin
+++ b/core/runtime/core_builtin_soa.odin
@@ -50,7 +50,7 @@ Raw_SOA_Footer_Dynamic_Array :: struct {
 	allocator: Allocator,
 }
 
-raw_soa_footer_slice :: proc(array: ^$T/#soa[]$E) -> (footer: ^Raw_SOA_Footer_Slice) {
+raw_soa_footer_slice :: proc "contextless" (array: ^$T/#soa[]$E) -> (footer: ^Raw_SOA_Footer_Slice) {
 	if array == nil {
 		return nil
 	}
@@ -58,7 +58,7 @@ raw_soa_footer_slice :: proc(array: ^$T/#soa[]$E) -> (footer: ^Raw_SOA_Footer_Sl
 	footer = (^Raw_SOA_Footer_Slice)(uintptr(array) + field_count*size_of(rawptr))
 	return
 }
-raw_soa_footer_dynamic_array :: proc(array: ^$T/#soa[dynamic]$E) -> (footer: ^Raw_SOA_Footer_Dynamic_Array) {
+raw_soa_footer_dynamic_array :: proc "contextless" (array: ^$T/#soa[dynamic]$E) -> (footer: ^Raw_SOA_Footer_Dynamic_Array) {
 	if array == nil {
 		return nil
 	}

--- a/core/slice/ptr.odin
+++ b/core/slice/ptr.odin
@@ -3,14 +3,14 @@ package slice
 import "core:builtin"
 import "core:mem"
 
-ptr_add :: proc(p: $P/^$T, x: int) -> ^T {
+ptr_add :: proc "contextless" (p: $P/^$T, x: int) -> ^T {
 	return ([^]T)(p)[x:]
 }
-ptr_sub :: proc(p: $P/^$T, x: int) -> ^T {
+ptr_sub :: proc "contextless" (p: $P/^$T, x: int) -> ^T {
 	return ([^]T)(p)[-x:]
 }
 
-ptr_swap_non_overlapping :: proc(x, y: rawptr, len: int) {
+ptr_swap_non_overlapping :: proc "contextless" (x, y: rawptr, len: int) {
 	if len <= 0 {
 		return
 	}
@@ -44,7 +44,7 @@ ptr_swap_non_overlapping :: proc(x, y: rawptr, len: int) {
 	}
 }
 
-ptr_swap_overlapping :: proc(x, y: rawptr, len: int) {
+ptr_swap_overlapping :: proc "contextless" (x, y: rawptr, len: int) {
 	if len <= 0 {
 		return
 	}
@@ -68,7 +68,7 @@ ptr_swap_overlapping :: proc(x, y: rawptr, len: int) {
 }
 
 
-ptr_rotate :: proc(left: int, mid: ^$T, right: int) {
+ptr_rotate :: proc "contextless" (left: int, mid: ^$T, right: int) {
 	when size_of(T) != 0 {
 		left, mid, right := left, mid, right
 

--- a/core/strconv/decimal/decimal.odin
+++ b/core/strconv/decimal/decimal.odin
@@ -93,7 +93,7 @@ set :: proc(d: ^Decimal, s: string) -> (ok: bool) {
 }
 
 decimal_to_string :: proc(buf: []byte, a: ^Decimal) -> string {
-	digit_zero :: proc(buf: []byte) -> int {
+	digit_zero :: proc "contextless" (buf: []byte) -> int {
 		for _, i in buf {
 			buf[i] = '0'
 		}
@@ -131,7 +131,7 @@ decimal_to_string :: proc(buf: []byte, a: ^Decimal) -> string {
 }
 
 // trim trailing zeros
-trim :: proc(a: ^Decimal) {
+trim :: proc "contextless" (a: ^Decimal) {
 	for a.count > 0 && a.digits[a.count-1] == '0' {
 		a.count -= 1
 	}
@@ -141,7 +141,7 @@ trim :: proc(a: ^Decimal) {
 }
 
 
-assign :: proc(a: ^Decimal, idx: u64) {
+assign :: proc "contextless" (a: ^Decimal, idx: u64) {
 	buf: [64]byte
 	n := 0
 	for i := idx; i > 0;  {
@@ -163,7 +163,7 @@ assign :: proc(a: ^Decimal, idx: u64) {
 
 
 
-shift_right :: proc(a: ^Decimal, k: uint) {
+shift_right :: proc "contextless" (a: ^Decimal, k: uint) {
 	r := 0 // read index
 	w := 0 // write index
 
@@ -284,7 +284,7 @@ shift :: proc(a: ^Decimal, i: int) {
 	}
 }
 
-can_round_up :: proc(a: ^Decimal, nd: int) -> bool {
+can_round_up :: proc "contextless" (a: ^Decimal, nd: int) -> bool {
 	if nd < 0 || nd >= a.count { return false  }
 	if a.digits[nd] == '5' && nd+1 == a.count {
 		if a.trunc {
@@ -296,7 +296,7 @@ can_round_up :: proc(a: ^Decimal, nd: int) -> bool {
 	return a.digits[nd] >= '5'
 }
 
-round :: proc(a: ^Decimal, nd: int) {
+round :: proc "contextless" (a: ^Decimal, nd: int) {
 	if nd < 0 || nd >= a.count { return }
 	if can_round_up(a, nd) {
 		round_up(a, nd)
@@ -305,7 +305,7 @@ round :: proc(a: ^Decimal, nd: int) {
 	}
 }
 
-round_up :: proc(a: ^Decimal, nd: int) {
+round_up :: proc "contextless" (a: ^Decimal, nd: int) {
 	if nd < 0 || nd >= a.count { return }
 
 	for i := nd-1; i >= 0; i -= 1 {
@@ -322,7 +322,7 @@ round_up :: proc(a: ^Decimal, nd: int) {
 	a.decimal_point += 1
 }
 
-round_down :: proc(a: ^Decimal, nd: int) {
+round_down :: proc "contextless" (a: ^Decimal, nd: int) {
 	if nd < 0 || nd >= a.count { return }
 	a.count = nd
 	trim(a)
@@ -330,7 +330,7 @@ round_down :: proc(a: ^Decimal, nd: int) {
 
 
 // Extract integer part, rounded appropriately. There are no guarantees about overflow.
-rounded_integer :: proc(a: ^Decimal) -> u64 {
+rounded_integer :: proc "contextless" (a: ^Decimal) -> u64 {
 	if a.decimal_point > 20 {
 		return 0xffff_ffff_ffff_ffff
 	}

--- a/core/strconv/generic_float.odin
+++ b/core/strconv/generic_float.odin
@@ -103,10 +103,10 @@ format_digits :: proc(buf: []byte, shortest: bool, neg: bool, digs: Decimal_Slic
 		n: int,
 	}
 
-	to_bytes :: proc(b: Buffer) -> []byte {
+	to_bytes :: proc "contextless" (b: Buffer) -> []byte {
 		return b.b[:b.n]
 	}
-	add_bytes :: proc(buf: ^Buffer, bytes: ..byte) {
+	add_bytes :: proc "contextless" (buf: ^Buffer, bytes: ..byte) {
 		buf.n += copy(buf.b[buf.n:], bytes)
 	}
 

--- a/core/strconv/strconv.odin
+++ b/core/strconv/strconv.odin
@@ -3,7 +3,7 @@ package strconv
 import "core:unicode/utf8"
 import "decimal"
 
-parse_bool :: proc(s: string, n: ^int = nil) -> (result: bool = false, ok: bool) {
+parse_bool :: proc "contextless" (s: string, n: ^int = nil) -> (result: bool = false, ok: bool) {
 	switch s {
 	case "1", "t", "T", "true", "TRUE", "True":
 		if n != nil { n^ = len(s) }
@@ -15,7 +15,7 @@ parse_bool :: proc(s: string, n: ^int = nil) -> (result: bool = false, ok: bool)
 	return
 }
 
-_digit_value :: proc(r: rune) -> int {
+_digit_value :: proc "contextless" (r: rune) -> int {
 	ri := int(r)
 	v: int = 16
 	switch r {
@@ -734,7 +734,7 @@ parse_f64 :: proc(str: string, n: ^int = nil) -> (value: f64, ok: bool) {
 		return
 	}
 
-	parse_hex :: proc(s: string, mantissa: u64, exp: int, neg, trunc: bool) -> (f64, bool) {
+	parse_hex :: proc "contextless" (s: string, mantissa: u64, exp: int, neg, trunc: bool) -> (f64, bool) {
 		info := &_f64_info
 
 		mantissa, exp := mantissa, exp
@@ -851,7 +851,7 @@ parse_f64 :: proc(str: string, n: ^int = nil) -> (value: f64, ok: bool) {
 }
 
 
-append_bool :: proc(buf: []byte, b: bool) -> string {
+append_bool :: proc "contextless" (buf: []byte, b: bool) -> string {
 	n := 0
 	if b {
 		n = copy(buf, "true")
@@ -925,19 +925,19 @@ quote :: proc(buf: []byte, str: string) -> string {
 }
 
 quote_rune :: proc(buf: []byte, r: rune) -> string {
-	write_byte :: proc(buf: []byte, i: ^int, bytes: ..byte) {
+	write_byte :: proc "contextless" (buf: []byte, i: ^int, bytes: ..byte) {
 		if i^ < len(buf) {
 			n := copy(buf[i^:], bytes[:])
 			i^ += n
 		}
 	}
-	write_string :: proc(buf: []byte, i: ^int, s: string) {
+	write_string :: proc "contextless" (buf: []byte, i: ^int, s: string) {
 		if i^ < len(buf) {
 			n := copy(buf[i^:], s)
 			i^ += n
 		}
 	}
-	write_rune :: proc(buf: []byte, i: ^int, r: rune) {
+	write_rune :: proc "contextless" (buf: []byte, i: ^int, r: rune) {
 		if i^ < len(buf) {
 			b, w := utf8.encode_rune(r)
 			n := copy(buf[i^:], b[:w])
@@ -983,8 +983,8 @@ quote_rune :: proc(buf: []byte, r: rune) -> string {
 
 
 
-unquote_char :: proc(str: string, quote: byte) -> (r: rune, multiple_bytes: bool, tail_string: string, success: bool) {
-	hex_to_int :: proc(c: byte) -> int {
+unquote_char :: proc "contextless" (str: string, quote: byte) -> (r: rune, multiple_bytes: bool, tail_string: string, success: bool) {
+	hex_to_int :: proc "contextless" (c: byte) -> int {
 		switch c {
 		case '0'..='9': return int(c-'0')
 		case 'a'..='f': return int(c-'a')+10
@@ -1079,7 +1079,7 @@ unquote_char :: proc(str: string, quote: byte) -> (r: rune, multiple_bytes: bool
 }
 
 unquote_string :: proc(lit: string, allocator := context.allocator) -> (res: string, allocated, success: bool) {
-	contains_rune :: proc(s: string, r: rune) -> int {
+	contains_rune :: proc "contextless" (s: string, r: rune) -> int {
 		for c, offset in s {
 			if c == r {
 				return offset

--- a/core/strings/ascii_set.odin
+++ b/core/strings/ascii_set.odin
@@ -6,7 +6,7 @@ import "core:unicode/utf8"
 Ascii_Set :: distinct [8]u32
 
 // create an ascii set of all unique characters in the string
-ascii_set_make :: proc(chars: string) -> (as: Ascii_Set, ok: bool) #no_bounds_check {
+ascii_set_make :: proc "contextless" (chars: string) -> (as: Ascii_Set, ok: bool) #no_bounds_check {
 	for i in 0..<len(chars) {
 		c := chars[i]
 		if c >= utf8.RUNE_SELF {
@@ -19,6 +19,6 @@ ascii_set_make :: proc(chars: string) -> (as: Ascii_Set, ok: bool) #no_bounds_ch
 }
 
 // returns true when the `c` byte is contained in the `as` ascii set
-ascii_set_contains :: proc(as: Ascii_Set, c: byte) -> bool #no_bounds_check {
+ascii_set_contains :: proc "contextless" (as: Ascii_Set, c: byte) -> bool #no_bounds_check {
 	return as[c>>5] & (1<<(c&31)) != 0
 }

--- a/core/strings/builder.odin
+++ b/core/strings/builder.odin
@@ -96,12 +96,12 @@ _builder_stream_vtable := io.Stream_VTable{
 }
 
 // return an `io.Stream` from a builder
-to_stream :: proc(b: ^Builder) -> io.Stream {
+to_stream :: proc "contextless" (b: ^Builder) -> io.Stream {
 	return io.Stream{stream_vtable=&_builder_stream_vtable, stream_data=b}
 }
 
 // return an `io.Writer` from a builder
-to_writer :: proc(b: ^Builder) -> io.Writer {
+to_writer :: proc "contextless" (b: ^Builder) -> io.Writer {
 	return io.to_writer(to_stream(b))
 }
 
@@ -117,7 +117,7 @@ builder_grow :: proc(b: ^Builder, cap: int) {
 }
 
 // clear the builder byte buffer content
-builder_reset :: proc(b: ^Builder) {
+builder_reset :: proc "contextless" (b: ^Builder) {
 	clear(&b.buf)
 }
 
@@ -146,22 +146,22 @@ builder_from_bytes :: proc(backing: []byte) -> Builder {
 builder_from_slice :: builder_from_bytes
 
 // cast the builder byte buffer to a string and return it
-to_string :: proc(b: Builder) -> string {
+to_string :: proc "contextless" (b: Builder) -> string {
 	return string(b.buf[:])
 }
 
 // return the length of the builder byte buffer
-builder_len :: proc(b: Builder) -> int {
+builder_len :: proc "contextless" (b: Builder) -> int {
 	return len(b.buf)
 }
 
 // return the cap of the builder byte buffer
-builder_cap :: proc(b: Builder) -> int {
+builder_cap :: proc "contextless" (b: Builder) -> int {
 	return cap(b.buf)
 }
 
 // returns the space left in the builder byte buffer to use up
-builder_space :: proc(b: Builder) -> int {
+builder_space :: proc "contextless" (b: Builder) -> int {
 	return cap(b.buf) - len(b.buf)
 }
 
@@ -242,7 +242,7 @@ write_string :: proc(b: ^Builder, s: string) -> (n: int) {
 
 // pops and returns the last byte in the builder
 // returns 0 when the builder is empty
-pop_byte :: proc(b: ^Builder) -> (r: byte) {
+pop_byte :: proc "contextless" (b: ^Builder) -> (r: byte) {
 	if len(b.buf) == 0 {
 		return 0
 	}
@@ -255,7 +255,7 @@ pop_byte :: proc(b: ^Builder) -> (r: byte) {
 
 // pops the last rune in the builder and returns the popped rune and its rune width
 // returns 0, 0 when the builder is empty
-pop_rune :: proc(b: ^Builder) -> (r: rune, width: int) {
+pop_rune :: proc "contextless" (b: ^Builder) -> (r: rune, width: int) {
 	if len(b.buf) == 0 {
 		return 0, 0
 	}

--- a/core/strings/conversion.odin
+++ b/core/strings/conversion.odin
@@ -92,12 +92,12 @@ to_upper :: proc(s: string, allocator := context.allocator) -> string {
 
 // returns true when the `c` rune is a space, '-' or '_' 
 // useful when treating strings like words in a text editor or html paths 
-is_delimiter :: proc(c: rune) -> bool {
+is_delimiter :: proc "contextless" (c: rune) -> bool {
 	return c == '-' || c == '_' || is_space(c)
 }
 
 // returns true when the `r` rune is a non alpha or `unicode.is_space` rune
-is_separator :: proc(r: rune) -> bool {
+is_separator :: proc "contextless" (r: rune) -> bool {
 	if r <= 0x7f {
 		switch r {
 		case '0'..='9': return false

--- a/core/strings/reader.odin
+++ b/core/strings/reader.odin
@@ -15,35 +15,35 @@ Reader :: struct {
 }
 
 // init the reader to the string `s` 
-reader_init :: proc(r: ^Reader, s: string) {
+reader_init :: proc "contextless" (r: ^Reader, s: string) {
 	r.s = s
 	r.i = 0
 	r.prev_rune = -1
 }
 
 // returns a stream from the reader data
-reader_to_stream :: proc(r: ^Reader) -> (s: io.Stream) {
+reader_to_stream :: proc "contextless" (r: ^Reader) -> (s: io.Stream) {
 	s.stream_data = r
 	s.stream_vtable = &_reader_vtable
 	return
 }
 
 // init a reader to the string `s` and return an io.Reader
-to_reader :: proc(r: ^Reader, s: string) -> io.Reader {
+to_reader :: proc "contextless" (r: ^Reader, s: string) -> io.Reader {
 	reader_init(r, s)
 	rr, _ := io.to_reader(reader_to_stream(r))
 	return rr
 }
 
 // init a reader to the string `s` and return an io.Reader_At
-to_reader_at :: proc(r: ^Reader, s: string) -> io.Reader_At {
+to_reader_at :: proc "contextless" (r: ^Reader, s: string) -> io.Reader_At {
 	reader_init(r, s)
 	rr, _ := io.to_reader_at(reader_to_stream(r))
 	return rr
 }
 
 // remaining length of the reader 
-reader_length :: proc(r: ^Reader) -> int {
+reader_length :: proc "contextless" (r: ^Reader) -> int {
 	if r.i >= i64(len(r.s)) {
 		return 0
 	}

--- a/core/unicode/letter.odin
+++ b/core/unicode/letter.odin
@@ -5,7 +5,7 @@ REPLACEMENT_CHAR :: '\ufffd'     // Represented an invalid code point
 MAX_ASCII        :: '\u007f'     // Maximum ASCII value
 MAX_LATIN1       :: '\u00ff'     // Maximum Latin-1 value
 
-binary_search :: proc(c: i32, table: []i32, length, stride: int) -> int {
+binary_search :: proc "contextless" (c: i32, table: []i32, length, stride: int) -> int {
 	n := length
 	t := 0
 	for n > 1 {
@@ -24,7 +24,7 @@ binary_search :: proc(c: i32, table: []i32, length, stride: int) -> int {
 	return -1
 }
 
-to_lower :: proc(r: rune) -> rune {
+to_lower :: proc "contextless" (r: rune) -> rune {
 	c := i32(r)
 	p := binary_search(c, to_lower_ranges[:], len(to_lower_ranges)/3, 3)
 	if p >= 0 && to_lower_ranges[p] <= c && c <= to_lower_ranges[p+1] {
@@ -36,7 +36,7 @@ to_lower :: proc(r: rune) -> rune {
 	}
 	return rune(c)
 }
-to_upper :: proc(r: rune) -> rune {
+to_upper :: proc "contextless" (r: rune) -> rune {
 	c := i32(r)
 	p := binary_search(c, to_upper_ranges[:], len(to_upper_ranges)/3, 3)
 	if p >= 0 && to_upper_ranges[p] <= c && c <= to_upper_ranges[p+1] {
@@ -48,7 +48,7 @@ to_upper :: proc(r: rune) -> rune {
 	}
 	return rune(c)
 }
-to_title :: proc(r: rune) -> rune {
+to_title :: proc "contextless" (r: rune) -> rune {
 	c := i32(r)
 	p := binary_search(c, to_upper_singlets[:], len(to_title_singlets)/2, 2)
 	if p >= 0 && c == to_upper_singlets[p] {
@@ -58,7 +58,7 @@ to_title :: proc(r: rune) -> rune {
 }
 
 
-is_lower :: proc(r: rune) -> bool {
+is_lower :: proc "contextless" (r: rune) -> bool {
 	if r <= MAX_ASCII {
 		return u32(r)-'a' < 26
 	}
@@ -74,7 +74,7 @@ is_lower :: proc(r: rune) -> bool {
 	return false
 }
 
-is_upper :: proc(r: rune) -> bool {
+is_upper :: proc "contextless" (r: rune) -> bool {
 	if r <= MAX_ASCII {
 		return u32(r)-'A' < 26
 	}
@@ -91,7 +91,7 @@ is_upper :: proc(r: rune) -> bool {
 }
 
 is_alpha :: is_letter
-is_letter :: proc(r: rune) -> bool {
+is_letter :: proc "contextless" (r: rune) -> bool {
 	if u32(r) <= MAX_LATIN1 {
 		return char_properties[u8(r)]&pLmask != 0
 	}
@@ -111,11 +111,11 @@ is_letter :: proc(r: rune) -> bool {
 	return false
 }
 
-is_title :: proc(r: rune) -> bool {
+is_title :: proc "contextless" (r: rune) -> bool {
 	return is_upper(r) && is_lower(r)
 }
 
-is_digit :: proc(r: rune) -> bool {
+is_digit :: proc "contextless" (r: rune) -> bool {
 	if r <= MAX_LATIN1 {
 		return '0' <= r && r <= '9'
 	}
@@ -124,7 +124,7 @@ is_digit :: proc(r: rune) -> bool {
 
 
 is_white_space :: is_space
-is_space :: proc(r: rune) -> bool {
+is_space :: proc "contextless" (r: rune) -> bool {
 	if u32(r) <= MAX_LATIN1 {
 		switch r {
 		case '\t', '\n', '\v', '\f', '\r', ' ', 0x85, 0xa0:
@@ -140,7 +140,7 @@ is_space :: proc(r: rune) -> bool {
 	return false
 }
 
-is_combining :: proc(r: rune) -> bool {
+is_combining :: proc "contextless" (r: rune) -> bool {
 	c := i32(r)
 
 	return c >= 0x0300 && (c <= 0x036f ||
@@ -152,42 +152,42 @@ is_combining :: proc(r: rune) -> bool {
 
 
 
-is_graphic :: proc(r: rune) -> bool {
+is_graphic :: proc "contextless" (r: rune) -> bool {
 	if u32(r) <= MAX_LATIN1 {
 		return char_properties[u8(r)]&pg != 0
 	}
 	return false
 }
 
-is_print :: proc(r: rune) -> bool {
+is_print :: proc "contextless" (r: rune) -> bool {
 	if u32(r) <= MAX_LATIN1 {
 		return char_properties[u8(r)]&pp != 0
 	}
 	return false
 }
 
-is_control :: proc(r: rune) -> bool {
+is_control :: proc "contextless" (r: rune) -> bool {
 	if u32(r) <= MAX_LATIN1 {
 		return char_properties[u8(r)]&pC != 0
 	}
 	return false
 }
 
-is_number :: proc(r: rune) -> bool {
+is_number :: proc "contextless" (r: rune) -> bool {
 	if u32(r) <= MAX_LATIN1 {
 		return char_properties[u8(r)]&pN != 0
 	}
 	return false
 }
 
-is_punct :: proc(r: rune) -> bool {
+is_punct :: proc "contextless" (r: rune) -> bool {
 	if u32(r) <= MAX_LATIN1 {
 		return char_properties[u8(r)]&pP != 0
 	}
 	return false
 }
 
-is_symbol :: proc(r: rune) -> bool {
+is_symbol :: proc "contextless" (r: rune) -> bool {
 	if u32(r) <= MAX_LATIN1 {
 		return char_properties[u8(r)]&pS != 0
 	}

--- a/core/unicode/utf16/utf16.odin
+++ b/core/unicode/utf16/utf16.odin
@@ -11,11 +11,11 @@ _surr3           :: 0xe000
 _surr_self       :: 0x10000
 
 
-is_surrogate :: proc(r: rune) -> bool {
+is_surrogate :: proc "contextless" (r: rune) -> bool {
 	return _surr1 <= r && r < _surr3
 }
 
-decode_surrogate_pair :: proc(r1, r2: rune) -> rune {
+decode_surrogate_pair :: proc "contextless" (r1, r2: rune) -> rune {
 	if _surr1 <= r1 && r1 < _surr2 && _surr2 <= r2 && r2 < _surr3 {
 		return (r1-_surr1)<<10 | (r2 - _surr2) + _surr_self
 	}
@@ -23,7 +23,7 @@ decode_surrogate_pair :: proc(r1, r2: rune) -> rune {
 }
 
 
-encode_surrogate_pair :: proc(c: rune) -> (r1, r2: rune) {
+encode_surrogate_pair :: proc "contextless" (c: rune) -> (r1, r2: rune) {
 	r := c
 	if r < _surr_self || r > MAX_RUNE {
 		return REPLACEMENT_CHAR, REPLACEMENT_CHAR
@@ -32,7 +32,7 @@ encode_surrogate_pair :: proc(c: rune) -> (r1, r2: rune) {
 	return _surr1 + (r>>10)&0x3ff, _surr2 + r&0x3ff
 }
 
-encode :: proc(d: []u16, s: []rune) -> int {
+encode :: proc "contextless" (d: []u16, s: []rune) -> int {
 	n, m := 0, len(d)
 	loop: for r in s {
 		switch r {
@@ -58,7 +58,7 @@ encode :: proc(d: []u16, s: []rune) -> int {
 }
 
 
-encode_string :: proc(d: []u16, s: string) -> int {
+encode_string :: proc "contextless" (d: []u16, s: string) -> int {
 	n, m := 0, len(d)
 	loop: for r in s {
 		switch r {
@@ -83,7 +83,7 @@ encode_string :: proc(d: []u16, s: string) -> int {
 	return n
 }
 
-decode :: proc(d: []rune, s: []u16) -> (n: int) {
+decode :: proc "contextless" (d: []rune, s: []u16) -> (n: int) {
 	for i := 0; i < len(s); i += 1 {
 		if n >= len(d) {
 			return
@@ -107,7 +107,7 @@ decode :: proc(d: []rune, s: []u16) -> (n: int) {
 }
 
 
-decode_to_utf8 :: proc(d: []byte, s: []u16) -> (n: int) {
+decode_to_utf8 :: proc "contextless" (d: []byte, s: []u16) -> (n: int) {
 	for i := 0; i < len(s); i += 1 {
 		if n >= len(d) {
 			return

--- a/core/unicode/utf8/utf8.odin
+++ b/core/unicode/utf8/utf8.odin
@@ -54,7 +54,7 @@ accept_sizes := [256]u8{
 	0xf5..=0xff = 0xf1,
 }
 
-encode_rune :: proc(c: rune) -> ([4]u8, int) {
+encode_rune :: proc "contextless" (c: rune) -> ([4]u8, int) {
 	r := c
 
 	buf: [4]u8
@@ -95,10 +95,10 @@ decode_rune :: proc{
 	decode_rune_in_string,
 	decode_rune_in_bytes,
 }
-decode_rune_in_string :: #force_inline proc(s: string) -> (rune, int) {
+decode_rune_in_string :: #force_inline proc "contextless" (s: string) -> (rune, int) {
 	return decode_rune_in_bytes(transmute([]u8)s)
 }
-decode_rune_in_bytes :: proc(s: []u8) -> (rune, int) {
+decode_rune_in_bytes :: proc "contextless" (s: []u8) -> (rune, int) {
 	n := len(s)
 	if n < 1 {
 		return RUNE_ERROR, 0
@@ -171,10 +171,10 @@ decode_last_rune :: proc{
 	decode_last_rune_in_bytes,
 }
 
-decode_last_rune_in_string :: #force_inline proc(s: string) -> (rune, int) {
+decode_last_rune_in_string :: #force_inline proc "contextless" (s: string) -> (rune, int) {
 	return decode_last_rune_in_bytes(transmute([]u8)s)
 }
-decode_last_rune_in_bytes :: proc(s: []u8) -> (rune, int) {
+decode_last_rune_in_bytes :: proc "contextless" (s: []u8) -> (rune, int) {
 	r: rune
 	size: int
 	start, end, limit: int
@@ -206,7 +206,7 @@ decode_last_rune_in_bytes :: proc(s: []u8) -> (rune, int) {
 	return r, size
 }
 
-rune_at_pos :: proc(s: string, pos: int) -> rune {
+rune_at_pos :: proc "contextless" (s: string, pos: int) -> rune {
 	if pos < 0 {
 		return RUNE_ERROR
 	}
@@ -221,7 +221,7 @@ rune_at_pos :: proc(s: string, pos: int) -> rune {
 	return RUNE_ERROR
 }
 
-rune_string_at_pos :: proc(s: string, pos: int) -> string {
+rune_string_at_pos :: proc "contextless" (s: string, pos: int) -> string {
 	if pos < 0 {
 		return ""
 	}
@@ -237,14 +237,14 @@ rune_string_at_pos :: proc(s: string, pos: int) -> string {
 	return ""
 }
 
-rune_at :: proc(s: string, byte_index: int) -> rune {
+rune_at :: proc "contextless" (s: string, byte_index: int) -> rune {
 	r, _ := decode_rune_in_string(s[byte_index:])
 	return r
 }
 
 // Returns the byte position of rune at position pos in s with an optional start byte position.
 // Returns -1 if it runs out of the string.
-rune_offset :: proc(s: string, pos: int, start: int = 0) -> int {
+rune_offset :: proc "contextless" (s: string, pos: int, start: int = 0) -> int {
 	if pos < 0 {
 		return -1
 	}
@@ -259,7 +259,7 @@ rune_offset :: proc(s: string, pos: int, start: int = 0) -> int {
 	return -1
 }
 
-valid_rune :: proc(r: rune) -> bool {
+valid_rune :: proc "contextless" (r: rune) -> bool {
 	if r < 0 {
 		return false
 	} else if SURROGATE_MIN <= r && r <= SURROGATE_MAX {
@@ -270,7 +270,7 @@ valid_rune :: proc(r: rune) -> bool {
 	return true
 }
 
-valid_string :: proc(s: string) -> bool {
+valid_string :: proc "contextless" (s: string) -> bool {
 	n := len(s)
 	for i := 0; i < n; {
 		si := s[i]
@@ -303,7 +303,7 @@ valid_string :: proc(s: string) -> bool {
 	return true
 }
 
-rune_start :: #force_inline proc(b: u8) -> bool {
+rune_start :: #force_inline proc "contextless" (b: u8) -> bool {
 	return b&0xc0 != 0x80
 }
 
@@ -312,10 +312,10 @@ rune_count :: proc{
 	rune_count_in_bytes,
 }
 
-rune_count_in_string :: #force_inline proc(s: string) -> int {
+rune_count_in_string :: #force_inline proc "contextless" (s: string) -> int {
 	return rune_count_in_bytes(transmute([]u8)s)
 }
-rune_count_in_bytes :: proc(s: []u8) -> int {
+rune_count_in_bytes :: proc "contextless" (s: []u8) -> int {
 	count := 0
 	n := len(s)
 
@@ -354,7 +354,7 @@ rune_count_in_bytes :: proc(s: []u8) -> int {
 }
 
 
-rune_size :: proc(r: rune) -> int {
+rune_size :: proc "contextless" (r: rune) -> int {
 	switch {
 	case r < 0:          return -1
 	case r <= 1<<7  - 1: return 1
@@ -375,7 +375,7 @@ full_rune :: proc{
 
 // full_rune_in_bytes reports if the bytes in b begin with a full utf-8 encoding of a rune or not
 // An invalid encoding is considered a full rune since it will convert as an error rune of width 1 (RUNE_ERROR)
-full_rune_in_bytes :: proc(b: []byte) -> bool {
+full_rune_in_bytes :: proc "contextless" (b: []byte) -> bool {
 	n := len(b)
 	if n == 0 {
 		return false
@@ -395,7 +395,7 @@ full_rune_in_bytes :: proc(b: []byte) -> bool {
 
 // full_rune_in_string reports if the bytes in s begin with a full utf-8 encoding of a rune or not
 // An invalid encoding is considered a full rune since it will convert as an error rune of width 1 (RUNE_ERROR)
-full_rune_in_string :: proc(s: string) -> bool {
+full_rune_in_string :: proc "contextless" (s: string) -> bool {
 	return full_rune_in_bytes(transmute([]byte)s)
 }
 

--- a/examples/all/all_main.odin
+++ b/examples/all/all_main.odin
@@ -171,6 +171,7 @@ _ :: varint
 _ :: xml
 _ :: fmt
 _ :: hash
+_ :: xxhash
 _ :: image
 _ :: netpbm
 _ :: png

--- a/examples/all/all_main.odin
+++ b/examples/all/all_main.odin
@@ -60,6 +60,7 @@ import xml              "core:encoding/xml"
 
 import fmt              "core:fmt"
 import hash             "core:hash"
+import xxhash           "core:hash/xxhash"
 
 import image            "core:image"
 import netpbm           "core:image/netpbm"


### PR DESCRIPTION
The following PR just marks a bunch of procedures inside Odin as `"contextless"` calling convention allowing them to be used in contextless procedures.

Several procedures which take a procedure themselves have been duplicated to take both an explicit `proc "odin"` and `proc "contextless"` procedure and named `_odin` and `_contextless` respectively with an explicit procedure group containing both, this enables stuff like `strings.index_proc` to accept any type of procedure, including a `"contextless"` one as an example.

The general rule is that a procedure taking a procedure accepting "odin" calling convention must itself be "odin" since it has to pass the context from itself to the inner procedure, however passing a "contextless" procedure is allowed from both a "odin" and "contextless" procedure. This can be seen in stuff like `strings.fields_proc` as an example.

The `_odin` and `_contextless` procedures are made `@(private)` and only accessible through the regular moniker which is the procedure group itself.

Since the context is passed as the last argument to a procedure this also reduces code size and register usage for procedures which do not actually use the context which enables slightly better code generation (more registers for the register allocator).