### PR TITLE
Fix procedure parameter checking with blank identifiers

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -5606,9 +5606,6 @@ gb_internal CallArgumentError check_call_arguments_internal(CheckerContext *c, A
 	for (isize i = 0; i < pt->param_count; i++) {
 		if (!visited[i]) {
 			Entity *e = pt->params->Tuple.variables[i];
-			if (is_blank_ident(e->token)) {
-				continue;
-			}
 			if (e->kind == Entity_Variable) {
 				if (e->Variable.param_value.kind != ParameterValue_Invalid) {
 					ordered_operands[i].mode = Addressing_Value;


### PR DESCRIPTION
This is a fix to #2955. Currently the compiler would completely ignore procedure parameters with blank identifier. This meant that it wouldn't check if they were assigned to by the caller.

I'm not sure what was the purpose of the original code, if it was a typo or something important. But it doesn't seem to break anything.

Here is an example of the problem (modified repro from the issue):
```odin
package play
import "core:fmt"

Datum :: struct {
	repr: #type proc(_: ^Datum) -> string,
}

repr_datum :: proc(self: ^Datum) -> string {
	return fmt.aprintf("repr %v", self)
}

make_datum :: proc() -> Datum {
	return {repr_datum}
}

foo :: proc(_: Datum) -> string {
	return "hey"
}

main :: proc() {
	d := make_datum()
	fmt.println(d.repr()) // compiler doesn't complain, repr receives nil as its arg
	// fmt.println (d.repr (d)) // intended
	foo() // Compiler doesn't complain as well
}
```