### PR TITLE
fix parse_address can return nil

### DIFF
--- a/core/net/dns.odin
+++ b/core/net/dns.odin
@@ -392,6 +392,10 @@ load_resolv_conf :: proc(resolv_conf_path: string, allocator := context.allocato
 		}
 
 		addr := parse_address(server_ip_str)
+		if addr == nil {
+			continue
+		}
+
 		endpoint := Endpoint{
 			addr,
 			53,


### PR DESCRIPTION
My /etc/resolv.conf has the following contents which I don't think I ever changed:
```
#
# macOS Notice
#
# This file is not consulted for DNS hostname resolution, address
# resolution, or the DNS query routing mechanism used by most
# processes on this system.
#
# To view the DNS configuration used by this system, use:
#   scutil --dns
#
# SEE ALSO
#   dns-sd(1), scutil(8)
#
# This file is automatically generated.
#
search home
nameserver fe80::76b5:7eff:fe26:36b5%en6
nameserver 192.168.2.254
```

`net.parse_address` can't parse the first nameserver and returns nil, further down the line this causes a nil pointer error. I think just skipping these non-addresses is fine.