### PR TITLE
Fix empty pass because of trailing comma

### DIFF
--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -1827,7 +1827,7 @@ cgscc(
 		function-attrs,
 		function(
 			require<should-not-run-function-passes>
-		),
+		)
 	)
 ),
 deadargelim,


### PR DESCRIPTION
Fixes this, it doesn't like trailing commas it seems:
```
$ odin run examples/minimal -o:aggressive                                        4.399s
LLVM Error:
unknown cgscc pass ''
```