### PR TITLE
remove misleading defer if example

### DIFF
--- a/examples/demo/demo.odin
+++ b/examples/demo/demo.odin
@@ -2145,6 +2145,10 @@ or_return_operator :: proc() {
 			return -345 * z, zerr
 		}
 
+		defer if err != nil {
+			fmt.println("Error in", #procedure, ":" , err)
+		}
+
 		n = 123
 		return
 	}

--- a/examples/demo/demo.odin
+++ b/examples/demo/demo.odin
@@ -2145,12 +2145,6 @@ or_return_operator :: proc() {
 			return -345 * z, zerr
 		}
 
-		// If the other return values need to be set depending on what the end value is,
-		// the 'defer if' idiom is can be used
-		defer if err != nil {
-			n = -1
-		}
-
 		n = 123
 		return
 	}


### PR DESCRIPTION
Using defer if cannot be used to change the return value (without an extra scope) as shown in the example, Should be removed.