### PR TITLE
Update build_odin.sh to better support optimisation on Arm CPUs

### DIFF
--- a/build_odin.sh
+++ b/build_odin.sh
@@ -135,7 +135,14 @@ build_odin() {
 		EXTRAFLAGS="-O3"
 		;;
 	release-native)
-		EXTRAFLAGS="-O3 -march=native"
+		local ARCH=$(uname -m)
+        	if [ "${ARCH}" == "arm64" ]; then
+            		# Use preferred flag for Arm (ie arm64 / aarch64 / etc)
+            		EXTRAFLAGS="-O3 -mcpu=native"
+        	else
+            		# Use preferred flag for x86 / amd64
+            		EXTRAFLAGS="-O3 -march=native"
+        	fi
 		;;
 	nightly)
 		EXTRAFLAGS="-DNIGHTLY -O3"


### PR DESCRIPTION
The `build_odin` flags include the option `release-native`.

The current `EXTRAFLAGS` set however don't work for Arm CPUs as they dont support `-march=native`.

Added code to detect CPU and either set the preferred flag for Arm CPUs (ie `-mcpu=native`) or keep the current default.

Information on preferred Arm CPU optimisation flag taken from here: https://community.arm.com/arm-community-blogs/b/tools-software-ides-blog/posts/compiler-flags-across-architectures-march-mtune-and-mcpu

Changes tested on an Apple Silicon M1 CPU (arm64) using HomeBrew installed llvm as follows:

```
Homebrew clang version 14.0.6                                                                                                                    
Target: arm64-apple-darwin22.5.0                                                                                                                 
Thread model: posix                                                                                                                              
InstalledDir: /opt/homebrew/opt/llvm@14/bin
```