### PR TITLE
vendor/x11: fix "display" with no pointer in XGenericEventCookie

### DIFF
--- a/vendor/x11/xlib/xlib_types.odin
+++ b/vendor/x11/xlib/xlib_types.odin
@@ -708,7 +708,7 @@ XGenericEventCookie :: struct {
     type:              EventType,
     serial:            uint,
     send_event:        b32,
-    display:           Display,
+    display:           ^Display,
     extension:         i32,
     evtype:            i32,
     cookie:            u32,


### PR DESCRIPTION
The type of the `display` member seems to be missing a pointer in the XGenericEventCookie struct as outlined by the [x.org docs](https://www.x.org/releases/current/doc/man/man3/XGetEventData.3.xhtml).