### PR TITLE
Fix out of range error with _alloc_command_line_arguments in darwin

### DIFF
--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -774,8 +774,8 @@ get_page_size :: proc() -> int {
 
 _alloc_command_line_arguments :: proc() -> []string {
 	res := make([]string, len(runtime.args__))
-	for arg, i in runtime.args__ {
-		res[i] = string(arg)
+	for _, i in res {
+		res[i] = string(runtime.args__[i])
 	}
 	return res
 }


### PR DESCRIPTION
If defaulting to nil allocator `res` will be set to a zero sized slice.
Thus we get an out of range error on the line
`res[i] = string(arg)`

Instead base the for loop iteration on the size of res (like on other platforms).
