### PR TITLE
Add a lot of bindings to NSFoundation

### DIFF
--- a/vendor/darwin/Foundation/NSApplication.odin
+++ b/vendor/darwin/Foundation/NSApplication.odin
@@ -8,10 +8,49 @@ ActivationPolicy :: enum UInteger {
 	Prohibited = 2,
 }
 
+ApplicationTerminateReply :: enum UInteger {
+	TerminateCancel = 0,
+	TerminateNow = 1,
+	TerminateLater = 2,
+}
+
+ApplicationPresentationOptionFlag :: enum UInteger {
+	AutoHideDock = 0,
+	HideDock = 1,
+	AutoHideMenuBar = 2,
+	HideMenuBar = 3,
+	DisableAppleMenu = 4,
+	DisableProcessSwitching = 5,
+	DisableForceQuit = 6,
+	DisableSessionTermination = 7,
+	DisableHideApplication = 8,
+	DisableMenuBarTransparency = 9,
+	FullScreen = 10,
+	AutoHideToolbar = 11,
+	DisableCursorLocationAssistance = 12,
+}
+ApplicationPresentationOptions :: distinct bit_set[ApplicationPresentationOptionFlag; UInteger]
+ApplicationPresentationOptionsDefault                         :: ApplicationPresentationOptions {}
+ApplicationPresentationOptionsAutoHideDock                    :: ApplicationPresentationOptions {.AutoHideDock}
+ApplicationPresentationOptionsHideDock                        :: ApplicationPresentationOptions {.HideDock}
+ApplicationPresentationOptionsAutoHideMenuBar                 :: ApplicationPresentationOptions {.AutoHideMenuBar}
+ApplicationPresentationOptionsHideMenuBar                     :: ApplicationPresentationOptions {.HideMenuBar}
+ApplicationPresentationOptionsDisableAppleMenu                :: ApplicationPresentationOptions {.DisableAppleMenu}
+ApplicationPresentationOptionsDisableProcessSwitching         :: ApplicationPresentationOptions {.DisableProcessSwitching}
+ApplicationPresentationOptionsDisableForceQuit                :: ApplicationPresentationOptions {.DisableForceQuit}
+ApplicationPresentationOptionsDisableSessionTermination       :: ApplicationPresentationOptions {.DisableSessionTermination}
+ApplicationPresentationOptionsDisableHideApplication          :: ApplicationPresentationOptions {.DisableHideApplication}
+ApplicationPresentationOptionsDisableMenuBarTransparency      :: ApplicationPresentationOptions {.DisableMenuBarTransparency}
+ApplicationPresentationOptionsFullScreen                      :: ApplicationPresentationOptions {.FullScreen}
+ApplicationPresentationOptionsAutoHideToolbar                 :: ApplicationPresentationOptions {.AutoHideToolbar}
+ApplicationPresentationOptionsDisableCursorLocationAssistance :: ApplicationPresentationOptions {.DisableCursorLocationAssistance}
+
 ApplicationDelegate :: struct {
 	willFinishLaunching:                  proc "c" (self: ^ApplicationDelegate, notification: ^Notification),
 	didFinishLaunching:                   proc "c" (self: ^ApplicationDelegate, notification: ^Notification),
 	shouldTerminateAfterLastWindowClosed: proc "c" (self: ^ApplicationDelegate, sender: ^Application) -> BOOL,
+	applicationShouldTerminate:           proc "c" (self: ^ApplicationDelegate, sender: ^Application) -> ApplicationTerminateReply,
+	applicationWillTerminate:             proc "c" (self: ^ApplicationDelegate, notification: ^Notification),
 
 	user_data: rawptr,
 }
@@ -38,12 +77,22 @@ Application_setDelegate :: proc(self: ^Application, delegate: ^ApplicationDelega
 		del := (^ApplicationDelegate)(self->pointerValue())
 		return del->shouldTerminateAfterLastWindowClosed(application)
 	}
+	applicationShouldTerminate :: proc "c" (self: ^Value, _: SEL, application: ^Application) -> ApplicationTerminateReply {
+		del := (^ApplicationDelegate)(self->pointerValue())
+		return del->applicationShouldTerminate(application)
+	}
+	applicationWillTerminate :: proc "c" (self: ^Value, _: SEL, notification: ^Notification) {
+		del := (^ApplicationDelegate)(self->pointerValue())
+		del->applicationWillTerminate(notification)
+	}
 
 	wrapper := Value.valueWithPointer(delegate)
 
 	class_addMethod(intrinsics.objc_find_class("NSValue"), intrinsics.objc_find_selector("applicationWillFinishLaunching:"),                  auto_cast willFinishLaunching,                  "v@:@")
 	class_addMethod(intrinsics.objc_find_class("NSValue"), intrinsics.objc_find_selector("applicationDidFinishLaunching:"),                   auto_cast didFinishLaunching,                   "v@:@")
 	class_addMethod(intrinsics.objc_find_class("NSValue"), intrinsics.objc_find_selector("applicationShouldTerminateAfterLastWindowClosed:"), auto_cast shouldTerminateAfterLastWindowClosed, "B@:@")
+	class_addMethod(intrinsics.objc_find_class("NSValue"), intrinsics.objc_find_selector("applicationWillTerminate:"),                        auto_cast applicationWillTerminate, "v@:@")
+	class_addMethod(intrinsics.objc_find_class("NSValue"), intrinsics.objc_find_selector("applicationShouldTerminate:"),                      auto_cast applicationShouldTerminate, size_of(UInteger) == 4 ? "I@:@" : "Q@:@")
 
 	msgSend(nil, self, "setDelegate:", wrapper)
 }
@@ -79,7 +128,20 @@ Application_terminate :: proc(self: ^Application, sender: ^Object) {
 	msgSend(nil, self, "terminate:", sender)
 }
 
+@(objc_type=Application, objc_name="updateWindows")
+Application_updateWindows :: proc(self: ^Application) {
+	msgSend(nil, self, "updateWindows")
+}
 
+@(objc_type=Application, objc_name="nextEventMatchingMask")
+Application_nextEventMatchingMask :: proc(self: ^Application, mask: EventMask, expiration: ^Date, mode: RunLoopMode, deque: BOOL) -> ^Event {
+	return msgSend(^Event, self, "nextEventMatchingMask:untilDate:inMode:dequeue:", mask, expiration, mode, deque)
+}
+
+@(objc_type=Application, objc_name="sendEvent")
+Application_sendEvent :: proc(self: ^Application, event: ^Event) {
+	msgSend(nil, self, "sendEvent:", event)
+}
 
 @(objc_class="NSRunningApplication")
 RunningApplication :: struct {using _: Object}

