### PR TITLE
update os2 to match core changes

### DIFF
--- a/core/os/os2/env_linux.odin
+++ b/core/os/os2/env_linux.odin
@@ -3,7 +3,7 @@ package os2
 
 import "core:runtime"
 
-_get_env :: proc(key: string, allocator: runtime.Allocator) -> (value: string, found: bool) {
+_lookup_env :: proc(key: string, allocator: runtime.Allocator) -> (value: string, found: bool) {
 	//TODO
 	return
 }

--- a/core/os/os2/file_linux.odin
+++ b/core/os/os2/file_linux.odin
@@ -9,19 +9,20 @@ import "core:sys/unix"
 
 INVALID_HANDLE :: -1
 
-_O_RDONLY    :: 0o0
-_O_WRONLY    :: 0o1
-_O_RDWR      :: 0o2
-_O_CREAT     :: 0o100
-_O_EXCL      :: 0o200
-_O_TRUNC     :: 0o1000
-_O_APPEND    :: 0o2000
-_O_NONBLOCK  :: 0o4000
-_O_LARGEFILE :: 0o100000
-_O_DIRECTORY :: 0o200000
-_O_NOFOLLOW  :: 0o400000
-_O_SYNC      :: 0o4010000
-_O_CLOEXEC   :: 0o2000000
+_O_RDONLY    :: 0o00000000
+_O_WRONLY    :: 0o00000001
+_O_RDWR      :: 0o00000002
+_O_CREAT     :: 0o00000100
+_O_EXCL      :: 0o00000200
+_O_NOCTTY    :: 0o00000400
+_O_TRUNC     :: 0o00001000
+_O_APPEND    :: 0o00002000
+_O_NONBLOCK  :: 0o00004000
+_O_LARGEFILE :: 0o00100000
+_O_DIRECTORY :: 0o00200000
+_O_NOFOLLOW  :: 0o00400000
+_O_SYNC      :: 0o04010000
+_O_CLOEXEC   :: 0o02000000
 _O_PATH      :: 0o10000000
 
 _AT_FDCWD :: -100
@@ -42,7 +43,10 @@ _open :: proc(name: string, flags: File_Flags, perm: File_Mode) -> (^File, Error
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	name_cstr := strings.clone_to_cstring(name, context.temp_allocator)
 
-	flags_i: int
+	// Just default to using O_NOCTTY because needing to open a controlling
+	// terminal would be incredibly rare. This has no effect on files while
+	// allowing us to open serial devices.
+	flags_i: int = _O_NOCTTY
 	switch flags & O_RDONLY|O_WRONLY|O_RDWR {
 	case O_RDONLY: flags_i = _O_RDONLY
 	case O_WRONLY: flags_i = _O_WRONLY

--- a/core/os/os2/file_linux.odin
+++ b/core/os/os2/file_linux.odin
@@ -40,7 +40,7 @@ _file_allocator :: proc() -> runtime.Allocator {
 
 _open :: proc(name: string, flags: File_Flags, perm: File_Mode) -> (^File, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
-	name_cstr := _name_to_cstring(name)
+	name_cstr := strings.clone_to_cstring(name, context.temp_allocator)
 
 	flags_i: int
 	switch flags & O_RDONLY|O_WRONLY|O_RDWR {
@@ -56,7 +56,7 @@ _open :: proc(name: string, flags: File_Flags, perm: File_Mode) -> (^File, Error
 	flags_i |= (_O_TRUNC * int(.Trunc in flags))
 	flags_i |= (_O_CLOEXEC * int(.Close_On_Exec in flags))
 
-	fd := unix.sys_open(name_cstr, flags_i, int(perm))
+	fd := unix.sys_open(name_cstr, flags_i, uint(perm))
 	if fd < 0 {
 		return nil, _get_platform_error(fd)
 	}
@@ -196,10 +196,7 @@ _truncate :: proc(f: ^File, size: i64) -> Error {
 }
 
 _remove :: proc(name: string) -> Error {
-	name_cstr, allocated := _name_to_cstring(name)
-	defer if allocated {
-		delete(name_cstr)
-	}
+	name_cstr := strings.clone_to_cstring(name, context.temp_allocator)
 
 	fd := unix.sys_open(name_cstr, int(File_Flags.Read))
 	if fd < 0 {
@@ -214,40 +211,22 @@ _remove :: proc(name: string) -> Error {
 }
 
 _rename :: proc(old_name, new_name: string) -> Error {
-	old_name_cstr, old_allocated := _name_to_cstring(old_name)
-	new_name_cstr, new_allocated := _name_to_cstring(new_name)
-	defer if old_allocated {
-		delete(old_name_cstr)
-	}
-	defer if new_allocated {
-		delete(new_name_cstr)
-	}
+	old_name_cstr := strings.clone_to_cstring(old_name, context.temp_allocator)
+	new_name_cstr := strings.clone_to_cstring(new_name, context.temp_allocator)
 
 	return _ok_or_error(unix.sys_rename(old_name_cstr, new_name_cstr))
 }
 
 _link :: proc(old_name, new_name: string) -> Error {
-	old_name_cstr, old_allocated := _name_to_cstring(old_name)
-	new_name_cstr, new_allocated := _name_to_cstring(new_name)
-	defer if old_allocated {
-		delete(old_name_cstr)
-	}
-	defer if new_allocated {
-		delete(new_name_cstr)
-	}
+	old_name_cstr := strings.clone_to_cstring(old_name, context.temp_allocator)
+	new_name_cstr := strings.clone_to_cstring(new_name, context.temp_allocator)
 
 	return _ok_or_error(unix.sys_link(old_name_cstr, new_name_cstr))
 }
 
 _symlink :: proc(old_name, new_name: string) -> Error {
-	old_name_cstr, old_allocated := _name_to_cstring(old_name)
-	new_name_cstr, new_allocated := _name_to_cstring(new_name)
-	defer if old_allocated {
-		delete(old_name_cstr)
-	}
-	defer if new_allocated {
-		delete(new_name_cstr)
-	}
+	old_name_cstr := strings.clone_to_cstring(old_name, context.temp_allocator)
+	new_name_cstr := strings.clone_to_cstring(new_name, context.temp_allocator)
 
 	return _ok_or_error(unix.sys_symlink(old_name_cstr, new_name_cstr))
 }
@@ -271,26 +250,17 @@ _read_link_cstr :: proc(name_cstr: cstring, allocator: runtime.Allocator) -> (st
 }
 
 _read_link :: proc(name: string, allocator: runtime.Allocator) -> (string, Error) {
-	name_cstr, allocated := _name_to_cstring(name)
-	defer if allocated {
-		delete(name_cstr)
-	}
+	name_cstr := strings.clone_to_cstring(name, context.temp_allocator)
 	return _read_link_cstr(name_cstr, allocator)
 }
 
 _unlink :: proc(name: string) -> Error {
-	name_cstr, allocated := _name_to_cstring(name)
-	defer if allocated {
-		delete(name_cstr)
-	}
+	name_cstr := strings.clone_to_cstring(name, context.temp_allocator)
 	return _ok_or_error(unix.sys_unlink(name_cstr))
 }
 
 _chdir :: proc(name: string) -> Error {
-	name_cstr, allocated := _name_to_cstring(name)
-	defer if allocated {
-		delete(name_cstr)
-	}
+	name_cstr := strings.clone_to_cstring(name, context.temp_allocator)
 	return _ok_or_error(unix.sys_chdir(name_cstr))
 }
 
@@ -299,32 +269,23 @@ _fchdir :: proc(f: ^File) -> Error {
 }
 
 _chmod :: proc(name: string, mode: File_Mode) -> Error {
-	name_cstr, allocated := _name_to_cstring(name)
-	defer if allocated {
-		delete(name_cstr)
-	}
-	return _ok_or_error(unix.sys_chmod(name_cstr, int(mode)))
+	name_cstr := strings.clone_to_cstring(name, context.temp_allocator)
+	return _ok_or_error(unix.sys_chmod(name_cstr, uint(mode)))
 }
 
 _fchmod :: proc(f: ^File, mode: File_Mode) -> Error {
-	return _ok_or_error(unix.sys_fchmod(f.impl.fd, int(mode)))
+	return _ok_or_error(unix.sys_fchmod(f.impl.fd, uint(mode)))
 }
 
 // NOTE: will throw error without super user priviledges
 _chown :: proc(name: string, uid, gid: int) -> Error {
-	name_cstr, allocated := _name_to_cstring(name)
-	defer if allocated {
-		delete(name_cstr)
-	}
+	name_cstr := strings.clone_to_cstring(name, context.temp_allocator)
 	return _ok_or_error(unix.sys_chown(name_cstr, uid, gid))
 }
 
 // NOTE: will throw error without super user priviledges
 _lchown :: proc(name: string, uid, gid: int) -> Error {
-	name_cstr, allocated := _name_to_cstring(name)
-	defer if allocated {
-		delete(name_cstr)
-	}
+	name_cstr := strings.clone_to_cstring(name, context.temp_allocator)
 	return _ok_or_error(unix.sys_lchown(name_cstr, uid, gid))
 }
 
@@ -334,10 +295,7 @@ _fchown :: proc(f: ^File, uid, gid: int) -> Error {
 }
 
 _chtimes :: proc(name: string, atime, mtime: time.Time) -> Error {
-	name_cstr, allocated := _name_to_cstring(name)
-	defer if allocated {
-		delete(name_cstr)
-	}
+	name_cstr := strings.clone_to_cstring(name, context.temp_allocator)
 	times := [2]Unix_File_Time {
 		{ atime._nsec, 0 },
 		{ mtime._nsec, 0 },
@@ -354,18 +312,12 @@ _fchtimes :: proc(f: ^File, atime, mtime: time.Time) -> Error {
 }
 
 _exists :: proc(name: string) -> bool {
-	name_cstr, allocated := _name_to_cstring(name)
-	defer if allocated {
-		delete(name_cstr)
-	}
+	name_cstr := strings.clone_to_cstring(name, context.temp_allocator)
 	return unix.sys_access(name_cstr, F_OK) == 0
 }
 
 _is_file :: proc(name: string) -> bool {
-	name_cstr, allocated := _name_to_cstring(name)
-	defer if allocated {
-		delete(name_cstr)
-	}
+	name_cstr := strings.clone_to_cstring(name, context.temp_allocator)
 	s: _Stat
 	res := unix.sys_stat(name_cstr, &s)
 	if res < 0 {
@@ -384,10 +336,7 @@ _is_file_fd :: proc(fd: int) -> bool {
 }
 
 _is_dir :: proc(name: string) -> bool {
-	name_cstr, allocated := _name_to_cstring(name)
-	defer if allocated {
-		delete(name_cstr)
-	}
+	name_cstr := strings.clone_to_cstring(name, context.temp_allocator)
 	s: _Stat
 	res := unix.sys_stat(name_cstr, &s)
 	if res < 0 {

--- a/core/os/os2/path_linux.odin
+++ b/core/os/os2/path_linux.odin
@@ -31,11 +31,8 @@ _mkdir :: proc(path: string, perm: File_Mode) -> Error {
 		return .Invalid_Argument
 	}
 
-	path_cstr, allocated := _name_to_cstring(path)
-	defer if allocated {
-		delete(path_cstr)
-	}
-	return _ok_or_error(unix.sys_mkdir(path_cstr, int(perm & 0o777)))
+	path_cstr := strings.clone_to_cstring(path, context.temp_allocator)
+	return _ok_or_error(unix.sys_mkdir(path_cstr, uint(perm & 0o777)))
 }
 
 _mkdir_all :: proc(path: string, perm: File_Mode) -> Error {
@@ -49,7 +46,7 @@ _mkdir_all :: proc(path: string, perm: File_Mode) -> Error {
 		new_dfd := unix.sys_openat(dfd, cstring(&path[0]), _OPENDIR_FLAGS)
 		switch new_dfd {
 		case -ENOENT:
-			if res := unix.sys_mkdirat(dfd, cstring(&path[0]), perm); res < 0 {
+			if res := unix.sys_mkdirat(dfd, cstring(&path[0]), uint(perm)); res < 0 {
 				return _get_platform_error(res)
 			}
 			has_created^ = true
@@ -82,9 +79,6 @@ _mkdir_all :: proc(path: string, perm: File_Mode) -> Error {
 		path_bytes = make([]u8, len(path) + 1)
 	} else {
 		path_bytes = make([]u8, len(path) + 1, context.temp_allocator)
-	}
-	defer if allocated {
-		delete(path_bytes)
 	}
 
 	// NULL terminate the byte slice to make it a valid cstring
@@ -182,10 +176,7 @@ _remove_all :: proc(path: string) -> Error {
 		return nil
 	}
 
-	path_cstr, allocated := _name_to_cstring(path)
-	defer if allocated {
-		delete(path_cstr)
-	}
+	path_cstr := strings.clone_to_cstring(path, context.temp_allocator)
 
 	fd := unix.sys_open(path_cstr, _OPENDIR_FLAGS)
 	switch fd {
@@ -222,10 +213,7 @@ _getwd :: proc(allocator: runtime.Allocator) -> (string, Error) {
 }
 
 _setwd :: proc(dir: string) -> Error {
-	dir_cstr, allocated := _name_to_cstring(dir)
-	defer if allocated {
-		delete(dir_cstr)
-	}
+	dir_cstr := strings.clone_to_cstring(dir, context.temp_allocator)
 	return _ok_or_error(unix.sys_chdir(dir_cstr))
 }
 

--- a/core/os/os2/stat_linux.odin
+++ b/core/os/os2/stat_linux.odin
@@ -3,6 +3,7 @@ package os2
 
 import "core:time"
 import "core:runtime"
+import "core:strings"
 import "core:sys/unix"
 import "core:path/filepath"
 
@@ -112,10 +113,7 @@ _fstat_internal :: proc(fd: int, allocator: runtime.Allocator) -> (File_Info, Er
 
 // NOTE: _stat and _lstat are using _fstat to avoid a race condition when populating fullpath
 _stat :: proc(name: string, allocator: runtime.Allocator) -> (File_Info, Error) {
-	name_cstr, allocated := _name_to_cstring(name)
-	defer if allocated {
-		delete(name_cstr)
-	}
+	name_cstr := strings.clone_to_cstring(name, context.temp_allocator)
 
 	fd := unix.sys_open(name_cstr, _O_RDONLY)
 	if fd < 0 {
@@ -126,10 +124,8 @@ _stat :: proc(name: string, allocator: runtime.Allocator) -> (File_Info, Error) 
 }
 
 _lstat :: proc(name: string, allocator: runtime.Allocator) -> (File_Info, Error) {
-	name_cstr, allocated := _name_to_cstring(name)
-	defer if allocated {
-		delete(name_cstr)
-	}
+	name_cstr := strings.clone_to_cstring(name, context.temp_allocator)
+
 	fd := unix.sys_open(name_cstr, _O_RDONLY | _O_PATH | _O_NOFOLLOW)
 	if fd < 0 {
 		return {}, _get_platform_error(fd)
@@ -143,10 +139,7 @@ _same_file :: proc(fi1, fi2: File_Info) -> bool {
 }
 
 _stat_internal :: proc(name: string) -> (s: _Stat, res: int) {
-	name_cstr, allocated := _name_to_cstring(name)
-	defer if allocated {
-		delete(name_cstr)
-	}
+	name_cstr := strings.clone_to_cstring(name, context.temp_allocator)
 	res = unix.sys_stat(name_cstr, &s)
 	return
 }

--- a/core/os/os2/user.odin
+++ b/core/os/os2/user.odin
@@ -8,12 +8,12 @@ user_cache_dir :: proc(allocator: runtime.Allocator) -> (dir: string, err: Error
 	case .Windows:
 		dir = get_env("LocalAppData", allocator)
 		if dir != "" {
-			dir = strings.clone_safe(dir, allocator) or_return
+			dir = strings.clone(dir, allocator) or_return
 		}
 	case .Darwin:
 		dir = get_env("HOME", allocator)
 		if dir != "" {
-			dir = strings.concatenate_safe({dir, "/Library/Caches"}, allocator) or_return
+			dir = strings.concatenate({dir, "/Library/Caches"}, allocator) or_return
 		}
 	case: // All other UNIX systems
 		dir = get_env("XDG_CACHE_HOME", allocator)
@@ -22,7 +22,7 @@ user_cache_dir :: proc(allocator: runtime.Allocator) -> (dir: string, err: Error
 			if dir == "" {
 				return
 			}
-			dir = strings.concatenate_safe({dir, "/.cache"}, allocator) or_return
+			dir = strings.concatenate({dir, "/.cache"}, allocator) or_return
 		}
 	}
 	if dir == "" {
@@ -36,12 +36,12 @@ user_config_dir :: proc(allocator: runtime.Allocator) -> (dir: string, err: Erro
 	case .Windows:
 		dir = get_env("AppData", allocator)
 		if dir != "" {
-			dir = strings.clone_safe(dir, allocator) or_return
+			dir = strings.clone(dir, allocator) or_return
 		}
 	case .Darwin:
 		dir = get_env("HOME", allocator)
 		if dir != "" {
-			dir = strings.concatenate_safe({dir, "/Library/Application Support"}, allocator) or_return
+			dir = strings.concatenate({dir, "/Library/Application Support"}, allocator) or_return
 		}
 	case: // All other UNIX systems
 		dir = get_env("XDG_CACHE_HOME", allocator)
@@ -50,7 +50,7 @@ user_config_dir :: proc(allocator: runtime.Allocator) -> (dir: string, err: Erro
 			if dir == "" {
 				return
 			}
-			dir = strings.concatenate_safe({dir, "/.config"}, allocator) or_return
+			dir = strings.concatenate({dir, "/.config"}, allocator) or_return
 		}
 	}
 	if dir == "" {


### PR DESCRIPTION
The Linux side of os2 had a number of errors related to changes in the core library.  Also, removed a utility (hack) to work around the limited size of the original `temp_allocator`.

EDIT: added default O_NOCTTY arg to `open`.  I was thinking about adding this to the `File_Flags`, but that would sort of be needless clutter when it is *nix specific.