### PR TITLE
Add `fmt.*printfln`

### DIFF
--- a/core/fmt/fmt_os.odin
+++ b/core/fmt/fmt_os.odin
@@ -30,7 +30,7 @@ fprintln :: proc(fd: os.Handle, args: ..any, sep := " ", flush := true) -> int {
 	return wprintln(w, ..args, sep=sep, flush=flush)
 }
 // fprintf formats according to the specified format string and writes to fd
-fprintf :: proc(fd: os.Handle, fmt: string, args: ..any, flush := true) -> int {
+fprintf :: proc(fd: os.Handle, fmt: string, args: ..any, flush := true, newline := false) -> int {
 	buf: [1024]byte
 	b: bufio.Writer
 	defer bufio.writer_flush(&b)
@@ -38,7 +38,11 @@ fprintf :: proc(fd: os.Handle, fmt: string, args: ..any, flush := true) -> int {
 	bufio.writer_init_with_buf(&b, os.stream_from_handle(fd), buf[:])
 
 	w := bufio.writer_to_writer(&b)
-	return wprintf(w, fmt, ..args, flush=flush)
+	return wprintf(w, fmt, ..args, flush=flush, newline=newline)
+}
+// fprintfln formats according to the specified format string and writes to fd, followed by a newline.
+fprintfln :: proc(fd: os.Handle, fmt: string, args: ..any, flush := true) -> int {
+	return fprintf(fd, fmt, ..args, flush=flush, newline=true)
 }
 fprint_type :: proc(fd: os.Handle, info: ^runtime.Type_Info, flush := true) -> (n: int, err: io.Error) {
 	buf: [1024]byte
@@ -62,15 +66,19 @@ fprint_typeid :: proc(fd: os.Handle, id: typeid, flush := true) -> (n: int, err:
 }
 
 // print formats using the default print settings and writes to os.stdout
-print   :: proc(args: ..any, sep := " ", flush := true) -> int { return fprint(os.stdout, ..args, sep=sep, flush=flush) }
+print    :: proc(args: ..any, sep := " ", flush := true) -> int { return fprint(os.stdout, ..args, sep=sep, flush=flush) }
 // println formats using the default print settings and writes to os.stdout
-println :: proc(args: ..any, sep := " ", flush := true) -> int { return fprintln(os.stdout, ..args, sep=sep, flush=flush) }
+println  :: proc(args: ..any, sep := " ", flush := true) -> int { return fprintln(os.stdout, ..args, sep=sep, flush=flush) }
 // printf formats according to the specified format string and writes to os.stdout
-printf  :: proc(fmt: string, args: ..any, flush := true) -> int { return fprintf(os.stdout, fmt, ..args, flush=flush) }
+printf   :: proc(fmt: string, args: ..any, flush := true) -> int { return fprintf(os.stdout, fmt, ..args, flush=flush) }
+// printfln formats according to the specified format string and writes to os.stdout, followed by a newline.
+printfln :: proc(fmt: string, args: ..any, flush := true) -> int { return fprintf(os.stdout, fmt, ..args, flush=flush, newline=true) }
 
 // eprint formats using the default print settings and writes to os.stderr
-eprint   :: proc(args: ..any, sep := " ", flush := true) -> int { return fprint(os.stderr, ..args, sep=sep, flush=flush) }
+eprint    :: proc(args: ..any, sep := " ", flush := true) -> int { return fprint(os.stderr, ..args, sep=sep, flush=flush) }
 // eprintln formats using the default print settings and writes to os.stderr
-eprintln :: proc(args: ..any, sep := " ", flush := true) -> int { return fprintln(os.stderr, ..args, sep=sep, flush=flush) }
+eprintln  :: proc(args: ..any, sep := " ", flush := true) -> int { return fprintln(os.stderr, ..args, sep=sep, flush=flush) }
 // eprintf formats according to the specified format string and writes to os.stderr
-eprintf  :: proc(fmt: string, args: ..any, flush := true) -> int { return fprintf(os.stderr, fmt, ..args, flush=flush) }
+eprintf   :: proc(fmt: string, args: ..any, flush := true) -> int { return fprintf(os.stderr, fmt, ..args, flush=flush) }
+// eprintfln formats according to the specified format string and writes to os.stderr, followed by a newline.
+eprintfln :: proc(fmt: string, args: ..any, flush := true) -> int { return fprintf(os.stderr, fmt, ..args, flush=flush, newline=true) }


### PR DESCRIPTION
Adds the following procedures, which just call through to the `printf` versions, with `newline = true`; a new parameter
also added in this commit.
In all cases, `wprintf` is the one that ultimately writes the newline, if requested.

- `printfln`
- `fprintfln`
- `eprintfln`
- `aprintfln`
- `tprintfln`
- `bprintfln`
- `caprintfln`
- `ctprintfln`
- `sbprintfln`
- `wprintfln`

These procs are useful as I often find myself switching between `println` and `printf`, and often find myself wanting the newline.

I originally just cutnpasted a version of `*printf` that also added a newline, but after doing so I figured that adding a `newline := false` parameter to the `*printf` procs might be a neater choice, so that's what I've done here.

I also noticed while doing this that something similar could be done with `*print` vs `*println`, but I've left that out of this PR.