### PR TITLE
fix #2779 ternary with a union of enum

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -7927,7 +7927,7 @@ gb_internal ExprKind check_ternary_if_expr(CheckerContext *c, Operand *o, Ast *n
 
 	// NOTE(bill, 2023-01-30): Allow for expression like this:
 	//     x: union{f32} = f32(123) if cond else nil
-	if (type_hint && !is_type_any(type_hint) && !ternary_compare_types(x.type, y.type)) {
+	if (type_hint && !is_type_any(type_hint)) {
 		if (check_is_assignable_to(c, &x, type_hint) && check_is_assignable_to(c, &y, type_hint)) {
 			check_cast(c, &x, type_hint);
 			check_cast(c, &y, type_hint);


### PR DESCRIPTION
Fixes #2779 

Smaller reproduction:
```odin
Foo :: enum {A, B}
x: union{Foo} = .B if false else nil
fmt.println(x) // .A
```

I have found that there is already a branch in the compiler that checks for for example:
```odin
x: union{int} = 1 if false else nil
```
But that is for cases where the two sides of the condition are not comparable.

This PR would make it always cast down to the given type hint.
I can currently not think of any cases where that would be wrong or break things, there probably is though, so please correct me.

If the comparable check needs to be kept in place we can also add an additional check if one of the sides is a union and one of the sides is an untyped nil.

