### PR TITLE
Fix for json marshaling of bit_set always returning .Unsupported_Type

### DIFF
--- a/core/encoding/json/marshal.odin
+++ b/core/encoding/json/marshal.odin
@@ -388,11 +388,9 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 				x = bits.byte_swap(x)
 			}
 			bit_data = u64(x)
-		case: panic("unknown bit_size size")
+		case: return .Unsupported_Type
 		}
 		io.write_u64(w, bit_data) or_return
-
-		return .Unsupported_Type
 	}
 
 	return


### PR DESCRIPTION
When JSON marshaling any kind of bit_set it always failed, this was due to it always returning .Unsupported_Type. Now it only fails if the bit_size is unsupported or if write_u64 fails.