### PR TITLE
Handle unmarshalling unknown values in `core:encoding/json`

### DIFF
--- a/core/encoding/json/unmarshal.odin
+++ b/core/encoding/json/unmarshal.odin
@@ -215,6 +215,12 @@ unmarshal_value :: proc(p: ^Parser, v: any) -> (err: Unmarshal_Error) {
 		}
 	}
 	
+    switch dst in &v {
+    // Handle json.Value as an unknown type
+    case Value:
+        dst = parse_value(p) or_return
+        return
+    }
 	
 	#partial switch token.kind {
 	case .Null:

--- a/core/encoding/json/unmarshal.odin
+++ b/core/encoding/json/unmarshal.odin
@@ -215,12 +215,12 @@ unmarshal_value :: proc(p: ^Parser, v: any) -> (err: Unmarshal_Error) {
 		}
 	}
 	
-    switch dst in &v {
-    // Handle json.Value as an unknown type
-    case Value:
-        dst = parse_value(p) or_return
-        return
-    }
+	switch dst in &v {
+	// Handle json.Value as an unknown type
+	case Value:
+		dst = parse_value(p) or_return
+		return
+	}
 	
 	#partial switch token.kind {
 	case .Null:


### PR DESCRIPTION
I added a small feature which allows unmarshalling fields with unknown types. This is useful when a JSON file contains something like a tagged union. Without this feature it's not possible to use `json.unmarshal`, even if just one field in the whole file has an unknown type.

My use-case is importing [LDtk](https://ldtk.io/) levels to a game I'm working on. E.g. [Entity Fields](https://ldtk.io/docs/game-dev/json-overview/entity-fields/) can have a value with different type based on `"__type"` field.

I don't know if there is a better way of implementing this behavior, but I think using `json.Value` is nicer than just using `any` for values of unknown type, and the implementation is extremely simple. Another benefit of using `json.Value` is that marshalling code works with it without any problems.

Here is a [github gist of my LDtk imporer](https://gist.github.com/jakubtomsu/287f7eb182854821979ade80f9a25648#:~:text=a%20JSON%20array.-,__value%3A%20%20%20%20%20%20any%2C,-//%20Reference%20of), the highlighted line shows a field with an unknown value.

Also, it might be a good idea to document this behavior somewhere, but since the json package doesn't have any documentation whatsoever I didn't know where to put it.