### PR TITLE
Make tests scripts error if a test fails

### DIFF
--- a/core/crypto/util/util.odin
+++ b/core/crypto/util/util.odin
@@ -11,6 +11,8 @@ package util
 */
 
 import "core:mem"
+// Keep vet happy
+_ :: mem
 
 // @note(bp): this can replace the other two
 cast_slice :: #force_inline proc "contextless" ($D: typeid/[]$DE, src: $S/[]$SE) -> D {

--- a/tests/core/build.bat
+++ b/tests/core/build.bat
@@ -6,87 +6,82 @@ python3 download_assets.py
 echo ---
 echo Running core:image tests
 echo ---
-%PATH_TO_ODIN% run image    %COMMON% -out:test_core_image.exe
+%PATH_TO_ODIN% run image    %COMMON% -out:test_core_image.exe || exit /b
 
 echo ---
 echo Running core:compress tests
 echo ---
-%PATH_TO_ODIN% run compress %COMMON% -out:test_core_compress.exe
+%PATH_TO_ODIN% run compress %COMMON% -out:test_core_compress.exe || exit /b
 
 echo ---
 echo Running core:strings tests
 echo ---
-%PATH_TO_ODIN% run strings %COMMON% -out:test_core_strings.exe
+%PATH_TO_ODIN% run strings %COMMON% -out:test_core_strings.exe || exit /b
 
 echo ---
 echo Running core:hash tests
 echo ---
-%PATH_TO_ODIN% run hash %COMMON% -o:size -out:test_core_hash.exe
+%PATH_TO_ODIN% run hash %COMMON% -o:size -out:test_core_hash.exe || exit /b
 
 echo ---
 echo Running core:odin tests
 echo ---
-%PATH_TO_ODIN% run odin %COMMON% -o:size -out:test_core_odin.exe
+%PATH_TO_ODIN% run odin %COMMON% -o:size -out:test_core_odin.exe || exit /b
 
 echo ---
 echo Running core:crypto hash tests
 echo ---
-%PATH_TO_ODIN% run crypto %COMMON% -out:test_crypto_hash.exe
+%PATH_TO_ODIN% run crypto %COMMON% -out:test_crypto_hash.exe || exit /b
 
 echo ---
 echo Running core:encoding tests
 echo ---
-%PATH_TO_ODIN% run encoding/hxa    %COMMON% %COLLECTION% -out:test_hxa.exe
-%PATH_TO_ODIN% run encoding/json   %COMMON% -out:test_json.exe
-%PATH_TO_ODIN% run encoding/varint %COMMON% -out:test_varint.exe
-%PATH_TO_ODIN% run encoding/xml    %COMMON% -out:test_xml.exe
+%PATH_TO_ODIN% run encoding/hxa    %COMMON% %COLLECTION% -out:test_hxa.exe || exit /b
+%PATH_TO_ODIN% run encoding/json   %COMMON% -out:test_json.exe || exit /b
+%PATH_TO_ODIN% run encoding/varint %COMMON% -out:test_varint.exe || exit /b
+%PATH_TO_ODIN% run encoding/xml    %COMMON% -out:test_xml.exe || exit /b
 
 echo ---
 echo Running core:math/noise tests
 echo ---
-%PATH_TO_ODIN% run math/noise %COMMON% -out:test_noise.exe
+%PATH_TO_ODIN% run math/noise %COMMON% -out:test_noise.exe || exit /b
 
 echo ---
 echo Running core:math tests
 echo ---
-%PATH_TO_ODIN% run math %COMMON% %COLLECTION% -out:test_core_math.exe
+%PATH_TO_ODIN% run math %COMMON% %COLLECTION% -out:test_core_math.exe || exit /b
 
 echo ---
 echo Running core:math/linalg/glsl tests
 echo ---
-%PATH_TO_ODIN% run math/linalg/glsl %COMMON% %COLLECTION% -out:test_linalg_glsl.exe
+%PATH_TO_ODIN% run math/linalg/glsl %COMMON% %COLLECTION% -out:test_linalg_glsl.exe || exit /b
 
 echo ---
 echo Running core:path/filepath tests
 echo ---
-%PATH_TO_ODIN% run path/filepath %COMMON% %COLLECTION% -out:test_core_filepath.exe
+%PATH_TO_ODIN% run path/filepath %COMMON% %COLLECTION% -out:test_core_filepath.exe || exit /b
 
 echo ---
 echo Running core:reflect tests
 echo ---
-%PATH_TO_ODIN% run reflect %COMMON% %COLLECTION% -out:test_core_reflect.exe
+%PATH_TO_ODIN% run reflect %COMMON% %COLLECTION% -out:test_core_reflect.exe || exit /b
 
 echo ---
 echo Running core:text/i18n tests
 echo ---
-%PATH_TO_ODIN% run text\i18n %COMMON% -out:test_core_i18n.exe
+%PATH_TO_ODIN% run text\i18n %COMMON% -out:test_core_i18n.exe || exit /b
 
 echo ---
 echo Running core:net
 echo ---
