### PR TITLE
Replace fallback f64 parsing path with libc.strtod

### DIFF
--- a/core/strconv/generic_float.odin
+++ b/core/strconv/generic_float.odin
@@ -287,8 +287,8 @@ round_shortest :: proc(d: ^decimal.Decimal, mant: u64, exp: int, flt: ^Float_Inf
 
 @(private)
 decimal_to_float_bits :: proc(d: ^decimal.Decimal, info: ^Float_Info) -> (b: u64, overflow: bool) {
-	end :: proc "contextless" (d: ^decimal.Decimal, mant: u64, exp: int, info: ^Float_Info) -> (b: u64) {
-		bits := mant & (u64(1)<<info.mantbits - 1)
+	end :: proc "contextless" (d: ^decimal.Decimal, mant: u64, exp: int, info: ^Float_Info) -> (bits: u64) {
+		bits = mant & (u64(1)<<info.mantbits - 1)
 		bits |= u64((exp-info.bias) & (1<<info.expbits - 1)) << info.mantbits
 		if d.neg {
 			bits |= 1<< info.mantbits << info.expbits

--- a/core/strconv/strconv.odin
+++ b/core/strconv/strconv.odin
@@ -1,7 +1,6 @@
 package strconv
 
 import "core:unicode/utf8"
-import "decimal"
 
 import "core:c/libc"
 


### PR DESCRIPTION
Temporary fix for #2277

1. Disabled fallback path in favour of `libc.strtod`.
    While I dislike libc, the fallback path `decimal_to_float_bits / decimal.Decimal` simply does not seem to work on my side.  
    After some research this seemed like the most commonly used fallback.
 
 2. Added **break** from **trunc_block**
 
The `parse_f64` code seems like it was originally a copy of Go's `atof64`, but parts of it have evolved where it is hard to compare them for correctness.

Go separates the parsing logic like this:
```go
f, ok = atofHex() 
f, ok = atof64exact()
f, ok = eiselLemire64()
bits, overflow = decimal.set(string).floatBits()
```
But what is effectively our `atof64exact` is not a separate proc. Returning to indicate "keep parsing with a different algorithm" returns from the main function, skipping the fallback path. Although this part of the logic is slightly different from Go so I am not 100% sure of what was being attempted here with the block.  
**Adding this break prevents the fallback from being skipped in the repro example case.**

The `decimal.Decimal` fallback path foes not seem to work for me and the nested proc "decimal_to_float_bits::end" gets optimized out preventing me from debugging it, besides not being able to printf without import cycles.

In any case, `strtod` does not exhibit the following issues:
```odin
fmt.println(strconv.parse_f64("0.81111111111111111"))  // 0.000 true
```
```odin
// Loops forever as `decimal_to_float_bits` is stuck in for loops computing something

import "core:fmt"
import "core:encoding/json"
Data :: struct {
	a: f64,
}
main :: proc () {
	data: Data
	str := `{"a":0.011111111111111111111}`
	bytes := transmute([]u8)str
	json.unmarshal(bytes, &data)
	fmt.println(data)
	fmt.printf("%.60f\n", data.a)
}
```

NOTES:
- Code appears to be missing Go's fast `eiselLemire64` "Eisel-Lemire" path when naive extraction fails -- this is the most commonly used and fastest algorithm (with 99% float coverage).
- Decimal fallback path: 
  https://cs.opensource.google/go/go/+/refs/tags/go1.19.5:src/strconv/decimal.go seems like a partial copy with some optimisations missing (`leftCheat`) -- could this explain the insanely slow parsing in some cases?  
- `strtod` Safety?
    1. Set errno to 0 and check it afterwards.
    2. Pass a &ptr:^u8 as second argument and check  ptr=&cstr => no number was found. (though I assume this is already handled.)
 
**Warning:** This has only tested against those two cases!