### PR TITLE
Allow zero-length enum array (to stay consistent with `[0]T`)

### DIFF
--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -2797,7 +2797,7 @@ gb_internal bool check_type_internal(CheckerContext *ctx, Ast *e, Type **type, T
 				Type *bt = base_type(index);
 				GB_ASSERT(bt->kind == Type_Enum);
 
-				Type *t = alloc_type_enumerated_array(elem, index, bt->Enum.min_value, bt->Enum.max_value, Token_Invalid);
+				Type *t = alloc_type_enumerated_array(elem, index, bt->Enum.min_value, bt->Enum.max_value, bt->Enum.fields.count, Token_Invalid);
 
 				bool is_sparse = false;
 				if (at->tag != nullptr) {

--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -2810,7 +2810,7 @@ gb_internal bool check_type_internal(CheckerContext *ctx, Ast *e, Type **type, T
 					}
 				}
 
-				if (!is_sparse && t->EnumeratedArray.count > bt->Enum.fields.count && bt->Enum.fields.count > 0) {
+				if (!is_sparse && t->EnumeratedArray.count > bt->Enum.fields.count) {
 					error(e, "Non-contiguous enumeration used as an index in an enumerated array");
 					long long ea_count   = cast(long long)t->EnumeratedArray.count;
 					long long enum_count = cast(long long)bt->Enum.fields.count;

--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -2810,7 +2810,7 @@ gb_internal bool check_type_internal(CheckerContext *ctx, Ast *e, Type **type, T
 					}
 				}
 
-				if (!is_sparse && t->EnumeratedArray.count > bt->Enum.fields.count) {
+				if (!is_sparse && t->EnumeratedArray.count > bt->Enum.fields.count && bt->Enum.fields.count > 0) {
 					error(e, "Non-contiguous enumeration used as an index in an enumerated array");
 					long long ea_count   = cast(long long)t->EnumeratedArray.count;
 					long long enum_count = cast(long long)bt->Enum.fields.count;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -983,7 +983,7 @@ gb_internal Type *alloc_type_matrix(Type *elem, i64 row_count, i64 column_count,
 }
 
 
-gb_internal Type *alloc_type_enumerated_array(Type *elem, Type *index, ExactValue const *min_value, ExactValue const *max_value, TokenKind op) {
+gb_internal Type *alloc_type_enumerated_array(Type *elem, Type *index, ExactValue const *min_value, ExactValue const *max_value, isize count, TokenKind op) {
 	Type *t = alloc_type(Type_EnumeratedArray);
 	t->EnumeratedArray.elem = elem;
 	t->EnumeratedArray.index = index;
@@ -993,7 +993,11 @@ gb_internal Type *alloc_type_enumerated_array(Type *elem, Type *index, ExactValu
 	gb_memmove(t->EnumeratedArray.max_value, max_value, gb_size_of(ExactValue));
 	t->EnumeratedArray.op = op;
 
-	t->EnumeratedArray.count = 1 + exact_value_to_i64(exact_value_sub(*max_value, *min_value));
+	if (count == 0) {
+		t->EnumeratedArray.count = 0;
+	} else {
+		t->EnumeratedArray.count = 1 + exact_value_to_i64(exact_value_sub(*max_value, *min_value));
+	}
 	return t;
 }
 


### PR DESCRIPTION
Previously enumerated arrays couldn't handle enums with zero fields (error: `Non-contiguous enumeration used as an index in an enumerated array`). This behavior is inconsistent with normal arrays, as `[0]T` is completely valid.

I added the support for this by allowing `EnumeratedArray.count` to be zero, when an enum field count is also zero.

I made sure this doesn't break existing code which uses RTTI, like `core:encoding/json` and `core:fmt`

This is the testing code:
```odin
package tst

import "core:encoding/json"
import "core:fmt"
import "core:runtime"

Empty :: enum {}

NonEmpty :: enum {
	x = 1,
	y = 1,
}

main :: proc() {
	// Empty array

	arr: [0]f32
	fmt.println(arr)

	// Empty enumerated array

	empty: [Empty]f32

	for x in empty do fmt.println(x)

	fmt.println(type_info_of([Empty]f32).variant.(runtime.Type_Info_Enumerated_Array))
	fmt.println(empty)

	if data, err := json.marshal(empty); err == nil {
		fmt.println("Marshalled json:", string(data))
		res: [Empty]f32
		if err := json.unmarshal(data, &res); err == nil {
			fmt.println("Success!")
		} else {
			fmt.println("Unmarshal failed:", err)
		}
	} else {
		fmt.println("Marshal error:", err)
	}

	// Non-empty enumerated array

	non_empty: [NonEmpty]f32

	fmt.println(type_info_of([NonEmpty]f32).variant.(runtime.Type_Info_Enumerated_Array))
}
```