### PR TITLE
fix(dns): don't exit early on no hosts in hosts file

### DIFF
--- a/core/net/dns_unix.odin
+++ b/core/net/dns_unix.odin
@@ -44,9 +44,6 @@ _get_dns_records_os :: proc(hostname: string, type: DNS_Record_Type, allocator :
 	if !hosts_ok {
 		return nil, .Invalid_Hosts_Config_Error
 	}
-	if len(hosts) == 0 {
-		return
-	}
 
 	host_overrides := make([dynamic]DNS_Record)
 	for host in hosts {


### PR DESCRIPTION
If we don't have any hosts specified we'll still not generate any overrides which is fine, but we'll continue onto actually trying to resolve the hostname we came into the function for initially. The early return on no hosts read in the hosts file seems unnecessary and is maybe a copy-paste of the same error for the name server(?).