### PR TITLE
resolve doc/spall package name conflict

### DIFF
--- a/core/prof/spall/spall.odin
+++ b/core/prof/spall/spall.odin
@@ -1,4 +1,4 @@
-package prof_spall
+package spall
 
 import "core:os"
 import "core:time"


### PR DESCRIPTION
`spall/spall.odin` and `spall/doc.odin` had a naming conflict, normalizing back to `spall`

fyi @colrdavidson - just incase you intended it the other way around.