### PR TITLE
Editor config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+
+root = true
+
+[*.{odin,c,h,cpp}]
+indent_style = tab
+end_of_line = lf

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 
 root = true
 
-[*.{odin,c,h,cpp}]
+[*]
 indent_style = tab
 end_of_line = lf

--- a/core/runtime/procs_windows_amd64.asm
+++ b/core/runtime/procs_windows_amd64.asm
@@ -45,35 +45,35 @@ section .text
 ; totally supports this kind of stack.
 __chkstk:
 	;; Allocate 16 bytes to store values of r10 and r11
-    sub   rsp, 0x10
-    mov   [rsp], r10
-    mov   [rsp+0x8], r11
-    ;; Set r10 to point to the stack as of the moment of the function call
-    lea   r10, [rsp+0x18]
-    ;; Subtract r10 til the bottom of the stack allocation, if we overflow
-    ;; reset r10 to 0, we'll crash with segfault anyway
-    xor   r11, r11
-    sub   r10, rax
-    cmovb r10, r11
-    ;; Load r11 with the bottom of the stack (lowest allocated address)
-    mov   r11, gs:[0x10] ; NOTE(flysand): gs:[0x10] is stack limit
-    ;; If the bottom of the allocation is above the bottom of the stack,
-    ;; we don't need to probe
-    cmp   r10, r11
-    jnb   .end
-    ;; Align the bottom of the allocation down to page size
-    and   r10w, 0xf000
+	sub   rsp, 0x10
+	mov   [rsp], r10
+	mov   [rsp+0x8], r11
+	;; Set r10 to point to the stack as of the moment of the function call
+	lea   r10, [rsp+0x18]
+	;; Subtract r10 til the bottom of the stack allocation, if we overflow
+	;; reset r10 to 0, we'll crash with segfault anyway
+	xor   r11, r11
+	sub   r10, rax
+	cmovb r10, r11
+	;; Load r11 with the bottom of the stack (lowest allocated address)
+	mov   r11, gs:[0x10] ; NOTE(flysand): gs:[0x10] is stack limit
+	;; If the bottom of the allocation is above the bottom of the stack,
+	;; we don't need to probe
+	cmp   r10, r11
+	jnb   .end
+	;; Align the bottom of the allocation down to page size
+	and   r10w, 0xf000
 .loop:
 	;; Move the pointer to the next guard page, and touch it by loading 0
 	;; into that page
-    lea   r11, [r11-0x1000]
-    mov   byte [r11], 0x0
-    ;; Did we reach the bottom of the allocation?
-    cmp   r10, r11
-    jnz   .loop
+	lea   r11, [r11-0x1000]
+	mov   byte [r11], 0x0
+	;; Did we reach the bottom of the allocation?
+	cmp   r10, r11
+	jnz   .loop
 .end:
 	;; Restore previous r10 and r11 and return
-    mov   r10, [rsp]
-    mov   r11, [rsp+0x8]
-    add   rsp, 0x10
-    ret
+	mov   r10, [rsp]
+	mov   r11, [rsp+0x8]
+	add   rsp, 0x10
+	ret


### PR DESCRIPTION

A few times there's been a precedent with people pull-requesting code with space indentation. Some of the code actually got into the master branch (mostly in `vendor`, botan is formatted exclusively with spaces). I thought it would be a good idea to introduce .editorconfig for people who are contributing and have different editor settings

I didn't touch the stuff in vendor, since the diff would be too large, but this could be fixed
