### PR TITLE
Fix some FreeBSD regressions

### DIFF
--- a/build_odin.sh
+++ b/build_odin.sh
@@ -32,11 +32,11 @@ if [ -z "$LLVM_CONFIG" ]; then
 	elif [ -n "$(command -v llvm-config-12)" ]; then LLVM_CONFIG="llvm-config-12"
 	elif [ -n "$(command -v llvm-config-11)" ]; then LLVM_CONFIG="llvm-config-11"
 	# freebsd
-	elif [ -n "$(command -v llvm-config17)" ]; then  LLVM_CONFIG="llvm-config-17"
-	elif [ -n "$(command -v llvm-config14)" ]; then  LLVM_CONFIG="llvm-config-14"
-	elif [ -n "$(command -v llvm-config13)" ]; then  LLVM_CONFIG="llvm-config-13"
-	elif [ -n "$(command -v llvm-config12)" ]; then  LLVM_CONFIG="llvm-config-12"
-	elif [ -n "$(command -v llvm-config11)" ]; then  LLVM_CONFIG="llvm-config-11"
+	elif [ -n "$(command -v llvm-config17)" ]; then  LLVM_CONFIG="llvm-config17"
+	elif [ -n "$(command -v llvm-config14)" ]; then  LLVM_CONFIG="llvm-config14"
+	elif [ -n "$(command -v llvm-config13)" ]; then  LLVM_CONFIG="llvm-config13"
+	elif [ -n "$(command -v llvm-config12)" ]; then  LLVM_CONFIG="llvm-config12"
+	elif [ -n "$(command -v llvm-config11)" ]; then  LLVM_CONFIG="llvm-config11"
 	# fallback
 	elif [ -n "$(command -v llvm-config)" ]; then LLVM_CONFIG="llvm-config"
 	else

--- a/core/os/os_freebsd.odin
+++ b/core/os/os_freebsd.odin
@@ -354,7 +354,7 @@ seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
 }
 
 file_size :: proc(fd: Handle) -> (i64, Errno) {
-	s, err := fstat(fd)
+	s, err := _fstat(fd)
 	if err != ERROR_NONE {
 		return -1, err
 	}

--- a/tests/core/Makefile
+++ b/tests/core/Makefile
@@ -1,5 +1,6 @@
 ODIN=../../odin
-PYTHON=$(shell which python3)
+PYTHON ?= $(shell which python3)
+PYTHON != which python3
 
 all: c_libc_test \
 	 compress_test \

--- a/tests/vendor/Makefile
+++ b/tests/vendor/Makefile
@@ -1,12 +1,11 @@
 ODIN=../../odin
 ODINFLAGS=
+OS ?= $(shell uname -s)
+OS != uname -s
 
-OS=$(shell uname)
+BSDFLAG != echo $(OS) | grep -E 'FreeBSD|OpenBSD' > /dev/null && echo -extra-linker-flags:-L/usr/local/lib
 
-ifeq ($(OS), OpenBSD)
-    ODINFLAGS:=$(ODINFLAGS) -extra-linker-flags:-L/usr/local/lib
-endif
-
+ODINFLAGS := $(ODINFLAGS) $(BSDFLAG)
 all: botan_test
 
 botan_test:


### PR DESCRIPTION
This pull request aiming to fix common issues on building FreeBSD such as compatibility with BSD Make, small typo issues such as detection of LLVM config command and small bug for `file_size` function of the FreeBSD. Besides that it also enables flag for FreeBSD on vendor test where it needs that to run the tests.  