### PR TITLE
Runtime arena edge cases

### DIFF
--- a/core/mem/virtual/arena.odin
+++ b/core/mem/virtual/arena.odin
@@ -98,15 +98,15 @@ arena_alloc :: proc(arena: ^Arena, size: uint, alignment: uint, loc := #caller_l
 
 	switch arena.kind {
 	case .Growing:
-		if arena.curr_block == nil || (safe_add(arena.curr_block.used, size) or_else 0) > arena.curr_block.reserved {
-			size = mem.align_forward_uint(size, alignment)
+		needed := mem.align_forward_uint(size, alignment)
+		if arena.curr_block == nil || (safe_add(arena.curr_block.used, needed) or_else 0) > arena.curr_block.reserved {
 			if arena.minimum_block_size == 0 {
 				arena.minimum_block_size = DEFAULT_ARENA_GROWING_MINIMUM_BLOCK_SIZE
 			}
 
-			block_size := max(size, arena.minimum_block_size)
+			block_size := max(needed, arena.minimum_block_size)
 
-			new_block := memory_block_alloc(size, block_size, {}) or_return
+			new_block := memory_block_alloc(needed, block_size, {}) or_return
 			new_block.prev = arena.curr_block
 			arena.curr_block = new_block
 			arena.total_reserved += new_block.reserved

--- a/core/mem/virtual/arena.odin
+++ b/core/mem/virtual/arena.odin
@@ -106,7 +106,7 @@ arena_alloc :: proc(arena: ^Arena, size: uint, alignment: uint, loc := #caller_l
 
 			block_size := max(needed, arena.minimum_block_size)
 
-			new_block := memory_block_alloc(needed, block_size, {}) or_return
+			new_block := memory_block_alloc(needed, block_size, alignment, {}) or_return
 			new_block.prev = arena.curr_block
 			arena.curr_block = new_block
 			arena.total_reserved += new_block.reserved

--- a/core/mem/virtual/virtual.odin
+++ b/core/mem/virtual/virtual.odin
@@ -68,7 +68,7 @@ align_formula :: #force_inline proc "contextless" (size, align: uint) -> uint {
 }
 
 @(require_results)
-memory_block_alloc :: proc(committed, reserved: uint, flags: Memory_Block_Flags) -> (block: ^Memory_Block, err: Allocator_Error) {
+memory_block_alloc :: proc(committed, reserved: uint, alignment: uint, flags: Memory_Block_Flags) -> (block: ^Memory_Block, err: Allocator_Error) {
 	page_size := DEFAULT_PAGE_SIZE
 	assert(mem.is_power_of_two(uintptr(page_size)))
 
@@ -79,8 +79,8 @@ memory_block_alloc :: proc(committed, reserved: uint, flags: Memory_Block_Flags)
 	reserved  = align_formula(reserved, page_size)
 	committed = clamp(committed, 0, reserved)
 	
-	total_size     := uint(reserved + size_of(Platform_Memory_Block))
-	base_offset    := uintptr(size_of(Platform_Memory_Block))
+	total_size     := uint(reserved + max(alignment, size_of(Platform_Memory_Block)))
+	base_offset    := uintptr(max(alignment, size_of(Platform_Memory_Block)))
 	protect_offset := uintptr(0)
 	
 	do_protection := false

--- a/core/mem/virtual/virtual.odin
+++ b/core/mem/virtual/virtual.odin
@@ -68,7 +68,7 @@ align_formula :: #force_inline proc "contextless" (size, align: uint) -> uint {
 }
 
 @(require_results)
-memory_block_alloc :: proc(committed, reserved: uint, alignment: uint, flags: Memory_Block_Flags) -> (block: ^Memory_Block, err: Allocator_Error) {
+memory_block_alloc :: proc(committed, reserved: uint, alignment: uint = 0, flags: Memory_Block_Flags = {}) -> (block: ^Memory_Block, err: Allocator_Error) {
 	page_size := DEFAULT_PAGE_SIZE
 	assert(mem.is_power_of_two(uintptr(page_size)))
 

--- a/core/runtime/default_allocators_arena.odin
+++ b/core/runtime/default_allocators_arena.odin
@@ -102,14 +102,14 @@ arena_alloc :: proc(arena: ^Arena, size, alignment: uint, loc := #caller_locatio
 	if size == 0 {
 		return
 	}
-
-	if arena.curr_block == nil || (safe_add(arena.curr_block.used, size) or_else 0) > arena.curr_block.capacity {
-		size = align_forward_uint(size, alignment)
+	
+	needed := align_forward_uint(size, alignment)
+	if arena.curr_block == nil || (safe_add(arena.curr_block.used, needed) or_else 0) > arena.curr_block.capacity {
 		if arena.minimum_block_size == 0 {
 			arena.minimum_block_size = DEFAULT_ARENA_GROWING_MINIMUM_BLOCK_SIZE
 		}
 
-		block_size := max(size, arena.minimum_block_size)
+		block_size := max(needed, arena.minimum_block_size)
 
 		if arena.backing_allocator.procedure == nil {
 			arena.backing_allocator = default_allocator()

--- a/tests/core/Makefile
+++ b/tests/core/Makefile
@@ -20,7 +20,8 @@ all: c_libc_test \
 	 reflect_test \
 	 slice_test \
 	 strings_test \
-	 thread_test
+	 thread_test \
+	 runtime_test
 
 download_test_assets:
 	$(PYTHON) download_assets.py
@@ -84,3 +85,6 @@ fmt_test:
 
 thread_test:
 	$(ODIN) run thread -out:test_core_thread
+
+runtime_test:
+	$(ODIN) run runtime -out:test_core_runtime

--- a/tests/core/build.bat
+++ b/tests/core/build.bat
@@ -95,3 +95,8 @@ echo ---
 echo Running core:thread tests
 echo ---
 %PATH_TO_ODIN% run thread %COMMON% %COLLECTION% -out:test_core_thread.exe || exit /b
+
+echo ---
+echo Running core:runtime tests
+echo ---
+%PATH_TO_ODIN% run runtime %COMMON% %COLLECTION% -out:test_core_runtime.exe || exit /b

--- a/tests/core/runtime/test_core_runtime.odin
+++ b/tests/core/runtime/test_core_runtime.odin
@@ -1,0 +1,61 @@
+package test_core_runtime
+
+import "core:fmt"
+import "core:intrinsics"
+import "core:mem"
+import "core:os"
+import "core:reflect"
+import "core:runtime"
+import "core:testing"
+
+TEST_count := 0
+TEST_fail  := 0
+
+when ODIN_TEST {
+	expect_value :: testing.expect_value
+} else {
+	expect_value :: proc(t: ^testing.T, value, expected: $T, loc := #caller_location) -> bool where intrinsics.type_is_comparable(T) {
+		TEST_count += 1
+		ok := value == expected || reflect.is_nil(value) && reflect.is_nil(expected)
+		if !ok {
+			TEST_fail += 1
+			fmt.printf("[%v] expected %v, got %v\n", loc, expected, value)
+		}
+		return ok
+	}
+}
+
+main :: proc() {
+	t := testing.T{}
+
+	test_temp_allocator_alignment_boundary(&t)
+	test_temp_allocator_big_alloc_and_alignment(&t)
+
+	fmt.printf("%v/%v tests successful.\n", TEST_count - TEST_fail, TEST_count)
+	if TEST_fail > 0 {
+		os.exit(1)
+	}
+}
+
+// Tests that having space for the allocation, but not for the allocation and alignment
+// is handled correctly.
+@(test)
+test_temp_allocator_alignment_boundary :: proc(t: ^testing.T) {
+	arena: runtime.Arena
+	context.allocator = runtime.arena_allocator(&arena)
+
+	_, _ = mem.alloc(int(runtime.DEFAULT_ARENA_GROWING_MINIMUM_BLOCK_SIZE)-120)
+	_, err := mem.alloc(112, 32)
+	expect_value(t, err, nil)
+}
+
+// Tests that big allocations with big alignments are handled correctly.
+@(test)
+test_temp_allocator_big_alloc_and_alignment :: proc(t: ^testing.T) {
+	arena: runtime.Arena
+	context.allocator = runtime.arena_allocator(&arena)
+
+	mappy: map[[8]int]int
+    err := reserve(&mappy, 50000)
+	expect_value(t, err, nil)
+}

--- a/tests/core/runtime/test_core_runtime.odin
+++ b/tests/core/runtime/test_core_runtime.odin
@@ -30,6 +30,7 @@ main :: proc() {
 
 	test_temp_allocator_big_alloc_and_alignment(&t)
 	test_temp_allocator_alignment_boundary(&t)
+	test_temp_allocator_returns_correct_size(&t)
 
 	fmt.printf("%v/%v tests successful.\n", TEST_count - TEST_fail, TEST_count)
 	if TEST_fail > 0 {
@@ -56,6 +57,16 @@ test_temp_allocator_big_alloc_and_alignment :: proc(t: ^testing.T) {
 	context.allocator = runtime.arena_allocator(&arena)
 
 	mappy: map[[8]int]int
-    err := reserve(&mappy, 50000)
+	err := reserve(&mappy, 50000)
 	expect_value(t, err, nil)
+}
+
+@(test)
+test_temp_allocator_returns_correct_size :: proc(t: ^testing.T) {
+	arena: runtime.Arena
+	context.allocator = runtime.arena_allocator(&arena)
+
+	bytes, err := mem.alloc_bytes(10, 16)
+	expect_value(t, err, nil)
+	expect_value(t, len(bytes), 10)
 }

--- a/tests/core/runtime/test_core_runtime.odin
+++ b/tests/core/runtime/test_core_runtime.odin
@@ -28,8 +28,8 @@ when ODIN_TEST {
 main :: proc() {
 	t := testing.T{}
 
-	test_temp_allocator_alignment_boundary(&t)
 	test_temp_allocator_big_alloc_and_alignment(&t)
+	test_temp_allocator_alignment_boundary(&t)
 
 	fmt.printf("%v/%v tests successful.\n", TEST_count - TEST_fail, TEST_count)
 	if TEST_fail > 0 {


### PR DESCRIPTION
There is an edge case in the runtime arena where with very specific sizes and alignments the arena thinks it has enough space so doesn't create a new block and then adding up the alignment causes an out of memory error.

There was also a report https://discord.com/channels/568138951836172421/585072813954564100/1186172289197297745 that the other test case with a big allocation and large alignment fails but I haven't been able to reproduce locally. (Edit: eventually the problem popped up in the Linux CI)

~~This PR just contains test cases for now and is a draft. Fix will come later but I wanted to see if the second case I wasn't able to reproduce does fail CI.~~