### PR TITLE
Additional fixes for errors in Raylib bindings since Raylib 4 -> 5 upgrade.

### DIFF
--- a/vendor/raylib/raylib.odin
+++ b/vendor/raylib/raylib.odin
@@ -318,11 +318,11 @@ GlyphInfo :: struct {
 // Font type, includes texture and charSet array data
 Font :: struct {
 	baseSize:     c.int,          // Base size (default chars height)
-	charsCount:   c.int,          // Number of characters
-	charsPadding: c.int,          // Padding around the chars
+	glyphCount:   c.int,          // Number of characters
+	glyphPadding: c.int,          // Padding around the chars
 	texture:      Texture2D,      // Characters texture atlas
 	recs:         [^]Rectangle,   // Characters rectangles in texture
-	chars:        [^]GlyphInfo,    // Characters info data
+	glyphs:       [^]GlyphInfo,    // Characters info data
 }
 
 // Camera type, defines a camera position/orientation in 3d space
@@ -425,7 +425,7 @@ ModelAnimation :: struct {
 	frameCount: c.int,            // Number of animation frames
 	bones:      [^]BoneInfo,      // Bones information (skeleton)
 	framePoses: [^][^]Transform,  // Poses array by frame
-	name:       [32]u8,           // Animation name
+	name:       [32]byte,           // Animation name
 }
 
 // Ray type (useful for raycast)
@@ -491,7 +491,6 @@ VrDeviceInfo :: struct {
 	vResolution:            c.int,    // Vertical resolution in pixels
 	hScreenSize:            f32,      // Horizontal size in meters
 	vScreenSize:            f32,      // Vertical size in meters
-	vScreenCenter:          f32,      // Screen center in meters
 	eyeToScreenDistance:    f32,      // Distance between eye and display in meters
 	lensSeparationDistance: f32,      // Lens separation distance in meters
 	interpupillaryDistance: f32,      // IPD (distance between pupils) in meters


### PR DESCRIPTION
- Field names have changed in `Font`
- `VrDeviceInfo` has become smaller in Raylib 5 due to a field being removed
- I changed `ModelAnimation.name` type from `[32]u8` to `[32]byte` just to be tidy and look like the rest of the bindings.