### PR TITLE
Ensure required licenses are in distributable bundles

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,6 +26,7 @@ jobs:
           rm bin/llvm/windows/LLVM-C.lib
           mkdir dist
           cp odin.exe dist
+          cp LICENSE dist
           cp LLVM-C.dll dist
           cp -r shared dist
           cp -r core dist
@@ -52,6 +53,7 @@ jobs:
         run: |
           mkdir dist
           cp odin dist
+          cp LICENSE dist
           cp libLLVM* dist
           cp -r shared dist
           cp -r core dist
@@ -81,6 +83,7 @@ jobs:
         run: |
           mkdir dist
           cp odin dist
+          cp LICENSE dist
           cp -r shared dist
           cp -r core dist
           cp -r vendor dist

--- a/vendor/botan/bindings/license.txt
+++ b/vendor/botan/bindings/license.txt
@@ -1,0 +1,24 @@
+Copyright (C) 1999-2023 The Botan Authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions, and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions, and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
This PR ensures that all license files are included in an Odin release/nightly distributable bundle.

Odin releases/nightlies are missing Odin's license. This violates clauses 1 and 2 of BSD-3 as `*.odin` files are `source code`, and the `odin` executable is a `binary form`:

```
1. Redistributions of source code must retain the above copyright notice, this
   list of conditions and the following disclaimer.

2. Redistributions in binary form must reproduce the above copyright notice,
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
```

From `vendor/`, the only missing required license is for `vendor/botan/bindings/botan-3.lib`. This violates clause 2 of BSD-2 as this is in `binary form`:

```
2. Redistributions in binary form must reproduce the above copyright
   notice, this list of conditions, and the following disclaimer in the
   documentation and/or other materials provided with the distribution.
```