### PR TITLE
Tiny fix to `DESCRIPTOR_HEAP_TYPE` from `vendor:directx/d3d12`

### DIFF
--- a/vendor/directx/d3d12/d3d12.odin
+++ b/vendor/directx/d3d12/d3d12.odin
@@ -1905,7 +1905,6 @@ DESCRIPTOR_HEAP_TYPE :: enum i32 {
 	SAMPLER     = 1,
 	RTV         = 2,
 	DSV         = 3,
-	NUM_TYPES   = 4,
 }
 
 DESCRIPTOR_HEAP_FLAGS :: distinct bit_set[DESCRIPTOR_HEAP_FLAG; u32]


### PR DESCRIPTION
I just removed the `NUM_TYPES` value from the enum. It's only useful in the original C code, since Odin has `len(DESCRIPTOR_HEAP_TYPE)`.

This is better for enumerated arrays and bit_sets.