--- a/vendor/darwin/Foundation/NSCursor.odin
+++ b/vendor/darwin/Foundation/NSCursor.odin
@@ -1,0 +1,59 @@
+package objc_Foundation
+
+@(objc_class="NSCursor")
+Cursor :: struct {using _: Object}
+
+@(objc_type=Cursor, objc_name="hide", objc_is_class_method=true)
+Cursor_hide :: proc() {
+	msgSend(nil, Cursor, "hide")
+}
+
+@(objc_type=Cursor, objc_name="unhide", objc_is_class_method=true)
+Cursor_unhide :: proc() {
+	msgSend(nil, Cursor, "unhide")
+}
+
+@(objc_type=Cursor, objc_name="arrowCursor", objc_is_class_method=true)
+Cursor_arrowCursor :: proc() -> ^Cursor {
+	return msgSend(^Cursor, Cursor, "arrowCursor")
+}
+
+@(objc_type=Cursor, objc_name="IBeamCursor", objc_is_class_method=true)
+Cursor_IBeamCursor :: proc() -> ^Cursor {
+	return msgSend(^Cursor, Cursor, "IBeamCursor")
+}
+
+@(objc_type=Cursor, objc_name="closedHandCursor", objc_is_class_method=true)
+Cursor_closedHandCursor :: proc() -> ^Cursor {
+	return msgSend(^Cursor, Cursor, "closedHandCursor")
+}
+
+@(objc_type=Cursor, objc_name="pointingHandCursor", objc_is_class_method=true)
+Cursor_pointingHandCursor :: proc() -> ^Cursor {
+	return msgSend(^Cursor, Cursor, "pointingHandCursor")
+}
+
+@(objc_type=Cursor, objc_name="operationNotAllowedCursor", objc_is_class_method=true)
+Cursor_operationNotAllowedCursor :: proc() -> ^Cursor {
+	return msgSend(^Cursor, Cursor, "operationNotAllowedCursor")
+}
+
+@(objc_type=Cursor, objc_name="resizeUpDownCursor", objc_is_class_method=true)
+Cursor_resizeUpDownCursor :: proc() -> ^Cursor {
+	return msgSend(^Cursor, Cursor, "resizeUpDownCursor")
+}
+
+@(objc_type=Cursor, objc_name="resizeLeftRightCursor", objc_is_class_method=true)
+Cursor_resizeLeftRightCursor :: proc() -> ^Cursor {
+	return msgSend(^Cursor, Cursor, "resizeLeftRightCursor")
+}
+
+@(objc_type=Cursor, objc_name="currentCursor", objc_is_class_method=true)
+Cursor_currentCursor :: proc() -> ^Cursor {
+	return msgSend(^Cursor, Cursor, "currentCursor")
+}
+
+@(objc_type=Cursor, objc_name="set", objc_is_class_method=false)
+Cursor_set :: proc(self: ^Cursor) {
+	msgSend(nil, self, "set")
+}

