### PR TITLE
fix(json): return `.Out_Of_Memory` when out of memory on parse

### DIFF
--- a/core/encoding/json/parser.odin
+++ b/core/encoding/json/parser.odin
@@ -3,7 +3,6 @@ package json
 import "core:mem"
 import "core:unicode/utf8"
 import "core:unicode/utf16"
-import "core:runtime"
 import "core:strconv"
 
 Parser :: struct {

--- a/core/encoding/json/parser.odin
+++ b/core/encoding/json/parser.odin
@@ -263,6 +263,12 @@ parse_object_body :: proc(p: ^Parser, end_token: Token_Kind) -> (obj: Object, er
 			return
 		}
 
+		if len(obj) == cap(obj) {
+			reserve_error := reserve(&obj, max(1, cap(obj) * 2))
+			if reserve_error != nil {
+				return nil, .Out_Of_Memory
+			}
+		}
 		obj[key] = elem
 		
 		if parse_comma(p) {

--- a/core/encoding/json/parser.odin
+++ b/core/encoding/json/parser.odin
@@ -265,6 +265,8 @@ parse_object_body :: proc(p: ^Parser, end_token: Token_Kind) -> (obj: Object, er
 		}
 
 		insert_success := runtime.map_insert(&obj, key, elem)
+		// NOTE(gonz): we'd rather check specifically for an allocation error here but
+		// `map_insert` doesn't differentiate; we can only check for `nil`
 		if insert_success == nil {
 			return nil, .Out_Of_Memory
 		}

--- a/core/encoding/json/parser.odin
+++ b/core/encoding/json/parser.odin
@@ -3,6 +3,7 @@ package json
 import "core:mem"
 import "core:unicode/utf8"
 import "core:unicode/utf16"
+import "core:runtime"
 import "core:strconv"
 
 Parser :: struct {
@@ -263,13 +264,10 @@ parse_object_body :: proc(p: ^Parser, end_token: Token_Kind) -> (obj: Object, er
 			return
 		}
 
-		if len(obj) == cap(obj) {
-			reserve_error := reserve(&obj, max(1, cap(obj) * 2))
-			if reserve_error != nil {
-				return nil, .Out_Of_Memory
-			}
+		insert_success := runtime.map_insert(&obj, key, elem)
+		if insert_success == nil {
+			return nil, .Out_Of_Memory
 		}
-		obj[key] = elem
 		
 		if parse_comma(p) {
 			break


### PR DESCRIPTION
`json.parse` would silently return empty or incomplete objects when not having enough memory for a map insert. With this patch we instead are able to return `.Out_Of_Memory` so that it can be handled.