### PR TITLE
Fix #2515 - Implement backward shift on `map` on insert and reseed hashes on resize

### DIFF
--- a/core/runtime/dynamic_map_internal.odin
+++ b/core/runtime/dynamic_map_internal.odin
@@ -610,6 +610,7 @@ map_shrink_dynamic :: proc "odin" (#no_alias m: ^Raw_Map, #no_alias info: ^Map_I
 
 		k := map_cell_index_dynamic(ks, info.ks, i)
 		v := map_cell_index_dynamic(vs, info.vs, i)
+		hash = info.key_hasher(rawptr(k), map_seed(shrunk))
 		_ = map_insert_hash_dynamic(&shrunk, info, hash, k, v)
 		// Only need to do this comparison on each actually added pair, so do not
 		// fold it into the for loop comparator as a micro-optimization.

--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -720,6 +720,7 @@ gb_internal lbValue lb_map_set_proc_for_type(lbModule *m, Type *type) {
 	lbBlock *check_grow_block = lb_create_block(p, "check-grow");
 	lbBlock *grow_fail_block  = lb_create_block(p, "grow-fail");
 	lbBlock *insert_block     = lb_create_block(p, "insert");
+	lbBlock *rehash_block     = lb_create_block(p, "rehash");
 
 	lb_emit_if(p, lb_emit_comp_against_nil(p, Token_NotEq, found_ptr), found_block, check_grow_block);
 	lb_start_block(p, found_block);
@@ -737,12 +738,19 @@ gb_internal lbValue lb_map_set_proc_for_type(lbModule *m, Type *type) {
 		args[0] = lb_emit_conv(p, map_ptr, t_rawptr);
 		args[1] = map_info;
 		args[2] = lb_emit_load(p, location_ptr);
-		lbValue grow_err = lb_emit_runtime_call(p, "__dynamic_map_check_grow", args);
+		lbValue grow_err_and_has_grown = lb_emit_runtime_call(p, "__dynamic_map_check_grow", args);
+		lbValue grow_err = lb_emit_struct_ev(p, grow_err_and_has_grown, 0);
+		lbValue has_grown = lb_emit_struct_ev(p, grow_err_and_has_grown, 1);
 
 		lb_emit_if(p, lb_emit_comp_against_nil(p, Token_NotEq, grow_err), grow_fail_block, insert_block);
 
 		lb_start_block(p, grow_fail_block);
 		LLVMBuildRet(p->builder, LLVMConstNull(lb_type(m, t_rawptr)));
+
+		lb_emit_if(p, has_grown, grow_fail_block, rehash_block);
+		lb_start_block(p, rehash_block);
+		lbValue key = lb_emit_load(p, key_ptr);
+		hash = lb_gen_map_key_hash(p, map_ptr, key, nullptr);
 	}
 
 	lb_start_block(p, insert_block);
@@ -916,7 +924,7 @@ gb_internal lbValue lb_const_hash(lbModule *m, lbValue key, Type *key_type) {
 	return hashed_key;
 }
 
-gb_internal lbValue lb_gen_map_key_hash(lbProcedure *p, lbValue key, Type *key_type, lbValue *key_ptr_) {
+gb_internal lbValue lb_gen_map_key_hash(lbProcedure *p, lbValue const &map_ptr, lbValue key, lbValue *key_ptr_) {
 	TEMPORARY_ALLOCATOR_GUARD();
 
 	lbValue key_ptr = lb_address_from_load_or_generate_local(p, key);
@@ -924,13 +932,22 @@ gb_internal lbValue lb_gen_map_key_hash(lbProcedure *p, lbValue key, Type *key_t
 
 	if (key_ptr_) *key_ptr_ = key_ptr;
 
+	Type* key_type = base_type(type_deref(map_ptr.type))->Map.key;
+
 	lbValue hashed_key = lb_const_hash(p->module, key, key_type);
 	if (hashed_key.value == nullptr) {
 		lbValue hasher = lb_hasher_proc_for_type(p->module, key_type);
 
+		lbValue seed = {};
+		{
+			auto args = array_make<lbValue>(temporary_allocator(), 1);
+			args[0] = lb_map_data_uintptr(p, lb_emit_load(p, map_ptr));
+			seed = lb_emit_runtime_call(p, "map_seed_from_map_data", args);
+		}
+
 		auto args = array_make<lbValue>(temporary_allocator(), 2);
 		args[0] = key_ptr;
-		args[1] = lb_const_int(p->module, t_uintptr, 0);
+		args[1] = seed;
 		hashed_key = lb_emit_call(p, hasher, args);
 	}
 
@@ -945,7 +962,7 @@ gb_internal lbValue lb_internal_dynamic_map_get_ptr(lbProcedure *p, lbValue cons
 
 	lbValue ptr = {};
 	lbValue key_ptr = {};
-	lbValue hash = lb_gen_map_key_hash(p, key, map_type->Map.key, &key_ptr);
+	lbValue hash = lb_gen_map_key_hash(p, map_ptr, key, &key_ptr);
 
 	if (build_context.dynamic_map_calls) {
 		auto args = array_make<lbValue>(temporary_allocator(), 4);
@@ -976,7 +993,7 @@ gb_internal void lb_internal_dynamic_map_set(lbProcedure *p, lbValue const &map_
 	GB_ASSERT(map_type->kind == Type_Map);
 
 	lbValue key_ptr = {};
-	lbValue hash = lb_gen_map_key_hash(p, map_key, map_type->Map.key, &key_ptr);
+	lbValue hash = lb_gen_map_key_hash(p, map_ptr, map_key, &key_ptr);
 
 	lbValue v = lb_emit_conv(p, map_value, map_type->Map.value);
 	lbValue value_ptr = lb_address_from_load_or_generate_local(p, v);

--- a/src/llvm_backend.hpp
+++ b/src/llvm_backend.hpp
@@ -477,7 +477,7 @@ gb_internal String lb_get_const_string(lbModule *m, lbValue value);
 
 gb_internal lbValue lb_generate_local_array(lbProcedure *p, Type *elem_type, i64 count, bool zero_init=true);
 gb_internal lbValue lb_generate_global_array(lbModule *m, Type *elem_type, i64 count, String prefix, i64 id);
-gb_internal lbValue lb_gen_map_key_hash(lbProcedure *p, lbValue key, Type *key_type, lbValue *key_ptr_);
+gb_internal lbValue lb_gen_map_key_hash(lbProcedure *p, lbValue const &map_ptr, lbValue key, lbValue *key_ptr_);
 gb_internal lbValue lb_gen_map_cell_info_ptr(lbModule *m, Type *type);
 gb_internal lbValue lb_gen_map_info_ptr(lbModule *m, Type *map_type);
 


### PR DESCRIPTION
This fixes issue #2515 and changes the `map` implementation in a couple ways.

The original issue stems from [map_insert_hash_dynamic](https://github.com/odin-lang/Odin/blob/master/core/runtime/dynamic_map_internal.odin#LL402C1-L421C5):

```odin
		if map_hash_is_empty(element_hash) {
			k_dst := map_cell_index_dynamic(ks, info.ks, pos)
			v_dst := map_cell_index_dynamic(vs, info.vs, pos)
			intrinsics.mem_copy_non_overlapping(rawptr(k_dst), rawptr(k), size_of_k)
			intrinsics.mem_copy_non_overlapping(rawptr(v_dst), rawptr(v), size_of_v)
			hp^ = h

			return result if result != 0 else v_dst
		}

		if probe_distance := map_probe_distance(m^, element_hash, pos); distance > probe_distance {
			if map_hash_is_deleted(element_hash) {
				k_dst := map_cell_index_dynamic(ks, info.ks, pos)
				v_dst := map_cell_index_dynamic(vs, info.vs, pos)
				intrinsics.mem_copy_non_overlapping(rawptr(k_dst), rawptr(k), size_of_k)
				intrinsics.mem_copy_non_overlapping(rawptr(v_dst), rawptr(v), size_of_v)
				hp^ = h

				return result if result != 0 else v_dst
			}
```

If there are no empty slots, elements can fall so that  `distance` goes beyond capacity and falsely inserts into a bad deleted slot.  Essentially, the deleted slots end up stealing some space.  This only becomes a problem when `len` gets close to `cap`, and deleted entries exist.

The solution I used may not be ideal, but I implemented the "backward shift" for erasing keys that was mentioned in the comments:

**Pros**

* likely faster lookups after some keys have been deleted due to smaller distances
* simpler insertion logic

**Cons**

* Likely slower `delete_key`
* Can no longer use `delete_key` while iterating through the map


NOTE: someone should double check the change to the compiler source.

**Other possible solutions**

* Play with parameters like `MAP_LOAD_FACTOR`
* Have `map_insert_hash_dynamic` grow if distance exceeds cap

