### PR TITLE
allow integer verbs in fmt_bit_set

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -1534,8 +1534,9 @@ stored_enum_value_to_string :: proc(enum_type: ^runtime.Type_Info, ev: runtime.T
 // - fi: A pointer to the Info structure where the formatted bit set will be written.
 // - v: The bit set value to be formatted.
 // - name: An optional string for the name of the bit set (default is an empty string).
+// - verb: An optional verb to adjust format.
 //
-fmt_bit_set :: proc(fi: ^Info, v: any, name: string = "") {
+fmt_bit_set :: proc(fi: ^Info, v: any, name: string = "", verb: rune = 'v') {
 	is_bit_set_different_endian_to_platform :: proc(ti: ^runtime.Type_Info) -> bool {
 		if ti == nil {
 			return false
@@ -1559,7 +1560,7 @@ fmt_bit_set :: proc(fi: ^Info, v: any, name: string = "") {
 	case runtime.Type_Info_Named:
 		val := v
 		val.id = info.base.id
-		fmt_bit_set(fi, val, info.name)
+		fmt_bit_set(fi, val, info.name, verb)
 
 	case runtime.Type_Info_Bit_Set:
 		bits: u128
@@ -1567,26 +1568,52 @@ fmt_bit_set :: proc(fi: ^Info, v: any, name: string = "") {
 
 		do_byte_swap := is_bit_set_different_endian_to_platform(info.underlying)
 
+		as_arg := verb == 'b' || verb == 'o' || verb == 'd' || verb == 'i' || verb == 'z' || verb == 'x' || verb == 'X'
+		if as_arg && !fi.width_set {
+			fi.width_set = true
+			fi.width = int(bit_size)
+		}
+
 		switch bit_size {
 		case  0: bits = 0
 		case  8:
 			x := (^u8)(v.data)^
+			if as_arg {
+				fmt_arg(fi, x, verb)
+				return
+			}
 			bits = u128(x)
 		case 16:
 			x := (^u16)(v.data)^
 			if do_byte_swap { x = byte_swap(x) }
+			if as_arg {
+				fmt_arg(fi, x, verb)
+				return
+			}
 			bits = u128(x)
 		case 32:
 			x := (^u32)(v.data)^
 			if do_byte_swap { x = byte_swap(x) }
+			if as_arg {
+				fmt_arg(fi, x, verb)
+				return
+			}
 			bits = u128(x)
 		case 64:
 			x := (^u64)(v.data)^
 			if do_byte_swap { x = byte_swap(x) }
+			if as_arg {
+				fmt_arg(fi, x, verb)
+				return
+			}
 			bits = u128(x)
 		case 128:
 			x := (^u128)(v.data)^
 			if do_byte_swap { x = byte_swap(x) }
+			if as_arg {
+				fmt_arg(fi, x, verb)
+				return
+			}
 			bits = x
 		case: panic("unknown bit_size size")
 		}
@@ -1628,6 +1655,7 @@ fmt_bit_set :: proc(fi: ^Info, v: any, name: string = "") {
 		}
 	}
 }
+
 // Writes the specified number of indents to the provided Info structure
 //
 // Inputs:
@@ -2173,7 +2201,7 @@ fmt_named :: proc(fi: ^Info, v: any, verb: rune, info: runtime.Type_Info_Named) 
 	case runtime.Type_Info_Struct:
 		fmt_struct(fi, v, verb, b, info.name)
 	case runtime.Type_Info_Bit_Set:
-		fmt_bit_set(fi, v)
+		fmt_bit_set(fi, v, verb = verb)
 	case:
 		fmt_value(fi, any{v.data, info.base.id}, verb)
 	}
@@ -2594,7 +2622,7 @@ fmt_value :: proc(fi: ^Info, v: any, verb: rune) {
 		reflect.write_typeid(fi.writer, id, &fi.n)
 
 	case runtime.Type_Info_Bit_Set:
-		fmt_bit_set(fi, v)
+		fmt_bit_set(fi, v, verb = verb)
 
 	case runtime.Type_Info_Relative_Pointer:
 		ptr := reflect.relative_pointer_to_absolute_raw(v.data, info.base_integer.id)


### PR DESCRIPTION
Allows usage of some of the integer verbs when formatting bit sets, the most useful application being `%b` to see the binary bits of the set.

Before: `fmt.printf("%8b", transmute(u8)set)` and have to know the size.
After: `fmt.printf("%b", set)`