### PR TITLE
Return value of _umtx_op on FreeBSD wasn't checked correctly

### DIFF
--- a/src/threading.cpp
+++ b/src/threading.cpp
@@ -660,7 +660,7 @@ gb_internal void futex_broadcast(Futex *addr) {
 gb_internal void futex_wait(Futex *addr, Footex val) {
 	for (;;) {
 		int ret = _umtx_op(addr, UMTX_OP_WAIT_UINT, val, 0, NULL);
-		if (ret == 0) {
+		if (ret == -1) {
 			if (errno == ETIMEDOUT || errno == EINTR) {
 				continue;
 			}


### PR DESCRIPTION
This fixes #2601.

I am not familiar with Odin at all. I downloaded it just to give it a try and write a "_Hellope!_". The build failed on FreeBSD immediately due to the same problem reported in #2601.

Taking a look at `futex_wait`, the if-else statements are immediately suspicious because it checks for `ret == 0` in both cases. This causes a successful call to `_umtx_op` to never be handled.

```
gb_internal void futex_wait(Futex *addr, Footex val) {
        for (;;) {
                int ret = _umtx_op(addr, UMTX_OP_WAIT_UINT, val, 0, NULL);
                if (ret == 0) {
                        if (errno == ETIMEDOUT || errno == EINTR) {
                                continue;
                        }

                        perror("Futex wait");  // Reports "No error: 0"
                        GB_PANIC("Failed in futex wait!\n");
                } else if (ret == 0) {
                        // This is never reached!
                        if (*addr != val) {
                                return;
                        }
                }
        }
}
```


According to the FreeBSD manpage for `_umtx_op`,

>   If successful, all requests, except UMTX_SHM_CREAT and UMTX_SHM_LOOKUP
>   sub-requests of the UMTX_OP_SHM request, will return zero.  The
>   UMTX_SHM_CREAT and UMTX_SHM_LOOKUP return a shared memory file descriptor
>   on success.  On error -1 is returned, and the errno variable is set to
>   indicate the error.

Because the call to `_umtx_op` is a `UMTX_OP_WAIT_UINT` request, a successful return value is 0 and a failure is -1.