### PR TITLE
Remove invalid allocator assignment to slice

### DIFF
--- a/base/runtime/core_builtin_soa.odin
+++ b/base/runtime/core_builtin_soa.odin
@@ -86,7 +86,6 @@ make_soa_aligned :: proc($T: typeid/#soa[]$E, length: int, alignment: int, alloc
 		return
 	}
 
-	array.allocator = allocator
 	footer := raw_soa_footer(&array)
 	if size_of(E) == 0 {
 		footer.len = length


### PR DESCRIPTION
`T` is `#soa[]$E`, which does not carry an allocator.