### PR TITLE
[core:thread] Fix `run` procedure

### DIFF
--- a/core/thread/thread.odin
+++ b/core/thread/thread.odin
@@ -80,6 +80,7 @@ run :: proc(fn: proc(), init_context: Maybe(runtime.Context) = nil, priority := 
 		fn()
 	}
 	t := create(thread_proc, priority)
+	t.data = rawptr(fn)
 	t.init_context = init_context
 	if auto_cleanup {
 		t.flags += {.Auto_Cleanup}

--- a/core/thread/thread.odin
+++ b/core/thread/thread.odin
@@ -75,7 +75,11 @@ yield :: proc() {
 
 
 run :: proc(fn: proc(), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal, auto_cleanup := true) -> ^Thread {
-	t := create(fn, priority)
+	thread_proc :: proc(t: ^Thread) {
+		fn := cast(proc())t.data
+		fn()
+	}
+	t := create(thread_proc, priority)
 	t.init_context = init_context
 	if auto_cleanup {
 		t.flags += {.Auto_Cleanup}

--- a/core/thread/thread.odin
+++ b/core/thread/thread.odin
@@ -207,3 +207,24 @@ run_with_poly_data4 :: proc(arg1: $T1, arg2: $T2, arg3: $T3, arg4: $T4, fn: proc
 	start(t)
 	return t
 }
+
+// NOTE(ftphikari): Keeping these here for backwards compatibility for a while.
+create_and_start_with_data :: proc(data: rawptr, fn: proc(data: rawptr), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal) -> ^Thread {
+	return run_with_data(data, fn, init_context, priority, false)
+}
+
+create_and_start_with_poly_data :: proc(data: $T, fn: proc(data: T), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal) -> ^Thread {
+	return run_with_poly_data(data, fn, init_context, priority, false)
+}
+
+create_and_start_with_poly_data2 :: proc(arg1: $T1, arg2: $T2, fn: proc(T1, T2), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal) -> ^Thread {
+	return run_with_poly_data2(arg1, arg2, fn, init_context, priority, false)
+}
+
+create_and_start_with_poly_data3 :: proc(arg1: $T1, arg2: $T2, arg3: $T3, fn: proc(arg1: T1, arg2: T2, arg3: T3), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal) -> ^Thread {
+	return run_with_poly_data3(arg1, arg2, arg3, fn, init_context, priority, false)
+}
+
+create_and_start_with_poly_data4 :: proc(arg1: $T1, arg2: $T2, arg3: $T3, arg4: $T4, fn: proc(arg1: T1, arg2: T2, arg3: T3, arg4: T4), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal, auto_cleanup := true) -> ^Thread {
+	return run_with_poly_data4(arg1, arg2, arg3, arg4, fn, init_context, priority, false)
+}

--- a/core/thread/thread.odin
+++ b/core/thread/thread.odin
@@ -74,135 +74,17 @@ yield :: proc() {
 
 
 
-run :: proc(fn: proc(), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal) {
-	thread_proc :: proc(t: ^Thread) {
-		fn := cast(proc())t.data
-		fn()
-	}
-	t := create(thread_proc, priority)
-	t.data = rawptr(fn)
-	t.flags += {.Auto_Cleanup}
-	t.init_context = init_context
-	start(t)
-}
-
-run_with_data :: proc(data: rawptr, fn: proc(data: rawptr), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal) {
-	thread_proc :: proc(t: ^Thread) {
-		fn := cast(proc(rawptr))t.data
-		assert(t.user_index >= 1)
-		data := t.user_args[0]
-		fn(data)
-	}
-	t := create(thread_proc, priority)
-	t.data = rawptr(fn)
-	t.flags += {.Auto_Cleanup}
-	t.user_index = 1
-	t.user_args = data
-	t.init_context = init_context
-	start(t)
-}
-
-run_with_poly_data :: proc(data: $T, fn: proc(data: T), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal)
-	where size_of(T) <= size_of(rawptr) {
-	thread_proc :: proc(t: ^Thread) {
-		fn := cast(proc(T))t.data
-		assert(t.user_index >= 1)
-		data := (^T)(&t.user_args[0])^
-		fn(data)
-	}
-	t := create(thread_proc, priority)
-	t.data = rawptr(fn)
-	t.flags += {.Auto_Cleanup}
-	t.user_index = 1
-	data := data
-	mem.copy(&t.user_args[0], &data, size_of(data))
-	t.init_context = init_context
-	start(t)
-}
-
-run_with_poly_data2 :: proc(arg1: $T1, arg2: $T2, fn: proc(T1, T2), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal)
-	where size_of(T1) <= size_of(rawptr),
-	      size_of(T2) <= size_of(rawptr) {
-	thread_proc :: proc(t: ^Thread) {
-		fn := cast(proc(T1, T2))t.data
-		assert(t.user_index >= 2)
-		arg1 := (^T1)(&t.user_args[0])^
-		arg2 := (^T2)(&t.user_args[1])^
-		fn(arg1, arg2)
-	}
-	t := create(thread_proc, priority)
-	t.data = rawptr(fn)
-	t.flags += {.Auto_Cleanup}
-	t.user_index = 2
-	arg1, arg2 := arg1, arg2
-	mem.copy(&t.user_args[0], &arg1, size_of(arg1))
-	mem.copy(&t.user_args[1], &arg2, size_of(arg2))
-	t.init_context = init_context
-	start(t)
-}
-
-run_with_poly_data3 :: proc(arg1: $T1, arg2: $T2, arg3: $T3, fn: proc(arg1: T1, arg2: T2, arg3: T3), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal)
-	where size_of(T1) <= size_of(rawptr),
-	      size_of(T2) <= size_of(rawptr),
-	      size_of(T3) <= size_of(rawptr) {
-	thread_proc :: proc(t: ^Thread) {
-		fn := cast(proc(T1, T2, T3))t.data
-		assert(t.user_index >= 3)
-		arg1 := (^T1)(&t.user_args[0])^
-		arg2 := (^T2)(&t.user_args[1])^
-		arg3 := (^T3)(&t.user_args[2])^
-		fn(arg1, arg2, arg3)
-	}
-	t := create(thread_proc, priority)
-	t.data = rawptr(fn)
-	t.flags += {.Auto_Cleanup}
-	t.user_index = 3
-	arg1, arg2, arg3 := arg1, arg2, arg3
-	mem.copy(&t.user_args[0], &arg1, size_of(arg1))
-	mem.copy(&t.user_args[1], &arg2, size_of(arg2))
-	mem.copy(&t.user_args[2], &arg3, size_of(arg3))
-	t.init_context = init_context
-	start(t)
-}
-run_with_poly_data4 :: proc(arg1: $T1, arg2: $T2, arg3: $T3, arg4: $T4, fn: proc(arg1: T1, arg2: T2, arg3: T3, arg4: T4), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal)
-	where size_of(T1) <= size_of(rawptr),
-	      size_of(T2) <= size_of(rawptr),
-	      size_of(T3) <= size_of(rawptr) {
-	thread_proc :: proc(t: ^Thread) {
-		fn := cast(proc(T1, T2, T3, T4))t.data
-		assert(t.user_index >= 4)
-		arg1 := (^T1)(&t.user_args[0])^
-		arg2 := (^T2)(&t.user_args[1])^
-		arg3 := (^T3)(&t.user_args[2])^
-		arg4 := (^T4)(&t.user_args[3])^
-		fn(arg1, arg2, arg3, arg4)
-	}
-	t := create(thread_proc, priority)
-	t.data = rawptr(fn)
-	t.flags += {.Auto_Cleanup}
-	t.user_index = 4
-	arg1, arg2, arg3, arg4 := arg1, arg2, arg3, arg4
-	mem.copy(&t.user_args[0], &arg1, size_of(arg1))
-	mem.copy(&t.user_args[1], &arg2, size_of(arg2))
-	mem.copy(&t.user_args[2], &arg3, size_of(arg3))
-	mem.copy(&t.user_args[3], &arg4, size_of(arg4))
-	t.init_context = init_context
-	start(t)
-}
-
-
-
-create_and_start :: proc(fn: Thread_Proc, init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal) -> ^Thread {
+run :: proc(fn: proc(), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal, auto_cleanup := true) -> ^Thread {
 	t := create(fn, priority)
 	t.init_context = init_context
+	if auto_cleanup {
+		t.flags += {.Auto_Cleanup}
+	}
 	start(t)
 	return t
 }
 
-
-
-
-create_and_start_with_data :: proc(data: rawptr, fn: proc(data: rawptr), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal) -> ^Thread {
+run_with_data :: proc(data: rawptr, fn: proc(data: rawptr), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal, auto_cleanup := true) -> ^Thread {
 	thread_proc :: proc(t: ^Thread) {
 		fn := cast(proc(rawptr))t.data
 		assert(t.user_index >= 1)
@@ -214,11 +96,14 @@ create_and_start_with_data :: proc(data: rawptr, fn: proc(data: rawptr), init_co
 	t.user_index = 1
 	t.user_args = data
 	t.init_context = init_context
+	if auto_cleanup {
+		t.flags += {.Auto_Cleanup}
+	}
 	start(t)
 	return t
 }
 
-create_and_start_with_poly_data :: proc(data: $T, fn: proc(data: T), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal) -> ^Thread 
+run_with_poly_data :: proc(data: $T, fn: proc(data: T), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal, auto_cleanup := true) -> ^Thread
 	where size_of(T) <= size_of(rawptr) {
 	thread_proc :: proc(t: ^Thread) {
 		fn := cast(proc(T))t.data
@@ -232,11 +117,14 @@ create_and_start_with_poly_data :: proc(data: $T, fn: proc(data: T), init_contex
 	data := data
 	mem.copy(&t.user_args[0], &data, size_of(data))
 	t.init_context = init_context
+	if auto_cleanup {
+		t.flags += {.Auto_Cleanup}
+	}
 	start(t)
 	return t
 }
 
-create_and_start_with_poly_data2 :: proc(arg1: $T1, arg2: $T2, fn: proc(T1, T2), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal) -> ^Thread 
+run_with_poly_data2 :: proc(arg1: $T1, arg2: $T2, fn: proc(T1, T2), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal, auto_cleanup := true) -> ^Thread
 	where size_of(T1) <= size_of(rawptr),
 	      size_of(T2) <= size_of(rawptr) {
 	thread_proc :: proc(t: ^Thread) {
@@ -253,11 +141,14 @@ create_and_start_with_poly_data2 :: proc(arg1: $T1, arg2: $T2, fn: proc(T1, T2),
 	mem.copy(&t.user_args[0], &arg1, size_of(arg1))
 	mem.copy(&t.user_args[1], &arg2, size_of(arg2))
 	t.init_context = init_context
+	if auto_cleanup {
+		t.flags += {.Auto_Cleanup}
+	}
 	start(t)
 	return t
 }
 
-create_and_start_with_poly_data3 :: proc(arg1: $T1, arg2: $T2, arg3: $T3, fn: proc(arg1: T1, arg2: T2, arg3: T3), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal) -> ^Thread 
+run_with_poly_data3 :: proc(arg1: $T1, arg2: $T2, arg3: $T3, fn: proc(arg1: T1, arg2: T2, arg3: T3), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal, auto_cleanup := true) -> ^Thread
 	where size_of(T1) <= size_of(rawptr),
 	      size_of(T2) <= size_of(rawptr),
 	      size_of(T3) <= size_of(rawptr) {
@@ -277,10 +168,13 @@ create_and_start_with_poly_data3 :: proc(arg1: $T1, arg2: $T2, arg3: $T3, fn: pr
 	mem.copy(&t.user_args[1], &arg2, size_of(arg2))
 	mem.copy(&t.user_args[2], &arg3, size_of(arg3))
 	t.init_context = init_context
+	if auto_cleanup {
+		t.flags += {.Auto_Cleanup}
+	}
 	start(t)
 	return t
 }
-create_and_start_with_poly_data4 :: proc(arg1: $T1, arg2: $T2, arg3: $T3, arg4: $T4, fn: proc(arg1: T1, arg2: T2, arg3: T3, arg4: T4), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal) -> ^Thread 
+run_with_poly_data4 :: proc(arg1: $T1, arg2: $T2, arg3: $T3, arg4: $T4, fn: proc(arg1: T1, arg2: T2, arg3: T3, arg4: T4), init_context: Maybe(runtime.Context) = nil, priority := Thread_Priority.Normal, auto_cleanup := true) -> ^Thread
 	where size_of(T1) <= size_of(rawptr),
 	      size_of(T2) <= size_of(rawptr),
 	      size_of(T3) <= size_of(rawptr) {
@@ -302,6 +196,9 @@ create_and_start_with_poly_data4 :: proc(arg1: $T1, arg2: $T2, arg3: $T3, arg4: 
 	mem.copy(&t.user_args[2], &arg3, size_of(arg3))
 	mem.copy(&t.user_args[3], &arg4, size_of(arg4))
 	t.init_context = init_context
+	if auto_cleanup {
+		t.flags += {.Auto_Cleanup}
+	}
 	start(t)
 	return t
 }

--- a/core/thread/thread_js.odin
+++ b/core/thread/thread_js.odin
@@ -5,12 +5,6 @@ import "core:intrinsics"
 import "core:sync"
 import "core:mem"
 
-Thread_State :: enum u8 {
-	Started,
-	Joined,
-	Done,
-}
-
 Thread_Os_Specific :: struct {
 	flags:       bit_set[Thread_State; u8],
 }

--- a/core/thread/thread_windows.odin
+++ b/core/thread/thread_windows.odin
@@ -7,17 +7,10 @@ import "core:intrinsics"
 import "core:sync"
 import win32 "core:sys/windows"
 
-Thread_State :: enum u8 {
-	Started,
-	Joined,
-	Done,
-}
-
 Thread_Os_Specific :: struct {
 	win32_thread:    win32.HANDLE,
 	win32_thread_id: win32.DWORD,
 	mutex:           sync.Mutex,
-	flags:           bit_set[Thread_State; u8],
 }
 
 _thread_priority_map := [Thread_Priority]i32{
@@ -44,6 +37,11 @@ _create :: proc(procedure: Thread_Proc, priority := Thread_Priority.Normal) -> ^
 				runtime.default_temp_allocator_destroy(auto_cast context.temp_allocator.data)
 			}
 		}
+
+		if .Auto_Cleanup in t.flags {
+			free(t, t.creation_allocator)
+		}
+
 		return 0
 	}
 

--- a/tests/documentation/documentation_tester.odin
+++ b/tests/documentation/documentation_tester.odin
@@ -290,7 +290,7 @@ _bad_test_found: bool
 
 @(private="file")
 _spawn_pipe_reader :: proc() {
-	thread.create_and_start(proc(^thread.Thread) {
+	thread.run(proc() {
 		stream := os.stream_from_handle(_read_pipe)
 		reader := io.to_reader(stream)
 		sync.post(&_pipe_reader_semaphore) // notify thread is ready


### PR DESCRIPTION
This commit fixes the behavior of `run`. Previously it would do `destroy(t)`, which would attempt to join the thread unto itself, which made no sense, thus it just deadlocked, and `free(t)` was never called.

This change adds `Auto_Cleanup` flag that is set when `run` procedure is called. Thread frees its memory at the end of its life if it finds that flag.