### PR TITLE
Fix glfw linker flags on linux

### DIFF
--- a/vendor/glfw/bindings/bindings.odin
+++ b/vendor/glfw/bindings/bindings.odin
@@ -22,7 +22,10 @@ when ODIN_OS == .Windows {
 		}
 	}
 } else when ODIN_OS == .Linux {
-	foreign import glfw "system:glfw"
+	foreign import glfw {
+		"system:glfw3",
+		"system:X11",
+	}
 } else when ODIN_OS == .Darwin {
 	foreign import glfw { 
 		"../lib/darwin/libglfw3.a",


### PR DESCRIPTION
The generated linker flag was `lglfw` when it should be `lglfw3`.

I also went ahead and added an import for `system:X11`, assuming this would be required in most use cases.

That was enough to compile and run a simple opengl program on my system (Ubuntu 22.04 with glfw installed system wide). Other linux distributions may require additional imports.

I was able to confirm the bug and the fix by running `tests/vendors/glfw`.