### PR TITLE
Remove usage of global_default_temp_allocator_data when not needed

### DIFF
--- a/core/runtime/core.odin
+++ b/core/runtime/core.odin
@@ -621,7 +621,9 @@ __init_context :: proc "contextless" (c: ^Context) {
 	c.allocator.data = nil
 
 	c.temp_allocator.procedure = default_temp_allocator_proc
-	c.temp_allocator.data = &global_default_temp_allocator_data
+	when !NO_DEFAULT_TEMP_ALLOCATOR {
+		c.temp_allocator.data = &global_default_temp_allocator_data
+	}
 	
 	when !ODIN_DISABLE_ASSERT {
 		c.assertion_failure_proc = default_assertion_failure_proc

--- a/core/runtime/core_builtin.odin
+++ b/core/runtime/core_builtin.odin
@@ -15,11 +15,15 @@ container_of :: #force_inline proc "contextless" (ptr: $P/^$Field_Type, $T: type
 }
 
 
-@thread_local global_default_temp_allocator_data: Default_Temp_Allocator
+when !NO_DEFAULT_TEMP_ALLOCATOR {
+	@thread_local global_default_temp_allocator_data: Default_Temp_Allocator
+}
 
-@builtin
+@(builtin, disabled=NO_DEFAULT_TEMP_ALLOCATOR)
 init_global_temporary_allocator :: proc(size: int, backup_allocator := context.allocator) {
-	default_temp_allocator_init(&global_default_temp_allocator_data, size, backup_allocator)
+	when !NO_DEFAULT_TEMP_ALLOCATOR {
+		default_temp_allocator_init(&global_default_temp_allocator_data, size, backup_allocator)
+	}
 }
 
 


### PR DESCRIPTION
When there is no default allocator (freestanding, OS==JS or --default-to-nil-allocator), all default allocator functions are replaced by the nil-allocator, so `global_default_temp_allocator_data` is not used, only referenced to get the address of.

Trying to initialize the odin runtime on a freestanding target would always to get the address of the data, but as it is marked as `@thread_local`, this will require a correct set up for TLS segments. While this problem would still exist for other thread_local variables, they can be avoided by not being used whereas the `global_default_temp_allocator_data` cannot be avoided.