### PR TITLE
Adding LLVM14 - Missing config but says supported in Error message.

### DIFF
--- a/build_odin.sh
+++ b/build_odin.sh
@@ -36,12 +36,12 @@ if [ -z "$LLVM_CONFIG" ]; then
 	elif [ -n "$(command -v llvm-config12)" ]; then  LLVM_CONFIG="llvm-config-12"
 	elif [ -n "$(command -v llvm-config11)" ]; then  LLVM_CONFIG="llvm-config-11"
 	# fallback
-  elif [ -n "$(command -v llvm-config-14)" ]; then
-    echo "WARN: Odin does not officially support LLVM14"
-    LLVM_CONFIG="llvm-config-14"
-  elif [ -n "$(command -v llvm-config14)" ]; then
-    echo "WARN: Odin does not officially support LLVM14"
-    LLVM_CONFIG="llvm-config14"
+	elif [ -n "$(command -v llvm-config-14)" ]; then
+		echo "WARN: Odin does not officially support LLVM14"
+		LLVM_CONFIG="llvm-config-14"
+	elif [ -n "$(command -v llvm-config14)" ]; then
+		echo "WARN: Odin does not officially support LLVM14"
+		LLVM_CONFIG="llvm-config14"
 	else
 		error "No llvm-config command found. Set LLVM_CONFIG to proceed."
 	fi

--- a/build_odin.sh
+++ b/build_odin.sh
@@ -27,11 +27,13 @@ error() {
 if [ -z "$LLVM_CONFIG" ]; then
 	# darwin, linux, openbsd
 	if   [ -n "$(command -v llvm-config-17)" ]; then LLVM_CONFIG="llvm-config-17"
+	elif [ -n "$(command -v llvm-config-14)" ]; then LLVM_CONFIG="llvm-config-14"
 	elif [ -n "$(command -v llvm-config-13)" ]; then LLVM_CONFIG="llvm-config-13"
 	elif [ -n "$(command -v llvm-config-12)" ]; then LLVM_CONFIG="llvm-config-12"
 	elif [ -n "$(command -v llvm-config-11)" ]; then LLVM_CONFIG="llvm-config-11"
 	# freebsd
 	elif [ -n "$(command -v llvm-config17)" ]; then  LLVM_CONFIG="llvm-config-17"
+	elif [ -n "$(command -v llvm-config14)" ]; then  LLVM_CONFIG="llvm-config-14"
 	elif [ -n "$(command -v llvm-config13)" ]; then  LLVM_CONFIG="llvm-config-13"
 	elif [ -n "$(command -v llvm-config12)" ]; then  LLVM_CONFIG="llvm-config-12"
 	elif [ -n "$(command -v llvm-config11)" ]; then  LLVM_CONFIG="llvm-config-11"

--- a/build_odin.sh
+++ b/build_odin.sh
@@ -27,18 +27,21 @@ error() {
 if [ -z "$LLVM_CONFIG" ]; then
 	# darwin, linux, openbsd
 	if   [ -n "$(command -v llvm-config-17)" ]; then LLVM_CONFIG="llvm-config-17"
-	elif [ -n "$(command -v llvm-config-14)" ]; then LLVM_CONFIG="llvm-config-14"
 	elif [ -n "$(command -v llvm-config-13)" ]; then LLVM_CONFIG="llvm-config-13"
 	elif [ -n "$(command -v llvm-config-12)" ]; then LLVM_CONFIG="llvm-config-12"
 	elif [ -n "$(command -v llvm-config-11)" ]; then LLVM_CONFIG="llvm-config-11"
 	# freebsd
 	elif [ -n "$(command -v llvm-config17)" ]; then  LLVM_CONFIG="llvm-config-17"
-	elif [ -n "$(command -v llvm-config14)" ]; then  LLVM_CONFIG="llvm-config-14"
 	elif [ -n "$(command -v llvm-config13)" ]; then  LLVM_CONFIG="llvm-config-13"
 	elif [ -n "$(command -v llvm-config12)" ]; then  LLVM_CONFIG="llvm-config-12"
 	elif [ -n "$(command -v llvm-config11)" ]; then  LLVM_CONFIG="llvm-config-11"
 	# fallback
-	elif [ -n "$(command -v llvm-config)" ]; then LLVM_CONFIG="llvm-config"
+  elif [ -n "$(command -v llvm-config-14)" ]; then
+    echo "WARN: Odin does not officially support LLVM14"
+    LLVM_CONFIG="llvm-config-14"
+  elif [ -n "$(command -v llvm-config14)" ]; then
+    echo "WARN: Odin does not officially support LLVM14"
+    LLVM_CONFIG="llvm-config14"
 	else
 		error "No llvm-config command found. Set LLVM_CONFIG to proceed."
 	fi


### PR DESCRIPTION
As it says on the tin, the build_odin.sh script says 14 is supported in the list of errors, however there is no check in the script to set it. Just popped it in and tested on Arch with the latest build and it worked with 14.