### PR TITLE
Fix left padding format specifier and float formatting

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -865,7 +865,7 @@ _pad :: proc(fi: ^Info, s: string) {
 	}
 }
 
-fmt_float_as :: proc(fi: ^Info, v: f64, bit_size: int, verb: rune, float_fmt: byte) {
+_fmt_float_as :: proc(fi: ^Info, v: f64, bit_size: int, verb: rune, float_fmt: byte) {
 	prec: int = 3
 	if fi.prec_set {
 		prec = fi.prec
@@ -874,7 +874,7 @@ fmt_float_as :: proc(fi: ^Info, v: f64, bit_size: int, verb: rune, float_fmt: by
 
 	// Can return "NaN", "+Inf", "-Inf", "+<value>", "-<value>".
 	str := strconv.append_float(buf[:], v, float_fmt, prec, bit_size)
-	assert(len(str) >= 2);
+	assert(len(str) >= 2)
 
 	if !fi.plus { // '+' modifier means preserve all signs.
 		switch {
@@ -892,10 +892,10 @@ fmt_float_as :: proc(fi: ^Info, v: f64, bit_size: int, verb: rune, float_fmt: by
 fmt_float :: proc(fi: ^Info, v: f64, bit_size: int, verb: rune) {
 	switch verb {
 	case 'f', 'F', 'g', 'G', 'v':
-		fmt_float_as(fi, v, bit_size, verb, 'f')
+		_fmt_float_as(fi, v, bit_size, verb, 'f')
 	case 'e', 'E':
 		// BUG(): "%.3e" returns "3.000e+00"
-		fmt_float_as(fi, v, bit_size, verb, 'e')
+		_fmt_float_as(fi, v, bit_size, verb, 'e')
 
 	case 'h', 'H':
 		prev_fi := fi^

--- a/core/strconv/integers.odin
+++ b/core/strconv/integers.odin
@@ -3,7 +3,6 @@ package strconv
 Int_Flag :: enum {
 	Prefix,
 	Plus,
-	Space,
 }
 Int_Flags :: bit_set[Int_Flag]
 

--- a/core/strconv/integers.odin
+++ b/core/strconv/integers.odin
@@ -73,8 +73,6 @@ append_bits :: proc(buf: []byte, x: u64, base: int, is_signed: bool, bit_size: i
 		i-=1; a[i] = '-'
 	case .Plus in flags:
 		i-=1; a[i] = '+'
-	case .Space in flags:
-		i-=1; a[i] = ' '
 	}
 
 	out := a[i:]
@@ -157,8 +155,6 @@ append_bits_128 :: proc(buf: []byte, x: u128, base: int, is_signed: bool, bit_si
 		i-=1; a[i] = '-'
 	case .Plus in flags:
 		i-=1; a[i] = '+'
-	case .Space in flags:
-		i-=1; a[i] = ' '
 	}
 
 	out := a[i:]


### PR DESCRIPTION
**Bug description:**
When attempting to left-pad a number with spaces, there is an extra space at the front. 

```odin
main :: proc() {
    fmt.printf("%5s\n",  "abc") // "  abc"  rigth padded
    fmt.printf("%-5s\n", "abc") // "abc  "  left padded
    
    fmt.printf("%5d\n",  123)   // "00123"  default padding uses zeroes
    fmt.printf("%-5d\n", 123)   // "12300"  default padding uses zeroes

    fmt.printf("% 5d\n",  123)   // "  123"
    fmt.printf("% -5d\n", 123)   // " 123 "
    // ERROR ========================^ extra ' '
    
    // Also floats
    fmt.printf("%-6.1f\n", 12.56)    // "12.600"
    fmt.printf("% -6.1f\n", 12.56)   // " 12.6 "   // ERROR
    fmt.printf("% -+6.1f\n", 12.56) // "+12.6 "
}
```

All uses of "core/strconv/integers.odin" `Int_Flag.Space` set by `fmt_float`, `_fmt_int` and `_fmt_int` have been removed.
All other uses in `append_bits_128` and `append_bits` removed as well.