### PR TITLE
[check_expr] add checker error for ! oper

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -1705,12 +1705,12 @@ gb_internal bool check_unary_op(CheckerContext *c, Operand *o, Token op) {
 		break;
 
 	case Token_Not:
-		if (!is_type_boolean(type)) {
+		if (!is_type_boolean(type) || is_type_array_like(o->type)) {
 			ERROR_BLOCK();
 			str = expr_to_string(o->expr);
 			error(op, "Operator '%.*s' is only allowed on boolean expressions", LIT(op.string));
 			gb_string_free(str);
-			if (is_type_integer(type)) {
+			if (is_type_array_like(o->type) || is_type_integer(type)) {
 				error_line("\tSuggestion: Did you mean to use the bitwise not operator '~'?\n");
 			}
 		} else {


### PR DESCRIPTION
- the ! is only intended to be used on a bool value and not on an array of booleans, instead we use ~ for the implied functionality

- update our checker to raise an error in the case the ! is used on an array of booleans and raise a suggestion to use the ~ operator

fixes #2624 