### PR TITLE
fix queue reserve always doubling in size when there is enough space

### DIFF
--- a/core/container/queue/queue.odin
+++ b/core/container/queue/queue.odin
@@ -56,7 +56,7 @@ space :: proc(q: $Q/Queue($T)) -> int {
 
 // Reserve enough space for at least the specified capacity
 reserve :: proc(q: ^$Q/Queue($T), capacity: int) -> runtime.Allocator_Error {
-	if uint(capacity) > q.len {
+	if capacity > space(q^) {
 		return _grow(q, uint(capacity)) 
 	}
 	return nil


### PR DESCRIPTION
The `queue.reserve` procedure would keep growing when there is enough space for the given `capacity`, this is because it was using the length in its comparison, when it should check free space instead.

If there was a queue with length 0 and capacity 16, when calling reserve like `queue.reserve(q, 1)` it would double in size to 32 when that is not needed.

I was calling this in a loop and my pc did not like it.