### PR TITLE
cpu_features - fix shift direction

### DIFF
--- a/core/sys/info/cpu_intel.odin
+++ b/core/sys/info/cpu_intel.odin
@@ -37,11 +37,11 @@ cpu_name:     Maybe(string)
 
 @(init, private)
 init_cpu_features :: proc "c" () {
-	is_set :: #force_inline proc "c" (hwc: u32, value: u32) -> bool {
-		return hwc&(1 << value) != 0
+	is_set :: #force_inline proc "c" (bit: u32, value: u32) -> bool {
+		return (value>>bit) & 0x1 != 0
 	}
-	try_set :: #force_inline proc "c" (set: ^CPU_Features, feature: CPU_Feature, hwc: u32, value: u32) {
-		if is_set(hwc, value) {
+	try_set :: #force_inline proc "c" (set: ^CPU_Features, feature: CPU_Feature, bit: u32, value: u32) {
+		if is_set(bit, value) {
 			set^ += {feature}
 		}
 	}


### PR DESCRIPTION
The current shift direction was backwards, as such the flags dont ever come back with any information. Now they present correctly, for example, my machine produces `CPU_Features{aes, adx, avx, avx2, bmi1, bmi2, fma, os_xsave, pclmulqdq, popcnt, rdrand, rdseed, sse2, sse3, ssse3, sse41, sse42}`.