### PR TITLE
build_odin.sh - fix build on darwin arm64

### DIFF
--- a/build_odin.sh
+++ b/build_odin.sh
@@ -25,11 +25,11 @@ panic() {
 version() { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
 
 config_darwin() {
-	ARCH=$(uname -m)
+	local ARCH=$(uname -m)
 	: ${LLVM_CONFIG=llvm-config}
 
 	# allow for arm only llvm's with version 13
-	if [ ARCH == arm64 ]; then
+	if [ "${ARCH}" == "arm64" ]; then
 		MIN_LLVM_VERSION=("13.0.0")
 	else
 		# allow for x86 / amd64 all llvm versions beginning from 11
@@ -37,7 +37,7 @@ config_darwin() {
 	fi
 
 	if [ $(version $($LLVM_CONFIG --version)) -lt $(version $MIN_LLVM_VERSION) ]; then
-		if [ ARCH == arm64 ]; then
+		if [ "${ARCH}" == "arm64" ]; then
 			panic "Requirement: llvm-config must be base version 13 for arm64"
 		else
 			panic "Requirement: llvm-config must be base version greater than 11 for amd64/x86"
@@ -59,11 +59,11 @@ config_freebsd() {
 	: ${LLVM_CONFIG=}
 
 	if [ ! "$LLVM_CONFIG" ]; then
-		if which llvm-config11 > /dev/null 2>&1; then
+		if [ -x "$(command -v llvm-config11)" ]; then
 			LLVM_CONFIG=llvm-config11
-		elif which llvm-config12 > /dev/null 2>&1; then
+		elif [ -x "$(command -v llvm-config12)" ]; then
 			LLVM_CONFIG=llvm-config12
-		elif which llvm-config13 > /dev/null 2>&1; then
+		elif [ -x "$(command -v llvm-config13)" ]; then
 			LLVM_CONFIG=llvm-config13
 		else
 			panic "Unable to find LLVM-config"
@@ -86,11 +86,11 @@ config_linux() {
 	: ${LLVM_CONFIG=}
 
 	if [ ! "$LLVM_CONFIG" ]; then
-		if which llvm-config > /dev/null 2>&1; then
+		if [ -x "$(command -v llvm-config)" ]; then
 			LLVM_CONFIG=llvm-config
-		elif which llvm-config-11 > /dev/null 2>&1; then
+		elif [ -x "$(command -v llvm-config-11)" ]; then
 			LLVM_CONFIG=llvm-config-11
-		elif which llvm-config-11-64 > /dev/null 2>&1; then
+		elif [ -x "$(command -v llvm-config-11-16)" ]; then
 			LLVM_CONFIG=llvm-config-11-64
 		else
 			panic "Unable to find LLVM-config"
@@ -111,7 +111,7 @@ config_linux() {
 
 	LDFLAGS="$LDFLAGS -ldl"
 	CXXFLAGS="$CXXFLAGS $($LLVM_CONFIG --cxxflags --ldflags)"
-	LDFLAGS="$LDFLAGS $($LLVM_CONFIG  --libs core native --system-libs --libfiles) -Wl,-rpath=\$ORIGIN"
+	LDFLAGS="$LDFLAGS $($LLVM_CONFIG --libs core native --system-libs --libfiles) -Wl,-rpath=\$ORIGIN"
 
 	# Creates a copy of the llvm library in the build dir, this is meant to support compiler explorer.
 	# The annoyance is that this copy can be cluttering the development folder. TODO: split staging folders
@@ -135,6 +135,7 @@ build_odin() {
 		;;
 	*)
 		panic "Build mode unsupported!"
+		;;
 	esac
 
 	set -x
@@ -147,7 +148,7 @@ run_demo() {
 }
 
 have_which() {
-	if ! which which > /dev/null 2>&1; then
+	if ! [ -x "$(command -v which)" ]; then
 		panic "Could not find \`which\`"
 	fi
 }
@@ -169,6 +170,7 @@ FreeBSD)
 	;;
 *)
 	panic "Platform unsupported!"
+	;;
 esac
 
 if [[ $# -eq 0 ]]; then


### PR DESCRIPTION
Done:
- use `ARCH` variable properly
- refactor `have_which()` to use POSIX compliant `command` - [ref](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html)
- use `command` instead of `which` for the same reason as above.
- run shfmt for consistency.

Tested on: Apple M1 Pro