### PR TITLE
Fix linalg shadowing error

### DIFF
--- a/core/math/linalg/general.odin
+++ b/core/math/linalg/general.odin
@@ -217,7 +217,7 @@ quaternion64_mul_vector3 :: proc "contextless" (q: $Q/quaternion64, v: $V/[3]$F/
 	Raw_Quaternion :: struct {xyz: [3]f16, r: f16}
 
 	q := transmute(Raw_Quaternion)q
-	v := transmute([3]f16)v
+	v := v
 
 	t := cross(2*q.xyz, v)
 	return V(v + q.r*t + cross(q.xyz, t))
@@ -227,7 +227,7 @@ quaternion128_mul_vector3 :: proc "contextless" (q: $Q/quaternion128, v: $V/[3]$
 	Raw_Quaternion :: struct {xyz: [3]f32, r: f32}
 
 	q := transmute(Raw_Quaternion)q
-	v := transmute([3]f32)v
+	v := v
 
 	t := cross(2*q.xyz, v)
 	return V(v + q.r*t + cross(q.xyz, t))
@@ -237,7 +237,7 @@ quaternion256_mul_vector3 :: proc "contextless" (q: $Q/quaternion256, v: $V/[3]$
 	Raw_Quaternion :: struct {xyz: [3]f64, r: f64}
 
 	q := transmute(Raw_Quaternion)q
-	v := transmute([3]f64)v
+	v := v
 
 	t := cross(2*q.xyz, v)
 	return V(v + q.r*t + cross(q.xyz, t))


### PR DESCRIPTION
the transmute caused the error, I guess it's not required anymore since the distinct is gone
```
Odin/core/math/linalg/general.odin(230:2) Error: Declaration of 'v' shadows declaration at line 226
        v := transmute([3]f32)v
```