### PR TITLE
Expose strings.ascii_set_* functions

### DIFF
--- a/core/strings/ascii_set.odin
+++ b/core/strings/ascii_set.odin
@@ -1,4 +1,3 @@
-//+private
 package strings
 
 import "core:unicode/utf8"


### PR DESCRIPTION
This makes the `strings.Ascii_Set` type and `strings.ascii_set_make` and `strings.ascii_set_contains` functions public. As they perfectly suit the need to check if some ascii range contains a character.