### PR TITLE
Add system_random and random_bytes for js target

### DIFF
--- a/core/crypto/rand_generic.odin
+++ b/core/crypto/rand_generic.odin
@@ -1,7 +1,7 @@
 package crypto
 
-when ODIN_OS != .Linux && ODIN_OS != .OpenBSD && ODIN_OS != .Windows {
-	_rand_bytes :: proc (dst: []byte) {
+when ODIN_OS != .Linux && ODIN_OS != .OpenBSD && ODIN_OS != .Windows && ODIN_OS != .JS {
+	_rand_bytes :: proc(dst: []byte) {
 		unimplemented("crypto: rand_bytes not supported on this OS")
 	}
 }

--- a/core/crypto/rand_js.odin
+++ b/core/crypto/rand_js.odin
@@ -1,0 +1,20 @@
+package crypto
+
+foreign import "odin_env"
+foreign odin_env {
+	@(link_name = "rand_bytes")
+	env_rand_bytes :: proc "contextless" (buf: []byte) ---
+}
+
+_MAX_PER_CALL_BYTES :: 65536
+
+_rand_bytes :: proc(dst: []byte) {
+	dst := dst
+
+	for len(dst) > 0 {
+		to_read := min(len(dst), _MAX_PER_CALL_BYTES)
+		env_rand_bytes(dst[:to_read])
+
+		dst = dst[to_read:]
+	}
+}

--- a/core/crypto/rand_js.odin
+++ b/core/crypto/rand_js.odin
@@ -6,7 +6,7 @@ foreign odin_env {
 	env_rand_bytes :: proc "contextless" (buf: []byte) ---
 }
 
-_MAX_PER_CALL_BYTES :: 65536
+_MAX_PER_CALL_BYTES :: 65536 // 64kiB
 
 _rand_bytes :: proc(dst: []byte) {
 	dst := dst

--- a/core/math/rand/system_js.odin
+++ b/core/math/rand/system_js.odin
@@ -2,10 +2,11 @@ package rand
 
 foreign import "odin_env"
 foreign odin_env {
-	rand :: proc "contextless" () -> f64 ---
+	@(link_name = "rand")
+	rand_f64 :: proc "contextless" () -> f64 ---
 }
 
 @(require_results)
 _system_random :: proc() -> u64 {
-	return u64(rand() * 0x1fffffffffffff)
+	return u64(rand_f64() * 0x1fffffffffffff)
 }

--- a/core/math/rand/system_js.odin
+++ b/core/math/rand/system_js.odin
@@ -2,11 +2,13 @@ package rand
 
 foreign import "odin_env"
 foreign odin_env {
-	@(link_name = "rand")
-	rand_f64 :: proc "contextless" () -> f64 ---
+	@(link_name = "rand_bytes")
+	env_rand_bytes :: proc "contextless" (buf: []byte) ---
 }
 
 @(require_results)
 _system_random :: proc() -> u64 {
-	return u64(rand_f64() * 0x1fffffffffffff)
+	buf: [8]u8
+	env_rand_bytes(buf[:])
+	return transmute(u64)buf
 }

--- a/core/math/rand/system_js.odin
+++ b/core/math/rand/system_js.odin
@@ -1,0 +1,11 @@
+package rand
+
+foreign import "odin_env"
+foreign odin_env {
+	rand :: proc "contextless" () -> f64 ---
+}
+
+@(require_results)
+_system_random :: proc() -> u64 {
+	return u64(rand() * 0x1fffffffffffff)
+}

--- a/vendor/wasm/js/runtime.js
+++ b/vendor/wasm/js/runtime.js
@@ -1349,6 +1349,12 @@ function odinSetupDefaultImports(wasmMemoryInterface, consoleElement) {
 			ln:      Math.log,
 			exp:     Math.exp,
 			ldexp:   (x, exp) => x * Math.pow(2, exp),
+
+			rand: Math.random,
+			rand_bytes: (ptr, len) => {
+				const view = new Uint8Array(wasm_memory.buffer, ptr, len)
+				crypto.getRandomValues(view)
+			},
 		},
 		"odin_dom": {
 			init_event_raw: (ep) => {

--- a/vendor/wasm/js/runtime.js
+++ b/vendor/wasm/js/runtime.js
@@ -1350,7 +1350,6 @@ function odinSetupDefaultImports(wasmMemoryInterface, consoleElement) {
 			exp:     Math.exp,
 			ldexp:   (x, exp) => x * Math.pow(2, exp),
 
-			rand: Math.random,
 			rand_bytes: (ptr, len) => {
 				const view = new Uint8Array(wasmMemoryInterface.memory.buffer, ptr, len)
 				crypto.getRandomValues(view)

--- a/vendor/wasm/js/runtime.js
+++ b/vendor/wasm/js/runtime.js
@@ -1352,7 +1352,7 @@ function odinSetupDefaultImports(wasmMemoryInterface, consoleElement) {
 
 			rand: Math.random,
 			rand_bytes: (ptr, len) => {
-				const view = new Uint8Array(wasm_memory.buffer, ptr, len)
+				const view = new Uint8Array(wasmMemoryInterface.memory.buffer, ptr, len)
 				crypto.getRandomValues(view)
 			},
 		},


### PR DESCRIPTION
~~This implements generating random numbers using [`Math.random`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random) and byte slices using [`crypto.getRandomValues`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues).
I'm not sure if `Math.random` is the best choice for generating `u64` because of missing precision, but it's much faster than using crypto for every number.~~

This implements generating random numbers in `rand` and byte slices in `crypto` using [`crypto.getRandomValues`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues).