### PR TITLE
Change default executable extension for non-Windows platforms

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1502,7 +1502,7 @@ gb_internal bool init_build_paths(String init_filename) {
 
 		if (build_context.metrics.os == TargetOs_windows) {
 			output_extension = STR_LIT("exe");
-		} else if (!str_eq(init_filename, str_lit(".")) && path_is_directory(init_filename)) {
+		} else if (!str_eq(init_filename, str_lit(".")) && path_is_directory(last_path_element(init_filename))) {
 			// Add .bin extension to avoid collision
 			// with package directory name
 			output_extension = STR_LIT("bin");

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1502,16 +1502,9 @@ gb_internal bool init_build_paths(String init_filename) {
 
 		if (build_context.metrics.os == TargetOs_windows) {
 			output_extension = STR_LIT("exe");
-		} else if (str_eq(init_filename, str_lit("."))) {
-			// Avoid conflict in edge case where directory to be compiled is
-			// the same as the current directory's name
-			if (path_is_directory(last_path_element(get_current_directory()))) {
-				// Add .bin extension to avoid collision
-				// with package directory name
-				output_extension = STR_LIT("bin");
-			}
-		// Path could be absolute or relative
 		} else if (path_is_directory(last_path_element(bc->build_paths[BuildPath_Main_Package].basename))) {
+			// Add .bin extension to avoid collision
+			// with package directory name
 			output_extension = STR_LIT("bin");
 		}
 	} else if (build_context.build_mode == BuildMode_DynamicLibrary) {

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1502,6 +1502,10 @@ gb_internal bool init_build_paths(String init_filename) {
 
 		if (build_context.metrics.os == TargetOs_windows) {
 			output_extension = STR_LIT("exe");
+		} else if (!str_eq(init_filename, str_lit(".")) && path_is_directory(init_filename)) {
+			// Add .bin extension to avoid collision
+			// with package directory name
+			output_extension = STR_LIT("bin");
 		}
 	} else if (build_context.build_mode == BuildMode_DynamicLibrary) {
 		// By default use a .so shared library extension.

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1510,7 +1510,8 @@ gb_internal bool init_build_paths(String init_filename) {
 				// with package directory name
 				output_extension = STR_LIT("bin");
 			}
-		} else if (path_is_directory(last_path_element(init_filename))) {
+		// Path could be absolute or relative
+		} else if (path_is_directory(last_path_element(init_filename)) || path_is_directory(init_filename)) {
 			output_extension = STR_LIT("bin");
 		}
 	} else if (build_context.build_mode == BuildMode_DynamicLibrary) {

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1511,7 +1511,7 @@ gb_internal bool init_build_paths(String init_filename) {
 				output_extension = STR_LIT("bin");
 			}
 		// Path could be absolute or relative
-		} else if (path_is_directory(last_path_element(init_filename)) || path_is_directory(init_filename)) {
+		} else if (path_is_directory(last_path_element(bc->build_paths[BuildPath_Main_Package].basename))) {
 			output_extension = STR_LIT("bin");
 		}
 	} else if (build_context.build_mode == BuildMode_DynamicLibrary) {

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1625,14 +1625,6 @@ gb_internal bool init_build_paths(String init_filename) {
 		return false;
 	}
 
-	if (path_is_directory(bc->build_paths[BuildPath_Output])) {
-		String output_file = path_to_string(ha, bc->build_paths[BuildPath_Output]);
-		defer (gb_free(ha, output_file.text));
-		gb_printf_err("Output path %.*s is a directory.\n", LIT(output_file));
-		return false;
-	}
-	//nocheckin char const *pathname = (char *)bc->build_paths[BuildPath_Output].basename.text;
-
 	if (!write_directory(bc->build_paths[BuildPath_Output].basename)) {
 		String output_file = path_to_string(ha, bc->build_paths[BuildPath_Output]);
 		defer (gb_free(ha, output_file.text));

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1497,13 +1497,11 @@ gb_internal bool init_build_paths(String init_filename) {
 	} else if (is_arch_wasm()) {
 		output_extension = STR_LIT("wasm");
 	} else if (build_context.build_mode == BuildMode_Executable) {
-		// By default use a .bin executable extension.
-		output_extension = STR_LIT("bin");
+		// By default use no executable extension.
+		output_extension = make_string(nullptr, 0);
 
 		if (build_context.metrics.os == TargetOs_windows) {
 			output_extension = STR_LIT("exe");
-		} else if (build_context.cross_compiling && selected_target_metrics->metrics == &target_essence_amd64) {
-			output_extension = make_string(nullptr, 0);
 		}
 	} else if (build_context.build_mode == BuildMode_DynamicLibrary) {
 		// By default use a .so shared library extension.

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1502,9 +1502,15 @@ gb_internal bool init_build_paths(String init_filename) {
 
 		if (build_context.metrics.os == TargetOs_windows) {
 			output_extension = STR_LIT("exe");
-		} else if (!str_eq(init_filename, str_lit(".")) && path_is_directory(last_path_element(init_filename))) {
-			// Add .bin extension to avoid collision
-			// with package directory name
+		} else if (str_eq(init_filename, str_lit("."))) {
+			// Avoid conflict in edge case where directory to be compiled is
+			// the same as the current directory's name
+			if (path_is_directory(last_path_element(get_current_directory()))) {
+				// Add .bin extension to avoid collision
+				// with package directory name
+				output_extension = STR_LIT("bin");
+			}
+		} else if (path_is_directory(last_path_element(init_filename))) {
 			output_extension = STR_LIT("bin");
 		}
 	} else if (build_context.build_mode == BuildMode_DynamicLibrary) {

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1499,12 +1499,19 @@ gb_internal bool init_build_paths(String init_filename) {
 	} else if (build_context.build_mode == BuildMode_Executable) {
 		// By default use no executable extension.
 		output_extension = make_string(nullptr, 0);
+		String const single_file_extension = str_lit(".odin");
 
 		if (build_context.metrics.os == TargetOs_windows) {
 			output_extension = STR_LIT("exe");
+		} else if (build_context.cross_compiling && selected_target_metrics->metrics == &target_essence_amd64) {
+			output_extension = make_string(nullptr, 0);
 		} else if (path_is_directory(last_path_element(bc->build_paths[BuildPath_Main_Package].basename))) {
 			// Add .bin extension to avoid collision
 			// with package directory name
+			output_extension = STR_LIT("bin");
+		} else if (string_ends_with(init_filename, single_file_extension) && path_is_directory(remove_extension_from_path(init_filename))) {
+			// Add bin extension if compiling single-file package
+			// with same output name as a directory
 			output_extension = STR_LIT("bin");
 		}
 	} else if (build_context.build_mode == BuildMode_DynamicLibrary) {

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -33,8 +33,6 @@ gb_internal String remove_directory_from_path(String const &s) {
 // NOTE(Mark Naughton): getcwd as String
 #if !defined(GB_SYSTEM_WINDOWS)
 gb_internal String get_current_directory(void) {
-	gbAllocator a = heap_allocator();
-
 	char cwd[256];
 	getcwd(cwd, 256);
 
@@ -48,7 +46,9 @@ gb_internal String get_current_directory(void) {
 	wchar_t cwd[256];
 	GetCurrentDirectoryW(256, cwd);
 
-	return make_string_c(cwd);
+	String16 wstr = make_string16_c(cwd);
+
+	return string16_to_string(a, wstr);
 }
 #endif
 

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -437,7 +437,7 @@ gb_internal bool write_directory(String path) {
 }
 #else
 gb_internal bool write_directory(String path) {
-	String16wstr = string_to_string16(heap_allocator(), path);
+	String16 wstr = string_to_string16(heap_allocator(), path);
 	LPCWSTR wdirectory_name = wstr.text;
 
 	HANDLE directory = CreateFileW(wdirectory_name,

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -1,7 +1,9 @@
 /*
 	Path handling utilities.
 */
+#if !defined(GB_SYSTEM_WINDOWS)
 #include<unistd.h>
+#endif
 
 gb_internal String remove_extension_from_path(String const &s) {
 	if (s.len != 0 && s.text[s.len-1] == '.') {
@@ -27,7 +29,9 @@ gb_internal String remove_directory_from_path(String const &s) {
 	return substring(s, s.len-len, s.len);
 }
 
+
 // NOTE(Mark Naughton): getcwd as String
+#if !defined(GB_SYSTEM_WINDOWS)
 gb_internal String get_current_directory(void) {
 	gbAllocator a = heap_allocator();
 
@@ -36,6 +40,17 @@ gb_internal String get_current_directory(void) {
 
 	return make_string_c(cwd);
 }
+
+#else
+gb_internal String get_current_directory(void) {
+	gbAllocator a = heap_allocator();
+
+	wchar_t cwd[256];
+	GetCurrentDirectoryW(256, cwd);
+
+	return make_string_c(cwd);
+}
+#endif
 
 gb_internal bool path_is_directory(String path);
 

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -1,6 +1,8 @@
 /*
 	Path handling utilities.
 */
+#include<unistd.h>
+
 gb_internal String remove_extension_from_path(String const &s) {
 	if (s.len != 0 && s.text[s.len-1] == '.') {
 		return s;
@@ -23,6 +25,16 @@ gb_internal String remove_directory_from_path(String const &s) {
 		len += 1;
 	}
 	return substring(s, s.len-len, s.len);
+}
+
+// NOTE(Mark Naughton): getcwd as String
+gb_internal String get_current_directory(void) {
+	gbAllocator a = heap_allocator();
+
+	char cwd[256];
+	getcwd(cwd, 256);
+
+	return make_string_c(cwd);
 }
 
 gb_internal bool path_is_directory(String path);

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -2,7 +2,7 @@
 	Path handling utilities.
 */
 #if !defined(GB_SYSTEM_WINDOWS)
-#include<unistd.h>
+#include <unistd.h>
 #endif
 
 gb_internal String remove_extension_from_path(String const &s) {


### PR DESCRIPTION
Putting a program into your path on a UNIX system with a file extension means that you have to type the extension out for every invocation of the program. A better default is to have no extension at all since most people will end up removing it anyway.

This change does not affect Windows since the .exe extension is set after the default extension if compiling on Windows.

One problem that arises from this is when you are building a package from the same directory that the package's directory is located in: the program name and directory name conflict. The second commit fixes this by adding the .bin extension to fix the conflict.