### PR TITLE
core:sys/windows: Deprecate htons, htonl, ntohl, ntohs in favor of endian specific integers

### DIFF
--- a/core/sys/windows/ws2_32.odin
+++ b/core/sys/windows/ws2_32.odin
@@ -211,7 +211,9 @@ foreign ws2_32 {
 	// [MS-Docs](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-ntohs)
 	ntohs :: proc(netshort: c_ushort) -> c_ushort ---
 	// [MS-Docs](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-htonl)
+	@(deprecated("Use endian specific integers instead, https://odin-lang.org/docs/overview/#basic-types"))
 	htonl :: proc(hostlong: c_ulong) -> c_ulong ---
 	// [MS-Docs](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-htons)
+	@(deprecated("Use endian specific integers instead, https://odin-lang.org/docs/overview/#basic-types"))
 	htons :: proc(hostshort: c_ushort) -> c_ushort ---
 }

--- a/core/sys/windows/ws2_32.odin
+++ b/core/sys/windows/ws2_32.odin
@@ -211,9 +211,9 @@ foreign ws2_32 {
 	// [MS-Docs](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-ntohs)
 	ntohs :: proc(netshort: c_ushort) -> c_ushort ---
 	// [MS-Docs](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-htonl)
-	@(deprecated("Use endian specific integers instead, https://odin-lang.org/docs/overview/#basic-types"))
+	@(deprecated="Use endian specific integers instead, https://odin-lang.org/docs/overview/#basic-types")
 	htonl :: proc(hostlong: c_ulong) -> c_ulong ---
 	// [MS-Docs](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-htons)
-	@(deprecated("Use endian specific integers instead, https://odin-lang.org/docs/overview/#basic-types"))
+	@(deprecated="Use endian specific integers instead, https://odin-lang.org/docs/overview/#basic-types")
 	htons :: proc(hostshort: c_ushort) -> c_ushort ---
 }


### PR DESCRIPTION
After a lengthily discussion on discord about whether or not the binding is correct, we came to the conclusion that these functions are useless since Odin supports natively endian specific integers, it's being used in the winsock binding, therefore to avoid confusions (like i had + a bug), deprecating them is better than not having them, so the user is properly educated on what is actually happening and what to use instead!