### PR TITLE
Remove trailing zeros after decimal when writing / parsing f64

### DIFF
--- a/core/io/util.odin
+++ b/core/io/util.odin
@@ -94,7 +94,27 @@ write_f64 :: proc(w: Writer, val: f64, n_written: ^int = nil) -> (n: int, err: E
 		s = s[1:]
 	}
 
-	return write_string(w, string(s), n_written)
+	use_trimmed_len := false
+	trimmed_len := len(s)
+
+	// Trim off any trailing zeroes after the decimal point. Makes sure we
+	// don't output unnecessary zeroes.
+	loop_trim: for ti := len(s) - 1; ti >= 0 ; ti -= 1 {
+		c := s[ti]
+		switch c {
+			case '.':
+				use_trimmed_len = true
+				trimmed_len -= 1
+				break loop_trim
+
+			case '0':
+				trimmed_len -= 1
+
+			case: break loop_trim
+		}
+	}
+
+	return write_string(w, string(s[:use_trimmed_len ? trimmed_len : len(s)]), n_written)
 }	
 
 

--- a/core/strconv/strconv.odin
+++ b/core/strconv/strconv.odin
@@ -925,7 +925,28 @@ parse_f64_prefix :: proc(str: string) -> (value: f64, nr: int, ok: bool) {
 		nd := 0
 		nd_mant := 0
 		decimal_point := 0
-		loop: for ; i < len(s); i += 1 {
+
+		use_trimmed_len := false
+		trimmed_len := len(s)
+
+		// Trim off any trailing zeroes after the decimal point. Makes sure we
+		// don't truncate floats when not needed.
+		loop_trim: for ti := len(s) - 1; ti >= 0 ; ti -= 1 {
+			c := s[ti]
+			switch c {
+				case '.':
+					use_trimmed_len = true
+					trimmed_len -= 1
+					break loop_trim
+
+				case '0':
+					trimmed_len -= 1
+
+				case: break loop_trim
+			}
+		}
+
+		loop: for ; i < (use_trimmed_len ? trimmed_len : len(s)); i += 1 {
 			switch c := s[i]; true {
 			case c == '_':
 				underscores = true


### PR DESCRIPTION
In `write_f64`: Remove trailing zeroes after decimal point, so it doesn't always write the max amount of zeroes.
In `parse_f64_prefix`: Skip trailing zeroes after decimal point, so it doesn't truncate the number when it wasn't needed.