### PR TITLE
Fix bit_* calls in `core:simd/x86`

### DIFF
--- a/core/simd/x86/sse.odin
+++ b/core/simd/x86/sse.odin
@@ -130,7 +130,7 @@ _mm_and_ps :: #force_inline proc "c" (a, b: __m128) -> __m128 {
 }
 @(require_results, enable_target_feature="sse")
 _mm_andnot_ps :: #force_inline proc "c" (a, b: __m128) -> __m128 {
-	return transmute(__m128)simd.and_not(transmute(__m128i)a, transmute(__m128i)b)
+	return transmute(__m128)simd.bit_and_not(transmute(__m128i)a, transmute(__m128i)b)
 }
 @(require_results, enable_target_feature="sse")
 _mm_or_ps :: #force_inline proc "c" (a, b: __m128) -> __m128 {

--- a/core/simd/x86/sse.odin
+++ b/core/simd/x86/sse.odin
@@ -126,7 +126,7 @@ _mm_max_ps :: #force_inline proc "c" (a, b: __m128) -> __m128 {
 
 @(require_results, enable_target_feature="sse")
 _mm_and_ps :: #force_inline proc "c" (a, b: __m128) -> __m128 {
-	return transmute(__m128)simd.and(transmute(__m128i)a, transmute(__m128i)b)
+	return transmute(__m128)simd.bit_and(transmute(__m128i)a, transmute(__m128i)b)
 }
 @(require_results, enable_target_feature="sse")
 _mm_andnot_ps :: #force_inline proc "c" (a, b: __m128) -> __m128 {
@@ -134,11 +134,11 @@ _mm_andnot_ps :: #force_inline proc "c" (a, b: __m128) -> __m128 {
 }
 @(require_results, enable_target_feature="sse")
 _mm_or_ps :: #force_inline proc "c" (a, b: __m128) -> __m128 {
-	return transmute(__m128)simd.or(transmute(__m128i)a, transmute(__m128i)b)
+	return transmute(__m128)simd.bit_or(transmute(__m128i)a, transmute(__m128i)b)
 }
 @(require_results, enable_target_feature="sse")
 _mm_xor_ps :: #force_inline proc "c" (a, b: __m128) -> __m128 {
-	return transmute(__m128)simd.xor(transmute(__m128i)a, transmute(__m128i)b)
+	return transmute(__m128)simd.bit_xor(transmute(__m128i)a, transmute(__m128i)b)
 }
 
 

--- a/core/simd/x86/sse2.odin
+++ b/core/simd/x86/sse2.odin
@@ -281,19 +281,19 @@ _mm_srl_epi64 :: #force_inline proc "c" (a, count: __m128i) -> __m128i {
 
 @(require_results, enable_target_feature="sse2")
 _mm_and_si128 :: #force_inline proc "c" (a, b: __m128i) -> __m128i {
-	return simd.and(a, b)
+	return simd.bit_and(a, b)
 }
 @(require_results, enable_target_feature="sse2")
 _mm_andnot_si128 :: #force_inline proc "c" (a, b: __m128i) -> __m128i {
-	return simd.and_not(b, a)
+	return simd.bit_and_not(b, a)
 }
 @(require_results, enable_target_feature="sse2")
 _mm_or_si128 :: #force_inline proc "c" (a, b: __m128i) -> __m128i {
-	return simd.or(a, b)
+	return simd.bit_or(a, b)
 }
 @(require_results, enable_target_feature="sse2")
 _mm_xor_si128 :: #force_inline proc "c" (a, b: __m128i) -> __m128i {
-	return simd.xor(a, b)
+	return simd.bit_xor(a, b)
 }
 @(require_results, enable_target_feature="sse2")
 _mm_cmpeq_epi8 :: #force_inline proc "c" (a, b: __m128i) -> __m128i {


### PR DESCRIPTION
It seems like the simd/x86 package wasn't updated when the bitwise simd intrinsics were renamed, this should fix it.