### PR TITLE
Fix grammar in warning message in parser

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1411,7 +1411,7 @@ gb_internal Token expect_operator(AstFile *f) {
 		             LIT(p));
 	}
 	if (f->curr_token.kind == Token_Ellipsis) {
-		syntax_warning(f->curr_token, "'..' for ranges has now been deprecated, prefer '..='");
+		syntax_warning(f->curr_token, "'..' for ranges have now been deprecated, prefer '..='");
 		f->tokens[f->curr_token_index].flags |= TokenFlag_Replace;
 	}
 	


### PR DESCRIPTION
To finish off the job from PR #2406 , I have changed `has` to `have` :) 