### PR TITLE
Add the form data variant of percent_encode/decode

### DIFF
--- a/core/strings/strings.odin
+++ b/core/strings/strings.odin
@@ -1430,6 +1430,53 @@ index_byte :: proc(s: string, c: byte) -> (res: int) {
 	return -1
 }
 /*
+Returns the byte offset of the first byte in the string s which is in `cs` that it finds, -1 when not found.
+NOTE: Can't find UTF-8 based runes.
+
+Inputs:
+- s: The input string to search in.
+- cs: The bytes to search for.
+
+Returns:
+- res: The byte offset of the first occurrence of any of `cs` in `s`, or -1 if not found.
+
+Example:
+
+	import "core:fmt"
+	import "core:strings"
+
+	index_byte_any_example :: proc() {
+		fmt.println(strings.index_byte_any("test", {'t'}))
+		fmt.println(strings.index_byte_any("test", {'e'}))
+		fmt.println(strings.index_byte_any("test", {'e', 't'}))
+		fmt.println(strings.index_byte_any("test", {'e', 's'}))
+		fmt.println(strings.index_byte_any("test", {'x'}))
+		fmt.println(strings.index_byte_any("test", {'s', 'x'}))
+		fmt.println(strings.index_byte_any("teäst", {'ä'}))
+	}
+
+Output:
+
+	0
+	1
+	0
+	1
+	-1
+	2
+	-1
+
+*/
+index_byte_any :: proc(s: string, cs: []byte) -> (res: int) {
+	for i := 0; i < len(s); i += 1 {
+		for c in cs {
+			if s[i] == c {
+				return i
+			}
+		}
+	}
+	return -1
+}
+/*
 Returns the byte offset of the last byte `c` in the string `s`, -1 when not found.
 
 Inputs:


### PR DESCRIPTION
There is a variant of percent encoding used in the body of HTTP requests that differs from the normal percent encoding. Instead of converting spaces to %20 they are instead converted to a +. 
https://en.wikipedia.org/wiki/Percent-encoding#The_application/x-www-form-urlencoded_type

This issue pops up when trying to decode values from a web form as +'s are not decoded to a space.

The form_data_decode can actually decode both variants as a + is always encoded to it's percent encoded version %2B so a + must always be a space. Regardless, I made a separate decode as the form_data variant is more complicated to decode.

A `index_byte_any` method was added to make decoding easier.