### PR TITLE
fix -test-name flag

### DIFF
--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -6091,9 +6091,6 @@ gb_internal void check_parsed_files(Checker *c) {
 	TIME_SECTION("calculate global init order");
 	calculate_global_init_order(c);
 
-	TIME_SECTION("check test procedures");
-	check_test_procedures(c);
-
 	TIME_SECTION("add type info for type definitions");
 	add_type_info_for_type_definitions(c);
 	check_merge_queues_into_arrays(c);
@@ -6103,6 +6100,11 @@ gb_internal void check_parsed_files(Checker *c) {
 
 	TIME_SECTION("generate minimum dependency set");
 	generate_minimum_dependency_set(c, c->info.entry_point);
+
+	// NOTE(laytan): has to be ran after generate_minimum_dependency_set,
+	// because that collects the test procedures.
+	TIME_SECTION("check test procedures");
+	check_test_procedures(c);
 
 	TIME_SECTION("check bodies have all been checked");
 	check_unchecked_bodies(c);


### PR DESCRIPTION
Because of the order of these procedures the logic for excluding tests based on the `-test-name:` flag didn't actually check any tests. This PR makes sure the test checker is ran after `generate_minimum_dependency_set` (which collects the test procedures).