### PR TITLE
Fix/macos no duplicated linkage

### DIFF
--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -485,7 +485,7 @@ gb_internal i32 linker_stage(LinkerData *gen) {
 			if (build_context.metrics.os == TargetOs_darwin) {
 				platform_lib_str = gb_string_appendc(platform_lib_str, "-lm -Wl,-syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib");
 				#if defined(GB_SYSTEM_OSX)
-				if(gen->needs_system_library_linked) {
+				if(gen->needs_system_library_linked == 1) {
 					platform_lib_str = gb_string_appendc(platform_lib_str, " -lSystem ");
 				}
 				#endif

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -7,9 +7,18 @@ struct LinkerData {
 	Array<String> output_temp_paths;
 	String   output_base;
 	String   output_name;
+#if defined(GB_SYSTEM_OSX)
+	b8       needs_system_library_linked;
+#endif
 };
 
 gb_internal i32 system_exec_command_line_app(char const *name, char const *fmt, ...);
+
+#if defined(GB_SYSTEM_OSX)
+gb_internal void linker_enable_system_library_linking(LinkerData *ld) {
+	ld->needs_system_library_linked = 1;
+}
+#endif
 
 gb_internal void linker_data_init(LinkerData *ld, CheckerInfo *info, String const &init_fullpath) {
 	gbAllocator ha = heap_allocator();
@@ -17,6 +26,10 @@ gb_internal void linker_data_init(LinkerData *ld, CheckerInfo *info, String cons
 	array_init(&ld->output_temp_paths,   ha);
 	array_init(&ld->foreign_libraries,   ha, 0, 1024);
 	ptr_set_init(&ld->foreign_libraries_set, 1024);
+
+#if defined(GB_SYSTEM_OSX)
+	ld->needs_system_library_linked = 0;
+#endif 
 
 	if (build_context.out_filepath.len == 0) {
 		ld->output_name = remove_directory_from_path(init_fullpath);
@@ -470,7 +483,10 @@ gb_internal i32 linker_stage(LinkerData *gen) {
 			gbString platform_lib_str = gb_string_make(heap_allocator(), "");
 			defer (gb_string_free(platform_lib_str));
 			if (build_context.metrics.os == TargetOs_darwin) {
-				platform_lib_str = gb_string_appendc(platform_lib_str, "-lSystem -lm -Wl,-syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib");
+				platform_lib_str = gb_string_appendc(platform_lib_str, "-lm -Wl,-syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib");
+				if(gen->needs_system_library_linked) {
+					platform_lib_str = gb_string_appendc(platform_lib_str, "-lSystem");
+				}
 			} else {
 				platform_lib_str = gb_string_appendc(platform_lib_str, "-lc -lm");
 			}

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -486,7 +486,7 @@ gb_internal i32 linker_stage(LinkerData *gen) {
 				platform_lib_str = gb_string_appendc(platform_lib_str, "-lm -Wl,-syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib");
 				#if defined(GB_SYSTEM_OSX)
 				if(gen->needs_system_library_linked) {
-					platform_lib_str = gb_string_appendc(platform_lib_str, "-lSystem");
+					platform_lib_str = gb_string_appendc(platform_lib_str, " -lSystem ");
 				}
 				#endif
 			} else {

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -484,9 +484,11 @@ gb_internal i32 linker_stage(LinkerData *gen) {
 			defer (gb_string_free(platform_lib_str));
 			if (build_context.metrics.os == TargetOs_darwin) {
 				platform_lib_str = gb_string_appendc(platform_lib_str, "-lm -Wl,-syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib");
+				#if defined(GB_SYSTEM_OSX)
 				if(gen->needs_system_library_linked) {
 					platform_lib_str = gb_string_appendc(platform_lib_str, "-lSystem");
 				}
+				#endif
 			} else {
 				platform_lib_str = gb_string_appendc(platform_lib_str, "-lc -lm");
 			}

--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -107,7 +107,7 @@ gb_internal bool lb_init_generator(lbGenerator *gen, Checker *c) {
 	String init_fullpath = c->parser->init_fullpath;
 	linker_data_init(gen, &c->info, init_fullpath);
 
-	#if defined(GB_SYSTEM_OSX) && (LLVM_MAJOR_VERSION < 14)
+	#if defined(GB_SYSTEM_OSX) && (LLVM_VERSION_MAJOR < 14)
 	linker_enable_system_library_linking(gen);
 	#endif
 

--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -107,6 +107,10 @@ gb_internal bool lb_init_generator(lbGenerator *gen, Checker *c) {
 	String init_fullpath = c->parser->init_fullpath;
 	linker_data_init(gen, &c->info, init_fullpath);
 
+	#if defined(GB_SYSTEM_OSX) && (LLVM_MAJOR_VERSION < 14)
+	linker_enable_system_library_linking(gen);
+	#endif
+
 	gen->info = &c->info;
 
 	map_init(&gen->modules, gen->info->packages.count*2);

--- a/src/tilde.cpp
+++ b/src/tilde.cpp
@@ -726,6 +726,10 @@ gb_internal bool cg_generate_code(Checker *c, LinkerData *linker_data) {
 
 	linker_data_init(linker_data, info, c->parser->init_fullpath);
 
+	#if defined(GB_SYSTEM_OSX)
+		linker_enable_system_library_linking(linker_data);
+	#endif
+
 	cg_global_arena_init();
 
 	cgModule *m = cg_module_create(c);


### PR DESCRIPTION
This fixes the linker warning we got when using newer llvm versions than 13+ where system is per default linked if not stated otherwise.