### PR TITLE
[core]: Remove `do` keyword from the core library

### DIFF
--- a/core/container/topological_sort/topological_sort.odin
+++ b/core/container/topological_sort/topological_sort.odin
@@ -80,11 +80,13 @@ sort :: proc(sorter: ^$S/Sorter($K)) -> (sorted, cycled: [dynamic]K) {
 		}
 	}
 
-	for root in sorted do for k, _ in relations[root].dependents {
-		relation := &relations[k]
-		relation.dependencies -= 1
-		if relation.dependencies == 0 {
-			append(&sorted, k)
+	for root in sorted {
+		for k, _ in relations[root].dependents {
+			relation := &relations[k]
+			relation.dependencies -= 1
+			if relation.dependencies == 0 {
+				append(&sorted, k)
+			}
 		}
 	}
 

--- a/core/math/fixed/fixed.odin
+++ b/core/math/fixed/fixed.odin
@@ -33,7 +33,9 @@ init_from_f64 :: proc(x: ^$T/Fixed($Backing, $Fraction_Width), val: f64) {
 	x.i  = Backing(f * (1<<Fraction_Width))
 	x.i &= 1<<Fraction_Width - 1
 	x.i |= Backing(i) << Fraction_Width
-	if val < 0 do x.i *= -1
+	if val < 0 {
+		x.i *= -1
+	}
 }
 
 init_from_parts :: proc(x: ^$T/Fixed($Backing, $Fraction_Width), integer, fraction: Backing) {

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -749,7 +749,9 @@ dynamic_pool_alloc_bytes :: proc(p: ^Dynamic_Pool, bytes: int) -> ([]byte, Alloc
 	n := bytes
 	extra := p.alignment - (n % p.alignment)
 	n += extra
-	if n > p.block_size do return nil, .Invalid_Argument
+	if n > p.block_size {
+		return nil, .Invalid_Argument
+	}
 	if n >= p.out_band_size {
 		assert(p.block_allocator.procedure != nil)
 		memory, err := p.block_allocator.procedure(p.block_allocator.data, Allocator_Mode.Alloc,

--- a/core/net/addr.odin
+++ b/core/net/addr.odin
@@ -462,7 +462,9 @@ split_port :: proc(endpoint_str: string) -> (addr_or_host: string, port: int, ok
 // Joins an address or hostname with a port.
 join_port :: proc(address_or_host: string, port: int, allocator := context.allocator) -> string {
 	addr_or_host, _, ok := split_port(address_or_host)
-	if !ok do return addr_or_host
+	if !ok {
+		return addr_or_host
+	}
 
 	b := strings.builder_make(allocator)
 

--- a/core/net/socket_linux.odin
+++ b/core/net/socket_linux.odin
@@ -333,7 +333,9 @@ _set_option :: proc(sock: Any_Socket, option: Socket_Option, value: any, loc := 
 		.Send_Timeout,
 		.Receive_Timeout:
 			t, ok := value.(time.Duration)
-			if !ok do panic("set_option() value must be a time.Duration here", loc)
+			if !ok {
+				panic("set_option() value must be a time.Duration here", loc)
+			}
 
 			micros := cast(i64) (time.duration_microseconds(t))
 			timeval_value.microseconds = cast(int) (micros % 1e6)

--- a/core/net/url.odin
+++ b/core/net/url.odin
@@ -123,7 +123,9 @@ percent_encode :: proc(s: string, allocator := context.allocator) -> string {
 percent_decode :: proc(encoded_string: string, allocator := context.allocator) -> (decoded_string: string, ok: bool) {
 	b := strings.builder_make(allocator)
 	strings.builder_grow(&b, len(encoded_string))
-	defer if !ok do strings.builder_destroy(&b)
+	defer if !ok {
+		strings.builder_destroy(&b)
+	}
 
 	s := encoded_string
 
@@ -137,7 +139,9 @@ percent_decode :: proc(encoded_string: string, allocator := context.allocator) -
 		strings.write_string(&b, s[:i])
 		s = s[i:]
 
-		if len(s) == 0 do return // percent without anything after it
+		if len(s) == 0 {
+			return // percent without anything after it
+		}
 		s = s[1:]
 
 		if s[0] == '%' {
@@ -177,7 +181,9 @@ base64url_encode :: proc(data: []byte, allocator := context.allocator) -> string
 	}
 	i := len(out)-1;
 	for ; i >= 0; i -= 1 {
-		if out[i] != '=' do break;
+		if out[i] != '=' {
+			break;
+		}
 	}
 	return string(out[:i+1]);
 }

--- a/core/odin/ast/clone.odin
+++ b/core/odin/ast/clone.odin
@@ -107,226 +107,228 @@ clone_node :: proc(node: ^Node) -> ^Node {
 		reflect.set_union_value(ds, res_ptr_any)
 	}
 
-	if res.derived != nil do switch r in res.derived {
-	case ^Package, ^File:
-	case ^Bad_Expr:
-	case ^Ident:
-	case ^Implicit:
-	case ^Undef:
-	case ^Basic_Lit:
-	case ^Basic_Directive:
-	case ^Comment_Group:
+	if res.derived != nil {
+		switch r in res.derived {
+		case ^Package, ^File:
+		case ^Bad_Expr:
+		case ^Ident:
+		case ^Implicit:
+		case ^Undef:
+		case ^Basic_Lit:
+		case ^Basic_Directive:
+		case ^Comment_Group:
 
-	case ^Ellipsis:
-		r.expr = clone(r.expr)
-	case ^Proc_Lit:
-		r.type = auto_cast clone(r.type)
-		r.body = clone(r.body)
-	case ^Comp_Lit:
-		r.type  = clone(r.type)
-		r.elems = clone(r.elems)
+		case ^Ellipsis:
+			r.expr = clone(r.expr)
+		case ^Proc_Lit:
+			r.type = auto_cast clone(r.type)
+			r.body = clone(r.body)
+		case ^Comp_Lit:
+			r.type  = clone(r.type)
+			r.elems = clone(r.elems)
 
-	case ^Tag_Expr:
-		r.expr = clone(r.expr)
-	case ^Unary_Expr:
-		r.expr = clone(r.expr)
-	case ^Binary_Expr:
-		r.left  = clone(r.left)
-		r.right = clone(r.right)
-	case ^Paren_Expr:
-		r.expr = clone(r.expr)
-	case ^Selector_Expr:
-		r.expr = clone(r.expr)
-		r.field = auto_cast clone(r.field)
-	case ^Implicit_Selector_Expr:
-		r.field = auto_cast clone(r.field)
-	case ^Selector_Call_Expr:
-		r.expr = clone(r.expr)
-		r.call = auto_cast clone(r.call)
-	case ^Index_Expr:
-		r.expr = clone(r.expr)
-		r.index = clone(r.index)
-	case ^Matrix_Index_Expr:
-		r.expr         = clone(r.expr)
-		r.row_index    = clone(r.row_index)
-		r.column_index = clone(r.column_index)
-	case ^Deref_Expr:
-		r.expr = clone(r.expr)
-	case ^Slice_Expr:
-		r.expr = clone(r.expr)
-		r.low  = clone(r.low)
-		r.high = clone(r.high)
-	case ^Call_Expr:
-		r.expr = clone(r.expr)
-		r.args = clone(r.args)
-	case ^Field_Value:
-		r.field = clone(r.field)
-		r.value = clone(r.value)
-	case ^Ternary_If_Expr:
-		r.x    = clone(r.x)
-		r.cond = clone(r.cond)
-		r.y    = clone(r.y)
-	case ^Ternary_When_Expr:
-		r.x    = clone(r.x)
-		r.cond = clone(r.cond)
-		r.y    = clone(r.y)
-	case ^Or_Else_Expr:
-		r.x    = clone(r.x)
-		r.y    = clone(r.y)
-	case ^Or_Return_Expr:
-		r.expr = clone(r.expr)
-	case ^Or_Branch_Expr:
-		r.expr  = clone(r.expr)
-		r.label = clone(r.label)
-	case ^Type_Assertion:
-		r.expr = clone(r.expr)
-		r.type = clone(r.type)
-	case ^Type_Cast:
-		r.type = clone(r.type)
-		r.expr = clone(r.expr)
-	case ^Auto_Cast:
-		r.expr = clone(r.expr)
-	case ^Inline_Asm_Expr:
-		r.param_types        = clone(r.param_types)
-		r.return_type        = clone(r.return_type)
-		r.constraints_string = clone(r.constraints_string)
-		r.asm_string         = clone(r.asm_string)
+		case ^Tag_Expr:
+			r.expr = clone(r.expr)
+		case ^Unary_Expr:
+			r.expr = clone(r.expr)
+		case ^Binary_Expr:
+			r.left  = clone(r.left)
+			r.right = clone(r.right)
+		case ^Paren_Expr:
+			r.expr = clone(r.expr)
+		case ^Selector_Expr:
+			r.expr = clone(r.expr)
+			r.field = auto_cast clone(r.field)
+		case ^Implicit_Selector_Expr:
+			r.field = auto_cast clone(r.field)
+		case ^Selector_Call_Expr:
+			r.expr = clone(r.expr)
+			r.call = auto_cast clone(r.call)
+		case ^Index_Expr:
+			r.expr = clone(r.expr)
+			r.index = clone(r.index)
+		case ^Matrix_Index_Expr:
+			r.expr         = clone(r.expr)
+			r.row_index    = clone(r.row_index)
+			r.column_index = clone(r.column_index)
+		case ^Deref_Expr:
+			r.expr = clone(r.expr)
+		case ^Slice_Expr:
+			r.expr = clone(r.expr)
+			r.low  = clone(r.low)
+			r.high = clone(r.high)
+		case ^Call_Expr:
+			r.expr = clone(r.expr)
+			r.args = clone(r.args)
+		case ^Field_Value:
+			r.field = clone(r.field)
+			r.value = clone(r.value)
+		case ^Ternary_If_Expr:
+			r.x    = clone(r.x)
+			r.cond = clone(r.cond)
+			r.y    = clone(r.y)
+		case ^Ternary_When_Expr:
+			r.x    = clone(r.x)
+			r.cond = clone(r.cond)
+			r.y    = clone(r.y)
+		case ^Or_Else_Expr:
+			r.x    = clone(r.x)
+			r.y    = clone(r.y)
+		case ^Or_Return_Expr:
+			r.expr = clone(r.expr)
+		case ^Or_Branch_Expr:
+			r.expr  = clone(r.expr)
+			r.label = clone(r.label)
+		case ^Type_Assertion:
+			r.expr = clone(r.expr)
+			r.type = clone(r.type)
+		case ^Type_Cast:
+			r.type = clone(r.type)
+			r.expr = clone(r.expr)
+		case ^Auto_Cast:
+			r.expr = clone(r.expr)
+		case ^Inline_Asm_Expr:
+			r.param_types        = clone(r.param_types)
+			r.return_type        = clone(r.return_type)
+			r.constraints_string = clone(r.constraints_string)
+			r.asm_string         = clone(r.asm_string)
 
-	case ^Bad_Stmt:
-		// empty
-	case ^Empty_Stmt:
-		// empty
-	case ^Expr_Stmt:
-		r.expr = clone(r.expr)
-	case ^Tag_Stmt:
-		r.stmt = clone(r.stmt)
+		case ^Bad_Stmt:
+			// empty
+		case ^Empty_Stmt:
+			// empty
+		case ^Expr_Stmt:
+			r.expr = clone(r.expr)
+		case ^Tag_Stmt:
+			r.stmt = clone(r.stmt)
 
-	case ^Assign_Stmt:
-		r.lhs = clone(r.lhs)
-		r.rhs = clone(r.rhs)
-	case ^Block_Stmt:
-		r.label = clone(r.label)
-		r.stmts = clone(r.stmts)
-	case ^If_Stmt:
-		r.label     = clone(r.label)
-		r.init      = clone(r.init)
-		r.cond      = clone(r.cond)
-		r.body      = clone(r.body)
-		r.else_stmt = clone(r.else_stmt)
-	case ^When_Stmt:
-		r.cond      = clone(r.cond)
-		r.body      = clone(r.body)
-		r.else_stmt = clone(r.else_stmt)
-	case ^Return_Stmt:
-		r.results = clone(r.results)
-	case ^Defer_Stmt:
-		r.stmt = clone(r.stmt)
-	case ^For_Stmt:
-		r.label = clone(r.label)
-		r.init = clone(r.init)
-		r.cond = clone(r.cond)
-		r.post = clone(r.post)
-		r.body = clone(r.body)
-	case ^Range_Stmt:
-		r.label = clone(r.label)
-		r.vals = clone(r.vals)
-		r.expr = clone(r.expr)
-		r.body = clone(r.body)
-	case ^Inline_Range_Stmt:
-		r.label = clone(r.label)
-		r.val0 = clone(r.val0)
-		r.val1 = clone(r.val1)
-		r.expr = clone(r.expr)
-		r.body = clone(r.body)
-	case ^Case_Clause:
-		r.list = clone(r.list)
-		r.body = clone(r.body)
-	case ^Switch_Stmt:
-		r.label = clone(r.label)
-		r.init = clone(r.init)
-		r.cond = clone(r.cond)
-		r.body = clone(r.body)
-	case ^Type_Switch_Stmt:
-		r.label = clone(r.label)
-		r.tag  = clone(r.tag)
-		r.expr = clone(r.expr)
-		r.body = clone(r.body)
-	case ^Branch_Stmt:
-		r.label = auto_cast clone(r.label)
-	case ^Using_Stmt:
-		r.list = clone(r.list)
-	case ^Bad_Decl:
-	case ^Value_Decl:
-		r.attributes = clone(r.attributes)
-		r.names      = clone(r.names)
-		r.type       = clone(r.type)
-		r.values     = clone(r.values)
-	case ^Package_Decl:
-	case ^Import_Decl:
-	case ^Foreign_Block_Decl:
-		r.attributes      = clone(r.attributes)
-		r.foreign_library = clone(r.foreign_library)
-		r.body            = clone(r.body)
-	case ^Foreign_Import_Decl:
-		r.name = auto_cast clone(r.name)
-	case ^Proc_Group:
-		r.args = clone(r.args)
-	case ^Attribute:
-		r.elems = clone(r.elems)
-	case ^Field:
-		r.names         = clone(r.names)
-		r.type          = clone(r.type)
-		r.default_value = clone(r.default_value)
-	case ^Field_List:
-		r.list = clone(r.list)
-	case ^Typeid_Type:
-		r.specialization = clone(r.specialization)
-	case ^Helper_Type:
-		r.type = clone(r.type)
-	case ^Distinct_Type:
-		r.type = clone(r.type)
-	case ^Poly_Type:
-		r.type = auto_cast clone(r.type)
-		r.specialization = clone(r.specialization)
-	case ^Proc_Type:
-		r.params  = auto_cast clone(r.params)
-		r.results = auto_cast clone(r.results)
-	case ^Pointer_Type:
-		r.elem = clone(r.elem)
-		r.tag  = clone(r.tag)
-	case ^Multi_Pointer_Type:
-		r.elem = clone(r.elem)
-	case ^Array_Type:
-		r.len  = clone(r.len)
-		r.elem = clone(r.elem)
-	case ^Dynamic_Array_Type:
-		r.elem = clone(r.elem)
-	case ^Struct_Type:
-		r.poly_params = auto_cast clone(r.poly_params)
-		r.align = clone(r.align)
-		r.fields = auto_cast clone(r.fields)
-	case ^Union_Type:
-		r.poly_params = auto_cast clone(r.poly_params)
-		r.align = clone(r.align)
-		r.variants = clone(r.variants)
-	case ^Enum_Type:
-		r.base_type = clone(r.base_type)
-		r.fields = clone(r.fields)
-	case ^Bit_Set_Type:
-		r.elem = clone(r.elem)
-		r.underlying = clone(r.underlying)
-	case ^Map_Type:
-		r.key = clone(r.key)
-		r.value = clone(r.value)
-	case ^Matrix_Type:
-		r.row_count = clone(r.row_count)
-		r.column_count = clone(r.column_count)
-		r.elem = clone(r.elem)
-	case ^Relative_Type:
-		r.tag = clone(r.tag)
-		r.type = clone(r.type)
-	case:
-		fmt.panicf("Unhandled node kind: %v", r)
+		case ^Assign_Stmt:
+			r.lhs = clone(r.lhs)
+			r.rhs = clone(r.rhs)
+		case ^Block_Stmt:
+			r.label = clone(r.label)
+			r.stmts = clone(r.stmts)
+		case ^If_Stmt:
+			r.label     = clone(r.label)
+			r.init      = clone(r.init)
+			r.cond      = clone(r.cond)
+			r.body      = clone(r.body)
+			r.else_stmt = clone(r.else_stmt)
+		case ^When_Stmt:
+			r.cond      = clone(r.cond)
+			r.body      = clone(r.body)
+			r.else_stmt = clone(r.else_stmt)
+		case ^Return_Stmt:
+			r.results = clone(r.results)
+		case ^Defer_Stmt:
+			r.stmt = clone(r.stmt)
+		case ^For_Stmt:
+			r.label = clone(r.label)
+			r.init = clone(r.init)
+			r.cond = clone(r.cond)
+			r.post = clone(r.post)
+			r.body = clone(r.body)
+		case ^Range_Stmt:
+			r.label = clone(r.label)
+			r.vals = clone(r.vals)
+			r.expr = clone(r.expr)
+			r.body = clone(r.body)
+		case ^Inline_Range_Stmt:
+			r.label = clone(r.label)
+			r.val0 = clone(r.val0)
+			r.val1 = clone(r.val1)
+			r.expr = clone(r.expr)
+			r.body = clone(r.body)
+		case ^Case_Clause:
+			r.list = clone(r.list)
+			r.body = clone(r.body)
+		case ^Switch_Stmt:
+			r.label = clone(r.label)
+			r.init = clone(r.init)
+			r.cond = clone(r.cond)
+			r.body = clone(r.body)
+		case ^Type_Switch_Stmt:
+			r.label = clone(r.label)
+			r.tag  = clone(r.tag)
+			r.expr = clone(r.expr)
+			r.body = clone(r.body)
+		case ^Branch_Stmt:
+			r.label = auto_cast clone(r.label)
+		case ^Using_Stmt:
+			r.list = clone(r.list)
+		case ^Bad_Decl:
+		case ^Value_Decl:
+			r.attributes = clone(r.attributes)
+			r.names      = clone(r.names)
+			r.type       = clone(r.type)
+			r.values     = clone(r.values)
+		case ^Package_Decl:
+		case ^Import_Decl:
+		case ^Foreign_Block_Decl:
+			r.attributes      = clone(r.attributes)
+			r.foreign_library = clone(r.foreign_library)
+			r.body            = clone(r.body)
+		case ^Foreign_Import_Decl:
+			r.name = auto_cast clone(r.name)
+		case ^Proc_Group:
+			r.args = clone(r.args)
+		case ^Attribute:
+			r.elems = clone(r.elems)
+		case ^Field:
+			r.names         = clone(r.names)
+			r.type          = clone(r.type)
+			r.default_value = clone(r.default_value)
+		case ^Field_List:
+			r.list = clone(r.list)
+		case ^Typeid_Type:
+			r.specialization = clone(r.specialization)
+		case ^Helper_Type:
+			r.type = clone(r.type)
+		case ^Distinct_Type:
+			r.type = clone(r.type)
+		case ^Poly_Type:
+			r.type = auto_cast clone(r.type)
+			r.specialization = clone(r.specialization)
+		case ^Proc_Type:
+			r.params  = auto_cast clone(r.params)
+			r.results = auto_cast clone(r.results)
+		case ^Pointer_Type:
+			r.elem = clone(r.elem)
+			r.tag  = clone(r.tag)
+		case ^Multi_Pointer_Type:
+			r.elem = clone(r.elem)
+		case ^Array_Type:
+			r.len  = clone(r.len)
+			r.elem = clone(r.elem)
+		case ^Dynamic_Array_Type:
+			r.elem = clone(r.elem)
+		case ^Struct_Type:
+			r.poly_params = auto_cast clone(r.poly_params)
+			r.align = clone(r.align)
+			r.fields = auto_cast clone(r.fields)
+		case ^Union_Type:
+			r.poly_params = auto_cast clone(r.poly_params)
+			r.align = clone(r.align)
+			r.variants = clone(r.variants)
+		case ^Enum_Type:
+			r.base_type = clone(r.base_type)
+			r.fields = clone(r.fields)
+		case ^Bit_Set_Type:
+			r.elem = clone(r.elem)
+			r.underlying = clone(r.underlying)
+		case ^Map_Type:
+			r.key = clone(r.key)
+			r.value = clone(r.value)
+		case ^Matrix_Type:
+			r.row_count = clone(r.row_count)
+			r.column_count = clone(r.column_count)
+			r.elem = clone(r.elem)
+		case ^Relative_Type:
+			r.tag = clone(r.tag)
+			r.type = clone(r.type)
+		case:
+			fmt.panicf("Unhandled node kind: %v", r)
+		}
 	}
 
 	return res

--- a/core/slice/heap/heap.odin
+++ b/core/slice/heap/heap.odin
@@ -26,7 +26,9 @@ package heap
 make :: proc(data: []$T, less: proc(a, b: T) -> bool) {
 	// amoritize length lookup
 	length := len(data)
-	if length <= 1 do return
+	if length <= 1 {
+		return
+	}
 
 	// start from data parent, no need to consider children
 	for start := (length - 2) / 2; start >= 0; start -= 1 {
@@ -53,7 +55,9 @@ push :: proc(data: []$T, less: proc(a, b: T) -> bool) {
 */
 pop :: proc(data: []$T, less: proc(a, b: T) -> bool) {
 	length := len(data)
-	if length <= 1 do return
+	if length <= 1 {
+		return
+	}
 
 	last := length
 
@@ -206,7 +210,9 @@ sift_up :: proc(data: []$T, less: proc(a, b: T) -> bool) {
 	// amoritize length lookup
 	length := len(data)
 
-	if length <= 1 do return
+	if length <= 1 {
+		return
+	}
 
 	last := length
 	length = (length - 2) / 2

--- a/core/thread/thread.odin
+++ b/core/thread/thread.odin
@@ -147,7 +147,9 @@ create_and_start :: proc(fn: proc(), init_context: Maybe(runtime.Context) = nil,
 	}
 	t := create(thread_proc, priority)
 	t.data = rawptr(fn)
-	if self_cleanup do t.flags += {.Self_Cleanup}
+	if self_cleanup {
+		t.flags += {.Self_Cleanup}
+	}
 	t.init_context = init_context
 	start(t)
 	return t
@@ -167,7 +169,9 @@ create_and_start_with_data :: proc(data: rawptr, fn: proc(data: rawptr), init_co
 	t.data = rawptr(fn)
 	t.user_index = 1
 	t.user_args = data
-	if self_cleanup do t.flags += {.Self_Cleanup}
+	if self_cleanup {
+		t.flags += {.Self_Cleanup}
+	}
 	t.init_context = init_context
 	start(t)
 	return t
@@ -186,7 +190,9 @@ create_and_start_with_poly_data :: proc(data: $T, fn: proc(data: T), init_contex
 	t.user_index = 1
 	data := data
 	mem.copy(&t.user_args[0], &data, size_of(data))
-	if self_cleanup do t.flags += {.Self_Cleanup}
+	if self_cleanup {
+		t.flags += {.Self_Cleanup}
+	}
 	t.init_context = init_context
 	start(t)
 	return t
@@ -208,7 +214,9 @@ create_and_start_with_poly_data2 :: proc(arg1: $T1, arg2: $T2, fn: proc(T1, T2),
 	arg1, arg2 := arg1, arg2
 	mem.copy(&t.user_args[0], &arg1, size_of(arg1))
 	mem.copy(&t.user_args[1], &arg2, size_of(arg2))
-	if self_cleanup do t.flags += {.Self_Cleanup}
+	if self_cleanup {
+		t.flags += {.Self_Cleanup}
+	}
 	t.init_context = init_context
 	start(t)
 	return t
@@ -233,7 +241,9 @@ create_and_start_with_poly_data3 :: proc(arg1: $T1, arg2: $T2, arg3: $T3, fn: pr
 	mem.copy(&t.user_args[0], &arg1, size_of(arg1))
 	mem.copy(&t.user_args[1], &arg2, size_of(arg2))
 	mem.copy(&t.user_args[2], &arg3, size_of(arg3))
-	if self_cleanup do t.flags += {.Self_Cleanup}
+	if self_cleanup {
+		t.flags += {.Self_Cleanup}
+	}
 	t.init_context = init_context
 	start(t)
 	return t
@@ -259,7 +269,9 @@ create_and_start_with_poly_data4 :: proc(arg1: $T1, arg2: $T2, arg3: $T3, arg4: 
 	mem.copy(&t.user_args[1], &arg2, size_of(arg2))
 	mem.copy(&t.user_args[2], &arg3, size_of(arg3))
 	mem.copy(&t.user_args[3], &arg4, size_of(arg4))
-	if self_cleanup do t.flags += {.Self_Cleanup}
+	if self_cleanup {
+		t.flags += {.Self_Cleanup}
+	}
 	t.init_context = init_context
 	start(t)
 	return t


### PR DESCRIPTION
This PR removes the usage of `do` keyword from the core library, making it accessible to those who compile with `-disallow-do` for some reason.