### PR TITLE
Add vendor:cmark support for macOS

### DIFF
--- a/vendor/commonmark/cmark.odin
+++ b/vendor/commonmark/cmark.odin
@@ -23,6 +23,8 @@ when ODIN_OS == .Windows {
 	}
 } else when ODIN_OS == .Linux {
 	foreign import lib "system:cmark"
+} else when ODIN_OS == .Darwin {
+	foreign import lib "system:cmark"
 }
 
 Option :: enum c.int {


### PR DESCRIPTION
After compiling cmark locally and installing it (macOS apple silicon/arm64), I was able to use the cmark foreign lib locally. I had to add support for `.Darwin` in order to make it work.

Seems to work fine, code taken from doco:

```
	str := "Hellope *world*!"
	root := cm.parse_document(raw_data(str), len(str), cm.DEFAULT_OPTIONS)
	defer cm.node_free(root)

	html := cm.render_html(root, cm.DEFAULT_OPTIONS)
	defer cm.free(html)

	fmt.println(html)
```

Result as expected

```
<p>Hellope <em>world</em>!</p>
```

Note: I am brand new to Odin.