### PR TITLE
fix strings.last_index_any for single char

### DIFF
--- a/core/strings/strings.odin
+++ b/core/strings/strings.odin
@@ -1792,7 +1792,8 @@ last_index_any :: proc(s, chars: string) -> (res: int) {
 		if r >= utf8.RUNE_SELF {
 			r = utf8.RUNE_ERROR
 		}
-		return index_rune(chars, r)
+		i := index_rune(chars, r)
+		return i if i < 0 else 0
 	}
 	
 	if len(s) > 8 {

--- a/tests/core/strings/test_core_strings.odin
+++ b/tests/core/strings/test_core_strings.odin
@@ -67,6 +67,18 @@ test_index_any_larger_string_found :: proc(t: ^testing.T) {
 	expect(t, index == 8, "index_any should be 8")
 }
 
+@test
+test_last_index_any_small_string_found :: proc(t: ^testing.T) {
+	index := strings.last_index_any(".", "/:.\"")
+	expect(t, index == 0, "last_index_any should be 0")
+}
+
+@test
+test_last_index_any_small_string_not_found :: proc(t: ^testing.T) {
+	index := strings.last_index_any(".", "/:\"")
+	expect(t, index == -1, "last_index_any should be -1")
+}
+
 Cut_Test :: struct {
 	input:  string,
 	offset: int,


### PR DESCRIPTION
Looks like for the case where the haystack was a single char, `strings.last_index_any` was returning its index into the "any" charset, instead of just `0` if found.

Also adds small tests.