### PR TITLE
Fixed a bug in DXGI

### DIFF
--- a/vendor/directx/dxgi/dxgi.odin
+++ b/vendor/directx/dxgi/dxgi.odin
@@ -375,7 +375,7 @@ MAPPED_RECT :: struct {
 }
 
 ADAPTER_DESC :: struct {
-	Description:           [128]i16,
+	Description:           [128]u16,
 	VendorId:              u32,
 	DeviceId:              u32,
 	SubSysId:              u32,
@@ -387,7 +387,7 @@ ADAPTER_DESC :: struct {
 }
 
 OUTPUT_DESC :: struct {
-	DeviceName:         [32]i16,
+	DeviceName:         [32]u16,
 	DesktopCoordinates: RECT,
 	AttachedToDesktop:  BOOL,
 	Rotation:           MODE_ROTATION,
@@ -613,7 +613,7 @@ ADAPTER_FLAG :: enum u32 { // TODO: convert to bit_set
 }
 
 ADAPTER_DESC1 :: struct {
-	Description:           [128]i16,
+	Description:           [128]u16,
 	VendorId:              u32,
 	DeviceId:              u32,
 	SubSysId:              u32,
@@ -890,7 +890,7 @@ COMPUTE_PREEMPTION_GRANULARITY :: enum i32 {
 }
 
 ADAPTER_DESC2 :: struct {
-	Description:                   [128]i16,
+	Description:                   [128]u16,
 	VendorId:                      u32,
 	DeviceId:                      u32,
 	SubSysId:                      u32,


### PR DESCRIPTION
DXGI's ADAPTER_DESC struct field Description is wstring containing the device name etc but the dxgi.odin has it has [128]i16 but original is WCHAR [128] as per msdn WCHAR is unsigned short. 

https://learn.microsoft.com/en-us/windows/win32/api/dxgi/ns-dxgi-dxgi_adapter_desc
https://learn.microsoft.com/en-us/windows/win32/extensible-storage-engine/wchar