### PR TITLE
Respect `-lld` CLI arg on non-windows machines

### DIFF
--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -516,7 +516,12 @@ gb_internal i32 linker_stage(LinkerData *gen) {
 			link_command_line = gb_string_append_fmt(link_command_line, " %.*s ", LIT(build_context.extra_linker_flags));
 			link_command_line = gb_string_append_fmt(link_command_line, " %s ", link_settings);
 
-			result = system_exec_command_line_app("ld-link", link_command_line);
+			if (build_context.use_lld) {
+				link_command_line = gb_string_append_fmt(link_command_line, " -fuse-ld=lld");
+				result = system_exec_command_line_app("lld-link", link_command_line);
+			} else {
+				result = system_exec_command_line_app("ld-link", link_command_line);
+			}
 
 			if (result) {
 				return result;


### PR DESCRIPTION
I noticed that it doesn't seem like the `-lld` flag does anything on Linux & MacOS hosts. I just naively added a check and appended `fuse-ld=lld` to the `clang` args.

I'm not sure if this is the best way to do this, or if there are unintended side-effects of this change (such as changing the `system_exec_command_line_app` call from `ld-link` to `lld-link`).

For more context of how I found this, see #3044 