### PR TITLE
lua MAXSTACK should be 1000000 on 32 bits OR greater

### DIFF
--- a/vendor/lua/5.4/lua.odin
+++ b/vendor/lua/5.4/lua.odin
@@ -44,7 +44,7 @@ REGISTRYINDEX :: -MAXSTACK - 1000
 ** space (and to reserve some numbers for pseudo-indices).
 ** (It must fit into max(size_t)/32.)
 */
-MAXSTACK :: 1000000 when size_of(rawptr) == 4 else 15000
+MAXSTACK :: 1000000 when size_of(rawptr) >= 4 else 15000
 
 
 /*


### PR DESCRIPTION
Code only checks if 4 bytes for `rawptr` size. However lua defines the macro (that I assume the odin code is based on) as:

```
/*
@@ LUAI_IS32INT is true iff 'int' has (at least) 32 bits.
*/
#define LUAI_IS32INT	((UINT_MAX >> 30) >= 3)
```

This error broke `upvalues` because it would be looking for the wrong index for lua to find them at.