### PR TITLE
Fix dropped "dev-" prefix from version tag

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -52,7 +52,7 @@ set compiler_defines= -DODIN_VERSION_RAW=\"%odin_version_raw%\"
 
 if not exist .git\ goto skip_git_hash
 for /f "tokens=1,2" %%i IN ('git show "--pretty=%%cd %%h" "--date=format:%%Y-%%m" --no-patch --no-notes HEAD') do (
-	set odin_version_raw=%%i
+	set odin_version_raw=dev-%%i
 	set GIT_SHA=%%j
 )
 if %ERRORLEVEL% equ 0 set compiler_defines=%compiler_defines% -DGIT_SHA=\"%GIT_SHA%\"

--- a/build_odin.sh
+++ b/build_odin.sh
@@ -14,7 +14,7 @@ LDFLAGS="$LDFLAGS -pthread -lm -lstdc++"
 if [ -d ".git" ] && [ $(which git) ]; then
 	versionTag=( $(git show --pretty='%cd %h' --date=format:%Y-%m --no-patch --no-notes HEAD) )
 	if [ $? -eq 0 ]; then
-		ODIN_VERSION="${versionTag[0]}"
+		ODIN_VERSION="dev-${versionTag[0]}"
 		GIT_SHA="${versionTag[1]}"
 		CPPFLAGS="$CPPFLAGS -DGIT_SHA=\"$GIT_SHA\""
 	fi


### PR DESCRIPTION
In commit c3a31666, "dev-" prefix was dropped unintentionally. This commit fixes that.