### PR TITLE
fixup are_types_identical for comparing procs and checking if parameter names differ

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -2775,8 +2775,8 @@ bool are_types_identical_internal(Type *x, Type *y, bool check_tuple_names) {
 			       x->Proc.variadic    == y->Proc.variadic    &&
 			       x->Proc.diverging   == y->Proc.diverging   &&
 			       x->Proc.optional_ok == y->Proc.optional_ok &&
-			       are_types_identical(x->Proc.params, y->Proc.params) &&
-			       are_types_identical(x->Proc.results, y->Proc.results);
+			       are_types_identical_internal(x->Proc.params, y->Proc.params, check_tuple_names) &&
+			       are_types_identical_internal(x->Proc.results, y->Proc.results, check_tuple_names);
 		}
 		break;
 


### PR DESCRIPTION
This fixes bugs with `odin doc examples/all -all-packages -doc-format` incorrectly de-duping proc types and resulting in incorrect documentation on the website.