### PR TITLE
Fix incorrect type condition in some built-in procs

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -5170,7 +5170,7 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 
 			Operand op = {};
 			check_expr(c, &op, ce->args[1]);
-			if (op.mode != Addressing_Constant && !is_type_integer(op.type)) {
+			if (op.mode != Addressing_Constant || !is_type_integer(op.type)) {
 				error(op.expr, "Expected a constant integer for the index of procedure parameter value");
 				return false;
 			}
@@ -5229,7 +5229,7 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 
 			Operand op = {};
 			check_expr(c, &op, ce->args[1]);
-			if (op.mode != Addressing_Constant && !is_type_integer(op.type)) {
+			if (op.mode != Addressing_Constant || !is_type_integer(op.type)) {
 				error(op.expr, "Expected a constant integer for the index of procedure parameter value");
 				return false;
 			}
@@ -5307,7 +5307,7 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 		} else {
 			Operand op = {};
 			check_expr(c, &op, ce->args[1]);
-			if (op.mode != Addressing_Constant && !is_type_integer(op.type)) {
+			if (op.mode != Addressing_Constant || !is_type_integer(op.type)) {
 				error(op.expr, "Expected a constant integer for the index of record parameter value");
 				return false;
 			}


### PR DESCRIPTION
A number intrinsics check if the parameter is an integer type with constant addressing. These procedures had the condition expressed incorrectly:
- type_proc_parameter_type
- type_proc_return_type
- type_polymorphic_record_parameter_value

This meant that any constant value passed the condition, so you could do this for example:
```odin
Proc :: proc(i: int, j: f32) -> f32
a: int
intrinsics.type_proc_parameter_type(Proc, a) // no error
intrinsics.type_proc_return_type(Proc, "hello") // no error
```
Since it passed the condition `exact_value_to_i64` would just return 0 and no error is reported.
