### PR TITLE
GetGestureDetected proc returns a Gesture not a Gestures bit_set

### DIFF
--- a/vendor/raylib/raylib.odin
+++ b/vendor/raylib/raylib.odin
@@ -1133,7 +1133,7 @@ foreign lib {
 
 	SetGesturesEnabled     :: proc(flags: Gestures) ---          // Enable a set of gestures using flags
 	IsGestureDetected      :: proc(gesture: Gesture) -> bool --- // Check if a gesture have been detected
-	GetGestureDetected     :: proc() -> Gesture ---              // Get latest detected gesture
+	GetGestureDetected     :: proc() -> Gestures ---             // Get latest detected gesture
 	GetGestureHoldDuration :: proc() -> f32 ---                  // Get gesture hold time in milliseconds
 	GetGestureDragVector   :: proc() -> Vector2 ---              // Get gesture drag vector
 	GetGestureDragAngle    :: proc() -> f32 ---                  // Get gesture drag angle


### PR DESCRIPTION
Just updating this to be in line with what I think the rest of the code is designed to do.

It returns a Gesture at the moment which will lead to BAD_ENUM 64 etc because the original header uses 2's complement numbers not a bit_set style.

Tested with the basic_input_detection raylib example and works a charm now!

