### PR TITLE
Fix for crash when using io.write_u128/io.write_i128 due to buffer being too small

### DIFF
--- a/core/io/util.odin
+++ b/core/io/util.odin
@@ -39,12 +39,12 @@ write_int :: proc(w: Writer, i: int, base: int = 10, n_written: ^int = nil) -> (
 }
 
 write_u128 :: proc(w: Writer, i: u128, base: int = 10, n_written: ^int = nil) -> (n: int, err: Error) {
-	buf: [32]byte
+	buf: [39]byte
 	s := strconv.append_bits_128(buf[:], i, base, false, 128, strconv.digits, nil)
 	return write_string(w, s, n_written)
 }
 write_i128 :: proc(w: Writer, i: i128, base: int = 10, n_written: ^int = nil) -> (n: int, err: Error) {
-	buf: [32]byte
+	buf: [40]byte
 	s := strconv.append_bits_128(buf[:], u128(i), base, true, 128, strconv.digits, nil)
 	return write_string(w, s, n_written)
 }


### PR DESCRIPTION
Longest u128 is 39 chars long (340282366920938463463374607431768211455)
Longest i128 is 40 chars long (−170141183460469231731687303715884105728)