### PR TITLE
virtual.protect returns inverted result on linux and darwin platforms

### DIFF
--- a/core/mem/virtual/virtual_darwin.odin
+++ b/core/mem/virtual/virtual_darwin.odin
@@ -136,7 +136,7 @@ _protect :: proc "contextless" (data: rawptr, size: uint, flags: Protect_Flags) 
 	if .Write   in flags { pflags |= PROT_WRITE }
 	if .Execute in flags { pflags |= PROT_EXEC  }
 	err := _mprotect(data, size, pflags)
-	return err != 0
+	return err == 0
 }
 
 

--- a/core/mem/virtual/virtual_linux.odin
+++ b/core/mem/virtual/virtual_linux.odin
@@ -40,7 +40,7 @@ _protect :: proc "contextless" (data: rawptr, size: uint, flags: Protect_Flags) 
 	if .Write   in flags { pflags |= {.WRITE} }
 	if .Execute in flags { pflags |= {.EXEC}  }
 	errno := linux.mprotect(data, size, pflags)
-	return errno != .NONE
+	return errno == .NONE
 }
 
 _platform_memory_init :: proc() {


### PR DESCRIPTION
```odin
_protect :: proc "contextless" (data: rawptr, size: uint, flags: Protect_Flags) -> bool {
	pflags: linux.Mem_Protection
	pflags = {}
	if .Read    in flags { pflags |= {.READ}  }
	if .Write   in flags { pflags |= {.WRITE} }
	if .Execute in flags { pflags |= {.EXEC}  }
	errno := linux.mprotect(data, size, pflags)
	return errno != .NONE
}
```
It should return errno == .NONE. Same is true for darwin