### PR TITLE
Promote types in `#c_varargs` according to C rules

### DIFF
--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -3361,9 +3361,9 @@ gb_internal lbValue lb_build_call_expr_internal(lbProcedure *p, Ast *expr) {
 					for (Ast *var_arg : variadic) {
 						lbValue arg = lb_build_expr(p, var_arg);
 						if (is_type_any(elem_type)) {
-							array_add(&args, lb_emit_conv(p, arg, default_type(arg.type)));
+							array_add(&args, lb_emit_conv(p, arg, c_vararg_promote_type(default_type(arg.type))));
 						} else {
-							array_add(&args, lb_emit_conv(p, arg, elem_type));
+							array_add(&args, lb_emit_conv(p, arg, c_vararg_promote_type(elem_type)));
 						}
 					}
 					break;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -2808,6 +2808,11 @@ gb_internal Type *c_vararg_promote_type(Type *type) {
 	GB_ASSERT(type != nullptr);
 
 	Type *core = core_type(type);
+
+	if (core->kind == Type_BitSet) {
+		core = core_type(bit_set_to_int(core));
+	}
+
 	if (core->kind == Type_Basic) {
 		switch (core->Basic.kind) {
 		case Basic_f32:

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -548,6 +548,14 @@ gb_global Type *t_f16             = &basic_types[Basic_f16];
 gb_global Type *t_f32             = &basic_types[Basic_f32];
 gb_global Type *t_f64             = &basic_types[Basic_f64];
 
+gb_global Type *t_f16be           = &basic_types[Basic_f16be];
+gb_global Type *t_f32be           = &basic_types[Basic_f32be];
+gb_global Type *t_f64be           = &basic_types[Basic_f64be];
+
+gb_global Type *t_f16le           = &basic_types[Basic_f16le];
+gb_global Type *t_f32le           = &basic_types[Basic_f32le];
+gb_global Type *t_f64le           = &basic_types[Basic_f64le];
+
 gb_global Type *t_complex32       = &basic_types[Basic_complex32];
 gb_global Type *t_complex64       = &basic_types[Basic_complex64];
 gb_global Type *t_complex128      = &basic_types[Basic_complex128];
@@ -2792,6 +2800,44 @@ gb_internal Type *default_type(Type *type) {
 		case Basic_UntypedRune:       return t_rune;
 		}
 	}
+	return type;
+}
+
+// See https://en.cppreference.com/w/c/language/conversion#Default_argument_promotions
+gb_internal Type *c_vararg_promote_type(Type *type) {
+	GB_ASSERT(type != nullptr);
+
+	Type *core = core_type(type);
+	if (core->kind == Type_Basic) {
+		switch (core->Basic.kind) {
+		case Basic_f32:
+		case Basic_UntypedFloat:
+			return t_f64;
+		case Basic_f32le:
+			return t_f64le;
+		case Basic_f32be:
+			return t_f64be;
+
+		case Basic_UntypedBool:
+		case Basic_bool:
+		case Basic_b8:
+		case Basic_b16:
+		case Basic_i8:
+		case Basic_i16:
+		case Basic_u8:
+		case Basic_u16:
+			return t_i32;
+
+		case Basic_i16le:
+		case Basic_u16le:
+			return t_i32le;
+
+		case Basic_i16be:
+		case Basic_u16be:
+			return t_i32be;
+		}
+	}
+
 	return type;
 }
 


### PR DESCRIPTION
C varargs apply type promotions, `#c_varargs` currently doesn't. This PR implements the promotion rules by referencing this page: https://en.cppreference.com/w/c/language/conversion#Default_argument_promotions.

There is a lot of text there, but I think these are all the rules we care about. **I would love a set of eyes to confirm though.**

This fixes `libc.printf("%f\n", f32(123))` for example, that currently prints 0, in C the `float` would be promoted to `double` and printed correctly.

I also contemplated emitting errors for usage of these types that need promotion, still not sure which approach would be better, I don't really care much personally.