### PR TITLE
Fix which command check

### DIFF
--- a/build_odin.sh
+++ b/build_odin.sh
@@ -157,7 +157,7 @@ run_demo() {
 }
 
 have_which() {
-	if ! [ -x "$(command -v which)" ]; then
+	if ! command -v which 2>&1 ; then
 		panic "Could not find \`which\`"
 	fi
 }

--- a/build_odin.sh
+++ b/build_odin.sh
@@ -157,7 +157,7 @@ run_demo() {
 }
 
 have_which() {
-	if ! command -v which 2>&1 ; then
+	if ! command -v which > /dev/null 2>&1 ; then
 		panic "Could not find \`which\`"
 	fi
 }


### PR DESCRIPTION
The function `have_witch` failed because `which` is an alias in my environment.

This change makes the function work even if `which` command is an alias.

And thanks to that the `make` command works out of the box instead of printing ```Could not find `which` ```. 