### PR TITLE
Fix fmt_js to match new io.Stream Interface

### DIFF
--- a/core/fmt/fmt_js.odin
+++ b/core/fmt/fmt_js.odin
@@ -10,28 +10,25 @@ foreign odin_env {
 	write :: proc "contextless" (fd: u32, p: []byte) ---
 }
 
-@(private="file")
-write_vtable := io.Stream_VTable{
-	impl_write = proc(s: io.Stream, p: []byte) -> (n: int, err: io.Error) {
-		fd := u32(uintptr(s.stream_data))
+write_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, offset: i64, whence: io.Seek_From) -> (n: i64, err: io.Error) {
+    #partial switch mode {
+    case .Write:
+        fd := u32(uintptr(stream_data))
 		write(fd, p)
-		return len(p), nil
-	},	
+		return i64(len(p)), nil
+    }
+    return 0, .Empty
 }
 
 @(private="file")
 stdout := io.Writer{
-	stream = {
-		stream_vtable = &write_vtable,
-		stream_data = rawptr(uintptr(1)),
-	},
+	procedure = write_proc,
+	data = rawptr(uintptr(1)),
 }
 @(private="file")
 stderr := io.Writer{
-	stream = {
-		stream_vtable = &write_vtable,
-		stream_data = rawptr(uintptr(2)),
-	},
+	procedure = write_proc,
+    data = rawptr(uintptr(2)),
 }
 
 // print formats using the default print settings and writes to stdout


### PR DESCRIPTION
After pulling #2584, I noticed that the fmt_js.odin file was not updated to match the new interface.