### PR TITLE
core:odin/parser allow args after varargs in parse_call_expr

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -2941,9 +2941,9 @@ parse_call_expr :: proc(p: ^Parser, operand: ^ast.Expr) -> ^ast.Expr {
 	p.expr_level += 1
 	open := expect_token(p, .Open_Paren)
 
+	seen_ellipsis := false
 	for p.curr_tok.kind != .Close_Paren &&
-	    p.curr_tok.kind != .EOF &&
-	    ellipsis.pos.line == 0 {
+		p.curr_tok.kind != .EOF {
 
 		if p.curr_tok.kind == .Comma {
 			error(p, p.curr_tok.pos, "expected an expression not ,")
@@ -2972,9 +2972,15 @@ parse_call_expr :: proc(p: ^Parser, operand: ^ast.Expr) -> ^ast.Expr {
 			fv.value = value
 
 			arg = fv
+		} else if seen_ellipsis {
+			error(p, arg.pos, "Positional arguments are not allowed after '..'")
 		}
 
 		append(&args, arg)
+
+		if ellipsis.pos.line != 0 {
+			seen_ellipsis = true
+		}
 
 		if !allow_token(p, .Comma) {
 			break

--- a/examples/demo/demo.odin
+++ b/examples/demo/demo.odin
@@ -459,6 +459,27 @@ named_proc_return_parameters :: proc() {
 	fmt.println("foo2 =", foo2()) // 567 321
 }
 
+variadic_procedures :: proc() {
+	fmt.println("\n# variadic procedures")
+	sum :: proc(nums: ..int, init_value:= 0) -> (result: int) {
+		result = init_value
+		for n in nums {
+			result += n
+		}
+		return
+	}
+	fmt.println("sum(()) =", sum())
+	fmt.println("sum(1, 2) =", sum(1, 2))
+	fmt.println("sum(1, 2, 3, 4, 5) =", sum(1, 2, 3, 4, 5))
+	fmt.println("sum(1, 2, 3, 4, 5, init_value = 5) =", sum(1, 2, 3, 4, 5, init_value = 5))
+
+	// pass a slice as varargs
+	odds := []int{1, 3, 5}
+	fmt.println("odds =", odds)
+	fmt.println("sum(..odds) =", sum(..odds))
+	fmt.println("sum(..odds, init_value = 5) =", sum(..odds, init_value = 5))
+}
+
 
 explicit_procedure_overloading :: proc() {
 	fmt.println("\n# explicit procedure overloading")
@@ -2463,6 +2484,7 @@ main :: proc() {
 		the_basics()
 		control_flow()
 		named_proc_return_parameters()
+		variadic_procedures()
 		explicit_procedure_overloading()
 		struct_type()
 		union_type()


### PR DESCRIPTION
Currently, `core:odin/parser` does not parse call expressions where there are additional arguments after the varargs (when passed with ellipses). It looks like things got out of sync after https://github.com/odin-lang/Odin/commit/9b54b99bf696a65bc5c8358b2a5ace1f6dc4fdcc

This PR
- Updates ellipsis parsing in `core:odin/parser` to reflect the compiler's changes.
- adds a demo snippet for variadic procedures which includes syntax triggering this bug, e.g. `sum(..odds, init_value = 5)`

Fixes https://github.com/DanielGavin/ols/issues/235
