### PR TITLE
Bump Darwin+Linux to LLVM-17 and test '-o' flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Download LLVM, botan and setup PATH
+        # NOTE(jcmdln): Brew will update everything on install without this
+        env: { HOMEBREW_NO_AUTO_UPDATE: 1}
         run: |
           brew update
           brew install llvm@17 botan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Download LLVM, botan and setup PATH
         run: |
+          brew update
           brew install llvm@17 botan
           echo "/usr/local/opt/llvm@17/bin" >> $GITHUB_PATH
           TMP_PATH=$(xcrun --show-sdk-path)/user/include

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,21 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build_linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Download LLVM, botan
-        run: sudo apt-get install llvm-11 clang-11 libbotan-2-dev botan
+        run: |
+          sudo ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+          sudo apt-get update
+          sudo apt-get install -y --no-install-{recommends,suggests} \
+              git gpg software-properties-common libbotan-2-dev botan
+          sudo wget https://apt.llvm.org/llvm.sh
+          sudo chmod +x llvm.sh
+          sudo ./llvm.sh 17
+          sudo ln -fs /usr/bin/clang-17   /usr/bin/clang
+          sudo ln -fs /usr/bin/clang++-17 /usr/bin/clang++
+          sudo ln -fs /usr/bin/lld-17     /usr/bin/lld
       - name: build odin
         run: ./build_odin.sh release
       - name: Odin version
@@ -25,6 +35,15 @@ jobs:
       - name: Odin run -debug
         run: ./odin run examples/demo -debug
         timeout-minutes: 10
+      - name: Odin run -o:size
+        run: ./odin run examples/demo -o:size
+        timeout-minutes: 5
+      - name: Odin run -o:speed
+        run: ./odin run examples/demo -o:speed
+        timeout-minutes: 5
+      - name: Odin run -o:aggressive
+        run: ./odin run examples/demo -o:aggressive
+        timeout-minutes: 5
       - name: Odin check examples/all
         run: ./odin check examples/all -strict-style
         timeout-minutes: 10
@@ -58,8 +77,8 @@ jobs:
       - uses: actions/checkout@v1
       - name: Download LLVM, botan and setup PATH
         run: |
-          brew install llvm@13 botan
-          echo "/usr/local/opt/llvm@13/bin" >> $GITHUB_PATH
+          brew install llvm@17 botan
+          echo "/usr/local/opt/llvm@17/bin" >> $GITHUB_PATH
           TMP_PATH=$(xcrun --show-sdk-path)/user/include
           echo "CPATH=$TMP_PATH" >> $GITHUB_ENV
       - name: build odin
@@ -79,6 +98,15 @@ jobs:
       - name: Odin run -debug
         run: ./odin run examples/demo -debug
         timeout-minutes: 10
+      - name: Odin run -o:size
+        run: ./odin run examples/demo -o:size
+        timeout-minutes: 5
+      - name: Odin run -o:speed
+        run: ./odin run examples/demo -o:speed
+        timeout-minutes: 5
+      - name: Odin run -o:aggressive
+        run: ./odin run examples/demo -o:aggressive
+        timeout-minutes: 5
       - name: Odin check examples/all
         run: ./odin check examples/all -strict-style
         timeout-minutes: 10
@@ -135,6 +163,23 @@ jobs:
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
           odin run examples/demo -debug
+      - name: Odin run -o:size
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+          odin run examples/demo -o:size
+        timeout-minutes: 10
+      - name: Odin run -o:speed
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+          odin run examples/demo -o:speed
+        timeout-minutes: 10
+      - name: Odin run -o:aggressive
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+          odin run examples/demo -o:aggressive
         timeout-minutes: 10
       - name: Odin check examples/all
         shell: cmd

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -81,6 +81,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Download LLVM and setup PATH
         run: |
+          brew update
           brew install llvm@17
           echo "/usr/local/opt/llvm@17/bin" >> $GITHUB_PATH
           TMP_PATH=$(xcrun --show-sdk-path)/user/include

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,7 +44,17 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: (Linux) Download LLVM
-        run: sudo apt-get install llvm-11 clang-11
+        run: |
+          sudo ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+          sudo apt-get update
+          sudo apt-get install -y --no-install-{recommends,suggests} \
+              git gpg software-properties-common libbotan-2-dev botan
+          sudo wget https://apt.llvm.org/llvm.sh
+          sudo chmod +x llvm.sh
+          sudo ./llvm.sh 17
+          sudo ln -fs /usr/bin/clang-17   /usr/bin/clang
+          sudo ln -fs /usr/bin/clang++-17 /usr/bin/clang++
+          sudo ln -fs /usr/bin/lld-17     /usr/bin/lld
       - name: build odin
         run: make nightly
       - name: Odin run
@@ -71,8 +81,8 @@ jobs:
       - uses: actions/checkout@v1
       - name: Download LLVM and setup PATH
         run: |
-          brew install llvm@13
-          echo "/usr/local/opt/llvm@13/bin" >> $GITHUB_PATH
+          brew install llvm@17
+          echo "/usr/local/opt/llvm@17/bin" >> $GITHUB_PATH
           TMP_PATH=$(xcrun --show-sdk-path)/user/include
           echo "CPATH=$TMP_PATH" >> $GITHUB_ENV
       - name: build odin

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,6 +80,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Download LLVM and setup PATH
+        # NOTE(jcmdln): Brew will update everything on install without this
+        env: { HOMEBREW_NO_AUTO_UPDATE: 1}
         run: |
           brew update
           brew install llvm@17


### PR DESCRIPTION
This PR builds Odin on LLVM-17 for all platforms and adds missing `-o` flag tests against `examples/demo`.

For Linux, I've dropped the Ubuntu version to 20.04 and used the official LLVM repo for installing LLVM-17. This gets Linux releases one step closer to being compatible with CompilerExplorer which requires all languages run on Ubuntu 20.04 though the real purpose of this PR is catching Linux-specific bugs with LLVM-17.

In my own fork, the Windows and Linux pipelines both succeeded while the MacOS pipeline failed during the `test_trunc_f16` tests.
