### PR TITLE
Fixed memory leak in dir_darwin.odin.

### DIFF
--- a/core/os/dir_darwin.odin
+++ b/core/os/dir_darwin.odin
@@ -14,10 +14,11 @@ read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []F
 
 	dirpath: string
 	dirpath, err = absolute_path_from_handle(fd)
-
 	if err != ERROR_NONE {
 		return
 	}
+
+	defer delete(dirpath)
 
 	n := n
 	size := n


### PR DESCRIPTION
This is a minor fix to core:os/dir_darwin.odin where there is an allocation to context.allocator that is followed by neither a delete nor a return, thereby causing a memory leak. 
```
    dirpath: string
    dirpath, err = absolute_path_from_handle(fd)

    if err != ERROR_NONE {
        return
    }
```