### PR TITLE
core:sys/linux: make Perf_Read_Format a bitset

### DIFF
--- a/core/sys/linux/bits.odin
+++ b/core/sys/linux/bits.odin
@@ -718,7 +718,7 @@ Perf_Event_Sample_Type_Bits :: enum {
 }
 
 /// Describes field sets to include in mmaped page
-Perf_Read_Format :: enum {
+Perf_Read_Format_Bits :: enum {
 	TOTAL_TIME_ENABLED = 0,
 	TOTAL_TIME_RUNNING = 1,
 	ID                 = 2,

--- a/core/sys/linux/types.odin
+++ b/core/sys/linux/types.odin
@@ -282,7 +282,8 @@ Get_Random_Flags :: bit_set[Get_Random_Flags_Bits; i32]
 Perf_Flags :: bit_set[Perf_Flags_Bits; uint]
 
 Perf_Event_Flags :: distinct bit_set[Perf_Event_Flags_Bits; u64]
-Perf_Read_Format_Flags :: distinct bit_set[Perf_Read_Format_Bits; u64]
+
+Perf_Read_Format :: distinct bit_set[Perf_Read_Format_Bits; u64]
 
 Perf_Cap_Flags :: distinct bit_set[Perf_Cap_Flags_Bits; u64]
 
@@ -306,7 +307,7 @@ Perf_Event_Attr :: struct #packed {
 		frequency: u64,
 	},
 	sample_type:        Perf_Event_Sample_Type,
-	read_format:        Perf_Read_Format_Flags,
+	read_format:        Perf_Read_Format,
 	flags:              Perf_Event_Flags,
 	wakeup: struct #raw_union {
 		events:    u32,

--- a/core/sys/linux/types.odin
+++ b/core/sys/linux/types.odin
@@ -282,6 +282,7 @@ Get_Random_Flags :: bit_set[Get_Random_Flags_Bits; i32]
 Perf_Flags :: bit_set[Perf_Flags_Bits; uint]
 
 Perf_Event_Flags :: distinct bit_set[Perf_Event_Flags_Bits; u64]
+Perf_Read_Format_Flags :: distinct bit_set[Perf_Read_Format_Bits; u64]
 
 Perf_Cap_Flags :: distinct bit_set[Perf_Cap_Flags_Bits; u64]
 
@@ -305,7 +306,7 @@ Perf_Event_Attr :: struct #packed {
 		frequency: u64,
 	},
 	sample_type:        Perf_Event_Sample_Type,
-	read_format:        Perf_Read_Format,
+	read_format:        Perf_Read_Format_Flags,
 	flags:              Perf_Event_Flags,
 	wakeup: struct #raw_union {
 		events:    u32,


### PR DESCRIPTION
The current definition is incompatible with how it's meant to be used, the values assume a bitset but it's used as regular flags.

Convert it to a bitset for consistency with the rest of the api.

cc @flysand7 