--- a/vendor/darwin/Foundation/NSDate.odin
+++ b/vendor/darwin/Foundation/NSDate.odin
@@ -17,3 +17,8 @@ Date_init :: proc(self: ^Date) -> ^Date {
 Date_dateWithTimeIntervalSinceNow :: proc(secs: TimeInterval) -> ^Date {
 	return msgSend(^Date, Date, "dateWithTimeIntervalSinceNow:", secs)
 }
+
+@(objc_type=Date, objc_name="distantFuture", objc_is_class_method=true)
+Date_distantFuture :: proc() -> ^Date {
+	return msgSend(^Date, Date, "distantFuture")
+}

--- a/vendor/darwin/Foundation/NSEvent.odin
+++ b/vendor/darwin/Foundation/NSEvent.odin
@@ -1,0 +1,253 @@
+package objc_Foundation
+
+import "core:c"
+
+@(objc_class="NSEvent")
+Event :: struct {using _: Object}
+
+EventMask :: bit_set[EventType; c.ulonglong]
+EventType :: enum UInteger {
+	LeftMouseDown         = 1,
+	LeftMouseUp           = 2,
+	RightMouseDown        = 3,
+	RightMouseUp          = 4,
+	MouseMoved            = 5,
+	LeftMouseDragged      = 6,
+	RightMouseDragged     = 7,
+	MouseEntered          = 8,
+	MouseExited           = 9,
+	KeyDown               = 10,
+	KeyUp                 = 11,
+	FlagsChanged          = 12,
+	AppKitDefined         = 13,
+	SystemDefined         = 14,
+	ApplicationDefined    = 15,
+	Periodic              = 16,
+	CursorUpdate          = 17,
+	EventTypeRotate       = 18,
+	EventTypeBeginGesture = 19,
+	EventTypeEndGesture   = 20,
+	ScrollWheel           = 22,
+	TabletPoint           = 23,
+	TabletProximity       = 24,
+	OtherMouseDown        = 25,
+	OtherMouseUp          = 26,
+	OtherMouseDragged     = 27,
+	EventTypeGesture      = 29,
+	EventTypeMagnify      = 30,
+	EventTypeSwipe        = 31,
+	EventTypeSmartMagnify = 32,
+	EventTypeQuickLook    = 33,
+}
+
+EventPhase :: enum UInteger {
+	None = 0,
+	Began = 1,
+	Stationary = 2,
+	Changed = 4,
+	Ended = 8,
+	Cancelled = 16,
+	MayBegin = 32,
+}
+
+ModifierFlags :: bit_set[ModifierFlag; UInteger]
+ModifierFlag :: enum UInteger {
+	CapsLock = 16,
+	Shift = 17,
+	Control = 18,
+	Option = 19,
+	Command = 20,
+}
+
+@(objc_type=Event, objc_name="addLocalMonitorForEventsMatchingMask", objc_is_class_method=true)
+Event_addLocalMonitorForEventsMatchingMask :: proc(mask: EventMask, handler: ^Block) -> id {
+	return msgSend(id, Event, "addLocalMonitorForEventsMatchingMask:handler:", mask, handler)
+}
+
+@(objc_type=Event, objc_name="type")
+Event_type :: proc(self: ^Event) -> EventType {
+	return msgSend(EventType, self, "type")
+}
+
+@(objc_type=Event, objc_name="locationInWindow")
+Event_locationInWindow :: proc(self: ^Event) -> Point {
+	return msgSend(Point, self, "locationInWindow")
+}
+
+@(objc_type=Event, objc_name="window")
+Event_window :: proc(self: ^Event) -> ^Window {
+	return msgSend(^Window, self, "window")
+}
+
+@(objc_type=Event, objc_name="keyCode")
+Event_keyCode :: proc(self: ^Event) -> c.ushort {
+	return msgSend(c.ushort, self, "keyCode")
+}
+
+@(objc_type=Event, objc_name="modifierFlags")
+Event_modifierFlags :: proc(self: ^Event) -> ModifierFlags {
+	return msgSend(ModifierFlags, self, "modifierFlags")
+}
+
+@(objc_type=Event, objc_name="mouseLocation", objc_is_class_method=true)
+Event_mouseLocation :: proc() -> Point {
+	return msgSend(Point, Event, "mouseLocation")
+}
+
+@(objc_type=Event, objc_name="buttonNumber")
+Event_buttonNumber :: proc(self: ^Event) -> Integer {
+	return msgSend(Integer, self, "buttonNumber")
+}
+
+@(objc_type=Event, objc_name="deltaX")
+Event_deltaX :: proc(self: ^Event) -> Float {
+	return msgSend(Float, self, "deltaX")
+}
+
+@(objc_type=Event, objc_name="deltaY")
+Event_deltaY :: proc(self: ^Event) -> Float {
+	return msgSend(Float, self, "deltaY")
+}
+
+@(objc_type=Event, objc_name="phase")
+Event_phase :: proc(self: ^Event) -> EventPhase {
+	return msgSend(EventPhase, self, "phase")
+}
+
+@(objc_type=Event, objc_name="isARepeat")
+Event_isARepeat :: proc(self: ^Event) -> BOOL {
+	return msgSend(BOOL, self, "isARepeat")
+}
+
+@(objc_type=Event, objc_name="characters")
+Event_characters :: proc(self: ^Event) -> ^String {
+	return msgSend(^String, self, "characters")
+}
+
+@(objc_type=Event, objc_name="scrollingDeltaX")
+Event_scrollingDeltaX :: proc(self: ^Event) -> Float {
+	return msgSend(Float, self, "scrollingDeltaX")
+}
+
+@(objc_type=Event, objc_name="scrollingDeltaY")
+Event_scrollingDeltaY :: proc(self: ^Event) -> Float {
+	return msgSend(Float, self, "scrollingDeltaY")
+}
+
+@(objc_type=Event, objc_name="hasPreciseScrollingDeltas")
+Event_hasPreciseScrollingDeltas :: proc(self: ^Event) -> BOOL {
+	return msgSend(BOOL, self, "hasPreciseScrollingDeltas")
+}
+
+kVK_ANSI_A                    :: 0x00
+kVK_ANSI_S                    :: 0x01
+kVK_ANSI_D                    :: 0x02
+kVK_ANSI_F                    :: 0x03
+kVK_ANSI_H                    :: 0x04
+kVK_ANSI_G                    :: 0x05
+kVK_ANSI_Z                    :: 0x06
+kVK_ANSI_X                    :: 0x07
+kVK_ANSI_C                    :: 0x08
+kVK_ANSI_V                    :: 0x09
+kVK_ANSI_B                    :: 0x0B
+kVK_ANSI_Q                    :: 0x0C
+kVK_ANSI_W                    :: 0x0D
+kVK_ANSI_E                    :: 0x0E
+kVK_ANSI_R                    :: 0x0F
+kVK_ANSI_Y                    :: 0x10
+kVK_ANSI_T                    :: 0x11
+kVK_ANSI_1                    :: 0x12
+kVK_ANSI_2                    :: 0x13
+kVK_ANSI_3                    :: 0x14
+kVK_ANSI_4                    :: 0x15
+kVK_ANSI_6                    :: 0x16
+kVK_ANSI_5                    :: 0x17
+kVK_ANSI_Equal                :: 0x18
+kVK_ANSI_9                    :: 0x19
+kVK_ANSI_7                    :: 0x1A
+kVK_ANSI_Minus                :: 0x1B
+kVK_ANSI_8                    :: 0x1C
+kVK_ANSI_0                    :: 0x1D
+kVK_ANSI_RightBracket         :: 0x1E
+kVK_ANSI_O                    :: 0x1F
+kVK_ANSI_U                    :: 0x20
+kVK_ANSI_LeftBracket          :: 0x21
+kVK_ANSI_I                    :: 0x22
+kVK_ANSI_P                    :: 0x23
+kVK_ANSI_L                    :: 0x25
+kVK_ANSI_J                    :: 0x26
+kVK_ANSI_Quote                :: 0x27
+kVK_ANSI_K                    :: 0x28
+kVK_ANSI_Semicolon            :: 0x29
+kVK_ANSI_Backslash            :: 0x2A
+kVK_ANSI_Comma                :: 0x2B
+kVK_ANSI_Slash                :: 0x2C
+kVK_ANSI_N                    :: 0x2D
+kVK_ANSI_M                    :: 0x2E
+kVK_ANSI_Period               :: 0x2F
+kVK_ANSI_Grave                :: 0x32
+kVK_ANSI_KeypadDecimal        :: 0x41
+kVK_ANSI_KeypadMultiply       :: 0x43
+kVK_ANSI_KeypadPlus           :: 0x45
+kVK_ANSI_KeypadClear          :: 0x47
+kVK_ANSI_KeypadDivide         :: 0x4B
+kVK_ANSI_KeypadEnter          :: 0x4C
+kVK_ANSI_KeypadMinus          :: 0x4E
+kVK_ANSI_KeypadEquals         :: 0x51
+kVK_ANSI_Keypad0              :: 0x52
+kVK_ANSI_Keypad1              :: 0x53
+kVK_ANSI_Keypad2              :: 0x54
+kVK_ANSI_Keypad3              :: 0x55
+kVK_ANSI_Keypad4              :: 0x56
+kVK_ANSI_Keypad5              :: 0x57
+kVK_ANSI_Keypad6              :: 0x58
+kVK_ANSI_Keypad7              :: 0x59
+kVK_ANSI_Keypad8              :: 0x5B
+kVK_ANSI_Keypad9              :: 0x5C
+kVK_Return                    :: 0x24
+kVK_Tab                       :: 0x30
+kVK_Space                     :: 0x31
+kVK_Delete                    :: 0x33
+kVK_Escape                    :: 0x35
+kVK_Command                   :: 0x37
+kVK_Shift                     :: 0x38
+kVK_CapsLock                  :: 0x39
+kVK_Option                    :: 0x3A
+kVK_Control                   :: 0x3B
+kVK_RightShift                :: 0x3C
+kVK_RightOption               :: 0x3D
+kVK_RightControl              :: 0x3E
+kVK_Function                  :: 0x3F
+kVK_F17                       :: 0x40
+kVK_VolumeUp                  :: 0x48
+kVK_VolumeDown                :: 0x49
+kVK_Mute                      :: 0x4A
+kVK_F18                       :: 0x4F
+kVK_F19                       :: 0x50
+kVK_F20                       :: 0x5A
+kVK_F5                        :: 0x60
+kVK_F6                        :: 0x61
+kVK_F7                        :: 0x62
+kVK_F3                        :: 0x63
+kVK_F8                        :: 0x64
+kVK_F9                        :: 0x65
+kVK_F11                       :: 0x67
+kVK_F13                       :: 0x69
+kVK_F16                       :: 0x6A
+kVK_F14                       :: 0x6B
+kVK_F10                       :: 0x6D
+kVK_F12                       :: 0x6F
+kVK_F15                       :: 0x71
+kVK_Help                      :: 0x72
+kVK_Home                      :: 0x73
+kVK_PageUp                    :: 0x74
+kVK_ForwardDelete             :: 0x75
+kVK_F4                        :: 0x76
+kVK_End                       :: 0x77
+kVK_F2                        :: 0x78
+kVK_PageDown                  :: 0x79
+kVK_F1                        :: 0x7A
+kVK_LeftArrow                 :: 0x7B
+kVK_RightArrow                :: 0x7C
+kVK_DownArrow                 :: 0x7D
+kVK_UpArrow                   :: 0x7E

--- a/vendor/darwin/Foundation/NSPanel.odin
+++ b/vendor/darwin/Foundation/NSPanel.odin
@@ -1,0 +1,117 @@
+package objc_Foundation
+
+@(objc_class="NSPanel")
+Panel :: struct {using _: Window}
+
+NSOpenSavePanelDelegate :: struct {
+
+}
+
+@(objc_class="NSSavePanel")
+SavePanel :: struct {using _: Panel}
+
+ModalResponse :: enum Integer {
+	ResponseCancel = 0,
+	ResponseOK = 1,
+	ResponseContinue = -1002,
+	ResponseStop = -1000,
+	ResponseAbort = -1001,
+}
+
+@(objc_type=SavePanel, objc_name="savePanel", objc_is_class_method=true)
+SavePanel_openPanel :: proc() -> ^SavePanel {
+	return msgSend(^SavePanel, SavePanel, "savePanel")
+}
+
+@(objc_type=SavePanel, objc_name="runModal")
+SavePanel_runModal :: proc(self: ^SavePanel) -> ModalResponse {
+	return msgSend(ModalResponse, self, "runModal")
+}
+
+@(objc_type=SavePanel, objc_name="URL")
+SavePanel_URL :: proc(self: ^SavePanel) -> ^URL {
+	return msgSend(^URL, self, "URL")
+}
+
+@(objc_class="NSOpenPanel")
+OpenPanel :: struct {using _: SavePanel}
+
+@(objc_type=OpenPanel, objc_name="openPanel", objc_is_class_method=true)
+OpenPanel_openPanel :: proc() -> ^OpenPanel {
+	return msgSend(^OpenPanel, OpenPanel, "openPanel")
+}
+
+@(objc_type=OpenPanel, objc_name="setCanChooseFiles")
+OpenPanel_setCanChooseFiles :: proc(self: ^OpenPanel, ok: BOOL) {
+	msgSend(nil, self, "setCanChooseFiles:", ok)
+}
+
+@(objc_type=OpenPanel, objc_name="canChooseFiles")
+OpenPanel_canChooseFiles :: proc(self: ^OpenPanel) -> BOOL {
+	return msgSend(BOOL, self, "canChooseFiles")
+}
+
+@(objc_type=OpenPanel, objc_name="setCanChooseDirectories")
+OpenPanel_setCanChooseDirectories :: proc(self: ^OpenPanel, ok: BOOL) {
+	msgSend(nil, self, "setCanChooseDirectories:", ok)
+}
+
+@(objc_type=OpenPanel, objc_name="canChooseDirectories")
+OpenPanel_canChooseDirectories :: proc(self: ^OpenPanel) -> BOOL {
+	return msgSend(BOOL, self, "canChooseDirectories")
+}
+
+@(objc_type=OpenPanel, objc_name="setResolvesAliases")
+OpenPanel_setResolvesAliases :: proc(self: ^OpenPanel, ok: BOOL) {
+	msgSend(nil, self, "setResolvesAliases:", ok)
+}
+
+@(objc_type=OpenPanel, objc_name="resolvesAliases")
+OpenPanel_resolvesAliases :: proc(self: ^OpenPanel) -> BOOL {
+	return msgSend(BOOL, self, "resolvesAliases")
+}
+
+@(objc_type=OpenPanel, objc_name="setAllowsMultipleSelection")
+OpenPanel_setAllowsMultipleSelection :: proc(self: ^OpenPanel, ok: BOOL) {
+	msgSend(nil, self, "setAllowsMultipleSelection:", ok)
+}
+
+@(objc_type=OpenPanel, objc_name="allowsMultipleSelection")
+OpenPanel_allowsMultipleSelection :: proc(self: ^OpenPanel) -> BOOL {
+	return msgSend(BOOL, self, "allowsMultipleSelection")
+}
+
+@(objc_type=OpenPanel, objc_name="setAccessoryViewDisclosed")
+OpenPanel_setAccessoryViewDisclosed :: proc(self: ^OpenPanel, ok: BOOL) {
+	msgSend(nil, self, "setAccessoryViewDisclosed:", ok)
+}
+
+@(objc_type=OpenPanel, objc_name="isAccessoryViewDisclosed")
+OpenPanel_accessoryViewDisclosed :: proc(self: ^OpenPanel) -> BOOL {
+	return msgSend(BOOL, self, "isAccessoryViewDisclosed")
+}
+
+@(objc_type=OpenPanel, objc_name="URLs")
+OpenPanel_URLs :: proc(self: ^OpenPanel) -> ^Array {
+	return msgSend(^Array, self, "URLs")
+}
+
+@(objc_type=OpenPanel, objc_name="setCanDownloadUbiquitousContents")
+OpenPanel_setCanDownloadUbiquitousContents :: proc(self: ^OpenPanel, ok: BOOL) {
+	msgSend(nil, self, "setCanDownloadUbiquitousContents:", ok)
+}
+
+@(objc_type=OpenPanel, objc_name="canDownloadUbiquitousContents")
+OpenPanel_canDownloadUbiquitousContents :: proc(self: ^OpenPanel) -> BOOL {
+	return msgSend(BOOL, self, "canDownloadUbiquitousContents")
+}
+
+@(objc_type=OpenPanel, objc_name="setCanResolveUbiquitousConflicts")
+OpenPanel_setCanResolveUbiquitousConflicts :: proc(self: ^OpenPanel, ok: BOOL) {
+	msgSend(nil, self, "setCanResolveUbiquitousConflicts:", ok)
+}
+
+@(objc_type=OpenPanel, objc_name="canResolveUbiquitousConflicts")
+OpenPanel_canResolveUbiquitousConflicts :: proc(self: ^OpenPanel) -> BOOL {
+	return msgSend(BOOL, self, "canResolveUbiquitousConflicts")
+}

--- a/vendor/darwin/Foundation/NSPasteboard.odin
+++ b/vendor/darwin/Foundation/NSPasteboard.odin
@@ -1,0 +1,5 @@
+package objc_Foundation
+
+@(objc_class="NSPasteboard")
+Pasteboard :: struct {using _: Object}
+// TODO: implement NSPasteboard

--- a/vendor/darwin/Foundation/NSRunLoop.odin
+++ b/vendor/darwin/Foundation/NSRunLoop.odin
@@ -1,0 +1,27 @@
+package objc_Foundation
+
+@(objc_class="NSRunLoop")
+RunLoop :: struct {
+	using _: Object,
+}
+
+RunLoopMode :: ^String
+foreign {
+	@(link_name = "NSDefaultRunLoopMode") DefaultRunLoopMode: RunLoopMode
+	@(link_name = "NSEventTrackingRunLoopMode") EventTrackingRunLoopMode: RunLoopMode
+}
+
+@(objc_type=RunLoop, objc_name="currentRunLoop", objc_is_class_method=true)
+RunLoop_currentRunLoop :: proc() -> ^RunLoop {
+	return msgSend(^RunLoop, RunLoop, "currentRunLoop")
+}
+
+@(objc_type=RunLoop, objc_name="mainRunLoop", objc_is_class_method=true)
+RunLoop_mainRunLoop :: proc() -> ^RunLoop {
+	return msgSend(^RunLoop, RunLoop, "mainRunLoop")
+}
+
+@(objc_type=RunLoop, objc_name="runMode")
+RunLoop_runMode :: proc(self: ^RunLoop, mode: RunLoopMode, limit_date: ^Date) -> BOOL {
+	return msgSend(BOOL, self, "runMode:beforeDate:", mode, limit_date)
+}

--- a/vendor/darwin/Foundation/NSScreen.odin
+++ b/vendor/darwin/Foundation/NSScreen.odin
@@ -1,0 +1,5 @@
+package objc_Foundation
+
+@(objc_class="NSScreen")
+Screen :: struct {using _: Object}
+// TODO: implement NSScreen

--- a/vendor/darwin/Foundation/NSTypes.odin
+++ b/vendor/darwin/Foundation/NSTypes.odin
@@ -45,3 +45,11 @@ Size :: struct {
 	width:  Float,
 	height: Float,
 }
+
+when size_of(Float) == 4 {
+	_SIZE_ENCODING :: "{NSSize=ff}"
+	_POINT_ENCODING :: "{NSPoint=ff}"
+} else {
+	_SIZE_ENCODING :: "{CGSize=dd}"
+	_POINT_ENCODING :: "{CGPoint=dd}"
+}

--- a/vendor/darwin/Foundation/NSURL.odin
+++ b/vendor/darwin/Foundation/NSURL.odin
@@ -28,3 +28,13 @@ URL_initFileURLWithPath :: proc(self: ^URL, path: ^String) -> ^URL {
 URL_fileSystemRepresentation :: proc(self: ^URL) -> ^String {
 	return msgSend(^String, self, "fileSystemRepresentation")
 }
+
+@(objc_type=URL, objc_name="absoluteString")
+URL_absoluteString :: proc(self: ^URL) -> ^String {
+	return msgSend(^String, self, "absoluteString")
+}
+
+@(objc_type=URL, objc_name="path")
+URL_path :: proc(self: ^URL) -> ^String {
+	return msgSend(^String, self, "path")
+}

--- a/vendor/darwin/Foundation/NSUndoManager.odin
+++ b/vendor/darwin/Foundation/NSUndoManager.odin
@@ -1,0 +1,5 @@
+package objc_Foundation
+
+@(objc_class="NSUndoManager")
+UndoManager :: struct {using _: Object}
+// TODO: implement NSUndoManager

--- a/vendor/darwin/Foundation/NSWindow.odin
+++ b/vendor/darwin/Foundation/NSWindow.odin
@@ -1,10 +1,19 @@
 package objc_Foundation
 
+import "core:strings"
+import "core:runtime"
+import "core:intrinsics"
 import NS "vendor:darwin/Foundation"
 
 Rect :: struct {
 	using origin: Point,
 	using size: Size,
+}
+
+when size_of(Float) == 4 {
+	_RECT_ENCODING :: "{NSRect="+_POINT_ENCODING+_SIZE_ENCODING+"}"
+} else {
+	_RECT_ENCODING :: "{CGRect="+_POINT_ENCODING+_SIZE_ENCODING+"}"
 }
 
 WindowStyleFlag :: enum NS.UInteger {
@@ -42,11 +51,515 @@ BackingStoreType :: enum NS.UInteger {
 	Buffered    = 2,
 }
 
+WindowDelegateTemplate :: struct {
+	// Managing Sheets
+	windowWillPositionSheetUsingRect: proc(window: ^Window, sheet: ^Window, rect: Rect) -> Rect,
+	windowWillBeginSheet: proc(notification: ^Notification),
+	windowDidEndSheet: proc(notification: ^Notification),
+	// Sizing Windows
+	windowWillResizeToSize: proc(sender: ^Window, frameSize: Size) -> Size,
+	windowDidResize: proc(notification: ^Notification),
+	windowWillStartLiveResize: proc(noitifcation: ^Notification),
+	windowDidEndLiveResize: proc(notification: ^Notification),
+	// Minimizing Windows
+	windowWillMiniaturize: proc(notification: ^Notification),
+	windowDidMiniaturize: proc(notification: ^Notification),
+	windowDidDeminiaturize: proc(notification: ^Notification),
+	// Zooming window
+	windowWillUseStandardFrameDefaultFrame: proc(window: ^Window, newFrame: Rect) -> Rect,
+	windowShouldZoomToFrame: proc(window: ^Window, newFrame: Rect) -> BOOL,
+	// Managing Full-Screen Presentation
+	windowWillUseFullScreenContentSize: proc(window: ^Window, proposedSize: Size) -> Size,
+	windowWillUseFullScreenPresentationOptions: proc(window: ^Window, proposedOptions: ApplicationPresentationOptions),
+	windowWillEnterFullScreen: proc(notification: ^Notification),
+	windowDidEnterFullScreen: proc(notification: ^Notification),
+	windowWillExitFullScreen: proc(notification: ^Notification),
+	windowDidExitFullScreen: proc(notification: ^Notification),
+	// Custom Full-Screen Presentation Animations
+	customWindowsToEnterFullScreenForWindow: proc(window: ^Window) -> ^Array,
+	customWindowsToEnterFullScreenForWindowOnScreen: proc(window: ^Window, screen: ^Screen) -> ^Array,
+	windowStartCustomAnimationToEnterFullScreenWithDuration: proc(window: ^Window, duration: TimeInterval),
+	windowStartCustomAnimationToEnterFullScreenOnScreenWithDuration: proc(window: ^Window, screen: ^Screen, duration: TimeInterval),
+	windowDidFailToEnterFullScreen: proc(window: ^Window),
+	customWindowsToExitFullScreenForWindow: proc(window: ^Window) -> ^Array,
+	windowStartCustomAnimationToExitFullScreenWithDuration: proc(window: ^Window, duration: TimeInterval),
+	windowDidFailToExitFullScreen: proc(window: ^Window),
+	// Moving Windows
+	windowWillMove: proc(notification: ^Notification),
+	windowDidMove: proc(notification: ^Notification),
+	windowDidChangeScreen: proc(notification: ^Notification),
+	windowDidChangeScreenProfile: proc(notification: ^Notification),
+	windowDidChangeBackingProperties: proc(notification: ^Notification),
+	// Closing Windows
+	windowShouldClose: proc(sender: ^Window) -> BOOL,
+	windowWillClose: proc(notification: ^Notification),
+	// Managing Key Status
+	windowDidBecomeKey: proc(notification: ^Notification),
+	windowDidResignKey: proc(notification: ^Notification),
+	// Managing Main Status
+	windowDidBecomeMain: proc(notification: ^Notification),
+	windowDidResignMain: proc(notification: ^Notification),
+	// Managing Field Editors
+	windowWillReturnFieldEditorToObject: proc(sender: ^Window, client: id),
+	// Updating Windows
+	windowDidUpdate: proc (notification: ^Notification),
+	// Exposing Windows
+	windowDidExpose: proc (notification: ^Notification),
+	// Managing Occlusion State
+	windowDidChangeOcclusionState: proc(notification: ^Notification),
+	// Dragging Windows
+	windowShouldDragDocumentWithEventFromWithPasteboard: proc(window: ^Window, event: ^Event, dragImageLocation: Point, pasteboard: ^Pasteboard) -> BOOL,
+	// Getting the Undo Manager
+	windowWillReturnUndoManager: proc(window: ^Window) -> ^UndoManager,
+	// Managing Titles
+	windowShouldPopUpDocumentPathMenu: proc(window: ^Window, menu: ^Menu) -> BOOL,
+	// Managing Restorable State
+	windowWillEncodeRestorableState: proc(window: ^Window, state: ^Coder),
+	windowDidEncodeRestorableState: proc(window: ^Window, state: ^Coder),
+	// Managing Presentation in Version Browsers
+	windowWillResizeForVersionBrowserWithMaxPreferredSizeMaxAllowedSize: proc(window: ^Window, maxPreferredFrameSize: Size, maxAllowedFrameSize: Size) -> Size,
+	windowWillEnterVersionBrowser: proc(notification: ^Notification),
+	windowDidEnterVersionBrowser: proc(notification: ^Notification),
+	windowWillExitVersionBrowser: proc(notification: ^Notification),
+	windowDidExitVersionBrowser: proc(notification: ^Notification),
+}
+
+WindowDelegate :: struct { using _: Object }
+_WindowDelegateInternal :: struct {
+	using _: WindowDelegateTemplate,
+	_context: runtime.Context,
+}
+
+window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, class_name: string, delegate_context: Maybe(runtime.Context)) -> ^WindowDelegate {
+	class := objc_allocateClassPair(intrinsics.objc_find_class("NSObject"), strings.clone_to_cstring(class_name, context.temp_allocator), 0); if class == nil {
+		// Class already registered
+		return nil
+	}
+	if template.windowWillPositionSheetUsingRect != nil {
+		windowWillPositionSheetUsingRect :: proc "c" (self: id, window: ^Window, sheet: ^Window, rect: Rect) -> Rect {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			return del.windowWillPositionSheetUsingRect(window, sheet, rect)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("window:willPositionSheet:usingRect:"), auto_cast windowWillPositionSheetUsingRect, _RECT_ENCODING+"@:@@"+_RECT_ENCODING)
+	}
+	if template.windowWillBeginSheet != nil {
+		windowWillBeginSheet :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowWillBeginSheet(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowWillBeginSheet:"), auto_cast windowWillBeginSheet, "v@:@")
+	}
+	if template.windowDidEndSheet != nil {
+		windowDidEndSheet :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidEndSheet(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidEndSheet:"), auto_cast windowDidEndSheet, "v@:@")
+	}
+	if template.windowWillResizeToSize != nil {
+		windowWillResizeToSize :: proc "c" (self: id, sender: ^Window, frameSize: Size) -> Size {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			return del.windowWillResizeToSize(sender, frameSize)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowWillResize:toSize:"), auto_cast windowWillResizeToSize, _SIZE_ENCODING+"@:@"+_SIZE_ENCODING)
+	}
+	if template.windowDidResize != nil {
+		windowDidResize :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidResize(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidResize:"), auto_cast windowDidResize, "v@:@")
+	}
+	if template.windowWillStartLiveResize != nil {
+		windowWillStartLiveResize :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowWillStartLiveResize(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowWillStartLiveResize:"), auto_cast windowWillStartLiveResize, "v@:@")
+	}
+	if template.windowDidEndLiveResize != nil {
+		windowDidEndLiveResize :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidEndLiveResize(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidEndLiveResize:"), auto_cast windowDidEndLiveResize, "v@:@")
+	}
+	if template.windowWillMiniaturize != nil {
+		windowWillMiniaturize :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowWillMiniaturize(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowWillMiniaturize:"), auto_cast windowWillMiniaturize, "v@:@")
+	}
+	if template.windowDidMiniaturize != nil {
+		windowDidMiniaturize :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidMiniaturize(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidMiniaturize:"), auto_cast windowDidMiniaturize, "v@:@")
+	}
+	if template.windowDidDeminiaturize != nil {
+		windowDidDeminiaturize :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidDeminiaturize(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidDeminiaturize:"), auto_cast windowDidDeminiaturize, "v@:@")
+	}
+	if template.windowWillUseStandardFrameDefaultFrame != nil {
+		windowWillUseStandardFrameDefaultFrame :: proc(self: id, window: ^Window, newFrame: Rect) -> Rect {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			return del.windowWillUseStandardFrameDefaultFrame(window, newFrame)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowWillUseStandardFrame:defaultFrame:"), auto_cast windowWillUseStandardFrameDefaultFrame, _RECT_ENCODING+"@:@"+_RECT_ENCODING)
+	}
+	if template.windowShouldZoomToFrame != nil {
+		windowShouldZoomToFrame :: proc "c" (self: id, window: ^Window, newFrame: Rect) -> BOOL {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			return del.windowShouldZoomToFrame(window, newFrame)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowShouldZoom:toFrame:"), auto_cast windowShouldZoomToFrame, "B@:@"+_RECT_ENCODING)
+	}
+	if template.windowWillUseFullScreenContentSize != nil {
+		windowWillUseFullScreenContentSize :: proc "c" (self: id, window: ^Window, proposedSize: Size) -> Size {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			return del.windowWillUseFullScreenContentSize(window, proposedSize)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("window:willUseFullScreenContentSize:"), auto_cast windowWillUseFullScreenContentSize, _SIZE_ENCODING+"@:@"+_SIZE_ENCODING)
+	}
+	if template.windowWillUseFullScreenPresentationOptions != nil {
+		windowWillUseFullScreenPresentationOptions :: proc(self: id, window: ^Window, proposedOptions: ApplicationPresentationOptions) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowWillUseFullScreenPresentationOptions(window, proposedOptions)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("window:willUseFullScreenPresentationOptions:"), auto_cast windowWillUseFullScreenPresentationOptions, "v@:@")
+	}
+	if template.windowWillEnterFullScreen != nil {
+		windowWillEnterFullScreen :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowWillEnterFullScreen(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowWillEnterFullScreen:"), auto_cast windowWillEnterFullScreen, "v@:@")
+	}
+	if template.windowDidEnterFullScreen != nil {
+		windowDidEnterFullScreen :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidEnterFullScreen(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidEnterFullScreen:"), auto_cast windowDidEnterFullScreen, "v@:@")
+	}
+	if template.windowWillExitFullScreen != nil {
+		windowWillExitFullScreen :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowWillExitFullScreen(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowWillExitFullScreen:"), auto_cast windowWillExitFullScreen, "v@:@")
+	}
+	if template.windowDidExitFullScreen != nil {
+		windowDidExitFullScreen :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidExitFullScreen(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidExitFullScreen:"), auto_cast windowDidExitFullScreen, "v@:@")
+	}
+	if template.customWindowsToEnterFullScreenForWindow != nil {
+		customWindowsToEnterFullScreenForWindow :: proc "c" (self: id, window: ^Window) -> ^Array {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			return del.customWindowsToEnterFullScreenForWindow(window)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("customWindowsToEnterFullScreenForWindow:"), auto_cast customWindowsToEnterFullScreenForWindow, "@@:@")
+	}
+	if template.customWindowsToEnterFullScreenForWindowOnScreen != nil {
+		customWindowsToEnterFullScreenForWindowOnScreen :: proc(self: id, window: ^Window, screen: ^Screen) -> ^Array {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			return del.customWindowsToEnterFullScreenForWindowOnScreen(window, screen)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("customWindowsToEnterFullScreenForWindow:onScreen:"), auto_cast customWindowsToEnterFullScreenForWindowOnScreen, "@@:@@")
+	}
+	if template.windowStartCustomAnimationToEnterFullScreenWithDuration != nil {
+		windowStartCustomAnimationToEnterFullScreenWithDuration :: proc "c" (self: id, window: ^Window, duration: TimeInterval) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowStartCustomAnimationToEnterFullScreenWithDuration(window, duration)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("window:startCustomAnimationToEnterFullScreenWithDuration:"), auto_cast windowStartCustomAnimationToEnterFullScreenWithDuration, "v@:@@")
+	}
+	if template.windowStartCustomAnimationToEnterFullScreenOnScreenWithDuration != nil {
+		windowStartCustomAnimationToEnterFullScreenOnScreenWithDuration :: proc(self: id, window: ^Window, screen: ^Screen, duration: TimeInterval) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowStartCustomAnimationToEnterFullScreenOnScreenWithDuration(window, screen, duration)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("window:startCustomAnimationToEnterFullScreenOnScreen:withDuration:"), auto_cast windowStartCustomAnimationToEnterFullScreenOnScreenWithDuration, "v@:@@d")
+	}
+	if template.windowDidFailToEnterFullScreen != nil {
+		windowDidFailToEnterFullScreen :: proc "c" (self: id, window: ^Window) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidFailToEnterFullScreen(window)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidFailToEnterFullScreen:"), auto_cast windowDidFailToEnterFullScreen, "v@:@")
+	}
+	if template.customWindowsToExitFullScreenForWindow != nil {
+		customWindowsToExitFullScreenForWindow :: proc "c" (self: id, window: ^Window) -> ^Array {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			return del.customWindowsToExitFullScreenForWindow(window)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("customWindowsToExitFullScreenForWindow:"), auto_cast customWindowsToExitFullScreenForWindow, "@@:@")
+	}
+	if template.windowStartCustomAnimationToExitFullScreenWithDuration != nil {
+		windowStartCustomAnimationToExitFullScreenWithDuration :: proc "c" (self: id, window: ^Window, duration: TimeInterval) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowStartCustomAnimationToExitFullScreenWithDuration(window, duration)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("window:startCustomAnimationToExitFullScreenWithDuration:"), auto_cast windowStartCustomAnimationToExitFullScreenWithDuration, "v@:@d")
+	}
+	if template.windowDidFailToExitFullScreen != nil {
+		windowDidFailToExitFullScreen :: proc "c" (self: id, window: ^Window) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidFailToExitFullScreen(window)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidFailToExitFullScreen:"), auto_cast windowDidFailToExitFullScreen, "v@:@")
+	}
+	if template.windowWillMove != nil {
+		windowWillMove :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowWillMove(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowWillMove:"), auto_cast windowWillMove, "v@:@")
+	}
+	if template.windowDidMove != nil {
+		windowDidMove :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidMove(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidMove:"), auto_cast windowDidMove, "v@:@")
+	}
+	if template.windowDidChangeScreen != nil {
+		windowDidChangeScreen :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidChangeScreen(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidChangeScreen:"), auto_cast windowDidChangeScreen, "v@:@")
+	}
+	if template.windowDidChangeScreenProfile != nil {
+		windowDidChangeScreenProfile :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidChangeScreenProfile(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidChangeScreenProfile:"), auto_cast windowDidChangeScreenProfile, "v@:@")
+	}
+	if template.windowDidChangeBackingProperties != nil {
+		windowDidChangeBackingProperties :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidChangeBackingProperties(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidChangeBackingProperties:"), auto_cast windowDidChangeBackingProperties, "v@:@")
+	}
+	if template.windowShouldClose != nil {
+		windowShouldClose :: proc "c" (self:id, sender: ^Window) -> BOOL {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			return del.windowShouldClose(sender)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowShouldClose:"), auto_cast windowShouldClose, "B@:@")
+	}
+	if template.windowWillClose != nil {
+		windowWillClose :: proc "c" (self:id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowWillClose(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowWillClose:"), auto_cast windowWillClose, "v@:@")
+	}
+	if template.windowDidBecomeKey != nil {
+		windowDidBecomeKey :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidBecomeKey(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidBecomeKey:"), auto_cast windowDidBecomeKey, "v@:@")
+	}
+	if template.windowDidResignKey != nil {
+		windowDidResignKey :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidResignKey(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidResignKey:"), auto_cast windowDidResignKey, "v@:@")
+	}
+	if template.windowDidBecomeMain != nil {
+		windowDidBecomeMain :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidBecomeMain(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidBecomeMain:"), auto_cast windowDidBecomeMain, "v@:@")
+	}
+	if template.windowDidResignMain != nil {
+		windowDidResignMain :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidResignMain(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidResignMain:"), auto_cast windowDidResignMain, "v@:@")
+	}
+	if template.windowWillReturnFieldEditorToObject != nil {
+		windowWillReturnFieldEditorToObject :: proc "c" (self:id, sender: ^Window, client: id) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowWillReturnFieldEditorToObject(sender, client)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowWillReturnFieldEditor:toObject:"), auto_cast windowWillReturnFieldEditorToObject, "v@:@@")
+	}
+	if template.windowDidUpdate != nil {
+		windowDidUpdate :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidUpdate(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidUpdate:"), auto_cast windowDidUpdate, "v@:@")
+	}
+	if template.windowDidExpose != nil {
+		windowDidExpose :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidExpose(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidExpose:"), auto_cast windowDidExpose, "v@:@")
+	}
+	if template.windowDidChangeOcclusionState != nil {
+		windowDidChangeOcclusionState :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidChangeOcclusionState(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidChangeOcclusionState:"), auto_cast windowDidChangeOcclusionState, "v@:@")
+	}
+	if template.windowShouldDragDocumentWithEventFromWithPasteboard != nil {
+		windowShouldDragDocumentWithEventFromWithPasteboard :: proc "c" (self: id, window: ^Window, event: ^Event, dragImageLocation: Point, pasteboard: ^Pasteboard) -> BOOL {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			return del.windowShouldDragDocumentWithEventFromWithPasteboard(window, event, dragImageLocation, pasteboard)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("window:shouldDragDocumentWithEvent:from:withPasteboard:"), auto_cast windowShouldDragDocumentWithEventFromWithPasteboard, "B@:@@"+_POINT_ENCODING+"@")
+	}
+	if template.windowWillReturnUndoManager != nil {
+		windowWillReturnUndoManager :: proc "c" (self: id, window: ^Window) -> ^UndoManager {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			return del.windowWillReturnUndoManager(window)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowWillReturnUndoManager:"), auto_cast windowWillReturnUndoManager, "@@:@")
+	}
+	if template.windowShouldPopUpDocumentPathMenu != nil {
+		windowShouldPopUpDocumentPathMenu :: proc "c" (self: id, window: ^Window, menu: ^Menu) -> BOOL {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			return del.windowShouldPopUpDocumentPathMenu(window, menu)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("window:shouldPopUpDocumentPathMenu:"), auto_cast windowShouldPopUpDocumentPathMenu, "B@:@@")
+	}
+	if template.windowWillEncodeRestorableState != nil {
+		windowWillEncodeRestorableState :: proc "c" (self: id, window: ^Window, state: ^Coder) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowWillEncodeRestorableState(window, state)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("window:willEncodeRestorableState:"), auto_cast windowWillEncodeRestorableState, "v@:@@")
+	}
+	if template.windowDidEncodeRestorableState != nil {
+		windowDidEncodeRestorableState :: proc "c" (self: id, window: ^Window, state: ^Coder) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidEncodeRestorableState(window, state)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("window:didDecodeRestorableState:"), auto_cast windowDidEncodeRestorableState, "v@:@@")
+	}
+	if template.windowWillResizeForVersionBrowserWithMaxPreferredSizeMaxAllowedSize != nil {
+		windowWillResizeForVersionBrowserWithMaxPreferredSizeMaxAllowedSize :: proc "c" (self: id, window: ^Window, maxPreferredFrameSize: Size, maxAllowedFrameSize: Size) -> Size {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			return del.windowWillResizeForVersionBrowserWithMaxPreferredSizeMaxAllowedSize(window, maxPreferredFrameSize, maxPreferredFrameSize)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("window:willResizeForVersionBrowserWithMaxPreferredSize:maxAllowedSize:"), auto_cast windowWillResizeForVersionBrowserWithMaxPreferredSizeMaxAllowedSize, _SIZE_ENCODING+"@:@"+_SIZE_ENCODING+_SIZE_ENCODING)
+	}
+	if template.windowWillEnterVersionBrowser != nil {
+		windowWillEnterVersionBrowser :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowWillEnterVersionBrowser(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowWillEnterVersionBrowser:"), auto_cast windowWillEnterVersionBrowser, "v@:@")
+	}
+	if template.windowDidEnterVersionBrowser != nil {
+		windowDidEnterVersionBrowser :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidEnterVersionBrowser(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidEnterVersionBrowser:"), auto_cast windowDidEnterVersionBrowser, "v@:@")
+	}
+	if template.windowWillExitVersionBrowser != nil {
+		windowWillExitVersionBrowser :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowWillExitVersionBrowser(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowWillExitVersionBrowser:"), auto_cast windowWillExitVersionBrowser, "v@:@")
+	}
+	if template.windowDidExitVersionBrowser != nil {
+		windowDidExitVersionBrowser :: proc "c" (self: id, notification: ^Notification) {
+			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
+			context = del._context
+			del.windowDidExitVersionBrowser(notification)
+		}
+		class_addMethod(class, intrinsics.objc_find_selector("windowDidExitVersionBrowser:"), auto_cast windowDidExitVersionBrowser, "v@:@")
+	}
+
+	objc_registerClassPair(class)
+	del := class_createInstance(class, size_of(_WindowDelegateInternal))
+	del_internal := cast(^_WindowDelegateInternal)object_getIndexedIvars(del)
+	del_internal^ = {
+		template,
+		delegate_context.(runtime.Context) or_else runtime.default_context(),
+	}
+
+	return cast(^WindowDelegate)del
+}
+
 @(objc_class="NSColor")
 Color :: struct {using _: Object}
 
 @(objc_class="CALayer")
-Layer :: struct { using _: NS.Object }
+Layer :: struct {using _: Object}
 
 @(objc_type=Layer, objc_name="contentsScale")
 Layer_contentsScale :: proc(self: ^Layer) -> Float {
@@ -71,7 +584,6 @@ Responder :: struct {using _: Object}
 @(objc_class="NSView")
 View :: struct {using _: Responder}
 
-
 @(objc_type=View, objc_name="initWithFrame")
 View_initWithFrame :: proc(self: ^View, frame: Rect) -> ^View {
 	return msgSend(^View, self, "initWithFrame:", frame)
@@ -92,6 +604,15 @@ View_wantsLayer :: proc(self: ^View) -> BOOL {
 View_setWantsLayer :: proc(self: ^View, wantsLayer: BOOL) {
 	msgSend(nil, self, "setWantsLayer:", wantsLayer)
 }
+@(objc_type=View, objc_name="bounds")
+View_getBounds :: proc(self: ^View) -> Rect {
+	return msgSend(Rect, self, "bounds")
+}
+@(objc_type=View, objc_name="convertPointFromView")
+View_convertPointFromView :: proc(self: ^View, point: Point, view: ^View) -> Point {
+	return msgSend(Point, self, "convertPoint:fromView:", point, view)
+}
+
 
 @(objc_class="NSWindow")
 Window :: struct {using _: Responder}
@@ -156,6 +677,10 @@ Window_setBackgroundColor :: proc(self: ^Window, color: ^NS.Color) {
 Window_makeKeyAndOrderFront :: proc(self: ^Window, key: ^NS.Object) {
 	msgSend(nil, self, "makeKeyAndOrderFront:", key)
 }
+@(objc_type=Window, objc_name="orderFrontRegardless")
+Window_orderFrontRegardless :: proc(self: ^Window) {
+	msgSend(nil, self, "orderFrontRegardless")
+}
 @(objc_type=Window, objc_name="setTitle")
 Window_setTitle :: proc(self: ^Window, title: ^NS.String) {
 	msgSend(nil, self, "setTitle:", title)
@@ -179,4 +704,16 @@ Window_setStyleMask :: proc(self: ^Window, style_mask: WindowStyleMask) {
 @(objc_type=Window, objc_name="close")
 Window_close :: proc(self: ^Window) {
 	msgSend(nil, self, "close")
+}
+@(objc_type=Window, objc_name="backingScaleFactor")
+Window_backingScaleFactor :: proc(self: ^Window) -> NS.Float {
+	return msgSend(NS.Float, self, "backingScaleFactor")
+}
+@(objc_type=Window, objc_name="convertPointFromScreen")
+Window_convertPointFromScreen :: proc(self: ^Window, point: Point) -> Point {
+	return msgSend(Point, self, "convertPointFromScreen:", point)
+}
+@(objc_type=Window, objc_name="setDelegate")
+Window_setDelegate :: proc(self: ^Window, delegate: ^WindowDelegate) {
+	msgSend(nil, self, "setDelegate:", delegate)
 }

--- a/vendor/darwin/Foundation/objc.odin
+++ b/vendor/darwin/Foundation/objc.odin
@@ -15,8 +15,10 @@ foreign Foundation {
 
 	class_addMethod :: proc "c" (cls: Class, name: SEL, imp: IMP, types: cstring) -> BOOL ---
 	class_getInstanceMethod :: proc "c" (cls: Class, name: SEL) -> Method ---
+	class_createInstance :: proc "c" (cls: Class, extraBytes: c.size_t) -> id ---
 
 	method_setImplementation :: proc "c" (method: Method, imp: IMP) ---
+	object_getIndexedIvars :: proc(obj: id) -> rawptr ---
 }
 
 


### PR DESCRIPTION
Just a ton of bindings I created for when I was porting my project to macos.
All of them are pretty straightforward, with the exception of the WindowDelegate.

I implemented the full window delegate protocol. To make life a little better than how the application delegate functions I register a class at runtime for the delegate.
Usage code looks like:
```odin
my_delegate := NS.WindowDelegateTemplate {
    // Implement delegate here. All functions are optional
    windowWillResizeToSize = proc(sender: ^NS.Window, size: NS.Size) -> NS.Size {
        fmt.println("Resized to:", size)
        return size
    },
}

// register and allocate the window delegate
// context is optional, with context set to runtime.default_context() if not explicitly provided
// this context is the odin context for all delegate calls
delegate := NS.window_delegate_register_and_alloc(my_delegate, "My_Delegate", context)
window->setDelegate(delegate)
```
The delegate template and odin context is copied into the created object. It returns nil if an allocation fails or the provided name has already been registered with.

Currently I haven't released a helper release mechanism. You can call `delegate->release()` but the class will still have its name registered.

I haven't extensively tested all the callbacks on the delegate. I just decided to implement it all in one swoop after I had what I needed done.
`NSUndoManager`, `NSScreen` and `NSPasteboard` were added simply for the WindowDelegate bindings