### PR TITLE
OS improvements

### DIFF
--- a/core/os/os_freebsd.odin
+++ b/core/os/os_freebsd.odin
@@ -326,8 +326,17 @@ close :: proc(fd: Handle) -> Errno {
 	return ERROR_NONE
 }
 
+// If you read or write more than `INT_MAX` bytes, FreeBSD returns `EINVAL`.
+// In practice a read/write call would probably never read/write these big buffers all at once,
+// which is why the number of bytes is returned and why there are procs that will call this in a
+// loop for you.
+// We set a max of 1GB to keep alignment and to be safe.
+@(private)
+MAX_RW :: 1 << 30
+
 read :: proc(fd: Handle, data: []byte) -> (int, Errno) {
-	bytes_read := _unix_read(fd, &data[0], c.size_t(len(data)))
+	to_read    := min(c.size_t(len(data)), MAX_RW)
+	bytes_read := _unix_read(fd, &data[0], to_read)
 	if bytes_read == -1 {
 		return -1, Errno(get_last_error())
 	}
@@ -338,7 +347,9 @@ write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 	if len(data) == 0 {
 		return 0, ERROR_NONE
 	}
-	bytes_written := _unix_write(fd, &data[0], c.size_t(len(data)))
+
+	to_write      := min(c.size_t(len(data)), MAX_RW)
+	bytes_written := _unix_write(fd, &data[0], to_write)
 	if bytes_written == -1 {
 		return -1, Errno(get_last_error())
 	}

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -547,12 +547,23 @@ close :: proc(fd: Handle) -> Errno {
 	return _get_errno(unix.sys_close(int(fd)))
 }
 
+// If you read or write more than `SSIZE_MAX` bytes, result is implementation defined (probably an error).
+// `SSIZE_MAX` is also implementation defined but usually the max of a `ssize_t` which is `max(int)` in Odin.
+// In practice a read/write call would probably never read/write these big buffers all at once,
+// which is why the number of bytes is returned and why there are procs that will call this in a
+// loop for you.
+// We set a max of 1GB to keep alignment and to be safe.
+@(private)
+MAX_RW :: 1 << 30
+
 read :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 	if len(data) == 0 {
 		return 0, ERROR_NONE
 	}
 
-	bytes_read := unix.sys_read(int(fd), raw_data(data), len(data))
+	to_read := min(uint(len(data)), MAX_RW)
+
+	bytes_read := unix.sys_read(int(fd), raw_data(data), to_read)
 	if bytes_read < 0 {
 		return -1, _get_errno(bytes_read)
 	}
@@ -564,18 +575,23 @@ write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 		return 0, ERROR_NONE
 	}
 
-	bytes_written := unix.sys_write(int(fd), raw_data(data), len(data))
+	to_write := min(uint(len(data)), MAX_RW)
+
+	bytes_written := unix.sys_write(int(fd), raw_data(data), to_write)
 	if bytes_written < 0 {
 		return -1, _get_errno(bytes_written)
 	}
 	return bytes_written, ERROR_NONE
 }
+
 read_at :: proc(fd: Handle, data: []byte, offset: i64) -> (int, Errno) {
 	if len(data) == 0 {
 		return 0, ERROR_NONE
 	}
 
-	bytes_read := unix.sys_pread(int(fd), raw_data(data), len(data), offset)
+	to_read := min(uint(len(data)), MAX_RW)
+
+	bytes_read := unix.sys_pread(int(fd), raw_data(data), to_read, offset)
 	if bytes_read < 0 {
 		return -1, _get_errno(bytes_read)
 	}
@@ -587,7 +603,9 @@ write_at :: proc(fd: Handle, data: []byte, offset: i64) -> (int, Errno) {
 		return 0, ERROR_NONE
 	}
 
-	bytes_written := unix.sys_pwrite(int(fd), raw_data(data), uint(len(data)), offset)
+	to_write := min(uint(len(data)), MAX_RW)
+
+	bytes_written := unix.sys_pwrite(int(fd), raw_data(data), to_write, offset)
 	if bytes_written < 0 {
 		return -1, _get_errno(bytes_written)
 	}

--- a/core/os/stream.odin
+++ b/core/os/stream.odin
@@ -54,6 +54,7 @@ _file_stream_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, 
 			return io.query_utility({.Close, .Flush, .Read, .Read_At, .Write, .Write_At, .Seek, .Size, .Query})
 		}
 	}
+
 	if err == nil && os_err != 0 {
 		when ODIN_OS == .Windows {
 			if os_err == ERROR_HANDLE_EOF {
@@ -62,5 +63,12 @@ _file_stream_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, 
 		}
 		err = .Unknown
 	}
+
+	when ODIN_OS != .Windows {
+		if err == nil && os_err == 0 && n == 0 {
+			err = .EOF
+		}
+	}
+
 	return
 }

--- a/core/os/stream.odin
+++ b/core/os/stream.odin
@@ -27,19 +27,31 @@ _file_stream_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, 
 	case .Read:
 		n_int, os_err = read(fd, p)
 		n = i64(n_int)
+		if n == 0 && os_err == 0 {
+			err = .EOF
+		}
 
 	case .Read_At:
 		when !(ODIN_OS == .FreeBSD || ODIN_OS == .OpenBSD) {
 			n_int, os_err = read_at(fd, p, offset)
 			n = i64(n_int)
+			if n == 0 && os_err == 0 {
+				err = .EOF
+			}
 		}
 	case .Write:
 		n_int, os_err = write(fd, p)
 		n = i64(n_int)
+		if n == 0 && os_err == 0 {
+			err = .EOF
+		}
 	case .Write_At:
 		when !(ODIN_OS == .FreeBSD || ODIN_OS == .OpenBSD) {
 			n_int, os_err = write_at(fd, p, offset)
 			n = i64(n_int)
+			if n == 0 && os_err == 0 {
+				err = .EOF
+			}
 		}
 	case .Seek:
 		n, os_err = seek(fd, offset, int(whence))
@@ -63,12 +75,5 @@ _file_stream_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, 
 		}
 		err = .Unknown
 	}
-
-	when ODIN_OS != .Windows {
-		if err == nil && os_err == 0 && n == 0 {
-			err = .EOF
-		}
-	}
-
 	return
 }


### PR DESCRIPTION
If you currently try to read or write more than about 2GB to/from a file on non-Windows you will probably get an error, this PR adds a max on each call (like Windows already has).
It was currently the case that a big file to os.read_entire_file would fail, this fixes that too and any callers of read/write will automatically handle it now.
This is safe because in practice any user will be checking the returned n and doing this in a loop anyway, and more than a gigabyte will probably never have filled fully without this.

I also added end-of-file propagation from the file streams, which was also already handled on Windows. According to man pages, a 0 byte read/write without an error is an end-of-file.
Because of this the bufio scanner/reader will also become much faster because they would previously do a syscall 128 times (by default) and then return .No_Progress, now this will just be a .EOF after the first empty call.