### PR TITLE
Fix `-foreign-error-procedures` flag doing nothing

### DIFF
--- a/core/runtime/error_checks.odin
+++ b/core/runtime/error_checks.odin
@@ -19,8 +19,6 @@ type_assertion_trap :: proc "contextless" () -> ! {
 when ODIN_FOREIGN_ERROR_PROCEDURES {
     foreign {
         bounds_check_error               :: proc "contextless" (file: string, line, column: i32, index, count: int) ---
-        slice_handle_error               :: proc "contextless" (file: string, line, column: i32, lo, hi: int, len: int) -> ! ---
-        multi_pointer_slice_handle_error :: proc "contextless" (file: string, line, column: i32, lo, hi: int) -> ! ---
         multi_pointer_slice_expr_error   :: proc "contextless" (file: string, line, column: i32, lo, hi: int) ---
         slice_expr_error_hi              :: proc "contextless" (file: string, line, column: i32, hi: int, len: int) ---
         slice_expr_error_lo_hi           :: proc "contextless" (file: string, line, column: i32, lo, hi: int, len: int) ---


### PR DESCRIPTION
This flag was introduced in commit [17f32cc](https://github.com/odin-lang/Odin/commit/0fa487f468b1f63d5ec97ae8bbb0da01717f32cc) with the purpose that freestanding targets would define exported symbols that bind to these procedures to allow for custom error handling.

However it seems like in commit [4f12b8](https://github.com/odin-lang/Odin/commit/01162e08b55406578a2972d74c472de8a14f12b8), the code that makes this flag work got removed and my odin-os code wasn't working since then for like a year without me noticing. It wasn't failing to compile, but the error procedures would be crashing the kernel instead of printing the error messages.
