### PR TITLE
Add DwmGetWindowAttribute to core/sys/windows

### DIFF
--- a/core/sys/windows/dwmapi.odin
+++ b/core/sys/windows/dwmapi.odin
@@ -43,5 +43,6 @@ foreign dwmapi {
 	DwmFlush :: proc() -> HRESULT ---
 	DwmIsCompositionEnabled :: proc(pfEnabled: ^BOOL) -> HRESULT ---
 	DwmExtendFrameIntoClientArea :: proc(hWnd: HWND, pMarInset: PMARGINS) -> HRESULT ---
+	DwmGetWindowAttribute :: proc(hWnd: HWND, dwAttribute: DWORD, pvAttribute: PVOID, cbAttribute: DWORD) -> HRESULT ---
 	DwmSetWindowAttribute :: proc(hWnd: HWND, dwAttribute: DWORD, pvAttribute: LPCVOID, cbAttribute: DWORD) -> HRESULT ---
 }


### PR DESCRIPTION
I was working on my custom window library and I noticed that there is DwmSetWindowAttribute but DwmGetWindowAttribute is missing.