### PR TITLE
Fix/dir opening mac os

### DIFF
--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -342,21 +342,33 @@ get_last_error_string :: proc() -> string {
 }
 
 open :: proc(path: string, flags: int = O_RDWR, mode: int = 0) -> (Handle, Errno) {
+	isDir := is_dir_path(path)
+	flags := flags
+	if isDir {
+		/*
+			@INFO(Platin): To make it impossible to use the wrong flag for dir's 
+			               as you can't write to a dir only read which makes it fail to open
+		*/
+		flags = O_RDONLY
+	}
+
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	handle := _unix_open(cstr, i32(flags), u16(mode))
 	if handle == -1 {
 		return INVALID_HANDLE, cast(Errno)get_last_error()
 	}
 
-when  ODIN_OS == .Darwin && ODIN_ARCH == .arm64 {
-	if mode != 0 && !is_dir_handle(handle) {
+	/*
+		@INFO(Platin): this is only done because O_CREATE for some reason fails to apply mode
+		               should not happen if the handle is a directory
+	*/
+	if mode != 0 && !isDir {
 		err := fchmod(handle, cast(u16)mode)
 		if err != 0 {
 			_unix_close(handle)
 			return INVALID_HANDLE, cast(Errno)err
 		}
 	}
-}
 
 	return handle, 0
 }

--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -350,6 +350,7 @@ open :: proc(path: string, flags: int = O_RDWR, mode: int = 0) -> (Handle, Errno
 
 when  ODIN_OS == .Darwin && ODIN_ARCH == .arm64 {
 	if mode != 0 {
+	if mode != 0 && !is_dir_handle(handle) {
 		err := fchmod(handle, cast(u16)mode)
 		if err != 0 {
 			_unix_close(handle)

--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -345,16 +345,15 @@ open :: proc(path: string, flags: int = O_RDWR, mode: int = 0) -> (Handle, Errno
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	handle := _unix_open(cstr, i32(flags), u16(mode))
 	if handle == -1 {
-		return INVALID_HANDLE, 1
+		return INVALID_HANDLE, cast(Errno)get_last_error()
 	}
 
 when  ODIN_OS == .Darwin && ODIN_ARCH == .arm64 {
-	if mode != 0 {
 	if mode != 0 && !is_dir_handle(handle) {
 		err := fchmod(handle, cast(u16)mode)
 		if err != 0 {
 			_unix_close(handle)
-			return INVALID_HANDLE, 1
+			return INVALID_HANDLE, cast(Errno)err
 		}
 	}
 }


### PR DESCRIPTION
As it seems to be a ongoing thing that it's not clear that O_RWDR doesn't work on DIR adding a prevention to open and also fixing the bug with fchmod being called on the dir which will also not work if we manage to open it. 
Bug is #2217 