### PR TITLE
Fix #2389

### DIFF
--- a/core/math/linalg/extended.odin
+++ b/core/math/linalg/extended.odin
@@ -429,11 +429,11 @@ reflect :: proc(I, N: $T) -> (out: T) where IS_ARRAY(T), IS_FLOAT(ELEM_TYPE(T)) 
 	b := N * (2 * dot(N, I))
 	return I - b
 }
-refract :: proc(I, N: $T) -> (out: T) where IS_ARRAY(T), IS_FLOAT(ELEM_TYPE(T)) {
-	dv := dot(N, I)
-	k := 1 - eta*eta - (1 - dv*dv)
+refract :: proc(I, Normal: $V/[$N]$E, eta: E) -> (out: V) where IS_ARRAY(V), IS_FLOAT(ELEM_TYPE(V)) {
+	dv := dot(Normal, I)
+	k := 1 - eta*eta * (1 - dv*dv)
 	a := I * eta
-	b := N * eta*dv*math.sqrt(k)
+	b := Normal * (eta*dv+math.sqrt(k))
 	return (a - b) * E(int(k >= 0))
 }
 


### PR DESCRIPTION
Adds missing `eta` parameter to the function, and fixes the `k` and `b` equations
I'm not sure if renaming the normal variable `N` to `Normal` follows convention or not but I needed the N in the template specialization part.
Feel free to suggest better names for the `Normal` parameter