### PR TITLE
[net]: Fix passing the wrong socket to `linux.connect` on linux

### DIFF
--- a/core/net/socket_linux.odin
+++ b/core/net/socket_linux.odin
@@ -125,7 +125,7 @@ _create_socket :: proc(family: Address_Family, protocol: Socket_Protocol) -> (An
 }
 
 @(private)
-_dial_tcp_from_endpoint :: proc(endpoint: Endpoint, options := default_tcp_options) -> (tcp_sock: TCP_Socket, err: Network_Error) {
+_dial_tcp_from_endpoint :: proc(endpoint: Endpoint, options := default_tcp_options) -> (TCP_Socket, Network_Error) {
 	errno: linux.Errno
 	if endpoint.port == 0 {
 		return 0, .Port_Required


### PR DESCRIPTION
Man these named return values.

P.S. The name of commit got screwed up a bit because in bash backticks mean command substitution.