### PR TITLE
Fix-up inline asm for i386 syscalls emit

### DIFF
--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -2769,7 +2769,7 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 				{
 					GB_ASSERT(arg_count <= 7);
 
-					char asm_string_default[] = "int $0x80";
+					char asm_string_default[] = "int $$0x80";
 					char *asm_string = asm_string_default;
 					gbString constraints = gb_string_make(heap_allocator(), "={eax}");
 


### PR DESCRIPTION

Compiling code with `-target:i386` on linux results in an llvm error:

```
error: <inline asm>:1:6: invalid register name
        int %eaxx80
            ^~~~~~~
```

The error was coming from the fact that llvm interprets `$n`, where `n` is a number as a register parameter to the assembly or something like that, but anyway that character needs to be escaped in order to be used to declare constants
