### PR TITLE
Fix #by_ptr argument overrides for Linux

### DIFF
--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -1586,6 +1586,10 @@ gb_internal LLVMTypeRef lb_type_internal_for_procedures_raw(lbModule *m, Type *t
 		if (params_by_ptr[i]) {
 			// NOTE(bill): The parameter needs to be passed "indirectly", override it
 			ft->args[i].kind = lbArg_Indirect;
+			ft->args[i].attribute = nullptr;
+			ft->args[i].align_attribute = nullptr;
+			ft->args[i].byval_alignment = 0;
+			ft->args[i].is_byval = false;
 		}
 	}
 


### PR DESCRIPTION
#by_ptr isn't working correctly on Linux as discussed here: https://github.com/floooh/sokol-odin/issues/4

This change makes the sokol example programs work on Linux.