### PR TITLE
remove return statement from case Type_Info_Enumerated_Array

### DIFF
--- a/core/encoding/json/unmarshal.odin
+++ b/core/encoding/json/unmarshal.odin
@@ -492,7 +492,6 @@ unmarshal_object :: proc(p: ^Parser, v: any, end_token: Token_Kind) -> (err: Unm
 			}
 		}
 
-		return nil
 	case:
 		return UNSUPPORTED_TYPE
 	}


### PR DESCRIPTION
I noticed when unmarshalling that this return statement is causes an early exit, and ignoring/defaulting all subsequent fields.