### PR TITLE
detect unix color support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2547,12 +2547,24 @@ gb_internal int strip_semicolons(Parser *parser) {
 	return cast(int)failed;
 }
 
-#if defined(GB_SYSTEM_OSX) || defined(GB_SYSTEM_UNIX)
-#include <stdio.h>
-#endif
-
 gb_internal void init_terminal(void) {
 	build_context.has_ansi_terminal_colours = false;
+
+    gbAllocator a = heap_allocator();
+
+    char const *no_color = gb_get_env("NO_COLOR", a);
+    defer (gb_free(a, cast(void *)no_color));
+    if (no_color != nullptr) {
+        return;
+    }
+
+    char const *force_color = gb_get_env("FORCE_COLOR", a);
+    defer (gb_free(a, cast(void *)force_color));
+    if (force_color != nullptr) {
+        build_context.has_ansi_terminal_colours = true;
+        return;
+    }
+
 #if defined(GB_SYSTEM_WINDOWS)
 	HANDLE hnd = GetStdHandle(STD_ERROR_HANDLE);
 	DWORD mode = 0;
@@ -2563,21 +2575,15 @@ gb_internal void init_terminal(void) {
 		}
 	}
 #elif defined(GB_SYSTEM_OSX) || defined(GB_SYSTEM_UNIX)
-    FILE* file = popen("tput colors 2>/dev/null", "r");
-    if (file) {
-        char buffer[20];
-        if (fgets(&buffer[0], 20, file)) {
-            u64 colors = gb_str_to_u64(buffer, nullptr, 10);
-            if (colors >= 8) {
-                build_context.has_ansi_terminal_colours = true;
-            }
-        }
-        pclose(file);
+    char const *term_ = gb_get_env("TERM", a);
+    defer (gb_free(a, cast(void *)term_));
+    String term = make_string_c(term_);
+    if (!str_eq(term, str_lit("dumb")) && isatty(STDERR_FILENO)) {
+        build_context.has_ansi_terminal_colours = true;
     }
 #endif
 
 	if (!build_context.has_ansi_terminal_colours) {
-		gbAllocator a = heap_allocator();
 		char const *odin_terminal_ = gb_get_env("ODIN_TERMINAL", a);
 		defer (gb_free(a, cast(void *)odin_terminal_));
 		String odin_terminal = make_string_c(odin_terminal_);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2550,20 +2550,20 @@ gb_internal int strip_semicolons(Parser *parser) {
 gb_internal void init_terminal(void) {
 	build_context.has_ansi_terminal_colours = false;
 
-    gbAllocator a = heap_allocator();
+	gbAllocator a = heap_allocator();
 
-    char const *no_color = gb_get_env("NO_COLOR", a);
-    defer (gb_free(a, cast(void *)no_color));
-    if (no_color != nullptr) {
-        return;
-    }
+	char const *no_color = gb_get_env("NO_COLOR", a);
+	defer (gb_free(a, cast(void *)no_color));
+	if (no_color != nullptr) {
+		return;
+	}
 
-    char const *force_color = gb_get_env("FORCE_COLOR", a);
-    defer (gb_free(a, cast(void *)force_color));
-    if (force_color != nullptr) {
-        build_context.has_ansi_terminal_colours = true;
-        return;
-    }
+	char const *force_color = gb_get_env("FORCE_COLOR", a);
+	defer (gb_free(a, cast(void *)force_color));
+	if (force_color != nullptr) {
+		build_context.has_ansi_terminal_colours = true;
+		return;
+	}
 
 #if defined(GB_SYSTEM_WINDOWS)
 	HANDLE hnd = GetStdHandle(STD_ERROR_HANDLE);
@@ -2575,12 +2575,12 @@ gb_internal void init_terminal(void) {
 		}
 	}
 #elif defined(GB_SYSTEM_OSX) || defined(GB_SYSTEM_UNIX)
-    char const *term_ = gb_get_env("TERM", a);
-    defer (gb_free(a, cast(void *)term_));
-    String term = make_string_c(term_);
-    if (!str_eq(term, str_lit("dumb")) && isatty(STDERR_FILENO)) {
-        build_context.has_ansi_terminal_colours = true;
-    }
+	char const *term_ = gb_get_env("TERM", a);
+	defer (gb_free(a, cast(void *)term_));
+	String term = make_string_c(term_);
+	if (!str_eq(term, str_lit("dumb")) && isatty(STDERR_FILENO)) {
+		build_context.has_ansi_terminal_colours = true;
+	}
 #endif
 
 	if (!build_context.has_ansi_terminal_colours) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2547,6 +2547,10 @@ gb_internal int strip_semicolons(Parser *parser) {
 	return cast(int)failed;
 }
 
+#if defined(GB_SYSTEM_OSX) || defined(GB_SYSTEM_UNIX)
+#include <stdio.h>
+#endif
+
 gb_internal void init_terminal(void) {
 	build_context.has_ansi_terminal_colours = false;
 #if defined(GB_SYSTEM_WINDOWS)
@@ -2558,6 +2562,18 @@ gb_internal void init_terminal(void) {
 			build_context.has_ansi_terminal_colours = true;
 		}
 	}
+#elif defined(GB_SYSTEM_OSX) || defined(GB_SYSTEM_UNIX)
+    FILE* file = popen("tput colors", "r");
+    if (file) {
+        char buffer[20];
+        if (fgets(&buffer[0], 20, file)) {
+            u64 colors = gb_str_to_u64(buffer, nullptr, 10);
+            if (colors >= 8) {
+                build_context.has_ansi_terminal_colours = true;
+            }
+        }
+        pclose(file);
+    }
 #endif
 
 	if (!build_context.has_ansi_terminal_colours) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2563,7 +2563,7 @@ gb_internal void init_terminal(void) {
 		}
 	}
 #elif defined(GB_SYSTEM_OSX) || defined(GB_SYSTEM_UNIX)
-    FILE* file = popen("tput colors", "r");
+    FILE* file = popen("tput colors 2>/dev/null", "r");
     if (file) {
         char buffer[20];
         if (fgets(&buffer[0], 20, file)) {


### PR DESCRIPTION
Adds a check for color support that was previously only on Windows.
`tput colors` outputs the amount of colors a terminal supports, I checked the `error.cpp` file and it seems to use 8 colors, thus the check for more than or equal to 8.

I have not tested the case where `tput` isn't available because it is available on all my available stuff. I would expect it to work because gb_str_to_u64 would return 0 because the output would be the message that it is not available.