### PR TITLE
Change help text to output to stdout

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -594,13 +594,13 @@ gb_internal Array<String> setup_args(int argc, char const **argv) {
 
 gb_internal void print_usage_line(i32 indent, char const *fmt, ...) {
 	while (indent --> 0) {
-		gb_printf_err("\t");
+		gb_printf("\t");
 	}
 	va_list va;
 	va_start(va, fmt);
-	gb_printf_err_va(fmt, va);
+	gb_printf_va(fmt, va);
 	va_end(va);
-	gb_printf_err("\n");
+	gb_printf("\n");
 }
 
 gb_internal void usage(String argv0) {


### PR DESCRIPTION
Right now, it outputs to stderr which means you can't pipe it into a pager, for example.