### PR TITLE
Correct run loop linking

### DIFF
--- a/vendor/darwin/Foundation/NSApplication.odin
+++ b/vendor/darwin/Foundation/NSApplication.odin
@@ -10,11 +10,10 @@ RunLoopMode :: ^String
 
 @(link_prefix="NS")
 foreign Foundation {
-	CommonRunLoopMode:        RunLoopMode
+	RunLoopCommonModes:       RunLoopMode
 	DefaultRunLoopMode:       RunLoopMode
 	EventTrackingRunLoopMode: RunLoopMode
 	ModalPanelRunLoopMode:    RunLoopMode
-	TrackingRunLoopMode:      RunLoopMode
 }
 
 ActivationPolicy :: enum UInteger {


### PR DESCRIPTION
`CommonRunLoopMode` should be `RunLoopCommonModes`
`TrackingRunLoopMode` is part of UIKit not foundation so it does not belong here

If you print the modes we get
```
kCFRunLoopCommonModes
kCFRunLoopDefaultMode
NSEventTrackingRunLoopMode
NSModalPanelRunLoopMode
```