### PR TITLE
Fix check for continuation byte in core/text/text_edit

### DIFF
--- a/core/text/edit/text_edit.odin
+++ b/core/text/edit/text_edit.odin
@@ -219,7 +219,7 @@ selection_delete :: proc(s: ^State) {
 
 translate_position :: proc(s: ^State, pos: int, t: Translation) -> int {
 	is_continuation_byte :: proc(b: byte) -> bool {
-		return b <= 0x80 && b < 0xc0
+		return b >= 0x80 && b < 0xc0
 	}
 	is_space :: proc(b: byte) -> bool {
 		return b == ' ' || b == '\t' || b == '\n'


### PR DESCRIPTION
Continuation byte check used less than or equal instead of greater than or equal so any loop checking it ALWAYS got to the begging or the end (eg .Left always returned 0)