### PR TITLE
Add allocator parameter to `json.detroy_value`

### DIFF
--- a/core/encoding/json/types.odin
+++ b/core/encoding/json/types.odin
@@ -87,21 +87,21 @@ Error :: enum {
 
 
 
-destroy_value :: proc(value: Value) {
+destroy_value :: proc(value: Value, allocator := context.allocator) {
 	#partial switch v in value {
 	case Object:
 		for key, elem in v {
-			delete(key)
-			destroy_value(elem)
+			delete(key, allocator)
+			destroy_value(elem, allocator)
 		}
 		delete(v)
 	case Array:
 		for elem in v {
-			destroy_value(elem)
+			destroy_value(elem, allocator)
 		}
 		delete(v)
 	case String:
-		delete(v)
+		delete(v, allocator)
 	}
 }
 

--- a/core/encoding/json/types.odin
+++ b/core/encoding/json/types.odin
@@ -88,20 +88,20 @@ Error :: enum {
 
 
 destroy_value :: proc(value: Value, allocator := context.allocator) {
+	context.allocator := allocator
 	#partial switch v in value {
 	case Object:
 		for key, elem in v {
-			delete(key, allocator)
-			destroy_value(elem, allocator)
+			delete(key)
+			destroy_value(elem)
 		}
 		delete(v)
 	case Array:
 		for elem in v {
-			destroy_value(elem, allocator)
+			destroy_value(elem)
 		}
 		delete(v)
 	case String:
-		delete(v, allocator)
+		delete(v)
 	}
 }
-


### PR DESCRIPTION
Just so I can use it like
```Odin
json.destroy_value(value, context.temp_allocator)
```
Instead of
```Odin
{
    context.allocator = context.temp_allocator
    json.destroy_value(value)
}
```