### PR TITLE
[fmt] Add allocator parameter to `fmt.aprintf`

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -152,9 +152,9 @@ aprintln :: proc(args: ..any, sep := " ") -> string {
 //
 // 	Returns: A formatted string. The returned string must be freed accordingly.
 //
-aprintf :: proc(fmt: string, args: ..any) -> string {
+aprintf :: proc(fmt: string, args: ..any, allocator := context.allocator) -> string {
 	str: strings.Builder
-	strings.builder_init(&str)
+	strings.builder_init(&str, allocator)
 	sbprintf(&str, fmt, ..args)
 	return strings.to_string(str)
 }


### PR DESCRIPTION
This allows you to do `fmt.aprintf("Hello, %v!", name, allocator = ally)`.

This allows you to easily make a formatted string with a specific allocator which isn't the current one, which required you to jump through some hoops to do before.