-%PATH_TO_ODIN% run net %COMMON% -out:test_core_net.exe
-
-echo ---
-echo Running core:text/lua tests
-echo ---
-%PATH_TO_ODIN% run text\lua %COMMON% -out:test_core_lua_strlib.exe
+%PATH_TO_ODIN% run net %COMMON% -out:test_core_net.exe || exit /b
 
 echo ---
 echo Running core:slice tests
 echo ---
-%PATH_TO_ODIN% run slice %COMMON% -out:test_core_slice.exe
+%PATH_TO_ODIN% run slice %COMMON% -out:test_core_slice.exe || exit /b
 
 echo ---
 echo Running core:container tests
 echo ---
-%PATH_TO_ODIN% run container %COMMON% %COLLECTION% -out:test_core_container.exe
+%PATH_TO_ODIN% run container %COMMON% %COLLECTION% -out:test_core_container.exe || exit /b

--- a/tests/core/compress/test_core_compress.odin
+++ b/tests/core/compress/test_core_compress.odin
@@ -151,6 +151,13 @@ shoco_test :: proc(t: ^testing.T) {
 	}
 
 	for v in Shoco_Tests {
+		when ODIN_OS == .Windows {
+			v := v
+			// Compressed source files are not encoded with carriage returns but git replaces raw files lf with crlf on commit (on windows only)
+			// So replace crlf with lf on windows
+			v.raw, _ = bytes.replace_all(v.raw, { 0xD, 0xA }, { 0xA })
+		}
+
 		expected_raw        := len(v.raw)
 		expected_compressed := len(v.compressed)
 

--- a/tests/documentation/build.bat
+++ b/tests/documentation/build.bat
@@ -4,9 +4,10 @@ set PATH_TO_ODIN==..\..\odin
 echo ---
 echo Building Documentation File
 echo ---
-%PATH_TO_ODIN% doc ..\..\examples\all -all-packages -doc-format
+%PATH_TO_ODIN% doc ..\..\examples\all -all-packages -doc-format || exit /b
+
 
 echo ---
 echo Running Documentation Tester
 echo ---
-%PATH_TO_ODIN% run documentation_tester.odin -file -vet -strict-style -- %PATH_TO_ODIN%
+%PATH_TO_ODIN% run documentation_tester.odin -file -vet -strict-style -- %PATH_TO_ODIN% || exit /b

--- a/tests/internal/build.bat
+++ b/tests/internal/build.bat
@@ -1,4 +1,4 @@
 @echo off
 set PATH_TO_ODIN==..\..\odin
-%PATH_TO_ODIN% run test_map.odin -file -vet -strict-style -o:minimal
+%PATH_TO_ODIN% run test_map.odin -file -vet -strict-style -o:minimal || exit /b
 rem -define:SEED=42

--- a/tests/issues/run.bat
+++ b/tests/issues/run.bat
@@ -5,19 +5,14 @@ pushd build
 
 set COMMON=-collection:tests=..\..
 
-set ERROR_DID_OCCUR=0
-
 @echo on
 
-..\..\..\odin test ..\test_issue_829.odin %COMMON% -file
-..\..\..\odin test ..\test_issue_1592.odin %COMMON% -file
-..\..\..\odin test ..\test_issue_2087.odin %COMMON% -file
-..\..\..\odin build ..\test_issue_2113.odin %COMMON% -file -debug
+..\..\..\odin test ..\test_issue_829.odin %COMMON% -file || exit /b
+..\..\..\odin test ..\test_issue_1592.odin %COMMON% -file || exit /b
+..\..\..\odin test ..\test_issue_2087.odin %COMMON% -file || exit /b
+..\..\..\odin build ..\test_issue_2113.odin %COMMON% -file -debug || exit /b
 
 @echo off
 
-if %ERRORLEVEL% NEQ 0 set ERROR_DID_OCCUR=1
-
 popd
 rmdir /S /Q build
-if %ERROR_DID_OCCUR% NEQ 0 EXIT /B 1

--- a/tests/vendor/build.bat
+++ b/tests/vendor/build.bat
@@ -5,9 +5,9 @@ set PATH_TO_ODIN==..\..\odin
 echo ---
 echo Running vendor:botan tests
 echo ---
-%PATH_TO_ODIN% run botan %COMMON% -out:vendor_botan.exe
+%PATH_TO_ODIN% run botan %COMMON% -out:vendor_botan.exe || exit /b
 
 echo ---
 echo Running vendor:glfw tests
 echo ---
-%PATH_TO_ODIN% run glfw %COMMON% -out:vendor_glfw.exe
+%PATH_TO_ODIN% run glfw %COMMON% -out:vendor_glfw.exe || exit /b


### PR DESCRIPTION
Additionally fixes tests that were found broken because of this.
* Keep vet happy
* Fix crlf encoding on windows platforms in compression tests
* remove non existant text/lua test