### PR TITLE
Use compound literal storage for ValueDecl lvals

### DIFF
--- a/src/llvm_backend_stmt.cpp
+++ b/src/llvm_backend_stmt.cpp
@@ -2303,6 +2303,7 @@ gb_internal void lb_build_stmt(lbProcedure *p, Ast *node) {
 							lb_add_entity(p->module, e, val);
 							lb_add_debug_local_variable(p, val.value, e->type, e->token);
 							lvals_preused[lval_index] = true;
+							lvals[lval_index] = *comp_lit_addr;
 						}
 					}
 				}

--- a/tests/issues/run.bat
+++ b/tests/issues/run.bat
@@ -12,6 +12,7 @@ set COMMON=-collection:tests=..\..
 ..\..\..\odin test ..\test_issue_2056.odin %COMMON% -file || exit /b
 ..\..\..\odin test ..\test_issue_2087.odin %COMMON% -file || exit /b
 ..\..\..\odin build ..\test_issue_2113.odin %COMMON% -file -debug || exit /b
+..\..\..\odin test ..\test_issue_2466.odin %COMMON% -file || exit /b
 
 @echo off
 

--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -13,6 +13,7 @@ $ODIN test ../test_issue_1592.odin $COMMON -file
 $ODIN test ../test_issue_2056.odin $COMMON -file
 $ODIN test ../test_issue_2087.odin $COMMON -file
 $ODIN build ../test_issue_2113.odin $COMMON -file -debug
+$ODIN test ../test_issue_2466.odin $COMMON -file
 
 set +x
 

--- a/tests/issues/test_issue_2466.odin
+++ b/tests/issues/test_issue_2466.odin
@@ -1,0 +1,22 @@
+// Tests issue #2466 https://github.com/odin-lang/Odin/issues/2466
+package test_issues
+
+import "core:fmt"
+import "core:testing"
+
+Bug :: struct  {
+	val: int,
+	arr: []int,
+}
+
+@test
+test_compound_literal_local_reuse :: proc(t: ^testing.T) {
+	v: int = 123
+	bug := Bug {
+		val = v,
+		arr = {42},
+	}
+	testing.expect(t, bug.val == 123, fmt.tprintf("expected 123, found %d", bug.val))
+	testing.expect(t, bug.arr[0] == 42, fmt.tprintf("expected 42, found %d", bug.arr[0]))
+}
+


### PR DESCRIPTION
Fixes #2466 

This should preserve the current stack usage optimization. The IR below diverges after the store to `%12`. For correctness there is an additional `llvm.memcpy` so that the prior store to `Bug.val` is copied to the `Bug` instance used by `printf`. I don't know why there are two `Bug` structs in the IR, but the compiler was already generating code like that.

### Test case

```odin
// odin build 2466.odin -file -build-mode:llvm
package issue2466

import "core:c/libc"

Bug :: struct {
	val: int,
	arr: []int,
}

main :: proc() {
	v: int = 123
	bug := Bug {
		val = v,
		arr = {42},
	}
	libc.printf("%d %d\n", bug.val, bug.arr[0])
}
```

### Before

