### PR TITLE
Fix core:odin/parser #force_inline/force_no_inline call expression when it's a statement 

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -1425,7 +1425,7 @@ parse_stmt :: proc(p: ^Parser) -> ^ast.Stmt {
 			return es
 
 		case "force_inline", "force_no_inline":
-			expr := parse_inlining_operand(p, true, tok)
+			expr := parse_inlining_operand(p, true, tag)
 			es := ast.new(ast.Expr_Stmt, expr.pos, expr.end)
 			es.expr = expr
 			return es


### PR DESCRIPTION
Need to forward the name of the directive, not the hash token

For `#force_no_inline my_func()` the Call_Expr.inline was None instead of No_Inline.