### PR TITLE
build_odin.sh: fix typo introduced in detection of llvm-config-11-64

### DIFF
--- a/build_odin.sh
+++ b/build_odin.sh
@@ -95,7 +95,7 @@ config_linux() {
 			LLVM_CONFIG=llvm-config
 		elif [ -x "$(command -v llvm-config-11)" ]; then
 			LLVM_CONFIG=llvm-config-11
-		elif [ -x "$(command -v llvm-config-11-16)" ]; then
+		elif [ -x "$(command -v llvm-config-11-64)" ]; then
 			LLVM_CONFIG=llvm-config-11-64
 		elif [ -x "$(command -v llvm-config-14)" ]; then
 			LLVM_CONFIG=llvm-config-14


### PR DESCRIPTION
appeared in https://github.com/odin-lang/Odin/commit/b22d71a74e5cd9ad6f810a2a7d155523bb7c0782