### PR TITLE
Don't gitignore folders named odin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,6 +270,7 @@ bin/
 
 # - Linux/MacOS
 odin
+!odin/
 odin.dSYM
 *.bin
 demo.bin


### PR DESCRIPTION
Not sure if the original intention of the odin line in .gitignore was just for the output binary, or also any folders with the name odin, but I'm assuming it was the former.

Removing folders named odin from gitignore so that modifications to, for example `core/odin` (where the parser, ast, etc live) play well with git. Also helps with tools like ripgrep which also look at the gitignore file and don't return results from there by default.