### PR TITLE
[sys/linux]: Remove +build comments in files with documentation

### DIFF
--- a/core/sys/linux/sys.odin
+++ b/core/sys/linux/sys.odin
@@ -1,4 +1,3 @@
-//+build linux
 package linux
 
 import "core:intrinsics"

--- a/core/sys/linux/types.odin
+++ b/core/sys/linux/types.odin
@@ -1,4 +1,3 @@
-//+build linux
 package linux
 
 /*


### PR DESCRIPTION

Turns out this magic comment was inhibiting documentation generation in deploy cycle (If I understand correctly). I removed that comment to generate the hand-written documentation in `sys/linux` package.
