### PR TITLE
feat(os_linux): add `poll` & `ppoll`

### DIFF
--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -440,9 +440,7 @@ pollfd :: struct {
 
 nfds_t :: distinct c.uint
 
-sigset_t :: struct {
-  __val: [16]c.ulong,
-}
+sigset_t :: distinct u64
 
 foreign libc {
 	@(link_name="__errno_location") __errno_location    :: proc() -> ^int ---

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -1100,14 +1100,6 @@ fcntl :: proc(fd: int, cmd: int, arg: int) -> (int, Errno) {
 	return result, ERROR_NONE
 }
 
-// select :: proc(nfds: int, readfds: ^fd_set, writefds: ^fd_set, exceptfds: ^fd_set, timeout: ^timeval) -> (int, Errno) {
-//   result := unix.sys_select(nfds, readfds, writefds, exceptfds, timeout)
-//   if result < 0 {
-//     return 0, _get_errno(result)
-//   }
-//   return result, ERROR_NONE
-// }
-
 poll :: proc(fds: [^]pollfd, nfds: nfds_t, timeout: int) -> (int, Errno) {
   result := unix.sys_poll(fds, uint(nfds), timeout)
   if result < 0 {

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -1099,17 +1099,17 @@ fcntl :: proc(fd: int, cmd: int, arg: int) -> (int, Errno) {
 }
 
 poll :: proc(fds: [^]pollfd, nfds: nfds_t, timeout: int) -> (int, Errno) {
-  result := unix.sys_poll(fds, uint(nfds), timeout)
-  if result < 0 {
-    return 0, _get_errno(result)
-  }
-  return result, ERROR_NONE
+	result := unix.sys_poll(fds, uint(nfds), timeout)
+	if result < 0 {
+		return 0, _get_errno(result)
+	}
+	return result, ERROR_NONE
 }
 
 ppoll :: proc(fds: [^]pollfd, nfds: nfds_t, timeout: ^unix.timespec, sigmask: ^sigset_t) -> (int, Errno) {
-  result := unix.sys_ppoll(fds, uint(nfds), timeout, sigmask, size_of(sigset_t))
-  if result < 0 {
-    return 0, _get_errno(result)
-  }
-  return result, ERROR_NONE
+	result := unix.sys_ppoll(fds, uint(nfds), timeout, sigmask, size_of(sigset_t))
+	if result < 0 {
+		return 0, _get_errno(result)
+	}
+	return result, ERROR_NONE
 }

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -433,12 +433,10 @@ AT_REMOVEDIR        :: uintptr(0x200)
 AT_SYMLINK_NOFOLLOW :: uintptr(0x100)
 
 pollfd :: struct {
-  fd:      c.int,
-  events:  c.short,
-  revents: c.short,
+	fd:      c.int,
+	events:  c.short,
+	revents: c.short,
 }
-
-nfds_t :: distinct c.uint
 
 sigset_t :: distinct u64
 
@@ -1098,16 +1096,16 @@ fcntl :: proc(fd: int, cmd: int, arg: int) -> (int, Errno) {
 	return result, ERROR_NONE
 }
 
-poll :: proc(fds: [^]pollfd, nfds: nfds_t, timeout: int) -> (int, Errno) {
-	result := unix.sys_poll(fds, uint(nfds), timeout)
+poll :: proc(fds: []pollfd, timeout: int) -> (int, Errno) {
+	result := unix.sys_poll(raw_data(fds), uint(len(fds)), timeout)
 	if result < 0 {
 		return 0, _get_errno(result)
 	}
 	return result, ERROR_NONE
 }
 
-ppoll :: proc(fds: [^]pollfd, nfds: nfds_t, timeout: ^unix.timespec, sigmask: ^sigset_t) -> (int, Errno) {
-	result := unix.sys_ppoll(fds, uint(nfds), timeout, sigmask, size_of(sigset_t))
+ppoll :: proc(fds: []pollfd, timeout: ^unix.timespec, sigmask: ^sigset_t) -> (int, Errno) {
+	result := unix.sys_ppoll(raw_data(fds), uint(len(fds)), timeout, sigmask, size_of(sigset_t))
 	if result < 0 {
 		return 0, _get_errno(result)
 	}

--- a/core/sys/unix/syscalls_linux.odin
+++ b/core/sys/unix/syscalls_linux.odin
@@ -2074,13 +2074,9 @@ sys_fcntl :: proc "contextless" (fd: int, cmd: int, arg: int) -> int {
 	return int(intrinsics.syscall(SYS_fcntl, uintptr(fd), uintptr(cmd), uintptr(arg)))
 }
 
-sys_select :: proc "contextless" (nfds: int, readfds, writefds, exceptfds: rawptr, timeout: rawptr) -> int {
-  return int(intrinsics.syscall(SYS_select, uintptr(nfds), uintptr(readfds), uintptr(writefds), uintptr(exceptfds), uintptr(timeout)))
-}
-
 sys_poll :: proc "contextless" (fds: rawptr, nfds: uint, timeout: int) -> int {
   // NOTE: specialcased here because `arm64` does not have `poll`
-	when ODIN_ARCH != .arm64 {
+	when ODIN_ARCH == .arm64 {
     // redefined because we can't depend on the `unix` module here
     timespec :: struct {
       tv_sec: i64,

--- a/core/sys/unix/syscalls_linux.odin
+++ b/core/sys/unix/syscalls_linux.odin
@@ -2075,22 +2075,21 @@ sys_fcntl :: proc "contextless" (fd: int, cmd: int, arg: int) -> int {
 }
 
 sys_poll :: proc "contextless" (fds: rawptr, nfds: uint, timeout: int) -> int {
-  // NOTE: specialcased here because `arm64` does not have `poll`
+	// NOTE: specialcased here because `arm64` does not have `poll`
 	when ODIN_ARCH == .arm64 {
-    // redefined because we can't depend on the `unix` module here
-    timespec :: struct {
-      tv_sec: i64,
-      tv_nsec: i64,
-    }
-    seconds := i64(timeout / 1_000)
-    nanoseconds := i64((timeout % 1000) * 1_000_000)
-    timeout_spec := timespec{seconds, nanoseconds}
-
+		// redefined because we can't depend on the `unix` module here
+		timespec :: struct {
+			tv_sec: i64,
+			tv_nsec: i64,
+		}
+		seconds := i64(timeout / 1_000)
+		nanoseconds := i64((timeout % 1000) * 1_000_000)
+		timeout_spec := timespec{seconds, nanoseconds}
+		
 		return int(intrinsics.syscall(SYS_ppoll, uintptr(fds), uintptr(nfds), uintptr(&timeout_spec), uintptr(0), uintptr(8)))
 	} else {
-    return int(intrinsics.syscall(SYS_poll, uintptr(fds), uintptr(nfds), uintptr(timeout)))
+		return int(intrinsics.syscall(SYS_poll, uintptr(fds), uintptr(nfds), uintptr(timeout)))
 	}
-  
 }
 
 sys_ppoll :: proc "contextless" (fds: rawptr, nfds: uint, timeout: rawptr, sigmask: rawptr, sigsetsize: uint) -> int {

--- a/core/sys/unix/syscalls_linux.odin
+++ b/core/sys/unix/syscalls_linux.odin
@@ -1567,6 +1567,23 @@ MADV_HWPOISON    :: 100
 // pipe2 flags
 O_CLOEXEC :: 0o2000000
 
+// poll events
+POLLIN         :: 0x0001
+POLLPRI        :: 0x0002
+POLLOUT        :: 0x0004
+POLLERR        :: 0x0008
+POLLHUP        :: 0x0010
+POLLNVAL       :: 0x0020
+POLLRDNORM     :: 0x0040
+POLLRDBAND     :: 0x0080
+POLLWRNORM     :: 0x0100
+POLLWRBAND     :: 0x0200
+POLLMSG        :: 0x0400
+POLLREMOVE     :: 0x1000
+POLLRDHUP      :: 0x2000
+POLLFREE       :: 0x4000
+POLL_BUSY_LOOP :: 0x8000
+
 // perf event data
 Perf_Sample :: struct #raw_union {
 	period:    u64,
@@ -2055,6 +2072,18 @@ sys_personality :: proc(persona: u64) -> int {
 
 sys_fcntl :: proc "contextless" (fd: int, cmd: int, arg: int) -> int {
 	return int(intrinsics.syscall(SYS_fcntl, uintptr(fd), uintptr(cmd), uintptr(arg)))
+}
+
+sys_select :: proc "contextless" (nfds: int, readfds, writefds, exceptfds: rawptr, timeout: rawptr) -> int {
+  return int(intrinsics.syscall(SYS_select, uintptr(nfds), uintptr(readfds), uintptr(writefds), uintptr(exceptfds), uintptr(timeout)))
+}
+
+sys_poll :: proc "contextless" (fds: rawptr, nfds: uint, timeout: int) -> int {
+  return int(intrinsics.syscall(SYS_poll, uintptr(fds), uintptr(nfds), uintptr(timeout)))
+}
+
+sys_ppoll :: proc "contextless" (fds: rawptr, nfds: uint, timeout: rawptr, sigmask: rawptr, sigsetsize: uint) -> int {
+  return int(intrinsics.syscall(SYS_ppoll, uintptr(fds), uintptr(nfds), uintptr(timeout), uintptr(sigmask), uintptr(sigsetsize)))
 }
 
 get_errno :: proc "contextless" (res: int) -> i32 {

--- a/core/sys/unix/syscalls_linux.odin
+++ b/core/sys/unix/syscalls_linux.odin
@@ -2088,7 +2088,7 @@ sys_poll :: proc "contextless" (fds: rawptr, nfds: uint, timeout: int) -> int {
 }
 
 sys_ppoll :: proc "contextless" (fds: rawptr, nfds: uint, timeout: rawptr, sigmask: rawptr, sigsetsize: uint) -> int {
-  return int(intrinsics.syscall(SYS_ppoll, uintptr(fds), uintptr(nfds), uintptr(timeout), uintptr(sigmask), uintptr(sigsetsize)))
+	return int(intrinsics.syscall(SYS_ppoll, uintptr(fds), uintptr(nfds), uintptr(timeout), uintptr(sigmask), uintptr(sigsetsize)))
 }
 
 get_errno :: proc "contextless" (res: int) -> i32 {

--- a/core/sys/unix/syscalls_linux.odin
+++ b/core/sys/unix/syscalls_linux.odin
@@ -2077,11 +2077,6 @@ sys_fcntl :: proc "contextless" (fd: int, cmd: int, arg: int) -> int {
 sys_poll :: proc "contextless" (fds: rawptr, nfds: uint, timeout: int) -> int {
 	// NOTE: specialcased here because `arm64` does not have `poll`
 	when ODIN_ARCH == .arm64 {
-		// redefined because we can't depend on the `unix` module here
-		timespec :: struct {
-			tv_sec: i64,
-			tv_nsec: i64,
-		}
 		seconds := i64(timeout / 1_000)
 		nanoseconds := i64((timeout % 1000) * 1_000_000)
 		timeout_spec := timespec{seconds, nanoseconds}


### PR DESCRIPTION
I wanted to play around with `poll` & friends in a project and noticed that we didn't have them in `os_linux` (while we obviously still have Windows equivalents).

It's not necessarily what people will go with in practice (they'll probably want `io_uring`), but I think it's still nice to have access to.