### PR TITLE
Fix: -target-feature list missing commas

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1369,6 +1369,7 @@ gb_internal char const *target_features_set_to_cstring(gbAllocator allocator, bo
 		gb_memmove(features + len, feature.text, feature.len);
 		len += feature.len;
 		if (with_quotes) features[len++] = '"';
+		i += 1;
 	}
 	features[len++] = 0;
 


### PR DESCRIPTION
## Expected Behavior
`-target-features` List should be passed to llvm as-is. The attached fix creates this behavior.

## Current Behavior
Commas separating list items are removed. Individually the values are accepted

## Failure Information (for bugs)

```
> odin build odin -out:bin/hello.wasm -debug -vet -target:freestanding_wasm32 -target-features:"+bulk-memory,+atomics,+simd128"
'+bulk-memory+atomics+simd128' is not a recognized feature for this target (ignoring feature)
'+bulk-memory+atomics+simd128' is not a recognized feature for this target (ignoring feature)
'+bulk-memory+atomics+simd128' is not a recognized feature for this target (ignoring feature)

> odin build odin -out:bin/hello.wasm -debug -vet -target:freestanding_wasm32 -target-features:"+bulk-memory" 

> odin build odin -out:bin/hello.wasm -debug -vet -target:freestanding_wasm32 -target-features:"+atomics" 
> odin build odin -out:bin/hello.wasm -debug -vet -target:freestanding_wasm32 -target-features:"+simd128"
```