### PR TITLE
Implement foreign asm (x86) imports for linux and osx

### DIFF
--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -4733,8 +4733,7 @@ gb_internal void check_add_foreign_import_decl(CheckerContext *ctx, Ast *decl) {
 	}
 
 	if (has_asm_extension(fullpath)) {
-		if (build_context.metrics.arch != TargetArch_amd64 ||
-		    build_context.metrics.os   != TargetOs_windows) {
+		if (build_context.metrics.arch != TargetArch_amd64) {
 			error(decl, "Assembly files are not yet supported on this platform: %.*s_%.*s",
 			      LIT(target_os_names[build_context.metrics.os]), LIT(target_arch_names[build_context.metrics.arch]));
 		}


### PR DESCRIPTION

People have been running into foreign asm imports not being supported on linux. This is a quick implementation that relies on nasm being installed on the host's system.

## Re: shipping binary

Shipping the nasm binary on those systems is not very portable, because we might accidentally ship the version that expects a different glibc version. Some systems don't have glibc and use musl instead (alpine linux).
