### PR TITLE
Add option to link to glfw3 dynamically

### DIFF
--- a/vendor/glfw/bindings/bindings.odin
+++ b/vendor/glfw/bindings/bindings.odin
@@ -3,13 +3,24 @@ package glfw_bindings
 import "core:c"
 import vk "vendor:vulkan"
 
+GLFW_DYNAMIC :: #config(GLFW_DYNAMIC, false)
+
 when ODIN_OS == .Windows {
-	foreign import glfw { 
-		"../lib/glfw3_mt.lib",
-		"system:user32.lib", 
-		"system:gdi32.lib", 
-		"system:shell32.lib",
-	} 
+	when GLFW_DYNAMIC {
+		foreign import glfw {
+			"../lib/glfw3dll.lib",
+			"system:user32.lib", 
+			"system:gdi32.lib", 
+			"system:shell32.lib",
+		}
+	} else {
+		foreign import glfw {
+			"../lib/glfw3mt.lib",
+			"system:user32.lib",
+			"system:gdi32.lib",
+			"system:shell32.lib",
+		}
+	}
 } else when ODIN_OS == .Linux {
 	// TODO: Add the billion-or-so static libs to link to in linux
 	foreign import glfw "system:glfw"

--- a/vendor/glfw/bindings/bindings.odin
+++ b/vendor/glfw/bindings/bindings.odin
@@ -15,7 +15,7 @@ when ODIN_OS == .Windows {
 		}
 	} else {
 		foreign import glfw {
-			"../lib/glfw3mt.lib",
+			"../lib/glfw3_mt.lib",
 			"system:user32.lib",
 			"system:gdi32.lib",
 			"system:shell32.lib",

--- a/vendor/glfw/constants.odin
+++ b/vendor/glfw/constants.odin
@@ -1,5 +1,8 @@
 package glfw
 
+/* Config */
+GLFW_DYNAMIC :: #config(GLFW_DYNAMIC, false)
+
 /*** Constants ***/
 /* Versions */
 VERSION_MAJOR    :: 3

--- a/vendor/glfw/native_windows.odin
+++ b/vendor/glfw/native_windows.odin
@@ -4,7 +4,11 @@ package glfw
 
 import win32 "core:sys/windows"
 
-foreign import glfw { "lib/glfw3_mt.lib", "system:user32.lib", "system:gdi32.lib", "system:shell32.lib" }
+when GLFW_DYNAMIC {
+    foreign import glfw { "lib/glfw3dll.lib", "system:user32.lib", "system:gdi32.lib", "system:shell32.lib" }
+} else {
+    foreign import glfw { "lib/glfw3_mt.lib", "system:user32.lib", "system:gdi32.lib", "system:shell32.lib" }
+}
 
 @(default_calling_convention="c", link_prefix="glfw")
 foreign glfw {


### PR DESCRIPTION
When implementing multi-module applications (for example applications that use hot reloading), static linking with GLFW3 creates problems related to duplication of global state in the different Odin modules.

This patch implements a configurable option to tell GLFW3 package to link to .DLL instead of .LIB. In order to use the option, supply `-define:GLFW_DYNAMIC=true` argument to odin compiler option and copy .dll file from `vendor:glfw/lib` folder to the same folder as your executable, or other folder where windows would search for the folder.

On linux dynamic linking (as of now) should be on by default. I didn't do any work for other OSes.