### PR TITLE
Fix loop condition in semaphore_wait

### DIFF
--- a/src/threading.cpp
+++ b/src/threading.cpp
@@ -210,7 +210,7 @@ gb_internal void semaphore_wait(Semaphore *s) {
 			original_count = s->count().load(std::memory_order_relaxed);
 		}
 
-		if (!s->count().compare_exchange_strong(original_count, original_count-1, std::memory_order_acquire, std::memory_order_acquire)) {
+		if (s->count().compare_exchange_strong(original_count, original_count-1, std::memory_order_acquire, std::memory_order_acquire)) {
 			return;
 		}
 	}


### PR DESCRIPTION
looks like the condition for looping based on the result of `compare_exchange_strong` was backwards, causing us to bail on failure and loop on success