### PR TITLE
Only build vendor:darwin on darwin

### DIFF
--- a/examples/all/all_vendor.odin
+++ b/examples/all/all_vendor.odin
@@ -39,11 +39,6 @@ import TTF        "vendor:sdl2/ttf"
 
 import vk         "vendor:vulkan"
 
-import NS         "vendor:darwin/Foundation"
-import MTL        "vendor:darwin/Metal"
-import MTK        "vendor:darwin/MetalKit"
-import CA         "vendor:darwin/QuartzCore"
-
 // NOTE(bill): only one can be checked at a time
 import lua_5_4    "vendor:lua/5.4"
 
@@ -90,11 +85,6 @@ _ :: MIX
 _ :: TTF
 
 _ :: vk
-
-_ :: NS
-_ :: MTL
-_ :: MTK
-_ :: CA
 
 _ :: lua_5_4
 

--- a/examples/all/all_vendor_darwin.odin
+++ b/examples/all/all_vendor_darwin.odin
@@ -1,0 +1,12 @@
+//+build darwin
+package all
+
+import NS         "vendor:darwin/Foundation"
+import MTL        "vendor:darwin/Metal"
+import MTK        "vendor:darwin/MetalKit"
+import CA         "vendor:darwin/QuartzCore"
+
+_ :: NS
+_ :: MTL
+_ :: MTK
+_ :: CA

--- a/vendor/darwin/CoreVideo/CVDisplayLink.odin
+++ b/vendor/darwin/CoreVideo/CVDisplayLink.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package CoreVideo
 
 DisplayLinkRef :: distinct rawptr

--- a/vendor/darwin/Foundation/NSApplication.odin
+++ b/vendor/darwin/Foundation/NSApplication.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 foreign import "system:Foundation.framework"

--- a/vendor/darwin/Foundation/NSArray.odin
+++ b/vendor/darwin/Foundation/NSArray.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 import "core:intrinsics"

--- a/vendor/darwin/Foundation/NSAutoreleasePool.odin
+++ b/vendor/darwin/Foundation/NSAutoreleasePool.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 @(objc_class="NSAutoreleasePool")

--- a/vendor/darwin/Foundation/NSBlock.odin
+++ b/vendor/darwin/Foundation/NSBlock.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 import "core:intrinsics"

--- a/vendor/darwin/Foundation/NSBundle.odin
+++ b/vendor/darwin/Foundation/NSBundle.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 @(objc_class="NSBundle")

--- a/vendor/darwin/Foundation/NSColor.odin
+++ b/vendor/darwin/Foundation/NSColor.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 @(objc_class="NSColorSpace")

--- a/vendor/darwin/Foundation/NSData.odin
+++ b/vendor/darwin/Foundation/NSData.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 @(objc_class="NSData")

--- a/vendor/darwin/Foundation/NSDate.odin
+++ b/vendor/darwin/Foundation/NSDate.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 @(objc_class="NSDate")

--- a/vendor/darwin/Foundation/NSDictionary.odin
+++ b/vendor/darwin/Foundation/NSDictionary.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 @(objc_class="NSDictionary")

--- a/vendor/darwin/Foundation/NSEnumerator.odin
+++ b/vendor/darwin/Foundation/NSEnumerator.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 import "core:c"

--- a/vendor/darwin/Foundation/NSError.odin
+++ b/vendor/darwin/Foundation/NSError.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 foreign import "system:Foundation.framework"

--- a/vendor/darwin/Foundation/NSEvent.odin
+++ b/vendor/darwin/Foundation/NSEvent.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 @(objc_class="NSEvent")

--- a/vendor/darwin/Foundation/NSLock.odin
+++ b/vendor/darwin/Foundation/NSLock.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 Locking :: struct($T: typeid) {using _: Object}

--- a/vendor/darwin/Foundation/NSMenu.odin
+++ b/vendor/darwin/Foundation/NSMenu.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 import "core:builtin"

--- a/vendor/darwin/Foundation/NSNotification.odin
+++ b/vendor/darwin/Foundation/NSNotification.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 @(objc_class="NSNotification")

--- a/vendor/darwin/Foundation/NSNumber.odin
+++ b/vendor/darwin/Foundation/NSNumber.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 import "core:c"

