### PR TITLE
Fix some issues with building on OpenBSD

### DIFF
--- a/build_odin.sh
+++ b/build_odin.sh
@@ -77,9 +77,9 @@ Linux)
 	LDFLAGS="$LDFLAGS -Wl,-rpath=\$ORIGIN"
 	;;
 OpenBSD)
-	CXXFLAGS="$CXXFLAGS $($LLVM_CONFIG --cxxflags --ldflags)"
-	LDFLAGS="$LDFLAGS -liconv"
+	CXXFLAGS="$CXXFLAGS -I/usr/local/include $($LLVM_CONFIG --cxxflags --ldflags)"
 	LDFLAGS="$LDFLAGS $($LLVM_CONFIG --libs core native --system-libs)"
+	LDFLAGS="$LDFLAGS -L/usr/local/lib -liconv"
 	;;
 *)
 	error "Platform \"$OS_NAME\" unsupported"

--- a/src/gb/gb.h
+++ b/src/gb/gb.h
@@ -5457,7 +5457,7 @@ gb_inline b32 gb_file_copy(char const *existing_filename, char const *new_filena
 		}
 	}
 	
-	gb_free(buf);
+	gb_mfree(buf);
 	close(new_fd);
 	close(existing_fd);
 


### PR DESCRIPTION
This PR fixes the following issues with building Odin on OpenBSD:

- In `build_odin.sh`, fix linking against iconv which was moved from `/usr` to `/usr/local`
- In `src/gb/gb.h`, replace `gb_free` with `gb_mfree` for `char *buf` allocated with `gb_malloc`

Because OpenBSD builds LLVM only with target support for the current architecture, other targets are simply not available. The LLVM toolchain in ports is built the same way, meaning that OpenBSD users will need to build LLVM themselves. OpenBSD hackers might consider carrying a patch in ports to `ifdef` away unavailable targets. Here is a very crude example patch:

```diff
diff --git a/src/llvm_backend.cpp b/src/llvm_backend.cpp
index 00c62f0f..51ede598 100644
--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -2018,6 +2018,7 @@ gb_internal bool lb_generate_code(lbGenerator *gen) {
        auto *min_dep_set = &info->minimum_dependency_set;

        switch (build_context.metrics.arch) {
+#ifndef GB_SYSTEM_OPENBSD || (GB_SYSTEM_OPENBSD && GB_CPU_X86)
        case TargetArch_amd64:
        case TargetArch_i386:
                LLVMInitializeX86TargetInfo();
@@ -2027,6 +2028,8 @@ gb_internal bool lb_generate_code(lbGenerator *gen) {
                LLVMInitializeX86AsmParser();
                LLVMInitializeX86Disassembler();
                break;
+#endif
+#ifndef GB_SYSTEM_OPENBSD || (GB_SYSTEM_OPENBSD && GB_CPU_ARM)
        case TargetArch_arm64:
                LLVMInitializeAArch64TargetInfo();
                LLVMInitializeAArch64Target();
@@ -2035,6 +2038,8 @@ gb_internal bool lb_generate_code(lbGenerator *gen) {
                LLVMInitializeAArch64AsmParser();
                LLVMInitializeAArch64Disassembler();
                break;
+#endif
+#ifndef GB_SYSTEM_OPENBSD
        case TargetArch_wasm32:
        case TargetArch_wasm64p32:
                LLVMInitializeWebAssemblyTargetInfo();
@@ -2052,6 +2057,7 @@ gb_internal bool lb_generate_code(lbGenerator *gen) {
                LLVMInitializeAllAsmParsers();
                LLVMInitializeAllDisassemblers();
                break;
+#endif // GB_SYSTEM_OPENBSD
        }
```
