### PR TITLE
core/sys/info: Fix the CPUID check

### DIFF
--- a/core/sys/info/cpu_intel.odin
+++ b/core/sys/info/cpu_intel.odin
@@ -38,7 +38,7 @@ cpu_name:     Maybe(string)
 @(init, private)
 init_cpu_features :: proc "c" () {
 	is_set :: #force_inline proc "c" (hwc: u32, value: u32) -> bool {
-		return hwc&value != 0
+		return hwc&(1 << value) != 0
 	}
 	try_set :: #force_inline proc "c" (set: ^CPU_Features, feature: CPU_Feature, hwc: u32, value: u32) {
 		if is_set(hwc, value) {


### PR DESCRIPTION
This needs to test that the n-th bit is set.