### PR TITLE
Replace `0` with `os.ERROR_NONE` in `demo.odin`

### DIFF
--- a/examples/demo/demo.odin
+++ b/examples/demo/demo.odin
@@ -352,7 +352,7 @@ control_flow :: proc() {
 
 		if false {
 			f, err := os.open("my_file.txt")
-			if err != 0 {
+			if err != os.ERROR_NONE {
 				// handle error
 			}
 			defer os.close(f)


### PR DESCRIPTION
Not sure which one is more proper, but looking at the distinct type helped me understand what's going on and why it is a number as you can "go to definition" using the type and find out more about the possible errors.