### PR TITLE
[runtime] Fix typo in shrink_dynamic_array()

### DIFF
--- a/core/runtime/core_builtin.odin
+++ b/core/runtime/core_builtin.odin
@@ -615,7 +615,7 @@ shrink_dynamic_array :: proc(array: ^$T/[dynamic]$E, new_cap := -1, loc := #call
 	old_size := a.cap * size_of(E)
 	new_size := new_cap * size_of(E)
 
-	new_data, err := mem_resize(a.data, old_size, new_size, align_of(E), allocator, loc)
+	new_data, err := mem_resize(a.data, old_size, new_size, align_of(E), a.allocator, loc)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Currentlly, if you try to shrink a dynamic array, you get an undeclared variable error, which seems due to a typo.

Who would have thunk it?

`mem_resize(..., allocator, ...)` -> `mem_resize(..., a.allocator, ...)`