### PR TITLE
Fix #3056

### DIFF
--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -3385,7 +3385,7 @@ gb_internal lbValue lb_build_call_expr_internal(lbProcedure *p, Ast *expr) {
 			}
 
 			lbValue arg = args[arg_index];
-			if (arg.value == nullptr) {
+			if (arg.value == nullptr && arg.type == nullptr) {
 				switch (e->kind) {
 				case Entity_TypeName:
 					args[arg_index] = lb_const_nil(p->module, e->type);


### PR DESCRIPTION
After processing positional and named arguments, the `args` array is iterated to fill any args left unassigned in the previous step with their respective default values.
This was accomplished by checking if the arg's `value` field is null.
Since an untyped `nil` has a null `value`, we need ensure the `type` is also null before using the default.
I'm not sure this is the best solution, but it seems to work.
Note that this fix only applies to the LLVM backend (I'm not sure if the tilde backend needs a separate fix, or if the bug just isn't present there).