### PR TITLE
Fix `core:slice.rotate_left`

### DIFF
--- a/core/slice/ptr.odin
+++ b/core/slice/ptr.odin
@@ -73,25 +73,17 @@ ptr_rotate :: proc(left: int, mid: ^$T, right: int) {
 		left, mid, right := left, mid, right
 
 		// TODO(bill): Optimization with a buffer for smaller ranges
-		if left >= right {
-			for {
-				ptr_swap_non_overlapping(ptr_sub(mid, right), mid, right)
+		for left > 0 && right > 0 {
+			if left >= right {
+				ptr_swap_non_overlapping(ptr_sub(mid, right), mid, right * size_of(T))
 				mid = ptr_sub(mid, right)
 
 				left -= right
-				if left < right {
-					break
-				}
-			}
-		} else {
-			for {
-				ptr_swap_non_overlapping(ptr_sub(mid, left), mid, left)
+			} else {
+				ptr_swap_non_overlapping(ptr_sub(mid, left), mid, left * size_of(T))
 				mid = ptr_add(mid, left)
 
 				right -= left
-				if right < left {
-					break
-				}
 			}
 		}
 	}

--- a/core/slice/ptr.odin
+++ b/core/slice/ptr.odin
@@ -75,15 +75,25 @@ ptr_rotate :: proc(left: int, mid: ^$T, right: int) {
 		// TODO(bill): Optimization with a buffer for smaller ranges
 		for left > 0 && right > 0 {
 			if left >= right {
-				ptr_swap_non_overlapping(ptr_sub(mid, right), mid, right * size_of(T))
-				mid = ptr_sub(mid, right)
+				for {
+					ptr_swap_non_overlapping(ptr_sub(mid, right), mid, right * size_of(T))
+					mid = ptr_sub(mid, right)
 
-				left -= right
+					left -= right
+					if left < right {
+						break
+					}
+				}
 			} else {
-				ptr_swap_non_overlapping(ptr_sub(mid, left), mid, left * size_of(T))
-				mid = ptr_add(mid, left)
+				for {
+					ptr_swap_non_overlapping(ptr_sub(mid, left), mid, left * size_of(T))
+					mid = ptr_add(mid, left)
 
-				right -= left
+					right -= left
+					if right < left {
+						break
+					}
+				}
 			}
 		}
 	}

--- a/core/slice/slice.odin
+++ b/core/slice/slice.odin
@@ -220,7 +220,7 @@ rotate_left :: proc(array: $T/[]$E, mid: int) {
 	k := n - m
 	// FIXME: (ap29600) this cast is a temporary fix for the compiler not matching
 	// [^T] with $P/^$T
-	p := cast(^int)raw_data(array)
+	p := cast(^E)raw_data(array)
 	ptr_rotate(m, ptr_add(p, m), k)
 }
 rotate_right :: proc(array: $T/[]$E, k: int) {

--- a/core/slice/slice.odin
+++ b/core/slice/slice.odin
@@ -218,8 +218,10 @@ rotate_left :: proc(array: $T/[]$E, mid: int) {
 	n := len(array)
 	m := mid %% n
 	k := n - m
-	p := raw_data(array)
-	ptr_rotate(mid, ptr_add(p, mid), k)
+	// FIXME: (ap29600) this cast is a temporary fix for the compiler not matching
+	// [^T] with $P/^$T
+	p := cast(^int)raw_data(array)
+	ptr_rotate(m, ptr_add(p, m), k)
 }
 rotate_right :: proc(array: $T/[]$E, k: int) {
 	rotate_left(array, -k)


### PR DESCRIPTION
This commit includes two fixes:
- a temporary cast to make the function compile
- a fix to a logic error that caused the function to hang or return incorrect results