### PR TITLE
Add `-test-build-only` flag

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -393,6 +393,7 @@ struct BuildContext {
 	Array<String> extra_packages;
 
 	StringSet test_names;
+	bool test_build_only;
 
 	gbAffinity affinity;
 	isize      thread_count;


### PR DESCRIPTION
As the name implies, passing this flag will stop tests from running when invoking `odin test`, only outputting the binary.

This change also makes some small style adjustments for consistency, and removes a TODO comment which has already been resolved.