### PR TITLE
Fix panic during fixed-size #soa array pointer formatting in `core:fmt`

### DIFF
--- a/core/reflect/types.odin
+++ b/core/reflect/types.odin
@@ -563,7 +563,7 @@ write_type_writer :: proc(w: io.Writer, ti: ^Type_Info, n_written: ^int = nil) -
 		case .None: // Ignore
 		case .Fixed:
 			io.write_string(w, "#soa[",           &n) or_return
-			io.write_i64(w, i64(info.soa_len), 10 &n) or_return
+			io.write_i64(w, i64(info.soa_len),    10) or_return
 			io.write_byte(w, ']',                 &n) or_return
 			write_type(w, info.soa_base_type,     &n) or_return
 			return


### PR DESCRIPTION
There was a typo in the formatting code for `#soa[N]Foo` style pointers, somebody accidentally copy-pasted the `&n` which resulted in bitwise AND operation.

This is the code I used for testing:
```odin
Foo :: struct { a, b: f32 }
foos: #soa[1024]Foo
b := &foos[123]
fmt.println(type_info_of(type_of(b)))
```

Which caused the following runtime error, since the base would end up as zero:
```
#soa ^#soa[D:/projects/odin/core/strconv/integers.odin(67:3) panic: strconv: illegal base passed to append_bits
```
After the fix, it prints this:
```
#soa ^#soa[1024]Foo
```