### PR TITLE
Add -no-tls flag

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -275,6 +275,7 @@ struct BuildContext {
 	bool   no_output_files;
 	bool   no_crt;
 	bool   no_entry_point;
+	bool   no_tls;
 	bool   use_lld;
 	bool   vet;
 	bool   vet_extra;

--- a/src/check_decl.cpp
+++ b/src/check_decl.cpp
@@ -1143,8 +1143,11 @@ gb_internal void check_global_variable_decl(CheckerContext *ctx, Entity *&e, Ast
 
 	if (is_arch_wasm() && e->Variable.thread_local_model.len != 0) {
 		e->Variable.thread_local_model.len = 0;
-		// NOTE(bill): ignore this message for the time begin
+		// NOTE(bill): ignore this message for the time being
 		// error(e->token, "@(thread_local) is not supported for this target platform");
+	}
+	if(build_context.no_tls) {
+		e->Variable.thread_local_model.len = 0;
 	}
 
 	String context_name = str_lit("variable declaration");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -634,6 +634,7 @@ enum BuildFlagKind {
 	BuildFlag_Microarch,
 	BuildFlag_TargetFeatures,
 	BuildFlag_MinimumOSVersion,
+	BuildFlag_NoTLS,
 
 	BuildFlag_RelocMode,
 	BuildFlag_DisableRedZone,
@@ -794,6 +795,7 @@ gb_internal bool parse_build_flags(Array<String> args) {
 	add_flag(&build_flags, BuildFlag_Debug,                   str_lit("debug"),                     BuildFlagParam_None,    Command__does_check);
 	add_flag(&build_flags, BuildFlag_DisableAssert,           str_lit("disable-assert"),            BuildFlagParam_None,    Command__does_check);
 	add_flag(&build_flags, BuildFlag_NoBoundsCheck,           str_lit("no-bounds-check"),           BuildFlagParam_None,    Command__does_check);
+	add_flag(&build_flags, BuildFlag_NoTLS,                   str_lit("no-tls"),                    BuildFlagParam_None,    Command__does_check);
 	add_flag(&build_flags, BuildFlag_NoDynamicLiterals,       str_lit("no-dynamic-literals"),       BuildFlagParam_None,    Command__does_check);
 	add_flag(&build_flags, BuildFlag_NoCRT,                   str_lit("no-crt"),                    BuildFlagParam_None,    Command__does_build);
 	add_flag(&build_flags, BuildFlag_NoEntryPoint,            str_lit("no-entry-point"),            BuildFlagParam_None,    Command__does_check &~ Command_test);
@@ -1311,6 +1313,9 @@ gb_internal bool parse_build_flags(Array<String> args) {
 							break;
 						case BuildFlag_NoEntryPoint:
 							build_context.no_entry_point = true;
+							break;
+						case BuildFlag_NoTLS:
+							build_context.no_tls = true;
 							break;
 						case BuildFlag_UseLLD:
 							build_context.use_lld = true;
@@ -2062,6 +2067,10 @@ gb_internal void print_show_help(String const arg0, String const &command) {
 
 		print_usage_line(1, "-no-crt");
 		print_usage_line(2, "Disables automatic linking with the C Run Time");
+		print_usage_line(0, "");
+
+		print_usage_line(1, "-no-tls");
+		print_usage_line(2, "Ignore @thread_local attribute, effectively treating the program as if it is single-threaded");
 		print_usage_line(0, "");
 
 		print_usage_line(1, "-lld");


### PR DESCRIPTION
Freestanding applications that do not initialize TLS may crash upon using `@thread_local` variables. This patch adds a `-no-tls` build flag, so that these applications can use `@thread_local` variables and treat them as normal variables (if there's only one thread, `@thread_local` should be the same as simply a global variable).

The need for the flag is due to some functionality in `core:` package declaring `@thread_local` variables that can not be avoided, in particular `default_temp_allocator_*` in `runtime` package.