### PR TITLE
Make run args take the first '--' as the start of the args, instead of the last '--'

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2425,14 +2425,18 @@ int main(int arg_count, char const **arg_ptr) {
 		Array<String> run_args = array_make<String>(heap_allocator(), 0, arg_count);
 		defer (array_free(&run_args));
 
+		isize run_args_start_idx = -1;
 		for_array(i, args) {
 			if (args[i] == "--") {
-				last_non_run_arg = i;
+				run_args_start_idx = i;
+				break;
 			}
-			if (i <= last_non_run_arg) {
-				continue;
+		}
+		if(run_args_start_idx != -1) {
+			last_non_run_arg = run_args_start_idx;
+			for(isize i = run_args_start_idx+1; i < args.count; ++i) {
+				array_add(&run_args, args[i]);
 			}
-			array_add(&run_args, args[i]);
 		}
 
 		args = array_slice(args, 0, last_non_run_arg);


### PR DESCRIPTION
This PR is a fix for issue #3158. The issue was in the parsing of command line arguments. Instead of scanning for the first `--` and taking everything after it as an argument for the executable for `odin run`, Odin was instead was trying to find the last `--` in the command line and taking everything after that as the run argument.

Which means that in case there are two instances of `--` odin will take one of them as a "non-run argument" and print something like `Unknown flag: ''`.

The fix was to scan the list of arguments in two passes. The first pass to identify the first `--` as the beginning of run arguments and the second one to add all run arguments to the array.