### PR TITLE
Adding "system" prefx to webgl foreign imports for non-Windows systems

### DIFF
--- a/vendor/wasm/WebGL/webgl.odin
+++ b/vendor/wasm/WebGL/webgl.odin
@@ -1,6 +1,10 @@
 package webgl
 
-foreign import "webgl"
+when ODIN_OS == .Windows {
+    foreign import "webgl"
+} else {
+    foreign import "system:webgl"
+}
 
 import glm "core:math/linalg/glsl"
 

--- a/vendor/wasm/WebGL/webgl2.odin
+++ b/vendor/wasm/WebGL/webgl2.odin
@@ -1,6 +1,10 @@
 package webgl
 
-foreign import "webgl2"
+when ODIN_OS == .Windows {
+    foreign import "webgl2"
+} else {
+    foreign import "system:webgl2"
+}
 
 import glm "core:math/linalg/glsl"
 


### PR DESCRIPTION
Projects including WebGL fail to compile on Linux due to this error. 

`webgl.odin(3:1) Error: File name, , cannot be as a library name as it is not a valid identifier
    foreign import "webgl"`

Seems that it doesn't resolve a file path by just specifying `"webgl"`, but changing it to `"system:webgl"` appears to do the trick!