### PR TITLE
add missing fields to fontinfo

### DIFF
--- a/vendor/stb/truetype/stb_truetype.odin
+++ b/vendor/stb/truetype/stb_truetype.odin
@@ -200,7 +200,7 @@ fontinfo :: struct {
 
 	numGlyphs: c.int,
 
-	loca, head, glyf, hhea, hmtx, kern: c.int,
+	loca, head, glyf, hhea, hmtx, kern, gpos, svg: c.int,
 	index_map: c.int,
 	indexToLocFormat: c.int,
 


### PR DESCRIPTION
fontinfo in  `vendor:stb/truetype` has 2 missing fields, `gpos` and `svg`. This results in crashes while rendering some specific glyphs from some fonts (Inconsolata in my case). This is for stb_truetype.h v1.26, which is the version currently shipped with vendor.