### PR TITLE
Make MacOS releases self contained / bundle LLVM

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -63,11 +63,13 @@ jobs:
           cp -r core dist
           cp -r vendor dist
           cp -r examples dist
+          # Zipping so executable permissions are retained, see https://github.com/actions/upload-artifact/issues/38
+          zip -r dist.zip dist
       - name: Upload artifact
         uses: actions/upload-artifact@v1
         with:
           name: ubuntu_artifacts
-          path: dist
+          path: dist.zip
   build_macos:
     name: MacOS Build
     if: github.repository == 'odin-lang/Odin'
@@ -93,13 +95,15 @@ jobs:
           cp -r vendor dist
           cp -r examples dist
           dylibbundler -b -x dist/odin -d dist/libs -od -p @executable_path/libs
+          # Zipping so executable permissions are retained, see https://github.com/actions/upload-artifact/issues/38
+          zip -r dist.zip dist
       - name: Odin run
         run: ./dist/odin run examples/demo
       - name: Upload artifact
         uses: actions/upload-artifact@v1
         with:
           name: macos_artifacts
-          path: dist
+          path: dist.zip
   build_macos_arm:
     name: MacOS ARM Build
     if: github.repository == 'odin-lang/Odin'
@@ -125,13 +129,15 @@ jobs:
           cp -r vendor dist
           cp -r examples dist
           dylibbundler -b -x dist/odin -d dist/libs -od -p @executable_path/libs
+          # Zipping so executable permissions are retained, see https://github.com/actions/upload-artifact/issues/38
+          zip -r dist.zip dist
       - name: Odin run
         run: ./dist/odin run examples/demo
       - name: Upload artifact
         uses: actions/upload-artifact@v1
         with:
           name: macos_arm_artifacts
-          path: dist
+          path: dist.zip
   upload_b2:
     runs-on: [ubuntu-latest]
     needs: [build_windows, build_macos, build_macos_arm, build_ubuntu]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,15 +76,13 @@ jobs:
       - uses: actions/checkout@v1
       - name: Download LLVM and setup PATH
         run: |
-          brew install llvm@13
+          brew install llvm@13 dylibbundler
           echo "/usr/local/opt/llvm@13/bin" >> $GITHUB_PATH
           TMP_PATH=$(xcrun --show-sdk-path)/user/include
           echo "CPATH=$TMP_PATH" >> $GITHUB_ENV
       - name: build odin
         run: make nightly
-      - name: Odin run
-        run: ./odin run examples/demo
-      - name: Copy artifacts
+      - name: Bundle
         run: |
           mkdir dist
           cp odin dist
@@ -94,6 +92,9 @@ jobs:
           cp -r core dist
           cp -r vendor dist
           cp -r examples dist
+          dylibbundler -b -x dist/odin -d dist/libs -od -p @executable_path/libs
+      - name: Odin run
+        run: ./dist/odin run examples/demo
       - name: Upload artifact
         uses: actions/upload-artifact@v1
         with:
@@ -107,15 +108,13 @@ jobs:
       - uses: actions/checkout@v1
       - name: Download LLVM and setup PATH
         run: |
-          brew install llvm@13
+          brew install llvm@13 dylibbundler
           echo "/opt/homebrew/opt/llvm@13/bin" >> $GITHUB_PATH
           TMP_PATH=$(xcrun --show-sdk-path)/user/include
           echo "CPATH=$TMP_PATH" >> $GITHUB_ENV
       - name: build odin
         run: make nightly
-      - name: Odin run
-        run: ./odin run examples/demo
-      - name: Copy artifacts
+      - name: Bundle
         run: |
           mkdir dist
           cp odin dist
@@ -125,6 +124,9 @@ jobs:
           cp -r core dist
           cp -r vendor dist
           cp -r examples dist
+          dylibbundler -b -x dist/odin -d dist/libs -od -p @executable_path/libs
+      - name: Odin run
+        run: ./dist/odin run examples/demo
       - name: Upload artifact
         uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
This makes all dynamic library dependencies bundle into `dist/libs`.

Just like before, macos will complain that the binary (and now additionally the bundled libraries) aren't signed/trusted, and you need to go to privacy settings to allow it to run.
To be clear, this already happened before this change with the binary.

This PR also makes the action zip up the dist folder, this is to keep the executable permissions when downloading it back, see https://github.com/actions/upload-artifact/issues/38 for why.