### PR TITLE
don't disable panic when -disable-assert is set

### DIFF
--- a/core/runtime/core_builtin.odin
+++ b/core/runtime/core_builtin.odin
@@ -817,7 +817,6 @@ assert :: proc(condition: bool, message := "", loc := #caller_location) {
 }
 
 @builtin
-@(disabled=ODIN_DISABLE_ASSERT)
 panic :: proc(message: string, loc := #caller_location) -> ! {
 	p := context.assertion_failure_proc
 	if p == nil {


### PR DESCRIPTION
If this is intentional I find it very weird behaviour, imo (and that of most people in the discord) `panic` should always cause a call to the failure proc.