### PR TITLE
GLFW binding fixes

### DIFF
--- a/vendor/glfw/bindings/bindings.odin
+++ b/vendor/glfw/bindings/bindings.odin
@@ -39,7 +39,7 @@ when ODIN_OS == .Windows {
 /*** Functions ***/
 @(default_calling_convention="c", link_prefix="glfw")
 foreign glfw {
-	Init      :: proc() -> bool ---
+	Init      :: proc() -> b32 ---
 	Terminate :: proc() ---
 	
 	InitHint  :: proc(hint, value: c.int) ---

--- a/vendor/glfw/bindings/bindings.odin
+++ b/vendor/glfw/bindings/bindings.odin
@@ -39,7 +39,7 @@ when ODIN_OS == .Windows {
 /*** Functions ***/
 @(default_calling_convention="c", link_prefix="glfw")
 foreign glfw {
-	Init      :: proc() -> c.int ---
+	Init      :: proc() -> bool ---
 	Terminate :: proc() ---
 	
 	InitHint  :: proc(hint, value: c.int) ---

--- a/vendor/glfw/bindings/types.odin
+++ b/vendor/glfw/bindings/types.odin
@@ -41,7 +41,7 @@ WindowMaximizeProc     :: #type proc "c" (window: WindowHandle, iconified: c.int
 WindowContentScaleProc :: #type proc "c" (window: WindowHandle, xscale, yscale: f32)
 FramebufferSizeProc    :: #type proc "c" (window: WindowHandle, width, height: c.int)
 DropProc               :: #type proc "c" (window: WindowHandle, count: c.int, paths: [^]cstring)
-MonitorProc            :: #type proc "c" (window: WindowHandle)
+MonitorProc            :: #type proc "c" (window: WindowHandle, event: c.int)
 
 KeyProc                :: #type proc "c" (window: WindowHandle, key, scancode, action, mods: c.int)
 MouseButtonProc        :: #type proc "c" (window: WindowHandle, button, action, mods: c.int)

--- a/vendor/glfw/wrapper.odin
+++ b/vendor/glfw/wrapper.odin
@@ -53,7 +53,7 @@ WindowHint_int :: proc "contextless" (hint: c.int, value: c.int) {
 	glfw.WindowHint(hint, value)
 }
 
-WindowHint_bool :: proc "contextless" (hint: c.int, value: bool) {
+WindowHint_bool :: proc "contextless" (hint: c.int, value: b32) {
 	glfw.WindowHint(hint, cast(c.int) value)
 }
 

--- a/vendor/glfw/wrapper.odin
+++ b/vendor/glfw/wrapper.odin
@@ -49,7 +49,19 @@ SetGammaRamp :: glfw.SetGammaRamp
 CreateWindow  :: glfw.CreateWindow
 DestroyWindow :: glfw.DestroyWindow
 
-WindowHint         :: glfw.WindowHint
+WindowHint_int :: proc "contextless" (hint: c.int, value: c.int) {
+	glfw.WindowHint(hint, value)
+}
+
+WindowHint_bool :: proc "contextless" (hint: c.int, value: bool) {
+	glfw.WindowHint(hint, cast(c.int) value)
+}
+
+WindowHint :: proc {
+	WindowHint_int,
+	WindowHint_bool,
+}
+
 DefaultWindowHints :: glfw.DefaultWindowHints
 WindowHintString   :: glfw.WindowHintString
 WindowShouldClose  :: glfw.WindowShouldClose


### PR DESCRIPTION

## Fixes implemented

- `GLFWmonitorfun` takes an additional [event parameter](https://www.glfw.org/docs/3.3/group__monitor.html#gab39df645587c8518192aa746c2fb06c3)

- `GLFW_TRUE` and `GLFW_FALSE` were defined as untyped boolean constants, despite the fact that `glfwInit` returns boolean. For consistency and useability in `if` statements, the functions were changed from returning `int` to returning `b32`.

- Replaced `WindowHint` function with a polymorphic procedure group, allowing to take both `c.int` and `b32` parameters for hints.

## Compatibility note

This PR breaks compatibility on any code that calls `glfw.Init()` function and checks for it's return value. In before, the check would have needed to be done like that:

```odin
if glfw.Init() != 0 {
    // log error, exit
}
```

or like that:

```odin
if ! cast(bool) glfw.Init() {
    // log error, exit
}
```

The first variant becomes broken, one needs to remove `!= 0` to make their code compile again