### PR TITLE
Adding linux & darwin makefile for cgltf

### DIFF
--- a/vendor/cgltf/cgltf.odin
+++ b/vendor/cgltf/cgltf.odin
@@ -3,8 +3,8 @@ package cgltf
 import "core:c"
 
 when ODIN_OS == .Windows      { foreign import lib "lib/cgltf.lib" } 
-else when ODIN_OS == .Linux   { foreign import lib "../lib/cgltf.a"        }
-else when ODIN_OS == .Darwin  { foreign import lib "../lib/darwin/cgltf.a" }
+else when ODIN_OS == .Linux   { foreign import lib "lib/cgltf.a"        }
+else when ODIN_OS == .Darwin  { foreign import lib "lib/darwin/cgltf.a" }
 else                          { foreign import lib "system:cgltf"          }
 
 

--- a/vendor/cgltf/cgltf.odin
+++ b/vendor/cgltf/cgltf.odin
@@ -1,12 +1,11 @@
 package cgltf
 
-import "core:c"
-
 when ODIN_OS == .Windows      { foreign import lib "lib/cgltf.lib" } 
 else when ODIN_OS == .Linux   { foreign import lib "lib/cgltf.a"        }
 else when ODIN_OS == .Darwin  { foreign import lib "lib/darwin/cgltf.a" }
 else                          { foreign import lib "system:cgltf"          }
 
+import "core:c"
 
 file_type :: enum c.int {
 	invalid,

--- a/vendor/cgltf/cgltf.odin
+++ b/vendor/cgltf/cgltf.odin
@@ -1,11 +1,11 @@
-//+build windows
 package cgltf
 
-when ODIN_OS == .Windows {
-	foreign import lib "lib/cgltf.lib"
-}
-
 import "core:c"
+
+when ODIN_OS == .Windows      { foreign import lib "lib/cgltf.lib" } 
+else when ODIN_OS == .Linux   { foreign import lib "../lib/cgltf.a"        }
+else when ODIN_OS == .Darwin  { foreign import lib "../lib/darwin/cgltf.a" }
+else                          { foreign import lib "system:cgltf"          }
 
 
 file_type :: enum c.int {

--- a/vendor/cgltf/src/Makefile
+++ b/vendor/cgltf/src/Makefile
@@ -1,0 +1,20 @@
+OS=$(shell uname)
+
+ifeq ($(OS), Darwin)
+all: darwin
+else
+all: unix
+endif
+
+unix:
+	mkdir -p ../lib
+	$(CC) -c -O2 -Os -fPIC cgltf.c 	
+	$(AR) rcs ../lib/cgltf.a        cgltf.o
+	rm *.o
+
+darwin:
+	mkdir -p ../lib
+	$(CC) -arch x86_64 -c -O2 -Os -fPIC cgltf.c -o cgltf-x86_64.o -mmacosx-version-min=10.12
+	$(CC) -arch arm64  -c -O2 -Os -fPIC cgltf.c -o cgltf-arm64.o -mmacosx-version-min=10.12
+	lipo -create cgltf-x86_64.o cgltf-arm64.o -output ../lib/darwin/cgltf.a
+	rm *.o


### PR DESCRIPTION
Hello I wanted to use the vendor binding for cgltf and I found out that it was made only for Windows. 
So I copypasted the Makefile from the stb vendor and tweaked it a little bit to build cgltf for linux and darwinj.  And I also changed cgltf.odin to use the generated library file for those systems. 

Thank you and have a nice day. 