### PR TITLE
[check-type] fix faulty #no_nil variants error

### DIFF
--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -729,6 +729,12 @@ gb_internal void check_union_type(CheckerContext *ctx, Type *union_type, Ast *no
 	union_type->Union.kind = ut->kind;
 	switch (ut->kind) {
 	case UnionType_no_nil:
+		if (union_type->Union.is_polymorphic && poly_operands == nullptr) {
+			GB_ASSERT(variants.count == 0);
+			if (ut->variants.count != 1) {
+				break;
+			}
+		}
 		if (variants.count < 2) {
 			error(ut->align, "A union with #no_nil must have at least 2 variants");
 		}

--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -6,6 +6,8 @@ pushd build
 ODIN=../../../odin
 COMMON="-collection:tests=../.."
 
+NO_NIL_ERR="Error: "
+
 set -x
 
 $ODIN test ../test_issue_829.odin  $COMMON -file
@@ -14,6 +16,11 @@ $ODIN test ../test_issue_2056.odin $COMMON -file
 $ODIN test ../test_issue_2087.odin $COMMON -file
 $ODIN build ../test_issue_2113.odin $COMMON -file -debug
 $ODIN test ../test_issue_2466.odin $COMMON -file
+if [[ $($ODIN build ../test_issue_2395.odin $COMMON -file 2>&1 >/dev/null | grep -c "$NO_NIL_ERR") -eq 2 ]] ; then
+	echo "SUCCESSFUL 1/1"
+else
+	echo "SUCCESSFUL 0/1"
+fi
 
 set +x
 

--- a/tests/issues/test_issue_2395.odin
+++ b/tests/issues/test_issue_2395.odin
@@ -1,0 +1,29 @@
+// Tests issue #2395 https://github.com/odin-lang/Odin/issues/2395
+
+// Ensures that we no longer raise the faulty error for #no_nil unions when
+// then are 2 variants with the polymorphic type. Also ensure that we raise
+// exactly 2 errors from the invalid unions
+package test_issues
+
+import "core:testing"
+
+ValidUnion :: union($T: typeid) #no_nil {
+    T,
+    f32,
+}
+
+OtherValidUnion :: union($T: typeid, $S: typeid) #no_nil {
+    T,
+    S,
+}
+
+InvalidUnion :: union($T: typeid) #no_nil {
+    T,
+}
+
+OtherInvalidUnion :: union($T: typeid) #no_nil {
+    u8,
+}
+
+main :: proc() {
+}


### PR DESCRIPTION
- when checking the variants of a union type we will skip adding the variants if we have an unspecialized polymorphic, hence our union_type variants will be empty and have a count of 0

- so when checking if we violate the #no_nil error, if we are in the unspecialized polymorphic case and there exists at least one variant in the original variants then we should not raise this error

- test checks that we do not raise the error anymore, and that we still detect the #no_nil error in the described circumstances

fixes #2395 