### PR TITLE
Fix read_cycle_counter intrinsic on arm64

### DIFF
--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -2115,7 +2115,7 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 			if (build_context.metrics.arch == TargetArch_arm64) {
 				LLVMTypeRef func_type = LLVMFunctionType(LLVMInt64TypeInContext(p->module->ctx), nullptr, 0, false);
 				bool has_side_effects = false;
-				LLVMValueRef the_asm = llvm_get_inline_asm(func_type, str_lit("mrs x9, cntvct_el0"), str_lit("=r"), has_side_effects);
+				LLVMValueRef the_asm = llvm_get_inline_asm(func_type, str_lit("mrs $0, cntvct_el0"), str_lit("=r"), has_side_effects);
 				GB_ASSERT(the_asm != nullptr);
 				res.value = LLVMBuildCall2(p->builder, func_type, the_asm, nullptr, 0, "");
 			} else {


### PR DESCRIPTION
Running this code with the hard-coded x9 register results in not returning the cycle count, but some other value.

This code (using $0 as the register), works on arm64 Linux and Darwin.

Test code:

```odin
package main

import "core:fmt"
import "core:intrinsics"
import "core:time"

main :: proc() {
	start := intrinsics.read_cycle_counter()

	time.sleep(time.Second)

	end := intrinsics.read_cycle_counter()

	elapsed := end - start

	fmt.printf("Start: {}, End: {}, Elapsed: {}\n", start, end, elapsed)
}
```

Using the above code, before this change I get end==0 and start is a large number on Linux (arm64) and a small number on Darwin (arm64).

I tested this on a Raspberry Pi 400 and an M2 Mac