### PR TITLE
RAYLIB_SHARED: use /NODEFAULTLIB:msvcrt

### DIFF
--- a/vendor/raylib/raylib.odin
+++ b/vendor/raylib/raylib.odin
@@ -99,7 +99,7 @@ RAYLIB_SHARED :: #config(RAYLIB_SHARED, false)
 
 when ODIN_OS == .Windows {
 	when RAYLIB_SHARED {
-		@(extra_linker_flags="/NODEFAULTLIB:libcmt")
+		@(extra_linker_flags="/NODEFAULTLIB:msvcrt")
 		foreign import lib {
 			"windows/raylibdll.lib",
 			"system:Winmm.lib",


### PR DESCRIPTION
When compiling with `RAYLIB_SHARED=true` use `/NODEFAULTLIB:msvcrt` extra linker arg instead of `/NODEFAULTLIB:libcmt`. This fixes linker errors like these: `error LNK2001: unresolved external symbol memset`