### PR TITLE
Fix intrinsics.alloca code generation

### DIFF
--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -2042,7 +2042,7 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 			i64 al = exact_value_to_i64(type_and_value_of_expr(ce->args[1]).value);
 
 			lbValue res = {};
-			res.type = t_u8_ptr;
+			res.type = alloc_type_multi_pointer(t_u8);
 			res.value = LLVMBuildArrayAlloca(p->builder, lb_type(p->module, t_u8), sz.value, "");
 			LLVMSetAlignment(res.value, cast(unsigned)al);
 			return res;


### PR DESCRIPTION
There was a disconnect between the declared return type for alloca intrinsic in check_builtin.cpp (multi_pointer(t_u8)) and the generated result type in llvm_backend_proc.cpp (t_u8_ptr).

This allowed slicing the return type, but in the code generation process the type of the expression wasn't sliceable, which triggered the assert.

Fixes #2139