### PR TITLE
Fix polymorphic fixed SOA pointers

### DIFF
--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -2390,7 +2390,7 @@ gb_internal Type *make_soa_struct_internal(CheckerContext *ctx, Ast *array_typ_e
 
 	bool is_polymorphic = is_type_polymorphic(elem);
 
-	if ((!is_polymorphic || soa_kind == StructSoa_Fixed) && !is_type_struct(elem) && !is_type_raw_union(elem) && !(is_type_array(elem) && bt_elem->Array.count <= 4)) {
+	if (!is_polymorphic && !is_type_struct(elem) && !is_type_raw_union(elem) && !(is_type_array(elem) && bt_elem->Array.count <= 4)) {
 		gbString str = type_to_string(elem);
 		error(elem_expr, "Invalid type for an #soa array, expected a struct or array of length 4 or below, got '%s'", str);
 		gb_string_free(str);
@@ -2407,7 +2407,7 @@ gb_internal Type *make_soa_struct_internal(CheckerContext *ctx, Ast *array_typ_e
 	case StructSoa_Slice:	extra_field_count = 1; break;
 	case StructSoa_Dynamic:	extra_field_count = 3; break;
 	}
-	if (is_polymorphic && soa_kind != StructSoa_Fixed) {
+	if (is_polymorphic) {
 		field_count = 0;
 
 		soa_struct = alloc_type_struct();


### PR DESCRIPTION
This PR allows generic `#soa^#soa[N]T` pointers.

Code I used for testing:
```odin
package game

import "core:fmt"

My_Container :: struct($N: int, $T: typeid) {
	data: #soa[N]T,
}

// Before this change, the following code triggered these errors:
// Error: Invalid type for an #soa array, expected a struct or array of length 4 or below, got '$T'
// Error: #soa pointers require an #soa record type as the element
my_container_get :: proc(c: ^$C/My_Container($N, $T), index: int) -> #soa^#soa[N]T {
	return &c.data[index]
}

Foo :: struct {
	a, b: u8,
	c:    string,
}

main :: proc() {
	c: My_Container(16, Foo)
	c.data[10] = {123, 88, "foo"}
	a := my_container_get(&c, 10)
	fmt.println(c)
	fmt.println(a.a, a.b, a.c)
	base := uintptr(&c)
	fmt.println(uintptr(&a.a) - base, uintptr(&a.b) - base, uintptr(&a.c) - base)
}
```