### PR TITLE
Add Rotate and Angle procs for 2D Vectors in core:math/linalg

### DIFF
--- a/core/math/linalg/specific.odin
+++ b/core/math/linalg/specific.odin
@@ -136,29 +136,6 @@ vector2_orthogonal :: proc "contextless" (v: $V/[2]$E) -> V where !IS_ARRAY(E), 
 }
 
 @(require_results)
-vector2_rotate :: proc(v: [2]$E, angle_radians: E) -> (v2: [2]E) where IS_FLOAT(E) {
-    sin, cos := math.sin(angle_radians), math.cos(angle_radians)
-    v2.x = cos * v.x - sin * v.y
-    v2.y = sin * v.x + cos * v.y
-    return
-}
-
-@(require_results)
-vector2_from_angle :: proc(angle_radians: $E) -> [2]E where IS_FLOAT(E) {
-    return {math.cos(angle_radians), math.sin(angle_radians)}
-}
-
-@(require_results)
-angle_between_vector2 :: proc(v1: [2]$E, v2: [2]E) -> E where IS_FLOAT(E) {
-    return math.atan2(cross(v1, v2), dot(v1, v2))
-}
-
-@(require_results)
-angle_from_vector2 :: proc(v: [2]$E) -> E where IS_FLOAT(E) {
-    return math.atan2(v.y, v.x)
-}
-
-@(require_results)
 vector3_orthogonal :: proc "contextless" (v: $V/[3]$E) -> V where !IS_ARRAY(E), IS_FLOAT(E) {
 	x := abs(v.x)
 	y := abs(v.y)
@@ -182,6 +159,31 @@ vector3_orthogonal :: proc "contextless" (v: $V/[3]$E) -> V where !IS_ARRAY(E), 
 }
 
 orthogonal :: proc{vector2_orthogonal, vector3_orthogonal}
+
+
+
+@(require_results)
+vector2_rotate :: proc(v: [2]$E, angle_radians: E) -> (v2: [2]E) where IS_FLOAT(E) {
+    sin, cos := math.sin(angle_radians), math.cos(angle_radians)
+    v2.x = cos * v.x - sin * v.y
+    v2.y = sin * v.x + cos * v.y
+    return
+}
+
+@(require_results)
+vector2_from_angle :: proc(angle_radians: $E) -> [2]E where IS_FLOAT(E) {
+    return {math.cos(angle_radians), math.sin(angle_radians)}
+}
+
+@(require_results)
+angle_between_vector2 :: proc(v1: [2]$E, v2: [2]E) -> E where IS_FLOAT(E) {
+    return math.atan2(cross(v1, v2), dot(v1, v2))
+}
+
+@(require_results)
+angle_from_vector2 :: proc(v: [2]$E) -> E where IS_FLOAT(E) {
+    return math.atan2(v.y, v.x)
+}
 
 
 

--- a/core/math/linalg/specific.odin
+++ b/core/math/linalg/specific.odin
@@ -150,7 +150,7 @@ vector2_from_angle :: proc(angle_radians: $E) -> [2]E where IS_FLOAT(E) {
 
 @(require_results)
 angle_between_vector2 :: proc(v1: [2]$E, v2: [2]E) -> E where IS_FLOAT(E) {
-    return math.atan2(linalg.cross(v1, v2), linalg.dot(v1, v2))
+    return math.atan2(cross(v1, v2), dot(v1, v2))
 }
 
 @(require_results)

--- a/core/math/linalg/specific.odin
+++ b/core/math/linalg/specific.odin
@@ -136,6 +136,29 @@ vector2_orthogonal :: proc "contextless" (v: $V/[2]$E) -> V where !IS_ARRAY(E), 
 }
 
 @(require_results)
+vector2_rotate :: proc(v: [2]$E, angle: E) -> (v2: [2]E) where IS_FLOAT(E) {
+    sin, cos := math.sin(angle), math.cos(angle)
+    v2.x = cos * v.x - sin * v.y
+    v2.y = sin * v.x + cos * v.y
+    return
+}
+
+@(require_results)
+vector2_from_angle :: proc(angle: $E) -> [2]E where IS_FLOAT(E) {
+    return {math.cos(angle), math.sin(angle)}
+}
+
+@(require_results)
+angle_between_vector2 :: proc(v1: [2]$E, v2: [2]E) -> E where IS_FLOAT(E) {
+    return math.atan2(linalg.cross(v1, v2), linalg.dot(v1, v2))
+}
+
+@(require_results)
+angle_from_vector2 :: proc(v: [2]$E) -> E where IS_FLOAT(E) {
+    return math.atan2(v.y, v.x)
+}
+
+@(require_results)
 vector3_orthogonal :: proc "contextless" (v: $V/[3]$E) -> V where !IS_ARRAY(E), IS_FLOAT(E) {
 	x := abs(v.x)
 	y := abs(v.y)

--- a/core/math/linalg/specific.odin
+++ b/core/math/linalg/specific.odin
@@ -136,7 +136,7 @@ vector2_orthogonal :: proc "contextless" (v: $V/[2]$E) -> V where !IS_ARRAY(E), 
 }
 
 @(require_results)
