### PR TITLE
Add script for removing platform-specific libs

### DIFF
--- a/misc/remove_libraries_for_other_platforms.sh
+++ b/misc/remove_libraries_for_other_platforms.sh
@@ -6,6 +6,12 @@ panic() {
 	exit 1
 }
 
+assert_vendor() {
+	if [ $(basename $(pwd)) != 'vendor' ]; then
+		panic "Not in vendor directory!"
+	fi
+}
+
 remove_windows_libraries() {
 	find . -type f -name '*.dll' | xargs rm -f 
 	find . -type f -name '*.lib' | xargs rm -f
@@ -24,6 +30,7 @@ remove_linux_libraries() {
 
 case $OS in
 	Linux)
+		assert_vendor
 		remove_windows_libraries
 		remove_macos_libraries
 		;;

--- a/misc/remove_libraries_for_other_platforms.sh
+++ b/misc/remove_libraries_for_other_platforms.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+OS=$(uname)
+
+panic() {
+	printf "%s\n" "$1"
+	exit 1
+}
+
+remove_windows_libraries() {
+	find . -type f -name '*.dll' | xargs rm -f 
+	find . -type f -name '*.lib' | xargs rm -f
+	find . -type d -name 'windows' | xargs rm -rf
+}
+
+remove_macos_libraries() {
+	find . -type f -name '*.dylib' | xargs rm -f 
+	find . -type d -name '*macos*' | xargs rm -rf
+}
+
+remove_linux_libraries() {
+	find . -type f -name '*.so' | xargs rm -f 
+	find . -type d -name 'linux' | xargs rm -rf
+}
+
+case $OS in
+	Linux)
+		remove_windows_libraries
+		remove_macos_libraries
+		;;
+	Darwin)
+		remove_windows_libraries
+		remove_linux_libraries
+		;;
+	OpenBSD)
+		remove_windows_libraries
+		remove_macos_libraries
+		remove_linux_libraries
+		;;
+	FreeBSD)
+		remove_windows_libraries
+		remove_macos_libraries
+		remove_linux_libraries
+		;;
+*)
+	panic "Platform unsupported!"
+esac

--- a/misc/remove_libraries_for_other_platforms.sh
+++ b/misc/remove_libraries_for_other_platforms.sh
@@ -35,15 +35,18 @@ case $OS in
 		remove_macos_libraries
 		;;
 	Darwin)
+		assert_vendor
 		remove_windows_libraries
 		remove_linux_libraries
 		;;
 	OpenBSD)
+		assert_vendor
 		remove_windows_libraries
 		remove_macos_libraries
 		remove_linux_libraries
 		;;
 	FreeBSD)
+		assert_vendor
 		remove_windows_libraries
 		remove_macos_libraries
 		remove_linux_libraries


### PR DESCRIPTION
Utility script for removing binary libraries from other platforms.

It is useful for doing a system install of the vendor library collection, for example.