```llvm
define internal void @issue2466.main(i8* noalias nocapture nonnull %__.context_ptr) {
decls:
  %0 = alloca %issue2466.Bug, align 8
  %1 = alloca [1 x i64], align 16
  %2 = alloca { i64*, i64 }, align 8
  %3 = alloca %issue2466.Bug, align 8
  br label %entry

entry:                                            ; preds = %decls
  %4 = bitcast %issue2466.Bug* %0 to i8*
  call void @llvm.memset.p0i8.i64(i8* %4, i8 0, i64 24, i1 false)
  store [1 x i64] [i64 42], [1 x i64]* %1, align 8
  %5 = getelementptr inbounds [1 x i64], [1 x i64]* %1, i64 0, i64 0
  %6 = getelementptr inbounds { i64*, i64 }, { i64*, i64 }* %2, i32 0, i32 0
  store i64* %5, i64** %6, align 8
  %7 = getelementptr inbounds { i64*, i64 }, { i64*, i64 }* %2, i32 0, i32 1
  store i64 1, i64* %7, align 8
  %8 = getelementptr inbounds %issue2466.Bug, %issue2466.Bug* %3, i32 0, i32 1
  %9 = bitcast %issue2466.Bug* %3 to i8*
  call void @llvm.memset.p0i8.i64(i8* align 8 %9, i8 0, i64 24, i1 false)
  %10 = bitcast { i64*, i64 }* %8 to i8*
  %11 = bitcast { i64*, i64 }* %2 to i8*
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %10, i8* align 8 %11, i64 16, i1 false)
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %4, i8* align 8 %9, i64 24, i1 false)
  %12 = getelementptr inbounds %issue2466.Bug, %issue2466.Bug* %0, i32 0, i32 0
  store i64 123, i64* %12, align 8
  %13 = getelementptr inbounds %issue2466.Bug, %issue2466.Bug* %3, i32 0, i32 0
  %14 = load i64, i64* %13, align 8
  %15 = getelementptr inbounds { i64*, i64 }, { i64*, i64 }* %8, i32 0, i32 0
  %16 = load i64*, i64** %15, align 8
  %17 = getelementptr inbounds { i64*, i64 }, { i64*, i64 }* %8, i32 0, i32 1
  %18 = load i64, i64* %17, align 8
  call void @runtime.bounds_check_error(%..string* @"ggv$e", i32 16, i32 42, i64 0, i64 %18)
  %19 = load i64, i64* %16, align 8
  %20 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"csbs$8", i64 0, i64 0), i64 %14, i64 %19)
  ret void
}
```

### After

```llvm
define internal void @issue2466.main(i8* noalias nocapture nonnull %__.context_ptr) {
decls:
  %0 = alloca %issue2466.Bug, align 8
  %1 = alloca [1 x i64], align 16
  %2 = alloca { i64*, i64 }, align 8
  %3 = alloca %issue2466.Bug, align 8
  br label %entry

entry:                                            ; preds = %decls
  %4 = bitcast %issue2466.Bug* %0 to i8*
  call void @llvm.memset.p0i8.i64(i8* %4, i8 0, i64 24, i1 false)
  store [1 x i64] [i64 42], [1 x i64]* %1, align 8
  %5 = getelementptr inbounds [1 x i64], [1 x i64]* %1, i64 0, i64 0
  %6 = getelementptr inbounds { i64*, i64 }, { i64*, i64 }* %2, i32 0, i32 0
  store i64* %5, i64** %6, align 8
  %7 = getelementptr inbounds { i64*, i64 }, { i64*, i64 }* %2, i32 0, i32 1
  store i64 1, i64* %7, align 8
  %8 = getelementptr inbounds %issue2466.Bug, %issue2466.Bug* %3, i32 0, i32 1
  %9 = bitcast %issue2466.Bug* %3 to i8*
  call void @llvm.memset.p0i8.i64(i8* align 8 %9, i8 0, i64 24, i1 false)
  %10 = bitcast { i64*, i64 }* %8 to i8*
  %11 = bitcast { i64*, i64 }* %2 to i8*
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %10, i8* align 8 %11, i64 16, i1 false)
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %4, i8* align 8 %9, i64 24, i1 false)
  %12 = getelementptr inbounds %issue2466.Bug, %issue2466.Bug* %0, i32 0, i32 0
  store i64 123, i64* %12, align 8
  ; diverges here
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %9, i8* align 8 %4, i64 24, i1 false)
  %13 = getelementptr inbounds %issue2466.Bug, %issue2466.Bug* %3, i32 0, i32 0
  %14 = load i64, i64* %13, align 8
  %15 = getelementptr inbounds { i64*, i64 }, { i64*, i64 }* %8, i32 0, i32 0
  %16 = load i64*, i64** %15, align 8
  %17 = getelementptr inbounds { i64*, i64 }, { i64*, i64 }* %8, i32 0, i32 1
  %18 = load i64, i64* %17, align 8
  call void @runtime.bounds_check_error(%..string* @"ggv$10", i32 16, i32 42, i64 0, i64 %18)
  %19 = load i64, i64* %16, align 8
  %20 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"csbs$a", i64 0, i64 0), i64 %14, i64 %19)
  ret void
}
```