--- a/vendor/darwin/Foundation/NSObject.odin
+++ b/vendor/darwin/Foundation/NSObject.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 import "core:intrinsics"

--- a/vendor/darwin/Foundation/NSOpenPanel.odin
+++ b/vendor/darwin/Foundation/NSOpenPanel.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 @(objc_class="NSOpenPanel")

--- a/vendor/darwin/Foundation/NSPanel.odin
+++ b/vendor/darwin/Foundation/NSPanel.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 ModalResponse :: enum UInteger {

--- a/vendor/darwin/Foundation/NSPasteboard.odin
+++ b/vendor/darwin/Foundation/NSPasteboard.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 @(objc_class="NSPasteboard")

--- a/vendor/darwin/Foundation/NSRange.odin
+++ b/vendor/darwin/Foundation/NSRange.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 Range :: struct {

--- a/vendor/darwin/Foundation/NSSavePanel.odin
+++ b/vendor/darwin/Foundation/NSSavePanel.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 @(objc_class="NSSavePanel")

--- a/vendor/darwin/Foundation/NSScreen.odin
+++ b/vendor/darwin/Foundation/NSScreen.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 @(objc_class="NSScreen")

--- a/vendor/darwin/Foundation/NSSet.odin
+++ b/vendor/darwin/Foundation/NSSet.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 @(objc_class="NSSet")

--- a/vendor/darwin/Foundation/NSString.odin
+++ b/vendor/darwin/Foundation/NSString.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 foreign import "system:Foundation.framework"

--- a/vendor/darwin/Foundation/NSTypes.odin
+++ b/vendor/darwin/Foundation/NSTypes.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 import "core:intrinsics"

--- a/vendor/darwin/Foundation/NSURL.odin
+++ b/vendor/darwin/Foundation/NSURL.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 @(objc_class="NSURL")

--- a/vendor/darwin/Foundation/NSUndoManager.odin
+++ b/vendor/darwin/Foundation/NSUndoManager.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 @(objc_class="NSUndoManager")

--- a/vendor/darwin/Foundation/NSUserActivity.odin
+++ b/vendor/darwin/Foundation/NSUserActivity.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 @(objc_class="NSUserActivity")

--- a/vendor/darwin/Foundation/NSUserDefaults.odin
+++ b/vendor/darwin/Foundation/NSUserDefaults.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 @(objc_class="NSUserDefaults")

--- a/vendor/darwin/Foundation/NSWindow.odin
+++ b/vendor/darwin/Foundation/NSWindow.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 import "core:strings"

--- a/vendor/darwin/Foundation/objc.odin
+++ b/vendor/darwin/Foundation/objc.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Foundation
 
 foreign import "system:Foundation.framework"

--- a/vendor/darwin/Metal/MetalClasses.odin
+++ b/vendor/darwin/Metal/MetalClasses.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Metal
 
 import NS "vendor:darwin/Foundation"

--- a/vendor/darwin/Metal/MetalEnums.odin
+++ b/vendor/darwin/Metal/MetalEnums.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Metal
 
 import NS "vendor:darwin/Foundation"

--- a/vendor/darwin/Metal/MetalErrors.odin
+++ b/vendor/darwin/Metal/MetalErrors.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Metal
 
 import NS "vendor:darwin/Foundation"

--- a/vendor/darwin/Metal/MetalProcedures.odin
+++ b/vendor/darwin/Metal/MetalProcedures.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Metal
 
 import NS "vendor:darwin/Foundation"

--- a/vendor/darwin/Metal/MetalTypes.odin
+++ b/vendor/darwin/Metal/MetalTypes.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_Metal
 
 import NS "vendor:darwin/Foundation"

--- a/vendor/darwin/MetalKit/MetalKit.odin
+++ b/vendor/darwin/MetalKit/MetalKit.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_MetalKit
 
 import NS "vendor:darwin/Foundation"

--- a/vendor/darwin/QuartzCore/QuartzCore.odin
+++ b/vendor/darwin/QuartzCore/QuartzCore.odin
@@ -1,3 +1,4 @@
+//+build darwin
 package objc_QuartzCore
 
 import NS "vendor:darwin/Foundation"


### PR DESCRIPTION
Running

```
odin run examples/all
```

Was printing a bunch of errors (something like `msgSend` is only available on `darwin`) on my linux machine. I honestly have no idea how this wasn't caught by the CI...