### PR TITLE
Draft: Add freestanding aarch64 target

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -582,7 +582,14 @@ gb_global TargetMetrics target_freestanding_amd64_sysv = {
 	TargetABI_SysV,
 };
 
-
+gb_global TargetMetrics target_freestanding_arm64_sysv = {
+	TargetOs_freestanding,
+	TargetArch_arm64,
+	8, 8, 8, 16,
+	str_lit("aarch64-none-elf"),
+	str_lit("e-m:o-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"),
+	TargetABI_SysV,
+};
 
 struct NamedTargetMetrics {
 	String name;
@@ -617,6 +624,7 @@ gb_global NamedTargetMetrics named_targets[] = {
 	{ str_lit("wasi_wasm64p32"),         &target_wasi_wasm64p32 },
 
 	{ str_lit("freestanding_amd64_sysv"), &target_freestanding_amd64_sysv },
+	{ str_lit("freestanding_arm64_sysv"), &target_freestanding_arm64_sysv },
 };
 
 gb_global NamedTargetMetrics *selected_target_metrics;

--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -2503,7 +2503,7 @@ gb_internal bool lb_generate_code(lbGenerator *gen) {
 	LLVMCodeModel code_mode = LLVMCodeModelDefault;
 	if (is_arch_wasm()) {
 		code_mode = LLVMCodeModelJITDefault;
-	} else if (build_context.metrics.os == TargetOs_freestanding) {
+	} else if (is_arch_x86() && build_context.metrics.os == TargetOs_freestanding) {
 		code_mode = LLVMCodeModelKernel;
 	}
 


### PR DESCRIPTION
* Added target metrics for freestanding aarch64 target
* Only use "kernel" code model for freestanding x86 targets - "kernel" is not supported by LLVM for aarch64