### PR TITLE
Documentation: Tracking_Allocator example is leaking memory

### DIFF
--- a/core/mem/doc.odin
+++ b/core/mem/doc.odin
@@ -18,6 +18,7 @@ _main :: proc() {
 main :: proc() {
 	track: mem.Tracking_Allocator
 	mem.tracking_allocator_init(&track, context.allocator)
+	defer mem.tracking_allocator_destroy(&track)
 	context.allocator = mem.tracking_allocator(&track)
 
 	_main()


### PR DESCRIPTION
Added the missing call to destroy the tracking allocator.