### PR TITLE
Add more NS bindings and correctly link NS block

### DIFF
--- a/vendor/darwin/Foundation/NSApplication.odin
+++ b/vendor/darwin/Foundation/NSApplication.odin
@@ -123,6 +123,10 @@ Application_nextEventMatchingMask :: proc "c" (self: ^Application, mask: EventMa
 Application_sendEvent :: proc "c" (self: ^Application, event: ^Event) {
 	msgSend(Event, self, "sendEvent:", event)
 }
+@(objc_type=Application, objc_name="updateWindows")
+Application_updateWindows :: proc "c" (self: ^Application) {
+	msgSend(nil, self, "updateWindows")
+}
 
 
 @(objc_class="NSRunningApplication")

--- a/vendor/darwin/Foundation/NSBlock.odin
+++ b/vendor/darwin/Foundation/NSBlock.odin
@@ -48,6 +48,11 @@ global_block_descriptor := Block_Descriptor{
 	size     = size_of(Internal_Block_Literal),
 }
 
+foreign import libSystem "system:System.framework"
+foreign libSystem {
+	_NSConcreteGlobalBlock: ^intrinsics.objc_class
+}
+
 @(private="file")
 Block_createInternal :: proc "c" (is_global: bool, user_data: rawptr, user_proc: proc "c" (user_data: rawptr)) -> ^Block {
 	// Set to true on blocks that have captures (and thus are not true
@@ -66,9 +71,8 @@ Block_createInternal :: proc "c" (is_global: bool, user_data: rawptr, user_proc:
 
 	extraBytes :: size_of(Internal_Block_Literal) - size_of(Internal_Block_Literal_Base)
 
-	cls := intrinsics.objc_find_class("NSConcreteGlobalBlock")
-	bl := (^Internal_Block_Literal)(AllocateObject(cls, extraBytes, nil))
-	bl.isa = cls
+	bl := (^Internal_Block_Literal)(AllocateObject(_NSConcreteGlobalBlock, extraBytes, nil))
+	bl.isa = _NSConcreteGlobalBlock
 	bl.flags = BLOCK_IS_GLOBAL if is_global else 0
 	bl.invoke = proc "c" (bl: ^Internal_Block_Literal) {
 		bl.user_proc(bl.user_data)

--- a/vendor/darwin/Foundation/NSWindow.odin
+++ b/vendor/darwin/Foundation/NSWindow.odin
@@ -612,6 +612,10 @@ View_wantsLayer :: proc "c" (self: ^View) -> BOOL {
 View_setWantsLayer :: proc "c" (self: ^View, wantsLayer: BOOL) {
 	msgSend(nil, self, "setWantsLayer:", wantsLayer)
 }
+@(objc_type=View, objc_name="convertPointFromView")
+View_convertPointFromView :: proc "c" (self: ^View, point: Point, view: ^View) -> Point {
+	return msgSend(Point, self, "convertPoint:fromView:", point, view)
+}
 
 @(objc_class="NSWindow")
 Window :: struct {using _: Responder}
@@ -703,4 +707,8 @@ Window_close :: proc "c" (self: ^Window) {
 @(objc_type=Window, objc_name="setDelegate")
 Window_setDelegate :: proc "c" (self: ^Window, delegate: ^WindowDelegate) {
 	msgSend(nil, self, "setDelegate:", delegate)
+}
+@(objc_type=Window, objc_name="backingScaleFactor")
+Window_backingScaleFactor :: proc "c" (self: ^Window) -> Float {
+	return msgSend(Float, self, "backingScaleFactor")
 }


### PR DESCRIPTION
Added new bindings specifically:
updateWindows:
https://developer.apple.com/documentation/appkit/nsapplication/1428675-updatewindows?language=objc
convertPointFromView:
https://developer.apple.com/documentation/spritekit/skscene/1520395-convertpointfromview
backingScaleFactor:
https://developer.apple.com/documentation/appkit/nswindow/1419459-backingscalefactor?language=objc

`NSConcreteGlobalBlock` is under libSystem with the class symbol being `_NSConcreteGlobalBlock`.
Changing this now makes it so creating a block doesn't segfault creating a nil class and blocks are working with
metal callbacks.

Using this in my metal layer.