### PR TITLE
Added missing Windows functions for console manipulation

### DIFF
--- a/core/sys/windows/kernel32.odin
+++ b/core/sys/windows/kernel32.odin
@@ -370,6 +370,9 @@ foreign kernel32 {
 	GenerateConsoleCtrlEvent :: proc(dwCtrlEvent: DWORD, dwProcessGroupId: DWORD) -> BOOL ---
 	FreeConsole :: proc() -> BOOL ---
 	GetConsoleWindow :: proc() -> HWND ---
+	GetConsoleScreenBufferInfo :: proc(hConsoleOutput: HANDLE, lpConsoleScreenBufferInfo: PCONSOLE_SCREEN_BUFFER_INFO) -> BOOL ---
+	SetConsoleScreenBufferSize :: proc(hConsoleOutput: HANDLE, dwSize: COORD) -> BOOL ---
+	SetConsoleWindowInfo :: proc(hConsoleOutput: HANDLE, bAbsolute : BOOL, lpConsoleWindow: ^SMALL_RECT) -> BOOL ---
 
 	GetDiskFreeSpaceExW :: proc(
 		lpDirectoryName: LPCWSTR,

--- a/core/sys/windows/types.odin
+++ b/core/sys/windows/types.odin
@@ -3884,3 +3884,21 @@ COORD :: struct {
 	X: SHORT,
 	Y: SHORT,
 }
+
+SMALL_RECT :: struct {
+	Left: SHORT,
+	Top: SHORT,
+	Right: SHORT,
+	Bottom: SHORT,
+}
+
+CONSOLE_SCREEN_BUFFER_INFO :: struct {
+	dwSize: COORD,
+	dwCursorPosition: COORD,
+	wAttributes: WORD,
+	srWindow: SMALL_RECT,
+	dwMaximumWindowSize: COORD,
+}
+
+
+PCONSOLE_SCREEN_BUFFER_INFO :: ^CONSOLE_SCREEN_BUFFER_INFO


### PR DESCRIPTION
This commit adds several missing types and functions to the Windows implementation to enable manipulation of console windows. The types added include 'SMALL_RECT', 'CONSOLE_SCREEN_BUFFER_INFO', and 'PCONSOLE_SCREEN_BUFFER_INFO'. The functions added include 'GetConsoleScreenBufferInfo', 'SetConsoleScreenBufferSize', and 'SetConsoleWindowInfo'. These functions were necessary to properly manage the console window.