### PR TITLE
fix bytes.buffer_init_allocator not using given allocator if len/cap is 0

### DIFF
--- a/core/bytes/buffer.odin
+++ b/core/bytes/buffer.odin
@@ -38,6 +38,11 @@ buffer_init_string :: proc(b: ^Buffer, s: string) {
 }
 
 buffer_init_allocator :: proc(b: ^Buffer, len, cap: int, allocator := context.allocator) {
+	if b.buf == nil {
+		b.buf = make([dynamic]byte, len, cap, allocator)
+		return
+	}
+
 	b.buf.allocator = allocator
 	reserve(&b.buf, cap)
 	resize(&b.buf, len)


### PR DESCRIPTION
Reproduction:
```odin
package main

import "core:fmt"
import "core:mem"
import "core:bytes"


main :: proc() {
	track: mem.Tracking_Allocator
	mem.tracking_allocator_init(&track, context.allocator)
	context.allocator = mem.tracking_allocator(&track)

	buf: bytes.Buffer
	bytes.buffer_init_allocator(nil, 0, 0, context.temp_allocator)
	bytes.buffer_write_string(&buf, "Hello, World!")
	free_all(context.temp_allocator)

	for _, leak in track.allocation_map {
		fmt.printf("%v leaked %v bytes\n", leak.location, leak.size)
	}
	for bad_free in track.bad_free_array {
		fmt.printf("%v allocation %p was freed badly\n", bad_free.location, bad_free.memory)
	}
}
```

In this case the context.allocator is used for the backing array. This is because of the check here: https://github.com/odin-lang/Odin/blob/29e476201154821a06d11d29bb662f4c51f9fcca/core/bytes/buffer.odin#L111-L112

Not sure if this is the best solution though, so I am of course open to changing it if there is a better idea.