### PR TITLE
Report error when a variadic procedure parameter has a default value

### DIFF
--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -1510,7 +1510,7 @@ gb_internal Type *check_get_params(CheckerContext *ctx, Scope *scope, Ast *_para
 			}
 
 			if (default_value != nullptr) {
-				if (type_expr->kind == Ast_TypeidType) {
+				if (type_expr != nullptr && type_expr->kind == Ast_TypeidType) {
 					error(type_expr, "A type parameter may not have a default value");
 				} else if (is_variadic) {
 					error(type_expr, "A variadic parameter may not have a default value");

--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -1510,8 +1510,10 @@ gb_internal Type *check_get_params(CheckerContext *ctx, Scope *scope, Ast *_para
 			}
 
 			if (default_value != nullptr) {
-				if (type_expr != nullptr && type_expr->kind == Ast_TypeidType) {
+				if (type_expr->kind == Ast_TypeidType) {
 					error(type_expr, "A type parameter may not have a default value");
+				} else if (is_variadic) {
+					error(type_expr, "A variadic parameter may not have a default value");
 				} else {
 					param_value = handle_parameter_value(ctx, type, nullptr, default_value, true);
 				}


### PR DESCRIPTION
Previously it was possible to do something like this:
```odin
foo :: proc(va: ..int = 1) {
  fmt.println(va)
}
```
Where the expected output of `foo()` would be `[1]`. But that's not the case, as variadic parameters always default to nil. So the output would be `[]`.

This PR simply checks if the parameter has a default value, and reports an error if it does.