### PR TITLE
Fix off by one error in %d parsing

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -547,7 +547,7 @@ _parse_int :: proc(s: string, offset: int) -> (result: int, new_offset: int, ok:
 	is_digit :: #force_inline proc(r: byte) -> bool { return '0' <= r && r <= '9' }
 
 	new_offset = offset
-	for new_offset <= len(s) {
+	for new_offset < len(s) {
 		c := s[new_offset]
 		if !is_digit(c) {
 			break


### PR DESCRIPTION
**Bug description:**
Crashes when you forget the type specifier at the very end of a string e.g. "%d" -> "%".
This used to work because the loop checked `!is_digit(c)` on the next character.

```odin
package main
import "core:fmt"

main :: proc() {
    fmt.printf("%", 12)
    // $ odin run . -debug
    // C:/dev/Odin/Odin/core/fmt/fmt.odin(551:10) Index 1 is out of range 0..<1
}
```