### PR TITLE
vendor/miniaudio: fix import for MacOS

### DIFF
--- a/vendor/miniaudio/common.odin
+++ b/vendor/miniaudio/common.odin
@@ -10,10 +10,8 @@ when MINIAUDIO_SHARED {
 
 when ODIN_OS == .Windows {
 	foreign import lib "lib/miniaudio.lib"
-} else when ODIN_OS == .Linux {
-	foreign import lib "lib/miniaudio.a"
 } else {
-	foreign import lib "system:miniaudio"
+	foreign import lib "lib/miniaudio.a"
 }
 
 handle :: distinct rawptr

--- a/vendor/miniaudio/data_conversion.odin
+++ b/vendor/miniaudio/data_conversion.odin
@@ -4,10 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "lib/miniaudio.lib"
-} else when ODIN_OS == .Linux {
-	foreign import lib "lib/miniaudio.a"
 } else {
-	foreign import lib "system:miniaudio"
+	foreign import lib "lib/miniaudio.a"
 }
 
 /************************************************************************************************************************************************************

--- a/vendor/miniaudio/decoding.odin
+++ b/vendor/miniaudio/decoding.odin
@@ -4,10 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "lib/miniaudio.lib"
-} else when ODIN_OS == .Linux {
-	foreign import lib "lib/miniaudio.a"
 } else {
-	foreign import lib "system:miniaudio"
+	foreign import lib "lib/miniaudio.a"
 }
 
 /************************************************************************************************************************************************************

--- a/vendor/miniaudio/device_io_procs.odin
+++ b/vendor/miniaudio/device_io_procs.odin
@@ -2,10 +2,8 @@ package miniaudio
 
 when ODIN_OS == .Windows {
 	foreign import lib "lib/miniaudio.lib"
-} else when ODIN_OS == .Linux {
-	foreign import lib "lib/miniaudio.a"
 } else {
-	foreign import lib "system:miniaudio"
+	foreign import lib "lib/miniaudio.a"
 }
 
 import "core:c"

--- a/vendor/miniaudio/effects.odin
+++ b/vendor/miniaudio/effects.odin
@@ -4,10 +4,8 @@ import c "core:c/libc"
 
 when ODIN_OS == .Windows {
 	foreign import lib "lib/miniaudio.lib"
-} else when ODIN_OS == .Linux {
-	foreign import lib "lib/miniaudio.a"
 } else {
-	foreign import lib "system:miniaudio"
+	foreign import lib "lib/miniaudio.a"
 }
 
 /*

--- a/vendor/miniaudio/encoding.odin
+++ b/vendor/miniaudio/encoding.odin
@@ -4,10 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "lib/miniaudio.lib"
-} else when ODIN_OS == .Linux {
-	foreign import lib "lib/miniaudio.a"
 } else {
-	foreign import lib "system:miniaudio"
+	foreign import lib "lib/miniaudio.a"
 }
 
 /************************************************************************************************************************************************************

--- a/vendor/miniaudio/engine.odin
+++ b/vendor/miniaudio/engine.odin
@@ -4,10 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "lib/miniaudio.lib"
-} else when ODIN_OS == .Linux {
-	foreign import lib "lib/miniaudio.a"
 } else {
-	foreign import lib "system:miniaudio"
+	foreign import lib "lib/miniaudio.a"
 }
 
 /************************************************************************************************************************************************************

--- a/vendor/miniaudio/filtering.odin
+++ b/vendor/miniaudio/filtering.odin
@@ -4,10 +4,8 @@ import c "core:c/libc"
 
 when ODIN_OS == .Windows {
 	foreign import lib "lib/miniaudio.lib"
-} else when ODIN_OS == .Linux {
-	foreign import lib "lib/miniaudio.a"
 } else {
-	foreign import lib "system:miniaudio"
+	foreign import lib "lib/miniaudio.a"
 }
 
 /**************************************************************************************************************************************************************

--- a/vendor/miniaudio/generation.odin
+++ b/vendor/miniaudio/generation.odin
@@ -4,10 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "lib/miniaudio.lib"
-} else when ODIN_OS == .Linux {
-	foreign import lib "lib/miniaudio.a"
 } else {
-	foreign import lib "system:miniaudio"
+	foreign import lib "lib/miniaudio.a"
 }
 
 waveform_type :: enum c.int {

--- a/vendor/miniaudio/job_queue.odin
+++ b/vendor/miniaudio/job_queue.odin
@@ -4,10 +4,8 @@ import c "core:c/libc"
 
 when ODIN_OS == .Windows {
 	foreign import lib "lib/miniaudio.lib"
-} else when ODIN_OS == .Linux {
-	foreign import lib "lib/miniaudio.a"
 } else {
-	foreign import lib "system:miniaudio"
+	foreign import lib "lib/miniaudio.a"
 }
 
 /*

--- a/vendor/miniaudio/logging.odin
+++ b/vendor/miniaudio/logging.odin
@@ -4,10 +4,8 @@ import c "core:c/libc"
 
 when ODIN_OS == .Windows {
 	foreign import lib "lib/miniaudio.lib"
-} else when ODIN_OS == .Linux {
-	foreign import lib "lib/miniaudio.a"
 } else {
-	foreign import lib "system:miniaudio"
+	foreign import lib "lib/miniaudio.a"
 }
 
 MAX_LOG_CALLBACKS :: 4

--- a/vendor/miniaudio/node_graph.odin
+++ b/vendor/miniaudio/node_graph.odin
@@ -4,10 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "lib/miniaudio.lib"
-} else when ODIN_OS == .Linux {
-	foreign import lib "lib/miniaudio.a"
 } else {
-	foreign import lib "system:miniaudio"
+	foreign import lib "lib/miniaudio.a"
 }
 
 /************************************************************************************************************************************************************

--- a/vendor/miniaudio/resource_manager.odin
+++ b/vendor/miniaudio/resource_manager.odin
@@ -4,10 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "lib/miniaudio.lib"
-} else when ODIN_OS == .Linux {
-	foreign import lib "lib/miniaudio.a"
 } else {
-	foreign import lib "system:miniaudio"
+	foreign import lib "lib/miniaudio.a"
 }
 
 /************************************************************************************************************************************************************

--- a/vendor/miniaudio/synchronization.odin
+++ b/vendor/miniaudio/synchronization.odin
@@ -2,10 +2,8 @@ package miniaudio
 
 when ODIN_OS == .Windows {
 	foreign import lib "lib/miniaudio.lib"
-} else when ODIN_OS == .Linux {
-	foreign import lib "lib/miniaudio.a"
 } else {
-	foreign import lib "system:miniaudio"
+	foreign import lib "lib/miniaudio.a"
 }
 
 @(default_calling_convention="c", link_prefix="ma_")

--- a/vendor/miniaudio/utilities.odin
+++ b/vendor/miniaudio/utilities.odin
@@ -4,10 +4,8 @@ import c "core:c/libc"
 
 when ODIN_OS == .Windows {
 	foreign import lib "lib/miniaudio.lib"
-} else when ODIN_OS == .Linux {
-	foreign import lib "lib/miniaudio.a"
 } else {
-	foreign import lib "system:miniaudio"
+	foreign import lib "lib/miniaudio.a"
 }
 
 @(default_calling_convention="c", link_prefix="ma_")

--- a/vendor/miniaudio/vfs.odin
+++ b/vendor/miniaudio/vfs.odin
@@ -4,10 +4,8 @@ import "core:c"
 
 when ODIN_OS == .Windows {
 	foreign import lib "lib/miniaudio.lib"
-} else when ODIN_OS == .Linux {
-	foreign import lib "lib/miniaudio.a"
 } else {
-	foreign import lib "system:miniaudio"
+	foreign import lib "lib/miniaudio.a"
 }
 
 /************************************************************************************************************************************************************


### PR DESCRIPTION
Using `system:miniaudio` is suboptimal, we already provide the `Makefile` that builds the `lib/miniaudio.a` and this works on MacOS. This PR makes linking with that library the default.