### PR TITLE
Add IsWindow to user32.odin

### DIFF
--- a/core/sys/windows/user32.odin
+++ b/core/sys/windows/user32.odin
@@ -38,6 +38,7 @@ foreign user32 {
 	DestroyWindow :: proc(hWnd: HWND) -> BOOL ---
 
 	ShowWindow :: proc(hWnd: HWND, nCmdShow: c_int) -> BOOL ---
+	IsWindow :: proc(hWnd: HWND) -> BOOL ---
 	BringWindowToTop :: proc(hWnd: HWND) -> BOOL ---
 	GetTopWindow :: proc(hWnd: HWND) -> HWND ---
 	SetForegroundWindow :: proc(hWnd: HWND) -> BOOL ---


### PR DESCRIPTION
This is useful for checking if a window has been closed without going through the WindowProc.