### PR TITLE
add frame pointer attribute to procs in debug mode

### DIFF
--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -2352,6 +2352,10 @@ gb_internal void lb_add_attribute_to_proc(lbModule *m, LLVMValueRef proc_value, 
 	LLVMAddAttributeAtIndex(proc_value, LLVMAttributeIndex_FunctionIndex, lb_create_enum_attribute(m->ctx, name, value));
 }
 
+gb_internal void lb_add_string_attribute_to_proc(lbModule *m, LLVMValueRef proc_value, char const *name, char const *value) {
+	LLVMAttributeRef attr = LLVMCreateStringAttribute(m->ctx, name, strlen(name), value, strlen(value));
+	LLVMAddAttributeAtIndex(proc_value, LLVMAttributeIndex_FunctionIndex, attr);
+}
 
 
 gb_internal void lb_add_edge(lbBlock *from, lbBlock *to) {

--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -2353,7 +2353,7 @@ gb_internal void lb_add_attribute_to_proc(lbModule *m, LLVMValueRef proc_value, 
 }
 
 gb_internal void lb_add_string_attribute_to_proc(lbModule *m, LLVMValueRef proc_value, char const *name, char const *value) {
-	LLVMAttributeRef attr = LLVMCreateStringAttribute(m->ctx, name, strlen(name), value, strlen(value));
+	LLVMAttributeRef attr = LLVMCreateStringAttribute(m->ctx, name, cast(unsigned)strlen(name), value, cast(unsigned)strlen(value));
 	LLVMAddAttributeAtIndex(proc_value, LLVMAttributeIndex_FunctionIndex, attr);
 }
 

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -316,7 +316,9 @@ gb_internal lbProcedure *lb_create_procedure(lbModule *m, Entity *entity, bool i
 			lb_set_llvm_metadata(m, p, p->debug_info);
 		}
 
-		lb_add_string_attribute_to_proc(m, p->value, "frame-pointer", "all");
+		if (build_context.metrics.os == TargetOs_darwin) {
+			lb_add_string_attribute_to_proc(m, p->value, "frame-pointer", "non-leaf");
+		}
 	}
 
 	if (p->body && entity->pkg && ((entity->pkg->kind == Package_Normal) || (entity->pkg->kind == Package_Init))) {

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -315,6 +315,8 @@ gb_internal lbProcedure *lb_create_procedure(lbModule *m, Entity *entity, bool i
 			LLVMSetSubprogram(p->value, p->debug_info);
 			lb_set_llvm_metadata(m, p, p->debug_info);
 		}
+
+		lb_add_string_attribute_to_proc(m, p->value, "frame-pointer", "all");
 	}
 
 	if (p->body && entity->pkg && ((entity->pkg->kind == Package_Normal) || (entity->pkg->kind == Package_Init))) {


### PR DESCRIPTION
The frame pointer attribute is an important attribute when debugging and traversing the call stack of MacOS programs. Without the frame pointer programs are unable to traverse the stack further than the most recent stack frame.

My main motivation for this change is adding MacOS support to [my backtrace package](https://github.com/laytan/obacktracing).