### PR TITLE
Odinfmt semicolon

### DIFF
--- a/tests/core/Makefile
+++ b/tests/core/Makefile
@@ -2,7 +2,7 @@ ODIN=../../odin
 PYTHON=$(shell which python3)
 
 all: download_test_assets image_test compress_test strings_test hash_test crypto_test noise_test encoding_test \
-	 math_test linalg_glsl_math_test filepath_test reflect_test os_exit_test i18n_test c_libc_test
+	 math_test linalg_glsl_math_test filepath_test reflect_test os_exit_test i18n_test c_libc_test parser_test
 
 download_test_assets:
 	$(PYTHON) download_assets.py
@@ -51,3 +51,6 @@ i18n_test:
 
 c_libc_test:
 	$(ODIN) run c/libc -out:test_core_libc
+
+parser_test:
+	$(ODIN) run odin/test_parser.odin -file -out:test_parser

--- a/tests/core/build.bat
+++ b/tests/core/build.bat
@@ -75,3 +75,8 @@ echo ---
 echo Running core:slice tests
 echo ---
 %PATH_TO_ODIN% run slice %COMMON% -out:test_core_slice.exe
+
+echo ---
+echo Running core:odin/parser tests
+echo ---
+%PATH_TO_ODIN% run odin %COMMON% -out:test_core_parser.exe

--- a/tests/core/odin/test_parser.odin
+++ b/tests/core/odin/test_parser.odin
@@ -40,7 +40,7 @@ main :: proc() {
 
 @test
 test_parse_demo :: proc(t: ^testing.T) {
-	pkg, ok := parser.parse_package_from_path("examples/demo")
+	pkg, ok := parser.parse_package_from_path("../../examples/demo")
 	
 	expect(t, ok == true, "parser.parse_package_from_path failed")
 

--- a/tools/odinfmt/main.odin
+++ b/tools/odinfmt/main.odin
@@ -3,6 +3,7 @@ package odinfmt
 import "core:os"
 import "core:odin/tokenizer"
 import "core:odin/format"
+import "core:odin/parser"
 import "core:fmt"
 import "core:strings"
 import "core:path/filepath"
@@ -47,7 +48,7 @@ print_arg_error :: proc(args: []string, error: flag.Flag_Error) {
 
 format_file :: proc(filepath: string) -> (string, bool) {
 	if data, ok := os.read_entire_file(filepath); ok {
-		return format.format(filepath, string(data), format.default_style);
+		return format.format(filepath, string(data), format.default_style, parser.Flags{.Optional_Semicolons});
 	} else {
 		return "", false;
 	}


### PR DESCRIPTION
Fix problem expected ';', got newline

Missing flag for optional semicolon `parser.Flags{.Optional_Semicolons}`
resulted problem:

```
unformatted.odin(4:12): expected ';', got newline
unformatted.odin(4:12): expected ';', got newline
unformatted.odin(5:1): you cannot use a block statement in the file scope
unformatted.odin(6:19): expected ';', got newline
```
    
where unformatted.odin is:
    
```
package   main
import"core:fmt"
still_oneline::proc(){fmt.println( "hello world" )}
main::proc()
{
fmt.println("main")
}
```
    
This commit fixes the problem. However, there is still an
indention issue to be fixed. Applying this commit still results in
incorrect indention:
    
```
package main
import "core:fmt"
                                     still_oneline :: proc() {fmt.println("hello world")}
                                     main :: proc() {
                                                         fmt.println("main")
                                                 }

```