### PR TITLE
Clearer syntax errors by having them print the line where they're found.

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -445,7 +445,7 @@ gb_internal void syntax_error_va(TokenPos const &pos, TokenPos end, char const *
 		error_out_coloured("Syntax Error: ", TerminalStyle_Normal, TerminalColour_Red);
 		error_out_va(fmt, va);
 		error_out("\n");
-		// show_error_on_line(pos, end);
+		show_error_on_line(pos, end);
 	} else if (pos.line == 0) {
 		error_out_coloured("Syntax Error: ", TerminalStyle_Normal, TerminalColour_Red);
 		error_out_va(fmt, va);
@@ -494,7 +494,7 @@ gb_internal void syntax_warning_va(TokenPos const &pos, TokenPos end, char const
 			error_out_coloured("Syntax Warning: ", TerminalStyle_Normal, TerminalColour_Yellow);
 			error_out_va(fmt, va);
 			error_out("\n");
-			// show_error_on_line(pos, end);
+			show_error_on_line(pos, end);
 		} else if (pos.line == 0) {
 			error_out_coloured("Syntax Warning: ", TerminalStyle_Normal, TerminalColour_Yellow);
 			error_out_va(fmt, va);


### PR DESCRIPTION
Odin generally has nice errors in the command line, that show with good detail where there was a problem. As someone who doesn't use an elaborate editor, this is super helpful, and I'd argue that having errors independent from such an editor is a good thing.

However, syntax errors only report their position, and the error message, but they don't actually show the line where the error was encountered, like other errors do. This makes it much more difficult to quickly understand what kind of mistake was made (and where it was made).

For some reason, the code that would show the line was commented out, and this might've been because someone thought that syntax errors were too verbose compared to their relevance? Some syntax errors have a very non-local nature (like missing braces). But having more space between the errors helps split up the noise, and presenting extra context to the programmer helps a lot to understand what kind of error was made, even if they are cascaded errors.