### PR TITLE
[sys/linux]: Fix numeric values for socket fd flags

### DIFF
--- a/core/sys/linux/bits.odin
+++ b/core/sys/linux/bits.odin
@@ -944,8 +944,8 @@ Socket_Type :: enum {
 	Bits for Socket_FD_Flags
 */
 Socket_FD_Flags_Bits :: enum {
-	NONBLOCK  = 14,
-	CLOEXEC   = 25,
+	NONBLOCK  = 11,
+	CLOEXEC   = 19,
 }
 
 /*


### PR DESCRIPTION
The values for constants were wrong, stole these from golang source