### PR TITLE
Add the form data variant of percent_encode/decode

### DIFF
--- a/core/net/socket_linux.odin
+++ b/core/net/socket_linux.odin
@@ -143,7 +143,7 @@ _dial_tcp_from_endpoint :: proc(endpoint: Endpoint, options := default_tcp_optio
 	reuse_addr: b32 = true
 	_ = linux.setsockopt(os_sock, linux.SOL_SOCKET, linux.Socket_Option.REUSEADDR, &reuse_addr)
 	addr := _unwrap_os_addr(endpoint)
-	errno = linux.connect(linux.Fd(tcp_sock), &addr)
+	errno = linux.connect(linux.Fd(os_sock), &addr)
 	if errno != .NONE {
 		return cast(TCP_Socket) os_sock, Dial_Error(errno)
 	}


### PR DESCRIPTION
There is a variant of percent encoding used in the body of HTTP requests that differs from the normal percent encoding. Instead of converting spaces to %20 they are instead converted to a +. 
https://en.wikipedia.org/wiki/Percent-encoding#The_application/x-www-form-urlencoded_type

This issue pops up when trying to decode values from a web form as +'s are not decoded to a space.

The form_data_decode can actually decode both variants as a + is always encoded to it's percent encoded version %2B so a + must always be a space. Regardless, I made a separate decode as the form_data variant is more complicated to decode.

A `index_byte_any` method was added to make decoding easier.