### PR TITLE
SJSON parser: Fix for broken single letter keys

### DIFF
--- a/core/encoding/json/tokenizer.odin
+++ b/core/encoding/json/tokenizer.odin
@@ -163,8 +163,9 @@ get_token :: proc(t: ^Tokenizer) -> (token: Token, err: Error) {
 
 	skip_alphanum :: proc(t: ^Tokenizer) {
 		for t.offset < len(t.data) {
-			switch next_rune(t) {
+			switch t.r {
 			case 'A'..='Z', 'a'..='z', '0'..='9', '_':
+				next_rune(t)
 				continue
 			}
 


### PR DESCRIPTION
When using SJSON parser, an object like this did not parse correctly:

```
{
  x = 0
  y = 0
  w = 200
  h = 50
}
```

It thought the keys were "x ", "y " etc. However, using a non-single-letter key made it work. The cause was a bug in `skip_alphanum` in the JSON tokenizer, it actually didn't check if the first character was alpha numeric or not.