### PR TITLE
Always include Cocoa for NSFoundation

### DIFF
--- a/vendor/darwin/Foundation/objc.odin
+++ b/vendor/darwin/Foundation/objc.odin
@@ -1,6 +1,8 @@
 package objc_Foundation
 
 foreign import "system:Foundation.framework"
+// NOTE: Most of our bindings are reliant on Cocoa (everything under appkit) so just unconditionally import it
+@(require) foreign import "system:Cocoa.framework"
 
 import "core:intrinsics"
 import "core:c"


### PR DESCRIPTION
Most of our Foundation bindings link to appkit so we need to link with Cocoa
I suppose my editor added a newline to the end too...