### PR TITLE
Update wasm `runtime.js`

### DIFF
--- a/vendor/wasm/js/runtime.js
+++ b/vendor/wasm/js/runtime.js
@@ -77,7 +77,7 @@ class WasmMemoryInterface {
 
 	loadString(ptr, len) {
 		const bytes = this.loadBytes(ptr, len);
-		return new TextDecoder("utf-8").decode(bytes);
+		return new TextDecoder().decode(bytes);
 	}
 
 	storeU8(addr, value)  { this.mem.setUint8  (addr, value, true); }
@@ -102,7 +102,7 @@ class WasmMemoryInterface {
 
 	storeString(addr, value) {
 		const bytes = this.loadBytes(addr, value.length);
-		new TextEncoder("utf-8").encodeInto(value, bytes);
+		new TextEncoder().encodeInto(value, bytes);
 	}
 };
 
@@ -570,7 +570,7 @@ class WebGLInterface {
 				if (buf_len > 0 && buf_ptr) {
 					let n = Math.min(buf_len, log.length);
 					log = log.substring(0, n);
-					this.mem.loadBytes(buf_ptr, buf_len).set(new TextEncoder("utf-8").encode(log))
+					this.mem.loadBytes(buf_ptr, buf_len).set(new TextEncoder().encode(log))
 
 					this.mem.storeInt(length_ptr, n);
 				}
@@ -583,7 +583,7 @@ class WebGLInterface {
 				if (buf_len > 0 && buf_ptr) {
 					let n = Math.min(buf_len, log.length);
 					log = log.substring(0, n);
-					this.mem.loadBytes(buf_ptr, buf_len).set(new TextEncoder("utf-8").encode(log))
+					this.mem.loadBytes(buf_ptr, buf_len).set(new TextEncoder().encode(log))
 
 					this.mem.storeInt(length_ptr, n);
 				}
@@ -1149,7 +1149,7 @@ class WebGLInterface {
 
 				let n = Math.min(buf_len, name.length);
 				name = name.substring(0, n);
-				this.mem.loadBytes(buf_ptr, buf_len).set(new TextEncoder("utf-8").encode(name))
+				this.mem.loadBytes(buf_ptr, buf_len).set(new TextEncoder().encode(name))
 				this.mem.storeInt(length_ptr, n);
 			},
 			UniformBlockBinding: (program, uniformBlockIndex, uniformBlockBinding) => {
@@ -1342,14 +1342,14 @@ function odinSetupDefaultImports(wasmMemoryInterface, consoleElement) {
 				}
 			},
 
-			sqrt:    (x) => Math.sqrt(x),
-			sin:     (x) => Math.sin(x),
-			cos:     (x) => Math.cos(x),
-			pow:     (x, power) => Math.pow(x, power),
+			sqrt:    Math.sqrt,
+			sin:     Math.sin,
+			cos:     Math.cos,
+			pow:     Math.pow,
 			fmuladd: (x, y, z) => x*y + z,
-			ln:      (x) => Math.log(x),
-			exp:     (x) => Math.exp(x),
-			ldexp:   (x) => Math.ldexp(x),
+			ln:      Math.log,
+			exp:     Math.exp,
+			ldexp:   (x, exp) => x * Math.pow(2, exp),
 		},
 		"odin_dom": {
 			init_event_raw: (ep) => {
@@ -1569,7 +1569,7 @@ function odinSetupDefaultImports(wasmMemoryInterface, consoleElement) {
 					if (buf_len > 0 && buf_ptr) {
 						let n = Math.min(buf_len, str.length);
 						str = str.substring(0, n);
-						this.mem.loadBytes(buf_ptr, buf_len).set(new TextEncoder("utf-8").encode(str))
+						this.mem.loadBytes(buf_ptr, buf_len).set(new TextEncoder().encode(str))
 						return n;
 					}
 				}

--- a/vendor/wasm/js/runtime.js
+++ b/vendor/wasm/js/runtime.js
@@ -10,7 +10,7 @@ function getElement(name) {
 }
 
 function stripNewline(str) {
-    return str.replace(/\n$/, ' ')
+    return str.replace(/\n/, ' ')
 }
 
 class WasmMemoryInterface {

--- a/vendor/wasm/js/runtime.js
+++ b/vendor/wasm/js/runtime.js
@@ -9,6 +9,10 @@ function getElement(name) {
 	return undefined;
 }
 
+function stripNewline(str) {
+    return str.replace(/\n$/, ' ')
+}
+
 class WasmMemoryInterface {
 	constructor() {
 		this.memory = null;

--- a/vendor/wasm/js/runtime.js
+++ b/vendor/wasm/js/runtime.js
@@ -1423,7 +1423,7 @@ function odinSetupDefaultImports(wasmMemoryInterface, consoleElement) {
 					wmi.storeI16(off(2), e.button);
 					wmi.storeU16(off(2), e.buttons);
 				} else if (e instanceof KeyboardEvent) {
-					// Note: those strigs are constructed
+					// Note: those strings are constructed
 					// on the native side from buffers that
 					// are filled later, so skip them 
 					const keyPtr  = off(W*2, W);

--- a/vendor/wasm/js/runtime.js
+++ b/vendor/wasm/js/runtime.js
@@ -47,8 +47,8 @@ class WasmMemoryInterface {
 	}
 
 
-	loadU8(addr) { return this.mem.getUint8  (addr, true); }
-	loadI8(addr) { return this.mem.getInt8   (addr, true); }
+	loadU8(addr)  { return this.mem.getUint8  (addr); }
+	loadI8(addr)  { return this.mem.getInt8   (addr); }
 	loadU16(addr) { return this.mem.getUint16 (addr, true); }
 	loadI16(addr) { return this.mem.getInt16  (addr, true); }
 	loadU32(addr) { return this.mem.getUint32 (addr, true); }
@@ -80,8 +80,8 @@ class WasmMemoryInterface {
 		return new TextDecoder().decode(bytes);
 	}
 
-	storeU8(addr, value)  { this.mem.setUint8  (addr, value, true); }
-	storeI8(addr, value)  { this.mem.setInt8   (addr, value, true); }
+	storeU8(addr, value)  { this.mem.setUint8  (addr, value); }
+	storeI8(addr, value)  { this.mem.setInt8   (addr, value); }
 	storeU16(addr, value) { this.mem.setUint16 (addr, value, true); }
 	storeI16(addr, value) { this.mem.setInt16  (addr, value, true); }
 	storeU32(addr, value) { this.mem.setUint32 (addr, value, true); }


### PR DESCRIPTION
- polyfill `Math.ldexp` method
- pass Math mathods streight through to exports object (they don't use `this`)
- Don't pass `"utf-8"` encodings to `TextEncoder` and `TextDecoder` (encoder doesn't take params and decoder has utf-8 as default)
- Don't pass `true` to enable littleEndian format for u8 and i8 as the DataView methods don't take a param for it.
- Define `stripNewline` function which was used when throwing an error without there being one