### PR TITLE
editorconfig: Use 2-column spaces in YAML

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,10 @@
-
 root = true
 
 [*]
 indent_style = tab
 end_of_line = lf
+
+[*.y{,a}ml]
+indent_size = 2
+indent_style = space
+tab_width = 2


### PR DESCRIPTION
This PR ensures that all YAML files use 2-column spaces.

When making changes in YAML files such as the GitHub workflows, editors that are configured to respect the `.editorconfig` settings will insert tabs rather than spaces. This is likely fine for all other files, but for YAML this is invalid.