### PR TITLE
Match C++ parser behavior in allowing newlines before a closing brace.

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -420,7 +420,7 @@ expect_closing_brace_of_field_list :: proc(p: ^Parser) -> tokenizer.Token {
 	if allow_token(p, .Close_Brace) {
 		return token
 	}
-	if allow_token(p, .Semicolon) {
+	if allow_token(p, .Semicolon) && !tokenizer.is_newline(token) {
 		str := tokenizer.token_to_string(token)
 		error(p, end_of_line_pos(p, p.prev_tok), "expected a comma, got %s", str)
 	}
@@ -1836,7 +1836,9 @@ parse_field_list :: proc(p: ^Parser, follow: tokenizer.Token_Kind, allowed_flags
 				return true
 			}
 			if allow_token(p, .Semicolon) {
-				error(p, tok.pos, "expected a comma, got a semicolon")
+				if !tokenizer.is_newline(tok) {
+					error(p, tok.pos, "expected a comma, got a semicolon")
+				}
 				return true
 			}
 			return false


### PR DESCRIPTION
The C++ parser allows newlines before a closing brace in field lists, but the parser in the Odin library does not.

Example file, and output below:

```
package main

import "core:os"
import "core:odin/parser"
import "core:odin/ast"
import "core:fmt"

Thing1 :: struct {
	one: int,
	two: int
}

Thing2 :: struct {
	a: string
}

Thing3 :: struct {
	a, b, c: f32
}

Thing4 :: proc(
	x, y: int
) {}

Thing5 :: enum {
	One,
	Two
}

Thing6 :: union {
	bool, int, string, f32
}

main :: proc() {
	filepath := "/d/tools/odin/faulty/field_list_separator.odin"

	src, ok := os.read_entire_file(filepath)
	if !ok {
		fmt.println("failed to read file")
		os.exit(1)
	}

	file := ast.File{
		src = string(src),
		fullpath = filepath,
	}

	p := parser.default_parser()
	if ok := parser.parse_file(&p, &file); !ok || p.error_count > 0 {
		fmt.println("failed to parse file")
		os.exit(1)
	}
}
```

Build output with C++ parser, and output from running the above program that uses library Odin parser:

```
$ odin build field_list_separator.odin -file
$ echo $?
0
$ ./field_list_separator 
/d/tools/odin/faulty/field_list_separator.odin(10:10): expected a comma, got a semicolon
/d/tools/odin/faulty/field_list_separator.odin(14:11): expected a comma, got a semicolon
/d/tools/odin/faulty/field_list_separator.odin(18:14): expected a comma, got a semicolon
/d/tools/odin/faulty/field_list_separator.odin(22:11): expected a comma, got a semicolon
/d/tools/odin/faulty/field_list_separator.odin(27:4): expected a comma, got newline
/d/tools/odin/faulty/field_list_separator.odin(31:23): expected a comma, got newline
failed to parse file
```

