### PR TITLE
Document return values of strings and add allocator errors where possible

### DIFF
--- a/core/encoding/csv/writer.odin
+++ b/core/encoding/csv/writer.odin
@@ -42,7 +42,7 @@ write :: proc(w: ^Writer, record: []string) -> io.Error {
 				}
 			}
 		case:
-			if strings.contains_rune(field, w.comma) >= 0 {
+			if strings.contains_rune(field, w.comma) {
 				return true
 			}
 			if strings.contains_any(field, CHAR_SET) {

--- a/core/strings/ascii_set.odin
+++ b/core/strings/ascii_set.odin
@@ -38,8 +38,8 @@ Inputs:
 - c: The char to check for in the Ascii_Set.
 
 Returns:
-A boolean indicating if the byte is contained in the Ascii_Set (true) or not (false).
+- res: A boolean indicating if the byte is contained in the Ascii_Set (true) or not (false).
 */
-ascii_set_contains :: proc(as: Ascii_Set, c: byte) -> bool #no_bounds_check {
+ascii_set_contains :: proc(as: Ascii_Set, c: byte) -> (res: bool) #no_bounds_check {
 	return as[c>>5] & (1<<(c&31)) != 0
 }

--- a/core/strings/conversion.odin
+++ b/core/strings/conversion.odin
@@ -1,6 +1,7 @@
 package strings
 
 import "core:io"
+import "core:mem"
 import "core:unicode"
 import "core:unicode/utf8"
 
@@ -17,15 +18,16 @@ Inputs:
 WARNING: Allocation does not occur when len(s) == 0
 
 Returns:
-A valid UTF-8 string with invalid sequences replaced by `replacement`.
+- res: A valid UTF-8 string with invalid sequences replaced by `replacement`.
+- err: An optional allocator error if one occured, `nil` otherwise
 */
-to_valid_utf8 :: proc(s, replacement: string, allocator := context.allocator) -> string {
+to_valid_utf8 :: proc(s, replacement: string, allocator := context.allocator) -> (res: string, err: mem.Allocator_Error) #optional_allocator_error {
 	if len(s) == 0 {
-		return ""
+		return "", nil
 	}
 
 	b: Builder
-	builder_init(&b, 0, 0, allocator)
+	builder_init(&b, 0, 0, allocator) or_return
 
 	s := s
 	for c, i in s {
@@ -70,7 +72,7 @@ to_valid_utf8 :: proc(s, replacement: string, allocator := context.allocator) ->
 		write_string(&b, s[i:][:w])
 		i += w
 	}
-	return to_string(b)
+	return to_string(b), nil
 }
 /*
 Converts the input string `s` to all lowercase characters.
@@ -82,7 +84,8 @@ Inputs:
 - allocator: (default: context.allocator).
 
 Returns:
-A new string with all characters converted to lowercase.
+- res: The new string with all characters converted to lowercase
+- err: An optional allocator error if one occured, `nil` otherwise
 
 Example:
 
@@ -98,13 +101,13 @@ Output:
 	test
 
 */
-to_lower :: proc(s: string, allocator := context.allocator) -> string {
+to_lower :: proc(s: string, allocator := context.allocator) -> (res: string, err: mem.Allocator_Error) #optional_allocator_error {
 	b: Builder
-	builder_init(&b, 0, len(s), allocator)
+	builder_init(&b, 0, len(s), allocator) or_return
 	for r in s {
 		write_rune(&b, unicode.to_lower(r))
 	}
-	return to_string(b)
+	return to_string(b), nil
 }
 /*
 Converts the input string `s` to all uppercase characters.
@@ -116,7 +119,8 @@ Inputs:
 - allocator: (default: context.allocator).
 
 Returns:
-A new string with all characters converted to uppercase.
+- res: The new string with all characters converted to uppercase
+- err: An optional allocator error if one occured, `nil` otherwise
 
 Example:
 
@@ -132,13 +136,13 @@ Output:
 	TEST
 
 */
-to_upper :: proc(s: string, allocator := context.allocator) -> string {
+to_upper :: proc(s: string, allocator := context.allocator) -> (res: string, err: mem.Allocator_Error) #optional_allocator_error {
 	b: Builder
-	builder_init(&b, 0, len(s), allocator)
+	builder_init(&b, 0, len(s), allocator) or_return
 	for r in s {
 		write_rune(&b, unicode.to_upper(r))
 	}
-	return to_string(b)
+	return to_string(b), nil
 }
 /*
 Checks if the rune `r` is a delimiter (' ', '-', or '_').
@@ -147,9 +151,9 @@ Inputs:
 - r: Rune to check for delimiter status.
 
 Returns:
-True if `r` is a delimiter, false otherwise.
+- res: True if `r` is a delimiter, false otherwise.
 */
-is_delimiter :: proc(r: rune) -> bool {
+is_delimiter :: proc(r: rune) -> (res: bool) {
 	return r == '-' || r == '_' || is_space(r)
 }
 /*
@@ -159,9 +163,9 @@ Inputs:
 - r: Rune to check for separator status.
 
 Returns:
-True if `r` is a non-alpha or `unicode.is_space` rune.
+- res: True if `r` is a non-alpha or `unicode.is_space` rune.
 */
-is_separator :: proc(r: rune) -> bool {
+is_separator :: proc(r: rune) -> (res: bool) {
 	if r <= 0x7f {
 		switch r {
 		case '0' ..= '9':
@@ -253,13 +257,14 @@ Inputs:
 - allocator: (default: context.allocator).
 
 Returns:
-A "lowerCamelCase" formatted string.
+- res: The converted string
+- err: An optional allocator error if one occured, `nil` otherwise
 */
-to_camel_case :: proc(s: string, allocator := context.allocator) -> string {
+to_camel_case :: proc(s: string, allocator := context.allocator) -> (res: string, err: mem.Allocator_Error) #optional_allocator_error {
 	s := s
 	s = trim_space(s)
 	b: Builder
-	builder_init(&b, 0, len(s), allocator)
+	builder_init(&b, 0, len(s), allocator) or_return
 	w := to_writer(&b)
 
 	string_case_iterator(w, s, proc(w: io.Writer, prev, curr, next: rune) {
@@ -274,7 +279,7 @@ to_camel_case :: proc(s: string, allocator := context.allocator) -> string {
 		}
 	})
 
-	return to_string(b)
+	return to_string(b), nil
 }
 // Alias to `to_pascal_case`
 to_upper_camel_case :: to_pascal_case
@@ -288,13 +293,14 @@ Inputs:
 - allocator: (default: context.allocator).
 
 Returns:
-A "PascalCase" formatted string.
+- res: The converted string
+- err: An optional allocator error if one occured, `nil` otherwise
 */
-to_pascal_case :: proc(s: string, allocator := context.allocator) -> string {
+to_pascal_case :: proc(s: string, allocator := context.allocator) -> (res: string, err: mem.Allocator_Error) #optional_allocator_error {
 	s := s
 	s = trim_space(s)
 	b: Builder
-	builder_init(&b, 0, len(s), allocator)
+	builder_init(&b, 0, len(s), allocator) or_return
 	w := to_writer(&b)
 
 	string_case_iterator(w, s, proc(w: io.Writer, prev, curr, next: rune) {
@@ -309,7 +315,7 @@ to_pascal_case :: proc(s: string, allocator := context.allocator) -> string {
 		}
 	})
 
-	return to_string(b)
+	return to_string(b), nil
 }
 /*
 Returns a string converted to a delimiter-separated case with configurable casing
@@ -323,7 +329,8 @@ Inputs:
 - allocator: (default: context.allocator).
 
 Returns:
-The converted string
+- res: The converted string
+- err: An optional allocator error if one occured, `nil` otherwise
 
 Example:
 
@@ -348,11 +355,11 @@ to_delimiter_case :: proc(
 	delimiter: rune,
 	all_upper_case: bool,
 	allocator := context.allocator,
-) -> string {
+) -> (res: string, err: mem.Allocator_Error) #optional_allocator_error {
 	s := s
 	s = trim_space(s)
 	b: Builder
-	builder_init(&b, 0, len(s), allocator)
+	builder_init(&b, 0, len(s), allocator) or_return
 	w := to_writer(&b)
 
 	adjust_case := unicode.to_upper if all_upper_case else unicode.to_lower
@@ -384,7 +391,7 @@ to_delimiter_case :: proc(
 		io.write_rune(w, adjust_case(curr))
 	}
 
-	return to_string(b)
+	return to_string(b), nil
 }
 /*
 Converts a string to "snake_case" with all runes lowercased
@@ -396,7 +403,8 @@ Inputs:
 - allocator: (default: context.allocator).
 
 Returns:
-The converted string
+- res: The converted string
+- err: An optional allocator error if one occured, `nil` otherwise
 
 Example:
 
@@ -414,7 +422,7 @@ Output:
 	hello_world
 
 */
-to_snake_case :: proc(s: string, allocator := context.allocator) -> string {
+to_snake_case :: proc(s: string, allocator := context.allocator) -> (res: string, err: mem.Allocator_Error) #optional_allocator_error {
 	return to_delimiter_case(s, '_', false, allocator)
 }
 // Alias for `to_upper_snake_case`
@@ -429,7 +437,8 @@ Inputs:
 - allocator: (default: context.allocator).
 
 Returns:
-The converted string
+- res: The converted string
+- err: An optional allocator error if one occured, `nil` otherwise
 
 Example:
 
@@ -445,7 +454,7 @@ Output:
 	HELLO_WORLD
 
 */
-to_upper_snake_case :: proc(s: string, allocator := context.allocator) -> string {
+to_upper_snake_case :: proc(s: string, allocator := context.allocator) -> (res: string, err: mem.Allocator_Error) #optional_allocator_error {
 	return to_delimiter_case(s, '_', true, allocator)
 }
 /*
@@ -458,7 +467,8 @@ Inputs:
 - allocator: (default: context.allocator).
 
 Returns:
-The converted string
+- res: The converted string
+- err: An optional allocator error if one occured, `nil` otherwise
 
 Example:
 
@@ -474,7 +484,7 @@ Output:
 	hello-world
 
 */
-to_kebab_case :: proc(s: string, allocator := context.allocator) -> string {
+to_kebab_case :: proc(s: string, allocator := context.allocator) -> (res: string, err: mem.Allocator_Error) #optional_allocator_error  {
 	return to_delimiter_case(s, '-', false, allocator)
 }
 /*
@@ -487,7 +497,8 @@ Inputs:
 - allocator: (default: context.allocator).
 
 Returns:
-The converted string
+- res: The converted string
+- err: An optional allocator error if one occured, `nil` otherwise
 
 Example:
 
@@ -503,7 +514,7 @@ Output:
 	HELLO-WORLD
 
 */
-to_upper_kebab_case :: proc(s: string, allocator := context.allocator) -> string {
+to_upper_kebab_case :: proc(s: string, allocator := context.allocator) -> (res: string, err: mem.Allocator_Error) #optional_allocator_error  {
 	return to_delimiter_case(s, '-', true, allocator)
 }
 /*
@@ -516,7 +527,8 @@ Inputs:
 - allocator: (default: context.allocator).
 
 Returns:
-The converted string
+- res: The converted string
+- err: An optional allocator error if one occured, `nil` otherwise
 
 Example:
 
@@ -532,11 +544,11 @@ Output:
 	Hello_World
 
 */
-to_ada_case :: proc(s: string, allocator := context.allocator) -> string {
+to_ada_case :: proc(s: string, allocator := context.allocator) -> (res: string, err: mem.Allocator_Error) #optional_allocator_error  {
 	s := s
 	s = trim_space(s)
 	b: Builder
-	builder_init(&b, 0, len(s), allocator)
+	builder_init(&b, 0, len(s), allocator) or_return
 	w := to_writer(&b)
 
 	string_case_iterator(w, s, proc(w: io.Writer, prev, curr, next: rune) {
@@ -552,5 +564,5 @@ to_ada_case :: proc(s: string, allocator := context.allocator) -> string {
 		}
 	})
 
-	return to_string(b)
+	return to_string(b), nil
 }

--- a/core/strings/intern.odin
+++ b/core/strings/intern.odin
@@ -1,6 +1,7 @@
 package strings
 
 import "core:runtime"
+import "core:mem"
 
 // Custom string entry struct
 Intern_Entry :: struct {
@@ -29,10 +30,14 @@ Inputs:
 - m: A pointer to the Intern struct to be initialized
 - allocator: The allocator for the Intern_Entry strings (Default: context.allocator)
 - map_allocator: The allocator for the map of entries (Default: context.allocator)
+
+Returns:
+- err: An allocator error if one occured, `nil` otherwise
 */
-intern_init :: proc(m: ^Intern, allocator := context.allocator, map_allocator := context.allocator) {
+intern_init :: proc(m: ^Intern, allocator := context.allocator, map_allocator := context.allocator) -> (err: mem.Allocator_Error) {
 	m.allocator = allocator
-	m.entries = make(map[string]^Intern_Entry, 16, map_allocator)
+	m.entries = make(map[string]^Intern_Entry, 16, map_allocator) or_return
+    return nil
 }
 /*
 Frees the map and all its content allocated using the `.allocator`.
@@ -58,7 +63,8 @@ Inputs:
 NOTE: The returned string lives as long as the map entry lives.
 
 Returns:
-The interned string and an allocator error if any
+- str: The interned string
+- err: An allocator error if one occured, `nil` otherwise
 */
 intern_get :: proc(m: ^Intern, text: string) -> (str: string, err: runtime.Allocator_Error) {
 	entry := _intern_get_entry(m, text) or_return
@@ -76,7 +82,8 @@ Inputs:
 NOTE: The returned cstring lives as long as the map entry lives
 
 Returns:
-The interned cstring and an allocator error if any
+- str: The interned cstring
+- err: An allocator error if one occured, `nil` otherwise
 */
 intern_get_cstring :: proc(m: ^Intern, text: string) -> (str: cstring, err: runtime.Allocator_Error) {
 	entry := _intern_get_entry(m, text) or_return
@@ -93,7 +100,8 @@ Inputs:
 - text: The string to be looked up or interned
 
 Returns:
-The new or existing interned entry and an allocator error if any
+- new_entry: The interned cstring
+- err: An allocator error if one occured, `nil` otherwise
 */
 _intern_get_entry :: proc(m: ^Intern, text: string) -> (new_entry: ^Intern_Entry, err: runtime.Allocator_Error) #no_bounds_check {
 	if prev, ok := m.entries[text]; ok {

--- a/core/strings/reader.odin
+++ b/core/strings/reader.odin
@@ -32,7 +32,7 @@ Inputs:
 - r: A pointer to a Reader struct
 
 Returns:
-An io.Stream for the given Reader
+- s: An io.Stream for the given Reader
 */
 reader_to_stream :: proc(r: ^Reader) -> (s: io.Stream) {
 	s.stream_data = r
@@ -47,9 +47,9 @@ Inputs:
 - s: The input string to be read
 
 Returns:
-An io.Reader for the given string
+- res: An io.Reader for the given string
 */
-to_reader :: proc(r: ^Reader, s: string) -> io.Reader {
+to_reader :: proc(r: ^Reader, s: string) -> (res: io.Reader) {
 	reader_init(r, s)
 	rr, _ := io.to_reader(reader_to_stream(r))
 	return rr
@@ -62,9 +62,9 @@ Inputs:
 - s: The input string to be read
 
 Returns:
-An `io.Reader_At` for the given string
+- res: An `io.Reader_At` for the given string
 */
-to_reader_at :: proc(r: ^Reader, s: string) -> io.Reader_At {
+to_reader_at :: proc(r: ^Reader, s: string) -> (res: io.Reader_At) {
 	reader_init(r, s)
 	rr, _ := io.to_reader_at(reader_to_stream(r))
 	return rr
@@ -76,9 +76,9 @@ Inputs:
 - r: A pointer to a Reader struct
 
 Returns:
-The remaining length of the Reader
+- res: The remaining length of the Reader
 */
-reader_length :: proc(r: ^Reader) -> int {
+reader_length :: proc(r: ^Reader) -> (res: int) {
 	if r.i >= i64(len(r.s)) {
 		return 0
 	}
@@ -91,9 +91,9 @@ Inputs:
 - r: A pointer to a Reader struct
 
 Returns:
-The length of the string stored in the Reader
+- res: The length of the string stored in the Reader
 */
-reader_size :: proc(r: ^Reader) -> i64 {
+reader_size :: proc(r: ^Reader) -> (res: i64) {
 	return i64(len(r.s))
 }
 /*
@@ -151,7 +151,7 @@ Returns:
 - The byte read from the Reader
 - err: An `io.Error` if an error occurs while reading, including `.EOF`, otherwise `nil` denotes success.
 */
-reader_read_byte :: proc(r: ^Reader) -> (byte, io.Error) {
+reader_read_byte :: proc(r: ^Reader) -> (res: byte, err: io.Error) {
 	r.prev_rune = -1
 	if r.i >= i64(len(r.s)) {
 		return 0, .EOF
@@ -167,9 +167,9 @@ Inputs:
 - r: A pointer to a Reader struct
 
 Returns:
-An `io.Error` if `r.i <= 0` (`.Invalid_Unread`), otherwise `nil` denotes success.
+- err: An `io.Error` if `r.i <= 0` (`.Invalid_Unread`), otherwise `nil` denotes success.
 */
-reader_unread_byte :: proc(r: ^Reader) -> io.Error {
+reader_unread_byte :: proc(r: ^Reader) -> (err: io.Error) {
 	if r.i <= 0 {
 		return .Invalid_Unread
 	}
@@ -211,9 +211,9 @@ Inputs:
 WARNING: May only be used once and after a valid `read_rune` call
 
 Returns:
-An `io.Error` if an error occurs while unreading (`.Invalid_Unread`), else `nil` denotes success.
+- err: An `io.Error` if an error occurs while unreading (`.Invalid_Unread`), else `nil` denotes success.
 */
-reader_unread_rune :: proc(r: ^Reader) -> io.Error {
+reader_unread_rune :: proc(r: ^Reader) -> (err: io.Error) {
 	if r.i <= 0 {
 		return .Invalid_Unread
 	}
@@ -236,7 +236,7 @@ Returns:
 - The absolute offset after seeking
 - err: An `io.Error` if an error occurs while seeking (`.Invalid_Whence`, `.Invalid_Offset`)
 */
-reader_seek :: proc(r: ^Reader, offset: i64, whence: io.Seek_From) -> (i64, io.Error) {
+reader_seek :: proc(r: ^Reader, offset: i64, whence: io.Seek_From) -> (res: i64, err: io.Error) {
 	r.prev_rune = -1
 	abs: i64
 	switch whence {

--- a/tests/core/strings/test_core_strings.odin
+++ b/tests/core/strings/test_core_strings.odin
@@ -5,6 +5,7 @@ import "core:testing"
 import "core:fmt"
 import "core:os"
 import "core:runtime"
+import "core:mem"
 
 TEST_count := 0
 TEST_fail  := 0
@@ -105,33 +106,46 @@ Case_Kind :: enum {
 	Ada_Case,
 }
 
-test_cases := [Case_Kind]struct{s: string, p: proc(r: string, allocator: runtime.Allocator) -> string}{
+Case_Proc :: proc(r: string, allocator: runtime.Allocator) -> (string, mem.Allocator_Error)
+
+test_cases := [Case_Kind]struct{s: string, p: Case_Proc}{
 	.Lower_Space_Case = {"hellope world", to_lower_space_case},
 	.Upper_Space_Case = {"HELLOPE WORLD", to_upper_space_case},
-	.Lower_Snake_Case = {"hellope_world", strings.to_snake_case},
-	.Upper_Snake_Case = {"HELLOPE_WORLD", strings.to_upper_snake_case},
-	.Lower_Kebab_Case = {"hellope-world", strings.to_kebab_case},
-	.Upper_Kebab_Case = {"HELLOPE-WORLD", strings.to_upper_kebab_case},
-	.Camel_Case       = {"hellopeWorld",  strings.to_camel_case},
-	.Pascal_Case      = {"HellopeWorld",  strings.to_pascal_case},
-	.Ada_Case         = {"Hellope_World", strings.to_ada_case},
+	.Lower_Snake_Case = {"hellope_world", to_snake_case},
+	.Upper_Snake_Case = {"HELLOPE_WORLD", to_upper_snake_case},
+	.Lower_Kebab_Case = {"hellope-world", to_kebab_case},
+	.Upper_Kebab_Case = {"HELLOPE-WORLD", to_upper_kebab_case},
+	.Camel_Case       = {"hellopeWorld",  to_camel_case},
+	.Pascal_Case      = {"HellopeWorld",  to_pascal_case},
+	.Ada_Case         = {"Hellope_World", to_ada_case},
 }
 
-to_lower_space_case :: proc(r: string, allocator: runtime.Allocator) -> string {
+to_lower_space_case :: proc(r: string, allocator: runtime.Allocator) -> (string, mem.Allocator_Error) {
 	return strings.to_delimiter_case(r, ' ', false, allocator)
 }
-to_upper_space_case :: proc(r: string, allocator: runtime.Allocator) -> string {
+to_upper_space_case :: proc(r: string, allocator: runtime.Allocator) -> (string, mem.Allocator_Error) {
 	return strings.to_delimiter_case(r, ' ', true, allocator)
 }
+
+// NOTE: we have these wrappers as having #optional_allocator_error changes the type to not be equivalent
+to_snake_case :: proc(r: string, allocator: runtime.Allocator) -> (string, mem.Allocator_Error) { return strings.to_snake_case(r, allocator) }
+to_upper_snake_case :: proc(r: string, allocator: runtime.Allocator) -> (string, mem.Allocator_Error) { return strings.to_upper_snake_case(r, allocator) }
+to_kebab_case :: proc(r: string, allocator: runtime.Allocator) -> (string, mem.Allocator_Error) { return strings.to_kebab_case(r, allocator) }
+to_upper_kebab_case :: proc(r: string, allocator: runtime.Allocator) -> (string, mem.Allocator_Error) { return strings.to_upper_kebab_case(r, allocator) }
+to_camel_case :: proc(r: string, allocator: runtime.Allocator) -> (string, mem.Allocator_Error) { return strings.to_camel_case(r, allocator) }
+to_pascal_case :: proc(r: string, allocator: runtime.Allocator) -> (string, mem.Allocator_Error) { return strings.to_pascal_case(r, allocator) }
+to_ada_case :: proc(r: string, allocator: runtime.Allocator) -> (string, mem.Allocator_Error) { return strings.to_ada_case(r, allocator) }
 
 @test
 test_case_conversion :: proc(t: ^testing.T) {
 	for entry in test_cases {
 		for test_case, case_kind in test_cases {
-			result := entry.p(test_case.s, context.allocator)
+			result, err := entry.p(test_case.s, context.allocator)
+			msg := fmt.tprintf("ERROR: We got the allocation error '{}'\n", err)
+			expect(t, err == nil, msg)
 			defer delete(result)
 
-			msg := fmt.tprintf("ERROR: Input `{}` to converter {} does not match `{}`, got `{}`.\n", test_case.s, case_kind, entry.s, result)
+			msg = fmt.tprintf("ERROR: Input `{}` to converter {} does not match `{}`, got `{}`.\n", test_case.s, case_kind, entry.s, result)
 			expect(t, result == entry.s, msg)
 		}
 	}

--- a/tests/documentation/documentation_tester.odin
+++ b/tests/documentation/documentation_tester.odin
@@ -411,7 +411,7 @@ main :: proc() {
 			// NOTE: this will escape the multiline string. Even with a backslash it still escapes due to the semantics of `
 			// I don't think any examples would really need this specific character so let's just make it forbidden and change
 			// in the future if we really need to
-			if strings.contains_rune(line, '`') >= 0 {
+			if strings.contains_rune(line, '`') {
 				fmt.eprintf("The line %q in the output for \"%s.%s\" contains a ` which is not allowed\n", line, test.package_name, test.entity_name)
 				g_bad_doc = true
 				had_line_error = true


### PR DESCRIPTION
Code changes:
* Make allocating procedures in `core:strings` return an optional allocator error
* Correct `contains_rune` to return a boolean rather than the index (we already have `index_rune` and all other `contain` functions return boolean)

Documentation changes:
* Make all procedures in `core:strings` have a named return value and document those returns.