### PR TITLE
llvm: specify calling convention on call

### DIFF
--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -891,6 +891,9 @@ gb_internal lbValue lb_emit_call_internal(lbProcedure *p, lbValue value, lbValue
 
 		LLVMValueRef ret = LLVMBuildCall2(p->builder, fnp, fn, args, arg_count, "");
 
+		auto llvm_cc = lb_calling_convention_map[proc_type->Proc.calling_convention];
+		LLVMSetInstructionCallConv(ret, llvm_cc);
+
 		LLVMAttributeIndex param_offset = LLVMAttributeIndex_FirstArgIndex;
 		if (return_ptr.value != nullptr) {
 			param_offset += 1;


### PR DESCRIPTION
Looks like the compiler only was specifying the calling convention on function declarations, but not on function calls.
But LLVM seems to produce "bad" code when optimizing with level -O2 unless you specify the same calling convention on the call too.

Solves this issue: https://github.com/odin-lang/Odin/issues/2854

Is there some regression test suite I should add a test case to, and which I should run?
I'm not familiar with the odin compiler or with LLVM, so I'm a bit worried I broke something inadvertently.

Also, are there more places where it's necessary to insert `LLVMSetInstructionCallConv`?

## How I figured out this fix

If we look at the LLVM IR generated by odin for this code (using `-keep-temp-files`):

```Odin
package main
import "core:runtime"

foo :: proc "stdcall" () {
}

main :: proc() {
  runtime.print_string("Hello\n")
  foo()
  runtime.print_string("Goodbye\n")
}
```

...we see the call looks like this: `call void @main.foo()`
...but the function declaration looks like this: `define internal x86_stdcallcc void @main.foo() {`

Let's compare what IR clang generates for some simmilar C code:

https://godbolt.org/z/4Ed5v9b1j

Notice how LLVM puts `x86_stdcallcc` both on the call and the function declaration.

From there I experimented with some minimal IR examples, letting clang optimize them:
```llvm
declare x86_stdcallcc i32 @GetLastError()

define internal void @main.bar() {
decls:
  %0 = call i32 @GetLastError()
  ret void
}

define internal x86_stdcallcc void @main.foo() {
decls:
  ret void
}

define internal void @main.main() {
decls:
  br label %entry

entry:                                            ; preds = %decls
  call void @main.bar()
  call void @main.foo()
  ret void
}

; Function Attrs: noinline
define dso_local x86_stdcallcc i32 @mainCRTStartup() noinline {
decls:
  call void @main.main() noinline
  ret i32 0
}
```
Running this through clang with optimizations (`clang bug.ll -O2 -S`) produces this assembly (abriged), which clearly will run straight into the `int3`:
```asm
main.bar:
	jmp	GetLastError                    # TAILCALL
main.main:
	callq	main.bar
	int3
```
But by changing `call void @main.foo()` to `call x86_stdcall void @main.foo()`, and `call i32 @GetLastError()` to `call x86_stdcallcc i32 @GetLastError()`, clang generates sensible assembly instead:
```asm
main.main:
	jmp	GetLastError                    # TAILCALL
```

Godbolt links for the two variants, for covenience: https://godbolt.org/z/Ys1W3vo9z and https://godbolt.org/z/Y8ssorGbj (notice I had to specify `-target x86_64-pc-windows-msvc`...).

Why clang produces garbage when optimizing this I don't know, especially because `x86_stdcall` doesn't appear to do anything when compiling for amd64 on windows (I'm looking at `X86Subtarget.h`, function `isCallingConvWin64`). Is it just a case of garbage-in-garbage-out, or is there something more subtle going on? Understanding this probably would be good, then I could be more confident that the fix I'm submitting here is a proper fix.