### PR TITLE
Added loc := #caller_location to slice.clone and slice.clone_to_dynamic

### DIFF
--- a/core/slice/slice.odin
+++ b/core/slice/slice.odin
@@ -274,16 +274,16 @@ concatenate :: proc(a: []$T/[]$E, allocator := context.allocator) -> (res: T, er
 
 // copies a slice into a new slice
 @(require_results)
-clone :: proc(a: $T/[]$E, allocator := context.allocator) -> ([]E, runtime.Allocator_Error) #optional_allocator_error {
-	d, err := make([]E, len(a), allocator)
+clone :: proc(a: $T/[]$E, allocator := context.allocator, loc := #caller_location) -> ([]E, runtime.Allocator_Error) #optional_allocator_error {
+	d, err := make([]E, len(a), allocator, loc)
 	copy(d[:], a)
 	return d, err
 }
 
 
 // copies slice into a new dynamic array
-clone_to_dynamic :: proc(a: $T/[]$E, allocator := context.allocator) -> ([dynamic]E, runtime.Allocator_Error) #optional_allocator_error {
-	d, err := make([dynamic]E, len(a), allocator)
+clone_to_dynamic :: proc(a: $T/[]$E, allocator := context.allocator, loc := #caller_location) -> ([dynamic]E, runtime.Allocator_Error) #optional_allocator_error {
+	d, err := make([dynamic]E, len(a), allocator, loc)
 	copy(d[:], a)
 	return d, err
 }


### PR DESCRIPTION
Added `loc := #caller_location` to `slice.clone` and `slice.clone_to_dynamic`

The `loc` inside the `make` called by `clone` and `clone_to_dynamic` often becomes less useful compared to using `make` directly, since my tracking allocator will just report `clone` or `clone_to_dynamic` leaking memory. So I added a `loc` to those two procs.