### PR TITLE
Fixed crash in `core:odin/parser` with `#reverse`

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -1438,7 +1438,7 @@ parse_stmt :: proc(p: ^Parser) -> ^ast.Stmt {
 				}
 				range.reverse = true
 			} else {
-				error(p, range.pos, "#reverse can only be applied to a 'for in' statement")
+				error(p, stmt.pos, "#reverse can only be applied to a 'for in' statement")
 			}
 			return stmt
 		case "include":


### PR DESCRIPTION
Was incorrectly using a derived statement in the else clause. Caused the position to be null in the error handling.

https://github.com/DanielGavin/ols/issues/278