### PR TITLE
Fix a `shrink(map[T]U)` bug in the core lib

### DIFF
--- a/core/runtime/dynamic_map_internal.odin
+++ b/core/runtime/dynamic_map_internal.odin
@@ -629,7 +629,7 @@ map_reserve_dynamic :: proc "odin" (#no_alias m: ^Raw_Map, #no_alias info: ^Map_
 
 
 @(require_results)
-map_shrink_dynamic :: proc "odin" (#no_alias m: ^Raw_Map, #no_alias info: ^Map_Info, loc := #caller_location) -> Allocator_Error {
+map_shrink_dynamic :: proc "odin" (#no_alias m: ^Raw_Map, #no_alias info: ^Map_Info, loc := #caller_location) -> (did_shrink: bool, err: Allocator_Error) {
 	if m.allocator.procedure == nil {
 		m.allocator = context.allocator
 	}
@@ -639,7 +639,7 @@ map_shrink_dynamic :: proc "odin" (#no_alias m: ^Raw_Map, #no_alias info: ^Map_I
 	// map needs to be within the max load factor.
 	log2_capacity := map_log2_cap(m^)
 	if uintptr(m.len) >= map_load_factor(log2_capacity - 1) {
-		return nil
+		return false, nil
 	}
 
 	shrunk := map_alloc_dynamic(info, log2_capacity - 1, m.allocator) or_return
@@ -672,7 +672,7 @@ map_shrink_dynamic :: proc "odin" (#no_alias m: ^Raw_Map, #no_alias info: ^Map_I
 
 	map_free_dynamic(m^, info, loc) or_return
 	m.data = shrunk.data
-	return nil
+	return true, nil
 }
 
 @(require_results)


### PR DESCRIPTION
Fixed this error from `core:runtime`:
```odin
odin/core/runtime/core_builtin.odin(387:3) Error: Expected 2 return values, got 1 (Allocator_Error)
        return map_shrink_dynamic((^Raw_Map)(m), map_info(T), loc)
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
```
See the discussion in the discord [here](https://discord.com/channels/568138951836172421/568871298428698645/1165309001072910376).

**Small repro:**
```odin
package repro

import "core:fmt"

main :: proc() {
    test_1()
    fmt.println("=====")
    test_2()
}

test_1 :: proc() {
    // make map, type check, check len and cap
    myMap := make(map[string]int)
    defer delete(myMap)

    typeCheck8 := typeid_of(type_of(myMap))
    fmt.println(typeCheck8)                                           // map[string]int
    fmt.println("len(myMap):", len(myMap), "cap(myMap):", cap(myMap)) // len(myMap): 0 cap(myMap): 64

    // insert elements, check len and cap, type check a value
    myMap["Bob"] = 2          // inserting element with key: "Bob" and value: 2
    fmt.println(myMap["Bob"]) // 2
    myMap["Mary"] = 3

    fmt.println(myMap["Mary"])                                        // 3
    fmt.println(myMap)                                                // map[Bob=2, Mary=3]
    fmt.println("len(myMap):", len(myMap), "cap(myMap):", cap(myMap)) // len(myMap): 2 cap(myMap): 64

    typeCheck8 = typeid_of(type_of(myMap["Bob"]))
    fmt.println(typeCheck8) // int

    //shrink capacity down to current length  <------ RESULTS IN ERROR, SEE BELOW
    shrink(&myMap) // odin/core/runtime/core_builtin.odin(387:3)
                   // Error: Expected 2 return values, got 1 (Allocator_Error)
                   // return map_shrink_dynamic((^Raw_Map)(m), map_info(T), loc)
    fmt.println("len(myMap):", len(myMap), "cap(myMap):", cap(myMap))
}

test_2 :: proc() {
    // initialize map w/literals, check type, print, check len and cap
    myMap2 := map[string]int {
        "Tom"  = 10,
        "Dick" = 20,
    }
    typeCheck9 := typeid_of(type_of(myMap2))

    fmt.println(typeCheck9)                                               // map[string]int
    fmt.println(myMap2)                                                   // map[Tom=10, Dick=20]
    fmt.println("len(myMap2):", len(myMap2), "cap(myMap2):", cap(myMap2)) // len(myMap2): 2 cap(myMap2): 64

    //shrink capacity down to current length  <------ RESULTS IN ERROR, SEE BELOW
    shrink(&myMap2) // odin/core/runtime/core_builtin.odin(387:3)
                    // Error: Expected 2 return values, got 1 (Allocator_Error)
                    // return map_shrink_dynamic((^Raw_Map)(m), map_info(T), loc)
    fmt.println("len(myMap2):", len(myMap2), "cap(myMap2):", cap(myMap2))
}
```