### PR TITLE
Update odinfmt with new filepath.Walk_Proc signature

### DIFF
--- a/tools/odinfmt/main.odin
+++ b/tools/odinfmt/main.odin
@@ -55,7 +55,7 @@ format_file :: proc(filepath: string) -> (string, bool) {
 
 files: [dynamic]string;
 
-walk_files :: proc(info: os.File_Info, in_err: os.Errno) -> (err: os.Errno, skip_dir: bool) {
+walk_files :: proc(info: os.File_Info, in_err: os.Errno, user_data: rawptr) -> (err: os.Errno, skip_dir: bool) {
 	if info.is_dir {
 		return 0, false;
 	}
@@ -111,7 +111,7 @@ main :: proc() {
 			}
 		}
 	} else if os.is_dir(path) {
-		filepath.walk(path, walk_files);
+		filepath.walk(path, walk_files, nil);
 
 		for file in files {
 


### PR DESCRIPTION
Commit [f9f4551e8d2d1e86dcf902c5c4f630cbb638ea83](https://github.com/odin-lang/Odin/commit/f9f4551e8d2d1e86dcf902c5c4f630cbb638ea83) introduced the additional parameter: `user_data: rawptr` to `filepath.Walk_Proc` callback. This commit updates odinfmt to meet this new additional parameter.