### PR TITLE
`core:time` - Added stopwatch procs to return the duration in relevant procedures. Added naming suggestion. 

### DIFF
--- a/core/time/time.odin
+++ b/core/time/time.odin
@@ -66,16 +66,19 @@ stopwatch_start :: proc "contextless" (stopwatch: ^Stopwatch) {
 	}
 }
 
-stopwatch_stop :: proc "contextless" (stopwatch: ^Stopwatch) {
+stopwatch_stop :: proc "contextless" (stopwatch: ^Stopwatch) -> (duration_running: Duration) {
 	if stopwatch.running {
 		stopwatch._accumulation += tick_diff(stopwatch._start_time, tick_now())
 		stopwatch.running = false
 	}
+	return stopwatch._accumulation
 }
 
-stopwatch_reset :: proc "contextless" (stopwatch: ^Stopwatch) {
+stopwatch_reset :: proc "contextless" (stopwatch: ^Stopwatch) -> (duration_running: Duration) {
+	duration_running = stopwatch._accumulation
 	stopwatch._accumulation = {}
 	stopwatch.running = false
+	return duration_running
 }
 
 stopwatch_duration :: proc "contextless" (stopwatch: Stopwatch) -> Duration {
@@ -118,6 +121,18 @@ duration_hours :: proc "contextless" (d: Duration) -> f64 {
 	nsec := d % Hour
 	return f64(hour) + f64(nsec)/(60*60*1e9)
 }
+
+/*
+	Note(Dragos): This is a renaming suggestion to make the Duration conversion naming be on par with the Time conversion. 
+                  Added them as aliases as to not cause breaking changes, and would still allow people to grep/search for duration_* equivalent procs
+	              These is just an idea, so feel free to remove it if it's inconsistent with other core-libs principles.
+*/
+nanoseconds  :: duration_nanoseconds
+microseconds :: duration_microseconds
+milliseconds :: duration_milliseconds
+seconds      :: duration_seconds
+minutes      :: duration_minutes
+hours        :: duration_hours
 
 duration_round :: proc "contextless" (d, m: Duration) -> Duration {
 	_less_than_half :: #force_inline proc "contextless" (x, y: Duration) -> bool {


### PR DESCRIPTION
`time.stopwatch_stop`, `time.stopwatch_reset` now  return the duration they ran for. This is to reduce the need of this common pattern
```odin
// BEFORE
time.stopwatch_start(&sw)
duration := time.stopwatch_duration(sw)
// This working differently than _stop, it could be incorrectly placed before the duration get
time.stopwatch_reset(&sw)

// AFTER
time.stopwatch_start(&sw)
duration := time.stopwatch_stop(&sw) // This can also be replaced by a _reset
```

There is another small naming convention suggestion later down the file. I'm not much attached to that particular change but i figured it wouldn't be bad to unify the procedure names between `Duration` and `Time`, plus it's much terser to write when you are working a lot with time. 