### PR TITLE
vendor/glfw: Add RawMouseMotionSupported to wrapper

### DIFF
--- a/vendor/glfw/wrapper.odin
+++ b/vendor/glfw/wrapper.odin
@@ -149,8 +149,9 @@ WaitEvents        :: glfw.WaitEvents
 WaitEventsTimeout :: glfw.WaitEventsTimeout
 PostEmptyEvent    :: glfw.PostEmptyEvent
 
-GetInputMode :: glfw.GetInputMode
-SetInputMode :: glfw.SetInputMode
+RawMouseMotionSupported :: glfw.RawMouseMotionSupported
+GetInputMode            :: glfw.GetInputMode
+SetInputMode            :: glfw.SetInputMode
 
 GetMouseButton :: glfw.GetMouseButton
 GetCursorPos :: proc "c" (window: WindowHandle) -> (xpos, ypos: f64) {


### PR DESCRIPTION
Adds the RawMouseMotionSupported proc to the glfw wrapper - it was declared in the bindings but not the wrapper.