### PR TITLE
Strings docfix

### DIFF
--- a/core/strings/builder.odin
+++ b/core/strings/builder.odin
@@ -81,13 +81,12 @@ Example:
 	import "core:fmt"
 	import "core:strings"
 	builder_make_example :: proc() {
-		sb := strings.builder_make() // Can also use the len, len/cap versions here
+		sb := strings.builder_make()
 		strings.write_byte(&sb, 'a')
-		strings.write_rune(&sb, ' ')
-		strings.write_string(&sb, "slice of ")
-		strings.write_f64(&sb, 3.14) // Also _float, _f32 etc
-		strings.write_string(&sb, "is ")
-		strings.write_int(&sb, 180) // Also _uint, _u64 etc
+		strings.write_string(&sb, " slice of ")
+		strings.write_f64(&sb, 3.14,'g',true) // See `fmt.fmt_float` byte codes
+		strings.write_string(&sb, " is ")
+		strings.write_int(&sb, 180)
 		strings.write_rune(&sb,'°')
 		the_string :=strings.to_string(sb)
 		fmt.println(the_string)

--- a/core/strings/builder.odin
+++ b/core/strings/builder.odin
@@ -71,7 +71,33 @@ Returns:
 builder_make_len_cap :: proc(len, cap: int, allocator := context.allocator) -> (res: Builder, err: mem.Allocator_Error) #optional_allocator_error {
 	return Builder{buf=make([dynamic]byte, len, cap, allocator) or_return }, nil
 }
-// overload simple `builder_make_*` with or without len / cap parameters
+/*
+Produces a String Builder
+
+*Allocates Using Provided Allocator*
+
+Example:
+
+	import "core:fmt"
+	import "core:strings"
+	builder_make_example :: proc() {
+		sb := strings.builder_make() // Can also use the len, len/cap versions here
+		strings.write_byte(&sb, 'a')
+		strings.write_rune(&sb, ' ')
+		strings.write_string(&sb, "slice of ")
+		strings.write_f64(&sb, 3.14) // Also _float, _f32 etc
+		strings.write_string(&sb, "is ")
+		strings.write_int(&sb, 180) // Also _uint, _u64 etc
+		strings.write_rune(&sb,'°')
+		the_string :=strings.to_string(sb)
+		fmt.println(the_string)
+	}
+
+Output:
+
+	a slice of +3.14 is 180°
+
+*/
 builder_make :: proc{
 	builder_make_none,
 	builder_make_len,

--- a/core/strings/strings.odin
+++ b/core/strings/strings.odin
@@ -263,7 +263,7 @@ compare :: proc(lhs, rhs: string) -> (result: int) {
 	return mem.compare(transmute([]byte)lhs, transmute([]byte)rhs)
 }
 /*
-Returns the byte offset of the rune `r` in the string `s`, -1 when not found
+Checks if rune `r` in the string `s`
 
 Inputs:
 - s: The input string


### PR DESCRIPTION
add sample string builder, fixed type on `contains_rune`. can squash the commits. 