### PR TITLE
Zero non-diagonal elements when converting to matrix

### DIFF
--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -2083,10 +2083,12 @@ gb_internal lbValue lb_emit_conv(lbProcedure *p, lbValue value, Type *t) {
 		Type *elem = base_array_type(dst);
 		lbValue e = lb_emit_conv(p, value, elem);
 		lbAddr v = lb_add_local_generated(p, t, false);
-		for (i64 i = 0; i < dst->Matrix.row_count; i++) {
-			isize j = cast(isize)i;
-			lbValue ptr = lb_emit_matrix_epi(p, v.addr, j, j);
-			lb_emit_store(p, ptr, e);
+		lbValue zero = lb_const_value(p->module, elem, exact_value_i64(0), true);
+		for (i64 j = 0; j < dst->Matrix.column_count; j++) {
+			for (i64 i = 0; i < dst->Matrix.row_count; i++) {
+				lbValue ptr = lb_emit_matrix_epi(p, v.addr, i, j);
+				lb_emit_store(p, ptr, i == j ? e : zero);
+			}
 		}
 
 

--- a/tests/issues/run.bat
+++ b/tests/issues/run.bat
@@ -9,6 +9,7 @@ set COMMON=-collection:tests=..\..
 
 ..\..\..\odin test ..\test_issue_829.odin %COMMON% -file || exit /b
 ..\..\..\odin test ..\test_issue_1592.odin %COMMON% -file || exit /b
+..\..\..\odin test ..\test_issue_2056.odin %COMMON% -file || exit /b
 ..\..\..\odin test ..\test_issue_2087.odin %COMMON% -file || exit /b
 ..\..\..\odin build ..\test_issue_2113.odin %COMMON% -file -debug || exit /b
 

--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -10,6 +10,7 @@ set -x
 
 $ODIN test ../test_issue_829.odin  $COMMON -file
 $ODIN test ../test_issue_1592.odin $COMMON -file
+$ODIN test ../test_issue_2056.odin $COMMON -file
 $ODIN test ../test_issue_2087.odin $COMMON -file
 $ODIN build ../test_issue_2113.odin $COMMON -file -debug
 

--- a/tests/issues/test_issue_2056.odin
+++ b/tests/issues/test_issue_2056.odin
@@ -1,0 +1,22 @@
+// Tests issue #2056 https://github.com/odin-lang/Odin/issues/2056
+package test_issues
+
+import "core:fmt"
+import "core:testing"
+
+@test
+test_scalar_matrix_conversion :: proc(t: ^testing.T) {
+	l := f32(1.0)
+	m := (matrix[4,4]f32)(l)
+
+	for i in 0..<4 {
+		for j in 0..<4 {
+			if i == j {
+				testing.expect(t, m[i,j] == 1, fmt.tprintf("expected 1 at m[%d,%d], found %f\n", i, j, m[i,j]))
+			} else {
+				testing.expect(t, m[i,j] == 0, fmt.tprintf("expected 0 at m[%d,%d], found %f\n", i, j, m[i,j]))
+			}
+		}
+	}
+}
+


### PR DESCRIPTION
Fixes #2056, which is caused by uninitialized elements in the matrix.

Codegen before:

```nasm
mov dword ptr ss:[rsp+AC],3F800000
movss xmm0,dword ptr ss:[rsp+AC]
movss dword ptr ss:[rsp+80],xmm0
movss dword ptr ss:[rsp+8C],xmm0
```

Codegen after:

```nasm
mov dword ptr ss:[rsp+AC],3F800000
movss xmm0,dword ptr ss:[rsp+AC]
movss dword ptr ss:[rsp+80],xmm0
mov dword ptr ss:[rsp+84],0
mov dword ptr ss:[rsp+88],0
movss dword ptr ss:[rsp+8C],xmm0
```

