### PR TITLE
darwin: actually honor no-crt by not linking with `-lSystem -lm`

### DIFF
--- a/core/runtime/procs.odin
+++ b/core/runtime/procs.odin
@@ -37,7 +37,18 @@ when ODIN_NO_CRT && ODIN_OS == .Windows {
 		}
 		return ptr
 	}
-	
+
+	@(link_name="bzero", linkage="strong", require)
+	bzero :: proc "c" (ptr: rawptr, len: int) -> rawptr {
+		if ptr != nil && len != 0 {
+			p := ([^]byte)(ptr)
+			for i := 0; i < len; i += 1 {
+				p[i] = 0
+			}
+		}
+		return ptr
+	}
+
 	@(link_name="memmove", linkage="strong", require)
 	memmove :: proc "c" (dst, src: rawptr, len: int) -> rawptr {
 		d, s := ([^]byte)(dst), ([^]byte)(src)

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -483,10 +483,13 @@ gb_internal i32 linker_stage(LinkerData *gen) {
 			gbString platform_lib_str = gb_string_make(heap_allocator(), "");
 			defer (gb_string_free(platform_lib_str));
 			if (build_context.metrics.os == TargetOs_darwin) {
-				platform_lib_str = gb_string_appendc(platform_lib_str, "-lm -Wl,-syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib");
+				platform_lib_str = gb_string_appendc(platform_lib_str, "-Wl,-syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib");
 				#if defined(GB_SYSTEM_OSX)
-				if(gen->needs_system_library_linked == 1) {
-					platform_lib_str = gb_string_appendc(platform_lib_str, " -lSystem ");
+				if(!build_context.no_crt) {
+					platform_lib_str = gb_string_appendc(platform_lib_str, " -lm ");
+					if(gen->needs_system_library_linked == 1) {
+						platform_lib_str = gb_string_appendc(platform_lib_str, " -lSystem ");
+					}
 				}
 				#endif
 			} else {


### PR DESCRIPTION
`-no-crt` was still linking with libSystem (libc of macos), with these changes `otool -L binary` does not say we are linking with anything anymore. `bzero` a needed addition or it would not link, it seems that `mem.zero_explicit` uses that under the hood.