### PR TITLE
Expose OpenGL shader procs to allow creation of pipelines with geometry shaders

### DIFF
--- a/vendor/OpenGL/helpers.odin
+++ b/vendor/OpenGL/helpers.odin
@@ -120,7 +120,6 @@ when GL_DEBUG {
 }
 
 // Compiling shaders are identical for any shader (vertex, geometry, fragment, tesselation, (maybe compute too))
-@private
 compile_shader_from_source :: proc(shader_data: string, shader_type: Shader_Type) -> (shader_id: u32, ok: bool) {
 	shader_id = CreateShader(cast(u32)shader_type)
 	length := i32(len(shader_data))
@@ -134,7 +133,6 @@ compile_shader_from_source :: proc(shader_data: string, shader_type: Shader_Type
 }
 
 // only used once, but I'd just make a subprocedure(?) for consistency
-@private
 create_and_link_program :: proc(shader_ids: []u32, binary_retrievable := false) -> (program_id: u32, ok: bool) {
 	program_id = CreateProgram()
 	for id in shader_ids {


### PR DESCRIPTION
Enables a user program (code outside the `gl` package) to setup shader pipelines that include a geometry shader (e.g. the GPU expands each submitted vertex to a textured quad). Tested working on Linux:
```c
shader_vertex_id, ok_vertex := gl.compile_shader_from_source(
	shader_vertex,
	gl.Shader_Type.VERTEX_SHADER,
)
shader_geom_id, ok_geom := gl.compile_shader_from_source(
	shader_geom,
	gl.Shader_Type.GEOMETRY_SHADER,
)
shader_frag_id, ok_frag := gl.compile_shader_from_source(
	shader_frag,
	gl.Shader_Type.FRAGMENT_SHADER,
)

shader_program, shader_ok := gl.create_and_link_program(
	[]u32{shader_vertex_id, shader_geom_id, shader_frag_id},
	false,
)
assert(shader_ok)
gl.UseProgram(shader_program)
```