### PR TITLE
Fix ModelAnimation in raylib.odin missing a field

### DIFF
--- a/vendor/raylib/raylib.odin
+++ b/vendor/raylib/raylib.odin
@@ -425,6 +425,7 @@ ModelAnimation :: struct {
 	frameCount: c.int,            // Number of animation frames
 	bones:      [^]BoneInfo,      // Bones information (skeleton)
 	framePoses: [^][^]Transform,  // Poses array by frame
+	name:       [32]u8,           // Animation name
 }
 
 // Ray type (useful for raycast)


### PR DESCRIPTION
The name field was probably not added when we went from Raylib 4 -> 5

This fixes crashes when using other models than the first one returned by `rl.LoadModelAnimations()`