### PR TITLE
fix(os): use `setenv` instead of `putenv`

### DIFF
--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -894,7 +894,6 @@ get_env :: proc(key: string, allocator := context.allocator) -> (value: string) 
 
 set_env :: proc(key, value: string) -> Errno {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
-	s := strings.concatenate({key, "=", value, "\x00"}, context.temp_allocator)
   key_cstring := strings.unsafe_string_to_cstring(strings.concatenate({key, "\x00"}, context.temp_allocator))
   value_cstring := strings.unsafe_string_to_cstring(strings.concatenate({value, "\x00"}, context.temp_allocator))
   // NOTE(GoNZooo): `setenv` instead of `putenv` because it copies both key and value more commonly

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -894,9 +894,9 @@ get_env :: proc(key: string, allocator := context.allocator) -> (value: string) 
 
 set_env :: proc(key, value: string) -> Errno {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
-  key_cstring := strings.unsafe_string_to_cstring(strings.concatenate({key, "\x00"}, context.temp_allocator))
-  value_cstring := strings.unsafe_string_to_cstring(strings.concatenate({value, "\x00"}, context.temp_allocator))
-  // NOTE(GoNZooo): `setenv` instead of `putenv` because it copies both key and value more commonly
+	key_cstring := strings.unsafe_string_to_cstring(strings.concatenate({key, "\x00"}, context.temp_allocator))
+	value_cstring := strings.unsafe_string_to_cstring(strings.concatenate({value, "\x00"}, context.temp_allocator))
+	// NOTE(GoNZooo): `setenv` instead of `putenv` because it copies both key and value more commonly
 	res := _unix_setenv(key_cstring, value_cstring, 1)
 	if res < 0 {
 		return Errno(get_last_error())

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -894,8 +894,8 @@ get_env :: proc(key: string, allocator := context.allocator) -> (value: string) 
 
 set_env :: proc(key, value: string) -> Errno {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
-	key_cstring := strings.unsafe_string_to_cstring(strings.concatenate({key, "\x00"}, context.temp_allocator))
-	value_cstring := strings.unsafe_string_to_cstring(strings.concatenate({value, "\x00"}, context.temp_allocator))
+	key_cstring := strings.clone_to_cstring(key, context.temp_allocator)
+	value_cstring := strings.clone_to_cstring(value, context.temp_allocator)
 	// NOTE(GoNZooo): `setenv` instead of `putenv` because it copies both key and value more commonly
 	res := _unix_setenv(key_cstring, value_cstring, 1)
 	if res < 0 {


### PR DESCRIPTION
`putenv` doesn't copy the value that is put, which means that the previous code had a bug where we free'd the temporary memory and the environment was accidentally cleared right after the function finished.

Using `setenv` the OS instead copies over the values and we're free to deallocate as the original code intended.