### PR TITLE
Fixing a pdb linker error when the path contains spaces

### DIFF
--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -195,7 +195,7 @@ gb_internal i32 linker_stage(LinkerData *gen) {
 
 			if (build_context.pdb_filepath != "") {
 				String pdb_path = path_to_string(heap_allocator(), build_context.build_paths[BuildPath_PDB]);
-				link_settings = gb_string_append_fmt(link_settings, " /PDB:%.*s", LIT(pdb_path));
+				link_settings = gb_string_append_fmt(link_settings, " /PDB:\"%.*s\"", LIT(pdb_path));
 			}
 
 			if (build_context.no_crt) {


### PR DESCRIPTION
Building on Windows, where the build path and the linker path contain spaces, the following error occurs:

LINK : fatal error LNK1201: error writing to program database '<incomplete path>'; check for insufficient disk space, invalid path, or insufficient privilege

This pull request escapes the path with double quotes, which allows for a succesful build