-vector2_rotate :: proc(v: [2]$E, angle: E) -> (v2: [2]E) where IS_FLOAT(E) {
+vector2_rotate :: proc(v: [2]$E, angle_radians: E) -> (v2: [2]E) where IS_FLOAT(E) {
     sin, cos := math.sin(angle), math.cos(angle)
     v2.x = cos * v.x - sin * v.y
     v2.y = sin * v.x + cos * v.y
@@ -144,7 +144,7 @@ vector2_rotate :: proc(v: [2]$E, angle: E) -> (v2: [2]E) where IS_FLOAT(E) {
 }
 
 @(require_results)
-vector2_from_angle :: proc(angle: $E) -> [2]E where IS_FLOAT(E) {
+vector2_from_angle :: proc(angle_radians: $E) -> [2]E where IS_FLOAT(E) {
     return {math.cos(angle), math.sin(angle)}
 }
 

--- a/core/math/linalg/specific.odin
+++ b/core/math/linalg/specific.odin
@@ -137,7 +137,7 @@ vector2_orthogonal :: proc "contextless" (v: $V/[2]$E) -> V where !IS_ARRAY(E), 
 
 @(require_results)
 vector2_rotate :: proc(v: [2]$E, angle_radians: E) -> (v2: [2]E) where IS_FLOAT(E) {
-    sin, cos := math.sin(angle), math.cos(angle)
+    sin, cos := math.sin(angle_radians), math.cos(angle_radians)
     v2.x = cos * v.x - sin * v.y
     v2.y = sin * v.x + cos * v.y
     return
@@ -145,7 +145,7 @@ vector2_rotate :: proc(v: [2]$E, angle_radians: E) -> (v2: [2]E) where IS_FLOAT(
 
 @(require_results)
 vector2_from_angle :: proc(angle_radians: $E) -> [2]E where IS_FLOAT(E) {
-    return {math.cos(angle), math.sin(angle)}
+    return {math.cos(angle_radians), math.sin(angle_radians)}
 }
 
 @(require_results)


### PR DESCRIPTION
# Add Rotate and Angle procs for 2D Vectors in core:math/linalg

**Is your feature request related to a problem? Please describe.**
I approached Odin from the perspective of someone who tinkers with 2D games with Raylib and Godot a ton, and I was really excited to see how good its builtin support for vectors and math was given that array math just kind of works. I was even more excited to see that it had a linear algebra package in core:math, though when I was looking around I noticed a distinct lack of any features to do with rotating 2d vectors, getting angles from them, creating them from angles, etc. Just misc. quality of life procs that would likely get implemented anyways in any 2D game.

**Describe the solution you'd like**
I wrote up four simple procs for 2d vector rotation/angle math that I think fit the style of the rest of the core:math/linalg package, and I think they could come in handy for anyone else trying to make simple 2D projects with Odin. The list below describes the procs I'm proposing with some pseudocode for their signatures:

- `vector2_rotate(vec, angle) -> vec`, returns a new vector2 representing the given vector rotated by the angle provided (radians)
- `vector2_from_angle(angle) -> vec`, returns a new vector2 based off the angle provided (radians)
- `angle_between_vector2(vec1, vec2) -> angle`, returns the angle between two vector2s in radians
- `angle_from_vector2(vec) -> angle`, returns the angle of a vector2 in radians

Positive angles imply counter-clockwise rotations, and negative angles imply clockwise rotations.

- `angle_from_vector2({0, -1})` returns the equivalent of `-math.PI/2`
- `vector2_rotate({1, 0}, math.PI/2)` returns `{0, 1}`

When measuring the angle between two vectors, the angle returned is the angle of vec2 relative to the angle of vec1

- `angle_between_vector2({1, 0}, {0, 1})` returns the equivalent of `math.PI/2`