### PR TITLE
Fix small memory leak in nanovg.

### DIFF
--- a/vendor/nanovg/nanovg.odin
+++ b/vendor/nanovg/nanovg.odin
@@ -336,6 +336,7 @@ DeleteInternal :: proc(ctx: ^Context) {
 		ctx.params.renderDelete(ctx.params.userPtr)
 	}
 
+	delete(ctx.commands)
 	free(ctx)
 }
 


### PR DESCRIPTION
It was just `delete(ctx.commands)` missing from `DeleteInternal`