### PR TITLE
Fix type comparison not accounting for parapoly params

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -2683,7 +2683,7 @@ gb_internal bool are_types_identical_internal(Type *x, Type *y, bool check_tuple
 					return false;
 				}
 			}
-			return true;
+			return are_types_identical(x->Struct.polymorphic_params, y->Struct.polymorphic_params);
 		}
 		break;
 


### PR DESCRIPTION
Fixes structs (especially empty ones) being mismatched against other structs with the exact same fields but with different parapoly params.

Let me know if this ain't it chief.