### PR TITLE
Fix math.round for some values

### DIFF
--- a/core/math/math.odin
+++ b/core/math/math.odin
@@ -594,40 +594,40 @@ trunc :: proc{
 
 @(require_results)
 round_f16   :: proc "contextless" (x: f16)   -> f16 {
-	return ceil(x - 0.5) if x < 0 else floor(x + 0.5)
+	return ceil(x - 0.4998) if x < 0 else floor(x + 0.4998)
 }
 @(require_results)
 round_f16le :: proc "contextless" (x: f16le) -> f16le {
-	return ceil(x - 0.5) if x < 0 else floor(x + 0.5)
+	return ceil(x - 0.4998) if x < 0 else floor(x + 0.4998)
 }
 @(require_results)
 round_f16be :: proc "contextless" (x: f16be) -> f16be {
-	return ceil(x - 0.5) if x < 0 else floor(x + 0.5)
+	return ceil(x - 0.4998) if x < 0 else floor(x + 0.4998)
 }
 
 @(require_results)
 round_f32   :: proc "contextless" (x: f32)   -> f32 {
-	return ceil(x - 0.5) if x < 0 else floor(x + 0.5)
+	return ceil(x - 0.49999997) if x < 0 else floor(x + 0.49999997)
 }
 @(require_results)
 round_f32le :: proc "contextless" (x: f32le) -> f32le {
-	return ceil(x - 0.5) if x < 0 else floor(x + 0.5)
+	return ceil(x - 0.49999997) if x < 0 else floor(x + 0.49999997)
 }
 @(require_results)
 round_f32be :: proc "contextless" (x: f32be) -> f32be {
-	return ceil(x - 0.5) if x < 0 else floor(x + 0.5)
+	return ceil(x - 0.49999997) if x < 0 else floor(x + 0.49999997)
 }
 @(require_results)
 round_f64   :: proc "contextless" (x: f64)   -> f64 {
-	return ceil(x - 0.5) if x < 0 else floor(x + 0.5)
+	return ceil(x - 0.49999999999999994) if x < 0 else floor(x + 0.49999999999999994)
 }
 @(require_results)
 round_f64le :: proc "contextless" (x: f64le) -> f64le {
-	return ceil(x - 0.5) if x < 0 else floor(x + 0.5)
+	return ceil(x - 0.49999999999999994) if x < 0 else floor(x + 0.49999999999999994)
 }
 @(require_results)
 round_f64be :: proc "contextless" (x: f64be) -> f64be {
-	return ceil(x - 0.5) if x < 0 else floor(x + 0.5)
+	return ceil(x - 0.49999999999999994) if x < 0 else floor(x + 0.49999999999999994)
 }
 round :: proc{
 	round_f16, round_f16le, round_f16be,


### PR DESCRIPTION
Currently, math.round works incorrectly on values just below 0.5: 

math.round(f32(0.49999997)) rounds to 1.0

0.49999997 (0h3effffff) is one step below 0.5, it can be computed as transmute(f32)((transmute(u32)f32(0.5)) - 1). Result of 0.49999997 + 0.5 is not representable in f32 and will round to 1.0.

and for large odd values for which x + 0.5 falls exactly halfway between two representable values:

math.round(f32(8388609)) rounds to 8388610, math.round(f32(8388611)) rounds to 8388612 ... etc

8388609 is exactly representable in f32, but 8388609 + 0.5 isn't and rounds to 8388610

And same happens for f16 and f64 too.

This PR replaces 0.5 constant in round_f* procs by corresponding value just below 0.5 (0.4998 (0h37ff) for f16, 0.49999997 (0h3effffff) for f32 and 0.49999999999999994 (0h3fdfffffffffffff) for f64). This way result of addition for those problematic numbers doesn't fall exactly in between two representable floats and rounds correctly: 

f32(0.49999997)+f32(0.49999997) is exactly 0.99999994 (0h3f7fffff)

result of f32(8388609)+f32(0.49999997) is closer to 8388609 than 8388610

For all other numbers it works the same way as 0.5