### PR TITLE
Added CSIDL_PROFILE in core:sys/windows

### DIFF
--- a/core/sys/windows/types.odin
+++ b/core/sys/windows/types.odin
@@ -1261,6 +1261,7 @@ SWP_ASYNCWINDOWPOS :: 0x4000 // same as SWP_CREATESPB
 
 CSIDL_APPDATA        :: 0x001a // <user name>\Application Data
 CSIDL_COMMON_APPDATA :: 0x0023 // All Users\Application Data
+CSIDL_PROFILE 		 :: 0x0028 // <user name>\
 
 HWND_TOP       :: HWND( uintptr(0))     //  0
 HWND_BOTTOM    :: HWND( uintptr(1))     //  1


### PR DESCRIPTION
Not a big change, just an useful ID for getting the current user folder path.