### PR TITLE
Fix calling `time.now()` in wasm js runtime

### DIFF
--- a/core/time/time_js.odin
+++ b/core/time/time_js.odin
@@ -10,7 +10,7 @@ _now :: proc "contextless" () -> Time {
 	foreign odin_env {
 		time_now :: proc "contextless" () -> i64 ---
 	}
-	return Time{time_now()}
+	return Time{time_now()*1e6}
 }
 
 _sleep :: proc "contextless" (d: Duration) {
@@ -26,7 +26,7 @@ _tick_now :: proc "contextless" () -> Tick {
 	foreign odin_env {
 		tick_now :: proc "contextless" () -> i64 ---
 	}
-	return Tick{tick_now()}
+	return Tick{tick_now()*1e6}
 }
 
 _yield :: proc "contextless" () {

--- a/vendor/wasm/js/runtime.js
+++ b/vendor/wasm/js/runtime.js
@@ -1334,14 +1334,9 @@ function odinSetupDefaultImports(wasmMemoryInterface, consoleElement) {
 			abort: () => { Module.abort() },
 			evaluate: (str_ptr, str_len) => { eval.call(null, wasmMemoryInterface.loadString(str_ptr, str_len)); },
 
-			time_now: () => {
-				// convert ms to ns
-				return Date.now() * 1e6;
-			},
-			tick_now: () => {
-				// convert ms to ns
-				return performance.now() * 1e6;
-			},
+			// return a bigint to be converted to i64
+			time_now: () => BigInt(Date.now()),
+			tick_now: () => BigInt(performance.now()),
 			time_sleep: (duration_ms) => {
 				if (duration_ms > 0) {
 					// TODO(bill): Does this even make any sense?


### PR DESCRIPTION
Calling `time.now()` in a `js_wasm32` target was causing this error to be shown:

```
Uncaught TypeError: Cannot convert 1697734255486 to a BigInt
    at time._now-998 (001342ce:0x3379c)
    at time.now (001342ce:0xc543)
    at store_own_post (001342ce:0xc2e0)
    at Module.storeOwnPost (runtime.ts:34:18)
    at HTMLFormElement.<anonymous> (app.ts:163:14)
```

Returning a bigint instead fixes the typeerror and time.now() works correctly.

Also I moved the ms -> ns convertion to the odin file, where it is also done for the sleep proc.