### PR TITLE
Fixed incorrect precision value in `fmt` doc.

### DIFF
--- a/core/fmt/doc.odin
+++ b/core/fmt/doc.odin
@@ -68,7 +68,7 @@ A period with no following number specifies a precision of 0.
 Examples:
 	%f     default width, default precision
 	%8f    width 8, default precision
-	%.3f   default width, precision 2
+	%.2f   default width, precision 2
 	%8.3f  width 8, precision 3
 	%8.f   width 8, precision 0
 


### PR DESCRIPTION
It seems like `%.2f` is the correct implementation of "precision 2" for displaying floats, not `$.3f`. It prints two decimal places.

Either that or the next case (`%8.3f`) would be wrong instead, if it's the other way around. 

So, there's a mistake here one way or the other at the least.