### PR TITLE
[vendor/darwin]: Fix missing cmd: SEL parameter in some delegate callbacks, and add a few more method bindings for NSView and NSWindow 

### DIFF
--- a/vendor/darwin/Foundation/NSApplication.odin
+++ b/vendor/darwin/Foundation/NSApplication.odin
@@ -223,7 +223,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		return nil
 	}
 	if template.applicationWillFinishLaunching != nil {
-		applicationWillFinishLaunching :: proc "c" (self: id, notification: ^Notification) {
+		applicationWillFinishLaunching :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationWillFinishLaunching(notification)
@@ -231,7 +231,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationWillFinishLaunching:"), auto_cast applicationWillFinishLaunching, "v@:@")
 	}
 	if template.applicationDidFinishLaunching != nil {
-		applicationDidFinishLaunching :: proc "c" (self: id, notification: ^Notification) {
+		applicationDidFinishLaunching :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidFinishLaunching(notification)
@@ -239,7 +239,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationDidFinishLaunching:"), auto_cast applicationDidFinishLaunching, "v@:@")
 	}
 	if template.applicationWillBecomeActive != nil {
-		applicationWillBecomeActive :: proc "c" (self: id, notification: ^Notification) {
+		applicationWillBecomeActive :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationWillBecomeActive(notification)
@@ -247,7 +247,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationWillBecomeActive:"), auto_cast applicationWillBecomeActive, "v@:@")
 	}
 	if template.applicationDidBecomeActive != nil {
-		applicationDidBecomeActive :: proc "c" (self: id, notification: ^Notification) {
+		applicationDidBecomeActive :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidBecomeActive(notification)
@@ -255,7 +255,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationDidBecomeActive:"), auto_cast applicationDidBecomeActive, "v@:@")
 	}
 	if template.applicationWillResignActive != nil {
-		applicationWillResignActive :: proc "c" (self: id, notification: ^Notification) {
+		applicationWillResignActive :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationWillResignActive(notification)
@@ -263,7 +263,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationWillResignActive:"), auto_cast applicationWillResignActive, "v@:@")
 	}
 	if template.applicationDidResignActive != nil {
-		applicationDidResignActive :: proc "c" (self: id, notification: ^Notification) {
+		applicationDidResignActive :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidResignActive(notification)
@@ -271,7 +271,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationDidResignActive:"), auto_cast applicationDidResignActive, "v@:@")
 	}
 	if template.applicationShouldTerminate != nil {
-		applicationShouldTerminate :: proc "c" (self: id, sender: ^Application) -> ApplicationTerminateReply {
+		applicationShouldTerminate :: proc "c" (self: id, cmd: SEL, sender: ^Application) -> ApplicationTerminateReply {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationShouldTerminate(sender)
@@ -279,7 +279,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationShouldTerminate:"), auto_cast applicationShouldTerminate, _UINTEGER_ENCODING+"@:@")
 	}
 	if template.applicationShouldTerminateAfterLastWindowClosed != nil {
-		applicationShouldTerminateAfterLastWindowClosed :: proc "c" (self: id, sender: ^Application) -> BOOL {
+		applicationShouldTerminateAfterLastWindowClosed :: proc "c" (self: id, cmd: SEL, sender: ^Application) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationShouldTerminateAfterLastWindowClosed(sender)
@@ -287,7 +287,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationShouldTerminateAfterLastWindowClosed:"), auto_cast applicationShouldTerminateAfterLastWindowClosed, "B@:@")
 	}
 	if template.applicationWillTerminate != nil {
-		applicationWillTerminate :: proc "c" (self: id, notification: ^Notification) {
+		applicationWillTerminate :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationWillTerminate(notification)
@@ -295,7 +295,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationWillTerminate:"), auto_cast applicationWillTerminate, "v@:@")
 	}
 	if template.applicationWillHide != nil {
-		applicationWillHide :: proc "c" (self: id, notification: ^Notification) {
+		applicationWillHide :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationWillHide(notification)
@@ -303,7 +303,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationWillHide:"), auto_cast applicationWillHide, "v@:@")
 	}
 	if template.applicationDidHide != nil {
-		applicationDidHide :: proc "c" (self: id, notification: ^Notification) {
+		applicationDidHide :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidHide(notification)
@@ -311,7 +311,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationDidHide:"), auto_cast applicationDidHide, "v@:@")
 	}
 	if template.applicationWillUnhide != nil {
-		applicationWillUnhide :: proc "c" (self: id, notification: ^Notification) {
+		applicationWillUnhide :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationWillUnhide(notification)
@@ -319,7 +319,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationWillUnhide:"), auto_cast applicationWillUnhide, "v@:@")
 	}
 	if template.applicationDidUnhide != nil {
-		applicationDidUnhide :: proc "c" (self: id, notification: ^Notification) {
+		applicationDidUnhide :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidUnhide(notification)
@@ -327,7 +327,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationDidUnhide:"), auto_cast applicationDidUnhide, "v@:@")
 	}
 	if template.applicationWillUpdate != nil {
-		applicationWillUpdate :: proc "c" (self: id, notification: ^Notification) {
+		applicationWillUpdate :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationWillUpdate(notification)
@@ -335,7 +335,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationWillUpdate:"), auto_cast applicationWillUpdate, "v@:@")
 	}
 	if template.applicationDidUpdate != nil {
-		applicationDidUpdate :: proc "c" (self: id, notification: ^Notification) {
+		applicationDidUpdate :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidUpdate(notification)
@@ -343,7 +343,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationDidUpdate:"), auto_cast applicationDidUpdate, "v@:@")
 	}
 	if template.applicationShouldHandleReopenHasVisibleWindows != nil {
-		applicationShouldHandleReopenHasVisibleWindows :: proc "c" (self: id, sender: ^Application, flag: BOOL) -> BOOL {
+		applicationShouldHandleReopenHasVisibleWindows :: proc "c" (self: id, cmd: SEL, sender: ^Application, flag: BOOL) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationShouldHandleReopenHasVisibleWindows(sender, flag)
@@ -351,7 +351,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationShouldHandleReopen:hasVisibleWindows:"), auto_cast applicationShouldHandleReopenHasVisibleWindows, "B@:@B")
 	}
 	if template.applicationDockMenu != nil {
-		applicationDockMenu :: proc "c" (self: id, sender: ^Application) -> ^Menu {
+		applicationDockMenu :: proc "c" (self: id, cmd: SEL, sender: ^Application) -> ^Menu {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationDockMenu(sender)
@@ -359,7 +359,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationDockMenu:"), auto_cast applicationDockMenu, "@@:@")
 	}
 	if template.applicationShouldAutomaticallyLocalizeKeyEquivalents != nil {
-		applicationShouldAutomaticallyLocalizeKeyEquivalents :: proc "c" (self: id, application: ^Application) -> BOOL {
+		applicationShouldAutomaticallyLocalizeKeyEquivalents :: proc "c" (self: id, cmd: SEL, application: ^Application) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationShouldAutomaticallyLocalizeKeyEquivalents(application)
@@ -367,7 +367,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationShouldAutomaticallyLocalizeKeyEquivalents:"), auto_cast applicationShouldAutomaticallyLocalizeKeyEquivalents, "B@:@")
 	}
 	if template.applicationWillPresentError != nil {
-		applicationWillPresentError :: proc "c" (self: id, application: ^Application, error: ^Error) -> ^Error {
+		applicationWillPresentError :: proc "c" (self: id, cmd: SEL, application: ^Application, error: ^Error) -> ^Error {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationWillPresentError(application, error)
@@ -375,7 +375,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:willPresentError:"), auto_cast applicationWillPresentError, "@@:@@")
 	}
 	if template.applicationDidChangeScreenParameters != nil {
-		applicationDidChangeScreenParameters :: proc "c" (self: id, notification: ^Notification) {
+		applicationDidChangeScreenParameters :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidChangeScreenParameters(notification)
@@ -383,7 +383,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationDidChangeScreenParameters:"), auto_cast applicationDidChangeScreenParameters, "v@:@")
 	}
 	if template.applicationWillContinueUserActivityWithType != nil {
-		applicationWillContinueUserActivityWithType :: proc "c" (self: id, application: ^Application, userActivityType: ^String) -> BOOL {
+		applicationWillContinueUserActivityWithType :: proc "c" (self: id, cmd: SEL, application: ^Application, userActivityType: ^String) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationWillContinueUserActivityWithType(application, userActivityType)
@@ -391,7 +391,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:willContinueUserActivityWithType:"), auto_cast applicationWillContinueUserActivityWithType, "B@:@@")
 	}
 	if template.applicationContinueUserActivityRestorationHandler != nil {
-		applicationContinueUserActivityRestorationHandler :: proc "c" (self: id, application: ^Application, userActivity: ^UserActivity, restorationHandler: ^Block) -> BOOL {
+		applicationContinueUserActivityRestorationHandler :: proc "c" (self: id, cmd: SEL, application: ^Application, userActivity: ^UserActivity, restorationHandler: ^Block) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationContinueUserActivityRestorationHandler(application, userActivity, restorationHandler)
@@ -399,7 +399,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:continueUserActivity:restorationHandler:"), auto_cast applicationContinueUserActivityRestorationHandler, "B@:@@?")
 	}
 	if template.applicationDidFailToContinueUserActivityWithTypeError != nil {
-		applicationDidFailToContinueUserActivityWithTypeError :: proc "c" (self: id, application: ^Application, userActivityType: ^String, error: ^Error) {
+		applicationDidFailToContinueUserActivityWithTypeError :: proc "c" (self: id, cmd: SEL, application: ^Application, userActivityType: ^String, error: ^Error) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidFailToContinueUserActivityWithTypeError(application, userActivityType, error)
@@ -407,7 +407,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:didFailToContinueUserActivityWithType:error:"), auto_cast applicationDidFailToContinueUserActivityWithTypeError, "v@:@@@")
 	}
 	if template.applicationDidUpdateUserActivity != nil {
-		applicationDidUpdateUserActivity :: proc "c" (self: id, application: ^Application, userActivity: ^UserActivity) {
+		applicationDidUpdateUserActivity :: proc "c" (self: id, cmd: SEL, application: ^Application, userActivity: ^UserActivity) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidUpdateUserActivity(application, userActivity)
@@ -415,7 +415,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:didUpdateUserActivity:"), auto_cast applicationDidUpdateUserActivity, "v@:@@")
 	}
 	if template.applicationDidRegisterForRemoteNotificationsWithDeviceToken != nil {
-		applicationDidRegisterForRemoteNotificationsWithDeviceToken :: proc "c" (self: id, application: ^Application, deviceToken: ^Data) {
+		applicationDidRegisterForRemoteNotificationsWithDeviceToken :: proc "c" (self: id, cmd: SEL, application: ^Application, deviceToken: ^Data) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidRegisterForRemoteNotificationsWithDeviceToken(application, deviceToken)
@@ -423,7 +423,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:didRegisterForRemoteNotificationsWithDeviceToken:"), auto_cast applicationDidRegisterForRemoteNotificationsWithDeviceToken, "v@:@@")
 	}
 	if template.applicationDidFailToRegisterForRemoteNotificationsWithError != nil {
-		applicationDidFailToRegisterForRemoteNotificationsWithError :: proc "c" (self: id, application: ^Application, error: ^Error) {
+		applicationDidFailToRegisterForRemoteNotificationsWithError :: proc "c" (self: id, cmd: SEL, application: ^Application, error: ^Error) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidFailToRegisterForRemoteNotificationsWithError(application, error)
@@ -431,7 +431,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:didFailToRegisterForRemoteNotificationsWithError:"), auto_cast applicationDidFailToRegisterForRemoteNotificationsWithError, "v@:@@")
 	}
 	if template.applicationDidReceiveRemoteNotification != nil {
-		applicationDidReceiveRemoteNotification :: proc "c" (self: id, application: ^Application, userInfo: ^Dictionary) {
+		applicationDidReceiveRemoteNotification :: proc "c" (self: id, cmd: SEL, application: ^Application, userInfo: ^Dictionary) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidReceiveRemoteNotification(application, userInfo)
@@ -439,7 +439,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:didReceiveRemoteNotification:"), auto_cast applicationDidReceiveRemoteNotification, "v@:@@")
 	}
 	// if template.applicationUserDidAcceptCloudKitShareWithMetadata != nil {
-	// 	applicationUserDidAcceptCloudKitShareWithMetadata :: proc "c" (self: id, application: ^Application, metadata: ^CKShareMetadata) {
+	// 	applicationUserDidAcceptCloudKitShareWithMetadata :: proc "c" (self: id, cmd: SEL, application: ^Application, metadata: ^CKShareMetadata) {
 	// 		del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 	// 		context = del._context
 	// 		del.applicationUserDidAcceptCloudKitShareWithMetadata(application, metadata)
@@ -447,7 +447,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 	// 	class_addMethod(class, intrinsics.objc_find_selector("application:userDidAcceptCloudKitShareWithMetadata:"), auto_cast applicationUserDidAcceptCloudKitShareWithMetadata, "v@:@@")
 	// }
 	// if template.applicationHandlerForIntent != nil {
-	// 	applicationHandlerForIntent :: proc "c" (self: id, application: ^Application, intent: ^INIntent) -> id {
+	// 	applicationHandlerForIntent :: proc "c" (self: id, cmd: SEL, application: ^Application, intent: ^INIntent) -> id {
 	// 		del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 	// 		context = del._context
 	// 		return del.applicationHandlerForIntent(application, intent)
@@ -455,7 +455,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 	// 	class_addMethod(class, intrinsics.objc_find_selector("application:handlerForIntent:"), auto_cast applicationHandlerForIntent, "@@:@@")
 	// }
 	if template.applicationOpenURLs != nil {
-		applicationOpenURLs :: proc "c" (self: id, application: ^Application, urls: ^Array) {
+		applicationOpenURLs :: proc "c" (self: id, cmd: SEL, application: ^Application, urls: ^Array) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationOpenURLs(application, urls)
@@ -463,7 +463,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:openURLs:"), auto_cast applicationOpenURLs, "v@:@@")
 	}
 	if template.applicationOpenFile != nil {
-		applicationOpenFile :: proc "c" (self: id, sender: ^Application, filename: ^String) -> BOOL {
+		applicationOpenFile :: proc "c" (self: id, cmd: SEL, sender: ^Application, filename: ^String) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationOpenFile(sender, filename)
@@ -471,7 +471,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:openFile:"), auto_cast applicationOpenFile, "B@:@@")
 	}
 	if template.applicationOpenFileWithoutUI != nil {
-		applicationOpenFileWithoutUI :: proc "c" (self: id, sender: id, filename: ^String) -> BOOL {
+		applicationOpenFileWithoutUI :: proc "c" (self: id, cmd: SEL, sender: id, filename: ^String) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationOpenFileWithoutUI(sender, filename)
@@ -479,7 +479,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:openFileWithoutUI:"), auto_cast applicationOpenFileWithoutUI, "B@:@@")
 	}
 	if template.applicationOpenTempFile != nil {
-		applicationOpenTempFile :: proc "c" (self: id, sender: ^Application, filename: ^String) -> BOOL {
+		applicationOpenTempFile :: proc "c" (self: id, cmd: SEL, sender: ^Application, filename: ^String) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationOpenTempFile(sender, filename)
@@ -487,7 +487,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:openTempFile:"), auto_cast applicationOpenTempFile, "B@:@@")
 	}
 	if template.applicationOpenFiles != nil {
-		applicationOpenFiles :: proc "c" (self: id, sender: ^Application, filenames: ^Array) {
+		applicationOpenFiles :: proc "c" (self: id, cmd: SEL, sender: ^Application, filenames: ^Array) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationOpenFiles(sender, filenames)
@@ -495,7 +495,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:openFiles:"), auto_cast applicationOpenFiles, "v@:@@")
 	}
 	if template.applicationShouldOpenUntitledFile != nil {
-		applicationShouldOpenUntitledFile :: proc "c" (self: id, sender: ^Application) -> BOOL {
+		applicationShouldOpenUntitledFile :: proc "c" (self: id, cmd: SEL, sender: ^Application) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationShouldOpenUntitledFile(sender)
@@ -503,7 +503,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationShouldOpenUntitledFile:"), auto_cast applicationShouldOpenUntitledFile, "B@:@")
 	}
 	if template.applicationOpenUntitledFile != nil {
-		applicationOpenUntitledFile :: proc "c" (self: id, sender: ^Application) -> BOOL {
+		applicationOpenUntitledFile :: proc "c" (self: id, cmd: SEL, sender: ^Application) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationOpenUntitledFile(sender)
@@ -511,7 +511,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationOpenUntitledFile:"), auto_cast applicationOpenUntitledFile, "B@:@")
 	}
 	if template.applicationPrintFile != nil {
-		applicationPrintFile :: proc "c" (self: id, sender: ^Application, filename: ^String) -> BOOL {
+		applicationPrintFile :: proc "c" (self: id, cmd: SEL, sender: ^Application, filename: ^String) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationPrintFile(sender, filename)
@@ -519,7 +519,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:printFile:"), auto_cast applicationPrintFile, "B@:@@")
 	}
 	if template.applicationPrintFilesWithSettingsShowPrintPanels != nil {
-		applicationPrintFilesWithSettingsShowPrintPanels :: proc "c" (self: id, application: ^Application, fileNames: ^Array, printSettings: ^Dictionary, showPrintPanels: BOOL) -> ApplicationPrintReply {
+		applicationPrintFilesWithSettingsShowPrintPanels :: proc "c" (self: id, cmd: SEL, application: ^Application, fileNames: ^Array, printSettings: ^Dictionary, showPrintPanels: BOOL) -> ApplicationPrintReply {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationPrintFilesWithSettingsShowPrintPanels(application, fileNames, printSettings, showPrintPanels)
@@ -527,7 +527,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:printFiles:withSettings:showPrintPanels:"), auto_cast applicationPrintFilesWithSettingsShowPrintPanels, _UINTEGER_ENCODING+"@:@@@B")
 	}
 	if template.applicationSupportsSecureRestorableState != nil {
-		applicationSupportsSecureRestorableState :: proc "c" (self: id, app: ^Application) -> BOOL {
+		applicationSupportsSecureRestorableState :: proc "c" (self: id, cmd: SEL, app: ^Application) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationSupportsSecureRestorableState(app)
@@ -535,7 +535,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationSupportsSecureRestorableState:"), auto_cast applicationSupportsSecureRestorableState, "B@:@")
 	}
 	if template.applicationProtectedDataDidBecomeAvailable != nil {
-		applicationProtectedDataDidBecomeAvailable :: proc "c" (self: id, notification: ^Notification) {
+		applicationProtectedDataDidBecomeAvailable :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationProtectedDataDidBecomeAvailable(notification)
@@ -543,7 +543,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationProtectedDataDidBecomeAvailable:"), auto_cast applicationProtectedDataDidBecomeAvailable, "v@:@")
 	}
 	if template.applicationProtectedDataWillBecomeUnavailable != nil {
-		applicationProtectedDataWillBecomeUnavailable :: proc "c" (self: id, notification: ^Notification) {
+		applicationProtectedDataWillBecomeUnavailable :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationProtectedDataWillBecomeUnavailable(notification)
@@ -551,7 +551,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationProtectedDataWillBecomeUnavailable:"), auto_cast applicationProtectedDataWillBecomeUnavailable, "v@:@")
 	}
 	if template.applicationWillEncodeRestorableState != nil {
-		applicationWillEncodeRestorableState :: proc "c" (self: id, app: ^Application, coder: ^Coder) {
+		applicationWillEncodeRestorableState :: proc "c" (self: id, cmd: SEL, app: ^Application, coder: ^Coder) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationWillEncodeRestorableState(app, coder)
@@ -559,7 +559,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:willEncodeRestorableState:"), auto_cast applicationWillEncodeRestorableState, "v@:@@")
 	}
 	if template.applicationDidDecodeRestorableState != nil {
-		applicationDidDecodeRestorableState :: proc "c" (self: id, app: ^Application, coder: ^Coder) {
+		applicationDidDecodeRestorableState :: proc "c" (self: id, cmd: SEL, app: ^Application, coder: ^Coder) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidDecodeRestorableState(app, coder)
@@ -567,7 +567,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:didDecodeRestorableState:"), auto_cast applicationDidDecodeRestorableState, "v@:@@")
 	}
 	if template.applicationDidChangeOcclusionState != nil {
-		applicationDidChangeOcclusionState :: proc "c" (self: id, notification: ^Notification) {
+		applicationDidChangeOcclusionState :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidChangeOcclusionState(notification)
@@ -575,7 +575,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationDidChangeOcclusionState:"), auto_cast applicationDidChangeOcclusionState, "v@:@")
 	}
 	if template.applicationDelegateHandlesKey != nil {
-		applicationDelegateHandlesKey :: proc "c" (self: id, sender: ^Application, key: ^String) -> BOOL {
+		applicationDelegateHandlesKey :: proc "c" (self: id, cmd: SEL, sender: ^Application, key: ^String) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationDelegateHandlesKey(sender, key)

--- a/vendor/darwin/Foundation/NSWindow.odin
+++ b/vendor/darwin/Foundation/NSWindow.odin
@@ -143,7 +143,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		return nil
 	}
 	if template.windowWillPositionSheetUsingRect != nil {
-		windowWillPositionSheetUsingRect :: proc "c" (self: id, window: ^Window, sheet: ^Window, rect: Rect) -> Rect {
+		windowWillPositionSheetUsingRect :: proc "c" (self: id, cmd: SEL, window: ^Window, sheet: ^Window, rect: Rect) -> Rect {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowWillPositionSheetUsingRect(window, sheet, rect)
@@ -151,7 +151,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:willPositionSheet:usingRect:"), auto_cast windowWillPositionSheetUsingRect, _RECT_ENCODING+"@:@@"+_RECT_ENCODING)
 	}
 	if template.windowWillBeginSheet != nil {
-		windowWillBeginSheet :: proc "c" (self: id, notification: ^Notification) {
+		windowWillBeginSheet :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillBeginSheet(notification)
@@ -159,7 +159,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillBeginSheet:"), auto_cast windowWillBeginSheet, "v@:@")
 	}
 	if template.windowDidEndSheet != nil {
-		windowDidEndSheet :: proc "c" (self: id, notification: ^Notification) {
+		windowDidEndSheet :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidEndSheet(notification)
@@ -167,7 +167,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidEndSheet:"), auto_cast windowDidEndSheet, "v@:@")
 	}
 	if template.windowWillResizeToSize != nil {
-		windowWillResizeToSize :: proc "c" (self: id, sender: ^Window, frameSize: Size) -> Size {
+		windowWillResizeToSize :: proc "c" (self: id, cmd: SEL, sender: ^Window, frameSize: Size) -> Size {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowWillResizeToSize(sender, frameSize)
@@ -175,7 +175,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillResize:toSize:"), auto_cast windowWillResizeToSize, _SIZE_ENCODING+"@:@"+_SIZE_ENCODING)
 	}
 	if template.windowDidResize != nil {
-		windowDidResize :: proc "c" (self: id, notification: ^Notification) {
+		windowDidResize :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidResize(notification)
@@ -183,7 +183,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidResize:"), auto_cast windowDidResize, "v@:@")
 	}
 	if template.windowWillStartLiveResize != nil {
-		windowWillStartLiveResize :: proc "c" (self: id, notification: ^Notification) {
+		windowWillStartLiveResize :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillStartLiveResize(notification)
@@ -191,7 +191,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillStartLiveResize:"), auto_cast windowWillStartLiveResize, "v@:@")
 	}
 	if template.windowDidEndLiveResize != nil {
-		windowDidEndLiveResize :: proc "c" (self: id, notification: ^Notification) {
+		windowDidEndLiveResize :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidEndLiveResize(notification)
@@ -199,7 +199,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidEndLiveResize:"), auto_cast windowDidEndLiveResize, "v@:@")
 	}
 	if template.windowWillMiniaturize != nil {
-		windowWillMiniaturize :: proc "c" (self: id, notification: ^Notification) {
+		windowWillMiniaturize :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillMiniaturize(notification)
@@ -207,7 +207,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillMiniaturize:"), auto_cast windowWillMiniaturize, "v@:@")
 	}
 	if template.windowDidMiniaturize != nil {
-		windowDidMiniaturize :: proc "c" (self: id, notification: ^Notification) {
+		windowDidMiniaturize :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidMiniaturize(notification)
@@ -215,7 +215,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidMiniaturize:"), auto_cast windowDidMiniaturize, "v@:@")
 	}
 	if template.windowDidDeminiaturize != nil {
-		windowDidDeminiaturize :: proc "c" (self: id, notification: ^Notification) {
+		windowDidDeminiaturize :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidDeminiaturize(notification)
@@ -223,7 +223,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidDeminiaturize:"), auto_cast windowDidDeminiaturize, "v@:@")
 	}
 	if template.windowWillUseStandardFrameDefaultFrame != nil {
-		windowWillUseStandardFrameDefaultFrame :: proc(self: id, window: ^Window, newFrame: Rect) -> Rect {
+		windowWillUseStandardFrameDefaultFrame :: proc(self: id, cmd: SEL, window: ^Window, newFrame: Rect) -> Rect {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowWillUseStandardFrameDefaultFrame(window, newFrame)
@@ -231,7 +231,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillUseStandardFrame:defaultFrame:"), auto_cast windowWillUseStandardFrameDefaultFrame, _RECT_ENCODING+"@:@"+_RECT_ENCODING)
 	}
 	if template.windowShouldZoomToFrame != nil {
-		windowShouldZoomToFrame :: proc "c" (self: id, window: ^Window, newFrame: Rect) -> BOOL {
+		windowShouldZoomToFrame :: proc "c" (self: id, cmd: SEL, window: ^Window, newFrame: Rect) -> BOOL {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowShouldZoomToFrame(window, newFrame)
@@ -239,7 +239,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowShouldZoom:toFrame:"), auto_cast windowShouldZoomToFrame, "B@:@"+_RECT_ENCODING)
 	}
 	if template.windowWillUseFullScreenContentSize != nil {
-		windowWillUseFullScreenContentSize :: proc "c" (self: id, window: ^Window, proposedSize: Size) -> Size {
+		windowWillUseFullScreenContentSize :: proc "c" (self: id, cmd: SEL, window: ^Window, proposedSize: Size) -> Size {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowWillUseFullScreenContentSize(window, proposedSize)
@@ -247,7 +247,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:willUseFullScreenContentSize:"), auto_cast windowWillUseFullScreenContentSize, _SIZE_ENCODING+"@:@"+_SIZE_ENCODING)
 	}
 	if template.windowWillUseFullScreenPresentationOptions != nil {
-		windowWillUseFullScreenPresentationOptions :: proc(self: id, window: ^Window, proposedOptions: ApplicationPresentationOptions) -> ApplicationPresentationOptions {
+		windowWillUseFullScreenPresentationOptions :: proc(self: id, cmd: SEL, window: ^Window, proposedOptions: ApplicationPresentationOptions) -> ApplicationPresentationOptions {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowWillUseFullScreenPresentationOptions(window, proposedOptions)
@@ -255,7 +255,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:willUseFullScreenPresentationOptions:"), auto_cast windowWillUseFullScreenPresentationOptions, _UINTEGER_ENCODING+"@:@"+_UINTEGER_ENCODING)
 	}
 	if template.windowWillEnterFullScreen != nil {
-		windowWillEnterFullScreen :: proc "c" (self: id, notification: ^Notification) {
+		windowWillEnterFullScreen :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillEnterFullScreen(notification)
@@ -263,7 +263,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillEnterFullScreen:"), auto_cast windowWillEnterFullScreen, "v@:@")
 	}
 	if template.windowDidEnterFullScreen != nil {
-		windowDidEnterFullScreen :: proc "c" (self: id, notification: ^Notification) {
+		windowDidEnterFullScreen :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidEnterFullScreen(notification)
@@ -271,7 +271,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidEnterFullScreen:"), auto_cast windowDidEnterFullScreen, "v@:@")
 	}
 	if template.windowWillExitFullScreen != nil {
-		windowWillExitFullScreen :: proc "c" (self: id, notification: ^Notification) {
+		windowWillExitFullScreen :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillExitFullScreen(notification)
@@ -279,7 +279,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillExitFullScreen:"), auto_cast windowWillExitFullScreen, "v@:@")
 	}
 	if template.windowDidExitFullScreen != nil {
-		windowDidExitFullScreen :: proc "c" (self: id, notification: ^Notification) {
+		windowDidExitFullScreen :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidExitFullScreen(notification)
@@ -287,7 +287,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidExitFullScreen:"), auto_cast windowDidExitFullScreen, "v@:@")
 	}
 	if template.customWindowsToEnterFullScreenForWindow != nil {
-		customWindowsToEnterFullScreenForWindow :: proc "c" (self: id, window: ^Window) -> ^Array {
+		customWindowsToEnterFullScreenForWindow :: proc "c" (self: id, cmd: SEL, window: ^Window) -> ^Array {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.customWindowsToEnterFullScreenForWindow(window)
@@ -295,7 +295,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("customWindowsToEnterFullScreenForWindow:"), auto_cast customWindowsToEnterFullScreenForWindow, "@@:@")
 	}
 	if template.customWindowsToEnterFullScreenForWindowOnScreen != nil {
-		customWindowsToEnterFullScreenForWindowOnScreen :: proc(self: id, window: ^Window, screen: ^Screen) -> ^Array {
+		customWindowsToEnterFullScreenForWindowOnScreen :: proc(self: id, cmd: SEL, window: ^Window, screen: ^Screen) -> ^Array {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.customWindowsToEnterFullScreenForWindowOnScreen(window, screen)
@@ -303,7 +303,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("customWindowsToEnterFullScreenForWindow:onScreen:"), auto_cast customWindowsToEnterFullScreenForWindowOnScreen, "@@:@@")
 	}
 	if template.windowStartCustomAnimationToEnterFullScreenWithDuration != nil {
-		windowStartCustomAnimationToEnterFullScreenWithDuration :: proc "c" (self: id, window: ^Window, duration: TimeInterval) {
+		windowStartCustomAnimationToEnterFullScreenWithDuration :: proc "c" (self: id, cmd: SEL, window: ^Window, duration: TimeInterval) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowStartCustomAnimationToEnterFullScreenWithDuration(window, duration)
@@ -311,7 +311,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:startCustomAnimationToEnterFullScreenWithDuration:"), auto_cast windowStartCustomAnimationToEnterFullScreenWithDuration, "v@:@@")
 	}
 	if template.windowStartCustomAnimationToEnterFullScreenOnScreenWithDuration != nil {
-		windowStartCustomAnimationToEnterFullScreenOnScreenWithDuration :: proc(self: id, window: ^Window, screen: ^Screen, duration: TimeInterval) {
+		windowStartCustomAnimationToEnterFullScreenOnScreenWithDuration :: proc(self: id, cmd: SEL, window: ^Window, screen: ^Screen, duration: TimeInterval) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowStartCustomAnimationToEnterFullScreenOnScreenWithDuration(window, screen, duration)
@@ -319,7 +319,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:startCustomAnimationToEnterFullScreenOnScreen:withDuration:"), auto_cast windowStartCustomAnimationToEnterFullScreenOnScreenWithDuration, "v@:@@d")
 	}
 	if template.windowDidFailToEnterFullScreen != nil {
-		windowDidFailToEnterFullScreen :: proc "c" (self: id, window: ^Window) {
+		windowDidFailToEnterFullScreen :: proc "c" (self: id, cmd: SEL, window: ^Window) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidFailToEnterFullScreen(window)
@@ -327,7 +327,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidFailToEnterFullScreen:"), auto_cast windowDidFailToEnterFullScreen, "v@:@")
 	}
 	if template.customWindowsToExitFullScreenForWindow != nil {
-		customWindowsToExitFullScreenForWindow :: proc "c" (self: id, window: ^Window) -> ^Array {
+		customWindowsToExitFullScreenForWindow :: proc "c" (self: id, cmd: SEL, window: ^Window) -> ^Array {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.customWindowsToExitFullScreenForWindow(window)
@@ -335,7 +335,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("customWindowsToExitFullScreenForWindow:"), auto_cast customWindowsToExitFullScreenForWindow, "@@:@")
 	}
 	if template.windowStartCustomAnimationToExitFullScreenWithDuration != nil {
-		windowStartCustomAnimationToExitFullScreenWithDuration :: proc "c" (self: id, window: ^Window, duration: TimeInterval) {
+		windowStartCustomAnimationToExitFullScreenWithDuration :: proc "c" (self: id, cmd: SEL, window: ^Window, duration: TimeInterval) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowStartCustomAnimationToExitFullScreenWithDuration(window, duration)
@@ -343,7 +343,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:startCustomAnimationToExitFullScreenWithDuration:"), auto_cast windowStartCustomAnimationToExitFullScreenWithDuration, "v@:@d")
 	}
 	if template.windowDidFailToExitFullScreen != nil {
-		windowDidFailToExitFullScreen :: proc "c" (self: id, window: ^Window) {
+		windowDidFailToExitFullScreen :: proc "c" (self: id, cmd: SEL, window: ^Window) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidFailToExitFullScreen(window)
@@ -351,7 +351,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidFailToExitFullScreen:"), auto_cast windowDidFailToExitFullScreen, "v@:@")
 	}
 	if template.windowWillMove != nil {
-		windowWillMove :: proc "c" (self: id, notification: ^Notification) {
+		windowWillMove :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillMove(notification)
@@ -359,7 +359,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillMove:"), auto_cast windowWillMove, "v@:@")
 	}
 	if template.windowDidMove != nil {
-		windowDidMove :: proc "c" (self: id, notification: ^Notification) {
+		windowDidMove :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidMove(notification)
@@ -367,7 +367,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidMove:"), auto_cast windowDidMove, "v@:@")
 	}
 	if template.windowDidChangeScreen != nil {
-		windowDidChangeScreen :: proc "c" (self: id, notification: ^Notification) {
+		windowDidChangeScreen :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidChangeScreen(notification)
@@ -375,7 +375,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidChangeScreen:"), auto_cast windowDidChangeScreen, "v@:@")
 	}
 	if template.windowDidChangeScreenProfile != nil {
-		windowDidChangeScreenProfile :: proc "c" (self: id, notification: ^Notification) {
+		windowDidChangeScreenProfile :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidChangeScreenProfile(notification)
@@ -383,7 +383,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidChangeScreenProfile:"), auto_cast windowDidChangeScreenProfile, "v@:@")
 	}
 	if template.windowDidChangeBackingProperties != nil {
-		windowDidChangeBackingProperties :: proc "c" (self: id, notification: ^Notification) {
+		windowDidChangeBackingProperties :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidChangeBackingProperties(notification)
@@ -391,7 +391,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidChangeBackingProperties:"), auto_cast windowDidChangeBackingProperties, "v@:@")
 	}
 	if template.windowShouldClose != nil {
-		windowShouldClose :: proc "c" (self:id, sender: ^Window) -> BOOL {
+		windowShouldClose :: proc "c" (self: id, cmd: SEL, sender: ^Window) -> BOOL {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowShouldClose(sender)
@@ -399,7 +399,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowShouldClose:"), auto_cast windowShouldClose, "B@:@")
 	}
 	if template.windowWillClose != nil {
-		windowWillClose :: proc "c" (self:id, notification: ^Notification) {
+		windowWillClose :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillClose(notification)
@@ -407,7 +407,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillClose:"), auto_cast windowWillClose, "v@:@")
 	}
 	if template.windowDidBecomeKey != nil {
-		windowDidBecomeKey :: proc "c" (self: id, notification: ^Notification) {
+		windowDidBecomeKey :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidBecomeKey(notification)
@@ -415,7 +415,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidBecomeKey:"), auto_cast windowDidBecomeKey, "v@:@")
 	}
 	if template.windowDidResignKey != nil {
-		windowDidResignKey :: proc "c" (self: id, notification: ^Notification) {
+		windowDidResignKey :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidResignKey(notification)
@@ -423,7 +423,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidResignKey:"), auto_cast windowDidResignKey, "v@:@")
 	}
 	if template.windowDidBecomeMain != nil {
-		windowDidBecomeMain :: proc "c" (self: id, notification: ^Notification) {
+		windowDidBecomeMain :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidBecomeMain(notification)
@@ -431,7 +431,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidBecomeMain:"), auto_cast windowDidBecomeMain, "v@:@")
 	}
 	if template.windowDidResignMain != nil {
-		windowDidResignMain :: proc "c" (self: id, notification: ^Notification) {
+		windowDidResignMain :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidResignMain(notification)
@@ -439,7 +439,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidResignMain:"), auto_cast windowDidResignMain, "v@:@")
 	}
 	if template.windowWillReturnFieldEditorToObject != nil {
-		windowWillReturnFieldEditorToObject :: proc "c" (self:id, sender: ^Window, client: id) -> id {
+		windowWillReturnFieldEditorToObject :: proc "c" (self: id, cmd: SEL, sender: ^Window, client: id) -> id {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowWillReturnFieldEditorToObject(sender, client)
@@ -447,7 +447,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillReturnFieldEditor:toObject:"), auto_cast windowWillReturnFieldEditorToObject, "@@:@@")
 	}
 	if template.windowDidUpdate != nil {
-		windowDidUpdate :: proc "c" (self: id, notification: ^Notification) {
+		windowDidUpdate :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidUpdate(notification)
@@ -455,7 +455,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidUpdate:"), auto_cast windowDidUpdate, "v@:@")
 	}
 	if template.windowDidExpose != nil {
-		windowDidExpose :: proc "c" (self: id, notification: ^Notification) {
+		windowDidExpose :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidExpose(notification)
@@ -463,7 +463,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidExpose:"), auto_cast windowDidExpose, "v@:@")
 	}
 	if template.windowDidChangeOcclusionState != nil {
-		windowDidChangeOcclusionState :: proc "c" (self: id, notification: ^Notification) {
+		windowDidChangeOcclusionState :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidChangeOcclusionState(notification)
@@ -471,7 +471,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidChangeOcclusionState:"), auto_cast windowDidChangeOcclusionState, "v@:@")
 	}
 	if template.windowShouldDragDocumentWithEventFromWithPasteboard != nil {
-		windowShouldDragDocumentWithEventFromWithPasteboard :: proc "c" (self: id, window: ^Window, event: ^Event, dragImageLocation: Point, pasteboard: ^Pasteboard) -> BOOL {
+		windowShouldDragDocumentWithEventFromWithPasteboard :: proc "c" (self: id, cmd: SEL, window: ^Window, event: ^Event, dragImageLocation: Point, pasteboard: ^Pasteboard) -> BOOL {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowShouldDragDocumentWithEventFromWithPasteboard(window, event, dragImageLocation, pasteboard)
@@ -479,7 +479,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:shouldDragDocumentWithEvent:from:withPasteboard:"), auto_cast windowShouldDragDocumentWithEventFromWithPasteboard, "B@:@@"+_POINT_ENCODING+"@")
 	}
 	if template.windowWillReturnUndoManager != nil {
-		windowWillReturnUndoManager :: proc "c" (self: id, window: ^Window) -> ^UndoManager {
+		windowWillReturnUndoManager :: proc "c" (self: id, cmd: SEL, window: ^Window) -> ^UndoManager {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowWillReturnUndoManager(window)
@@ -487,7 +487,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillReturnUndoManager:"), auto_cast windowWillReturnUndoManager, "@@:@")
 	}
 	if template.windowShouldPopUpDocumentPathMenu != nil {
-		windowShouldPopUpDocumentPathMenu :: proc "c" (self: id, window: ^Window, menu: ^Menu) -> BOOL {
+		windowShouldPopUpDocumentPathMenu :: proc "c" (self: id, cmd: SEL, window: ^Window, menu: ^Menu) -> BOOL {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowShouldPopUpDocumentPathMenu(window, menu)
@@ -495,7 +495,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:shouldPopUpDocumentPathMenu:"), auto_cast windowShouldPopUpDocumentPathMenu, "B@:@@")
 	}
 	if template.windowWillEncodeRestorableState != nil {
-		windowWillEncodeRestorableState :: proc "c" (self: id, window: ^Window, state: ^Coder) {
+		windowWillEncodeRestorableState :: proc "c" (self: id, cmd: SEL, window: ^Window, state: ^Coder) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillEncodeRestorableState(window, state)
@@ -503,7 +503,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:willEncodeRestorableState:"), auto_cast windowWillEncodeRestorableState, "v@:@@")
 	}
 	if template.windowDidEncodeRestorableState != nil {
-		windowDidEncodeRestorableState :: proc "c" (self: id, window: ^Window, state: ^Coder) {
+		windowDidEncodeRestorableState :: proc "c" (self: id, cmd: SEL, window: ^Window, state: ^Coder) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidEncodeRestorableState(window, state)
@@ -511,7 +511,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:didDecodeRestorableState:"), auto_cast windowDidEncodeRestorableState, "v@:@@")
 	}
 	if template.windowWillResizeForVersionBrowserWithMaxPreferredSizeMaxAllowedSize != nil {
-		windowWillResizeForVersionBrowserWithMaxPreferredSizeMaxAllowedSize :: proc "c" (self: id, window: ^Window, maxPreferredFrameSize: Size, maxAllowedFrameSize: Size) -> Size {
+		windowWillResizeForVersionBrowserWithMaxPreferredSizeMaxAllowedSize :: proc "c" (self: id, cmd: SEL, window: ^Window, maxPreferredFrameSize: Size, maxAllowedFrameSize: Size) -> Size {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowWillResizeForVersionBrowserWithMaxPreferredSizeMaxAllowedSize(window, maxPreferredFrameSize, maxPreferredFrameSize)
@@ -519,7 +519,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:willResizeForVersionBrowserWithMaxPreferredSize:maxAllowedSize:"), auto_cast windowWillResizeForVersionBrowserWithMaxPreferredSizeMaxAllowedSize, _SIZE_ENCODING+"@:@"+_SIZE_ENCODING+_SIZE_ENCODING)
 	}
 	if template.windowWillEnterVersionBrowser != nil {
-		windowWillEnterVersionBrowser :: proc "c" (self: id, notification: ^Notification) {
+		windowWillEnterVersionBrowser :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillEnterVersionBrowser(notification)
@@ -527,7 +527,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillEnterVersionBrowser:"), auto_cast windowWillEnterVersionBrowser, "v@:@")
 	}
 	if template.windowDidEnterVersionBrowser != nil {
-		windowDidEnterVersionBrowser :: proc "c" (self: id, notification: ^Notification) {
+		windowDidEnterVersionBrowser :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidEnterVersionBrowser(notification)
@@ -535,7 +535,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidEnterVersionBrowser:"), auto_cast windowDidEnterVersionBrowser, "v@:@")
 	}
 	if template.windowWillExitVersionBrowser != nil {
-		windowWillExitVersionBrowser :: proc "c" (self: id, notification: ^Notification) {
+		windowWillExitVersionBrowser :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillExitVersionBrowser(notification)
@@ -543,7 +543,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillExitVersionBrowser:"), auto_cast windowWillExitVersionBrowser, "v@:@")
 	}
 	if template.windowDidExitVersionBrowser != nil {
-		windowDidExitVersionBrowser :: proc "c" (self: id, notification: ^Notification) {
+		windowDidExitVersionBrowser :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidExitVersionBrowser(notification)
@@ -588,6 +588,16 @@ Responder :: struct {using _: Object}
 @(objc_class="NSView")
 View :: struct {using _: Responder}
 
+AutoresizingFlag :: enum UInteger {
+	NotSizable    = 0,
+	MinXMargin    = 1,
+	WidthSizable  = 2,
+	MaxXMargin    = 4,
+	MinYMargin    = 8,
+	HeightSizable = 16,
+	MaxYMargin    = 32,
+}
+AutoresizingMask :: distinct bit_set[AutoresizingFlag; UInteger]
 
 @(objc_type=View, objc_name="initWithFrame")
 View_initWithFrame :: proc "c" (self: ^View, frame: Rect) -> ^View {
@@ -616,6 +626,35 @@ View_setWantsLayer :: proc "c" (self: ^View, wantsLayer: BOOL) {
 @(objc_type=View, objc_name="convertPointFromView")
 View_convertPointFromView :: proc "c" (self: ^View, point: Point, view: ^View) -> Point {
 	return msgSend(Point, self, "convertPoint:fromView:", point, view)
+}
+@(objc_type=View, objc_name="frame")
+View_frame :: proc "c" (self: ^View) -> Rect {
+	return msgSend(Rect, self, "frame")
+}
+@(objc_type=View, objc_name="setFrame")
+View_setFrame :: proc "c" (self: ^View, frame: Rect) {
+	msgSend(nil, self, "setFrame:", frame)
+}
+@(objc_type=View, objc_name="setFrameOrigin")
+View_setFrameOrigin :: proc "c" (self: ^View, origin: Point) {
+	msgSend(nil, self, "setFrameOrigin:", origin)
+}
+@(objc_type=View, objc_name="superview")
+View_superview :: proc "c" (self: ^View) -> ^View {
+	return msgSend(^View, self, "superview")
+}
+@(objc_type=View, objc_name="addSubview")
+View_addSubview :: proc "c" (self: ^View, subview: ^View) {
+	msgSend(nil, self, "addSubview:", subview)
+}
+@(objc_type=View, objc_name="setAutoresizingMask")
+View_setAutoresizingMask :: proc "c" (self: ^View, mask: AutoresizingMask) {
+	msgSend(nil, self, "setAutoresizingMask:", mask)
+}
+
+TitleVisibility :: enum Integer {
+	Visible = 0,
+	Hidden  = 1,
 }
 
 @(objc_class="NSWindow")
@@ -712,4 +751,8 @@ Window_setDelegate :: proc "c" (self: ^Window, delegate: ^WindowDelegate) {
 @(objc_type=Window, objc_name="backingScaleFactor")
 Window_backingScaleFactor :: proc "c" (self: ^Window) -> Float {
 	return msgSend(Float, self, "backingScaleFactor")
+}
+@(objc_type=Window, objc_name="setTitleVisibility")
+Window_setTitleVisibility :: proc "c" (self: ^Window, visibility: TitleVisibility) {
+	msgSend(nil, self, "setTitleVisibility:", visibility)
 }


### PR DESCRIPTION
This PR fixes a bug in [NSWindow.odin](https://github.com/odin-lang/Odin/blob/master/vendor/darwin/Foundation/NSWindow.odin) and [NSApplication.odin](https://github.com/odin-lang/Odin/blob/master/vendor/darwin/Foundation/NSApplication.odin) where the "cmd" parameter is not getting passed to the delegate callback functions, which results in a signature mismatch bug and causes a crash when trying to use an argument from a delegate callback in an NSApplicationDelegate or NSWindowDelegate

Example reproduction of the bug: (using SDL)
```odin
// create a window delegate
window_delegate: NS.WindowDelegateTemplate

// set the resize callback
window_delegate.windowDidResize = proc(notification: ^NS.Notification) {
	// attempt to print the parameter 'notification's description
	name := notification->name() /* crashes because notification is not 
					a pointer to a Notifiction, but rather a SEL object */

	// however with my commit this is fixed and the following works:
	fmt.println(name->odinString()) // prints "NSWindowDidResizeNotification"
}

// get the native window from SDL
window_system_info: SDL.SysWMinfo
SDL.GetWindowWMInfo(window, &window_system_info)
native_window := (^NS.Window)(window_system_info.info.cocoa.window)

// set the window delegate
native_window->setDelegate(NS.window_delegate_register_and_alloc(window_delegate, "myDelegate", context))
```

This PR also adds a few more method bindings for NSView and NSWindow