### PR TITLE
Fixed typo in GGPO bindings

### DIFF
--- a/vendor/ggpo/ggpo.odin
+++ b/vendor/ggpo/ggpo.odin
@@ -50,7 +50,7 @@ Player :: struct {
 	player_num: c.int,
 	using u: struct #raw_union {
 		local: struct {},
-		remove: struct {
+		remote: struct {
 			ip_address: [32]byte,
 			port: u16,
 		},


### PR DESCRIPTION
[Here is a link to the definition in GGPO's source code](https://github.com/pond3r/ggpo/blob/7ddadef8546a7d99ff0b3530c6056bc8ee4b9c0a/src/include/ggponet.h#L83C16-L83C16)