### PR TITLE
Rename `save_to_memory` for consistency.

### DIFF
--- a/core/image/qoi/qoi.odin
+++ b/core/image/qoi/qoi.odin
@@ -23,7 +23,7 @@ Options :: image.Options
 RGB_Pixel  :: image.RGB_Pixel
 RGBA_Pixel :: image.RGBA_Pixel
 
-save_to_memory  :: proc(output: ^bytes.Buffer, img: ^Image, options := Options{}, allocator := context.allocator) -> (err: Error) {
+save_to_buffer  :: proc(output: ^bytes.Buffer, img: ^Image, options := Options{}, allocator := context.allocator) -> (err: Error) {
 	context.allocator = allocator
 
 	if img == nil {

--- a/core/image/qoi/qoi_js.odin
+++ b/core/image/qoi/qoi_js.odin
@@ -1,6 +1,6 @@
 //+build js
 package qoi
 
-save :: proc{save_to_memory}
+save :: proc{save_to_buffer}
 
 load :: proc{load_from_bytes, load_from_context}

--- a/core/image/qoi/qoi_os.odin
+++ b/core/image/qoi/qoi_os.odin
@@ -4,7 +4,7 @@ package qoi
 import "core:os"
 import "core:bytes"
 
-save :: proc{save_to_memory, save_to_file}
+save :: proc{save_to_buffer, save_to_file}
 
 
 save_to_file :: proc(output: string, img: ^Image, options := Options{}, allocator := context.allocator) -> (err: Error) {
@@ -13,7 +13,7 @@ save_to_file :: proc(output: string, img: ^Image, options := Options{}, allocato
 	out := &bytes.Buffer{}
 	defer bytes.buffer_destroy(out)
 
-	save_to_memory(out, img, options) or_return
+	save_to_buffer(out, img, options) or_return
 	write_ok := os.write_entire_file(output, out.buf[:])
 
 	return nil if write_ok else .Unable_To_Write_File

--- a/core/image/tga/tga.odin
+++ b/core/image/tga/tga.odin
@@ -27,7 +27,7 @@ GA_Pixel   :: image.GA_Pixel
 RGB_Pixel  :: image.RGB_Pixel
 RGBA_Pixel :: image.RGBA_Pixel
 
-save_to_memory  :: proc(output: ^bytes.Buffer, img: ^Image, options := Options{}, allocator := context.allocator) -> (err: Error) {
+save_to_buffer  :: proc(output: ^bytes.Buffer, img: ^Image, options := Options{}, allocator := context.allocator) -> (err: Error) {
 	context.allocator = allocator
 
 	if img == nil {

--- a/core/image/tga/tga_js.odin
+++ b/core/image/tga/tga_js.odin
@@ -1,5 +1,5 @@
 //+build js
 package tga
 
-save :: proc{save_to_memory}
+save :: proc{save_to_buffer}
 load :: proc{load_from_bytes, load_from_context}

--- a/core/image/tga/tga_os.odin
+++ b/core/image/tga/tga_os.odin
@@ -4,7 +4,7 @@ package tga
 import "core:os"
 import "core:bytes"
 
-save :: proc{save_to_memory, save_to_file}
+save :: proc{save_to_buffer, save_to_file}
 
 save_to_file :: proc(output: string, img: ^Image, options := Options{}, allocator := context.allocator) -> (err: Error) {
 	context.allocator = allocator
@@ -12,7 +12,7 @@ save_to_file :: proc(output: string, img: ^Image, options := Options{}, allocato
 	out := &bytes.Buffer{}
 	defer bytes.buffer_destroy(out)
 
-	save_to_memory(out, img, options) or_return
+	save_to_buffer(out, img, options) or_return
 	write_ok := os.write_entire_file(output, out.buf[:])
 
 	return nil if write_ok else .Unable_To_Write_File


### PR DESCRIPTION
NetPBM's `save_to_buffer` is more consistent with the 1st parameter taking `bytes.Buffer`. Let's call them all `save_to_buffer` instead of `save_to_memory`.