### PR TITLE
Re-enable documentation CI and improve error messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat
           cd tests\documentation
-          rem call build.bat
+          call build.bat
         timeout-minutes: 10
       - name: core:math/big tests
         shell: cmd


### PR DESCRIPTION
Errors now read:

If no procedure is present:
```
We could not find the procedure "parse_f64_prefix_example :: proc()" needed to test the example created for "strconv.parse_f64_prefix"
No procedures were found?
```
and if procedures actually exist in the example:
```
We could not find the procedure "parse_f64_prefix_example :: proc()" needed to test the example created for "strconv.parse_f64_prefix"
The following procedures were found:
        totally_something_different :: proc()
        some_helper_procedure_in_this_example :: proc(i: int) -> int
```
In the above cases the CI won't fail.

We also found out that outputs with backticks will escape the output block so I just made them forbidden. We can't use ``` \` ``` it'll still escape. It'll print the following
```
The line "Source: The raven `Huginn` is black." in the output for "strconv.unquote_string" contains a ` which is not allowed
The line "Unquoted: <he raven `Huginn` is black>, alloc:false, ok:true" in the output for "strconv.unquote_string" contains a ` which is not allowed
```

Also some helper print outs so it's more clear on what item actually failed.

I'd expect the CI will pass after https://github.com/odin-lang/Odin/pull/2440 is merged in.