### PR TITLE
Use SDL2.framework instead of SDL2 library when Darwin is the target OS.

### DIFF
--- a/vendor/sdl2/sdl2.odin
+++ b/vendor/sdl2/sdl2.odin
@@ -27,6 +27,8 @@ import "core:intrinsics"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_audio.odin
+++ b/vendor/sdl2/sdl_audio.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_blendmode.odin
+++ b/vendor/sdl2/sdl_blendmode.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_cpuinfo.odin
+++ b/vendor/sdl2/sdl_cpuinfo.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_events.odin
+++ b/vendor/sdl2/sdl_events.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_gamecontroller.odin
+++ b/vendor/sdl2/sdl_gamecontroller.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_gesture_haptic.odin
+++ b/vendor/sdl2/sdl_gesture_haptic.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_hints.odin
+++ b/vendor/sdl2/sdl_hints.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_joystick.odin
+++ b/vendor/sdl2/sdl_joystick.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_keyboard.odin
+++ b/vendor/sdl2/sdl_keyboard.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_log.odin
+++ b/vendor/sdl2/sdl_log.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_messagebox.odin
+++ b/vendor/sdl2/sdl_messagebox.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_metal.odin
+++ b/vendor/sdl2/sdl_metal.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_mouse.odin
+++ b/vendor/sdl2/sdl_mouse.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_mutex.odin
+++ b/vendor/sdl2/sdl_mutex.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_pixels.odin
+++ b/vendor/sdl2/sdl_pixels.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_rect.odin
+++ b/vendor/sdl2/sdl_rect.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_render.odin
+++ b/vendor/sdl2/sdl_render.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_rwops.odin
+++ b/vendor/sdl2/sdl_rwops.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_stdinc.odin
+++ b/vendor/sdl2/sdl_stdinc.odin
@@ -7,6 +7,8 @@ _, _ :: intrinsics, runtime
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_surface.odin
+++ b/vendor/sdl2/sdl_surface.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_system.odin
+++ b/vendor/sdl2/sdl_system.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_syswm.odin
+++ b/vendor/sdl2/sdl_syswm.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_thread.odin
+++ b/vendor/sdl2/sdl_thread.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_timer.odin
+++ b/vendor/sdl2/sdl_timer.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_touch.odin
+++ b/vendor/sdl2/sdl_touch.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_video.odin
+++ b/vendor/sdl2/sdl_video.odin
@@ -4,6 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }

--- a/vendor/sdl2/sdl_vulkan.odin
+++ b/vendor/sdl2/sdl_vulkan.odin
@@ -5,6 +5,8 @@ import vk "vendor:vulkan"
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL2.lib"
+} else when ODIN_OS == .Darwin {
+    foreign import lib "system:SDL2.framework"
 } else {
 	foreign import lib "system:SDL2"
 }


### PR DESCRIPTION
The `vendor:sdl2` package will try to link against an SDL2 library on MacOS X (and any other Darwin-based OS). The problem is that in the Darwin ecosystem the common practice is to use frameworks instead of libraries. In fact the official SDL2 distribution for MacOS X is a framework. See: https://www.libsdl.org/

This PR attempts to fix this issue by linking against an SDL2 framework instead. Here's a simple program that can be used to test this:
```odin
package main

import "vendor:sdl2"

main :: proc() {
        if sdl2.Init(sdl2.INIT_EVERYTHING) != 0 {
                sdl2.Log("Failed to initialize the SDL2 library: %s", sdl2.GetError())
        }
        defer sdl2.Quit()
}
```

It can be built with the following command:
```bash
odin build main.odin -file -lld -target:darwin_arm64 -minimum-os-version:13 -extra-linker-flags:'-F. -rpath @loader_path'
```

This command builds the test application for MacOS X Ventura (Apple M1/M2 chips).

P.S. This test assumes that the `SDL2.framework` is in the same directory as the `main.odin` file.