### PR TITLE
Change `runtime.type_table` layout to allow RTTI to be constantly initialized

### DIFF
--- a/base/runtime/core.odin
+++ b/base/runtime/core.odin
@@ -280,7 +280,7 @@ Typeid_Kind :: enum u8 {
 
 // NOTE(bill): only the ones that are needed (not all types)
 // This will be set by the compiler
-type_table: []Type_Info
+type_table: []^Type_Info
 
 args__: []cstring
 
@@ -609,7 +609,7 @@ __type_info_of :: proc "contextless" (id: typeid) -> ^Type_Info #no_bounds_check
 	if n < 0 || n >= len(type_table) {
 		n = 0
 	}
-	return &type_table[n]
+	return type_table[n]
 }
 
 when !ODIN_NO_RTTI {

--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -1164,7 +1164,7 @@ gb_internal lbProcedure *lb_create_startup_runtime(lbModule *main_module, lbProc
 				lbValue data = lb_emit_struct_ep(p, var.var, 0);
 				lbValue ti   = lb_emit_struct_ep(p, var.var, 1);
 				lb_emit_store(p, data, lb_emit_conv(p, gp, t_rawptr));
-				lb_emit_store(p, ti,   lb_type_info(main_module, var_type));
+				lb_emit_store(p, ti,   lb_type_info(p, var_type));
 			} else {
 				LLVMTypeRef vt = llvm_addr_type(p->module, var.var);
 				lbValue src0 = lb_emit_conv(p, var.init, t);

--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -1104,6 +1104,8 @@ gb_internal lbProcedure *lb_create_startup_runtime(lbModule *main_module, lbProc
 
 	lb_begin_procedure_body(p);
 
+	lb_setup_type_info_data(main_module);
+
 	if (objc_names) {
 		LLVMBuildCall2(p->builder, lb_type_internal_for_procedures_raw(main_module, objc_names->type), objc_names->value, nullptr, 0, "");
 	}

--- a/src/llvm_backend.hpp
+++ b/src/llvm_backend.hpp
@@ -485,7 +485,7 @@ gb_internal lbValue lb_emit_mul_add(lbProcedure *p, lbValue a, lbValue b, lbValu
 
 gb_internal void lb_fill_slice(lbProcedure *p, lbAddr const &slice, lbValue base_elem, lbValue len);
 
-gb_internal lbValue lb_type_info(lbModule *m, Type *type);
+gb_internal lbValue lb_type_info(lbProcedure *p, Type *type);
 
 gb_internal lbValue lb_find_or_add_entity_string(lbModule *m, String const &str);
 gb_internal lbValue lb_generate_anonymous_proc_lit(lbModule *m, String const &prefix_name, Ast *expr, lbProcedure *parent = nullptr);

--- a/src/llvm_backend.hpp
+++ b/src/llvm_backend.hpp
@@ -225,7 +225,6 @@ struct lbGenerator : LinkerData {
 	std::atomic<u32> global_array_index;
 	std::atomic<u32> global_generated_index;
 
-	lbProcedure *startup_type_info;
 	lbProcedure *startup_runtime;
 	lbProcedure *cleanup_runtime;
 	lbProcedure *objc_names;
@@ -587,7 +586,6 @@ gb_internal LLVMTypeRef llvm_array_type(LLVMTypeRef ElementType, uint64_t Elemen
 
 #define LB_STARTUP_RUNTIME_PROC_NAME   "__$startup_runtime"
 #define LB_CLEANUP_RUNTIME_PROC_NAME   "__$cleanup_runtime"
-#define LB_STARTUP_TYPE_INFO_PROC_NAME "__$startup_type_info"
 #define LB_TYPE_INFO_DATA_NAME       "__$type_info_data"
 #define LB_TYPE_INFO_TYPES_NAME      "__$type_info_types_data"
 #define LB_TYPE_INFO_NAMES_NAME      "__$type_info_names_data"

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -1755,7 +1755,7 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 		TypeAndValue tav = type_and_value_of_expr(arg);
 		if (tav.mode == Addressing_Type) {
 			Type *t = default_type(type_of_expr(arg));
-			return lb_type_info(p->module, t);
+			return lb_type_info(p, t);
 		}
 		GB_ASSERT(is_type_typeid(tav.type));
 

--- a/src/llvm_backend_stmt.cpp
+++ b/src/llvm_backend_stmt.cpp
@@ -748,7 +748,7 @@ gb_internal void lb_build_range_enum(lbProcedure *p, Type *enum_type, Type *val_
 	i64 enum_count = t->Enum.fields.count;
 	lbValue max_count = lb_const_int(m, t_int, enum_count);
 
-	lbValue ti          = lb_type_info(m, t);
+	lbValue ti          = lb_type_info(p, t);
 	lbValue variant     = lb_emit_struct_ep(p, ti, 4);
 	lbValue eti_ptr     = lb_emit_conv(p, variant, t_type_info_enum_ptr);
 	lbValue values      = lb_emit_load(p, lb_emit_struct_ep(p, eti_ptr, 2));

--- a/src/llvm_backend_type.cpp
+++ b/src/llvm_backend_type.cpp
@@ -180,16 +180,7 @@ gb_internal lbValue lb_type_info_member_tags_offset(lbModule *m, isize count, i6
 	return offset;
 }
 
-// enum {LB_USE_GIANT_PACKED_STRUCT = LB_USE_NEW_PASS_SYSTEM};
-enum {LB_USE_GIANT_PACKED_STRUCT = 0};
-
-gb_internal LLVMTypeRef lb_setup_type_info_data_internal_type(lbModule *m, isize max_type_info_count) {
-	if (!LB_USE_GIANT_PACKED_STRUCT) {
-		Type *t = alloc_type_array(t_type_info, max_type_info_count);
-		return lb_type(m, t);
-	}
-	CheckerInfo *info = m->gen->info;
-
+gb_internal LLVMTypeRef *lb_setup_modified_types_for_type_info(lbModule *m, isize max_type_info_count) {
 	LLVMTypeRef *element_types = gb_alloc_array(heap_allocator(), LLVMTypeRef, max_type_info_count);
 	defer (gb_free(heap_allocator(), element_types));
 
@@ -219,8 +210,8 @@ gb_internal LLVMTypeRef lb_setup_type_info_data_internal_type(lbModule *m, isize
 		variant_index = 4;
 	}
 
-	LLVMTypeRef modified_types[32] = {};
-	GB_ASSERT(gb_count_of(modified_types) >= ut->Union.variants.count);
+	LLVMTypeRef *modified_types = gb_alloc_array(heap_allocator(), LLVMTypeRef, Typeid__COUNT);
+	GB_ASSERT(Typeid__COUNT == ut->Union.variants.count);
 	modified_types[0] = element_types[0];
 
 	i64 tag_offset = ut->Union.variant_block_size;
@@ -242,40 +233,24 @@ gb_internal LLVMTypeRef lb_setup_type_info_data_internal_type(lbModule *m, isize
 		modified_types[i] = modified_type;
 	}
 
-	for_array(type_info_type_index, info->type_info_types) {
-		Type *t = info->type_info_types[type_info_type_index];
-		if (t == nullptr || t == t_invalid) {
-			continue;
-		}
-		isize entry_index = lb_type_info_index(info, t, false);
-		if (entry_index <= 0) {
-			continue;
-		}
-
-		if (entries_handled[entry_index]) {
-			continue;
-		}
-		entries_handled[entry_index] = true;
-
-
-		if (t->kind == Type_Named) {
-			element_types[entry_index] = modified_types[0];
-		} else {
-			i64 variant_index = lb_typeid_kind(m, t);
-			element_types[entry_index] = modified_types[variant_index];
-		}
-
-		GB_ASSERT(element_types[entry_index] != nullptr);
+	for (isize i = 0; i < Typeid__COUNT; i++) {
+		GB_ASSERT_MSG(modified_types[i] != nullptr, "%td", ut->Union.variants.count);
 	}
 
-	for_array(i, entries_handled) {
-		GB_ASSERT(entries_handled[i]);
-	}
-
-	return LLVMStructType(element_types, cast(unsigned)max_type_info_count, true);
+	return modified_types;
 }
 
-gb_internal void lb_setup_type_info_data_giant_packed_struct(lbModule *m, i64 global_type_info_data_entity_count, lbProcedure *p) { // NOTE(bill): Setup type_info data
+gb_internal void lb_setup_type_info_data_giant_array(lbModule *m, i64 global_type_info_data_entity_count, lbProcedure *p) { // NOTE(bill): Setup type_info data
+	auto const &ADD_GLOBAL_TYPE_INFO_ENTRY = [](lbModule *m, LLVMTypeRef type, isize index) -> LLVMValueRef {
+		char name[64] = {};
+		gb_snprintf(name, 63, "__$ti-%lld", cast(long long)index);
+		LLVMValueRef g = LLVMAddGlobal(m->mod, type, name);
+		LLVMSetLinkage(g, LLVMInternalLinkage);
+		LLVMSetUnnamedAddress(g, LLVMGlobalUnnamedAddr);
+		LLVMSetGlobalConstant(g, true);
+		return g;
+	};
+
 	CheckerInfo *info = m->info;
 
 	// Useful types
@@ -292,18 +267,46 @@ gb_internal void lb_setup_type_info_data_giant_packed_struct(lbModule *m, i64 gl
 	defer (gb_free(heap_allocator(), entries_handled.data));
 	entries_handled[0] = true;
 
-	LLVMValueRef giant_struct = lb_global_type_info_data_ptr(m).value;
-	LLVMTypeRef giant_struct_type = LLVMGlobalGetValueType(giant_struct);
-	GB_ASSERT(LLVMGetTypeKind(giant_struct_type) == LLVMStructTypeKind);
-
 	LLVMValueRef *giant_const_values = gb_alloc_array(heap_allocator(), LLVMValueRef, global_type_info_data_entity_count);
 	defer (gb_free(heap_allocator(), giant_const_values));
 
-	giant_const_values[0] = LLVMConstNull(LLVMStructGetTypeAtIndex(giant_struct_type, 0));
+	// zero value is just zero data
+	giant_const_values[0] = ADD_GLOBAL_TYPE_INFO_ENTRY(m, lb_type(m, t_type_info), 0);
+	LLVMSetInitializer(giant_const_values[0], LLVMConstNull(lb_type(m, t_type_info)));
+
+
+	LLVMTypeRef *modified_types = lb_setup_modified_types_for_type_info(m, global_type_info_data_entity_count);
+	defer (gb_free(heap_allocator(), modified_types));
+	for_array(type_info_type_index, info->type_info_types) {
+		Type *t = info->type_info_types[type_info_type_index];
+		if (t == nullptr || t == t_invalid) {
+			continue;
+		}
+
+		isize entry_index = lb_type_info_index(info, t, false);
+		if (entry_index <= 0) {
+			continue;
+		}
+
+		if (entries_handled[entry_index]) {
+			continue;
+		}
+		entries_handled[entry_index] = true;
+
+
+		LLVMTypeRef stype = modified_types[0];
+		if (t->kind != Type_Named) {
+			stype = modified_types[lb_typeid_kind(m, t)];
+		}
+		giant_const_values[entry_index] = ADD_GLOBAL_TYPE_INFO_ENTRY(m, stype, entry_index);
+	}
+	for (isize i = 1; i < global_type_info_data_entity_count; i++) {
+		entries_handled[i] = false;
+	}
+
 
 	LLVMValueRef *small_const_values = gb_alloc_array(heap_allocator(), LLVMValueRef, 6);
 	defer (gb_free(heap_allocator(), small_const_values));
-
 
 	#define type_info_allocate_values(name) \
 		LLVMValueRef *name##_values = gb_alloc_array(heap_allocator(), LLVMValueRef, type_deref(name.addr.type)->Array.count); \
@@ -316,7 +319,7 @@ gb_internal void lb_setup_type_info_data_giant_packed_struct(lbModule *m, i64 gl
 					(name##_values)[i] = LLVMConstNull(elem);                                                      \
 				}                                                                                                      \
 			}                                                                                                              \
-			LLVMSetInitializer(name.addr.value, llvm_const_array(elem, name##_values, at->Array.count));                    \
+			LLVMSetInitializer(name.addr.value, llvm_const_array(elem, name##_values, at->Array.count));                   \
 		})
 
 	type_info_allocate_values(lb_global_type_info_member_types);
@@ -326,27 +329,13 @@ gb_internal void lb_setup_type_info_data_giant_packed_struct(lbModule *m, i64 gl
 	type_info_allocate_values(lb_global_type_info_member_tags);
 
 
-	i64 const type_info_struct_size = type_size_of(t_type_info);
-	LLVMTypeRef llvm_u8 = lb_type(m, t_u8);
-	LLVMTypeRef llvm_int = lb_type(m, t_int);
-	// LLVMTypeRef llvm_type_info_ptr = lb_type(m, t_type_info_ptr);
-
 	auto const get_type_info_ptr = [&](lbModule *m, Type *type) -> LLVMValueRef {
 		type = default_type(type);
 
 		isize index = lb_type_info_index(m->info, type);
 		GB_ASSERT(index >= 0);
 
-		u64 offset = cast(u64)(index * type_info_struct_size);
-
-		LLVMValueRef indices[1] = {
-			LLVMConstInt(llvm_int, offset, false)
-		};
-
-		// LLVMValueRef ptr = LLVMConstInBoundsGEP2(llvm_u8, giant_struct, indices, gb_count_of(indices));
-		LLVMValueRef ptr = LLVMConstGEP2(llvm_u8, giant_struct, indices, gb_count_of(indices));
-		return ptr;
-		// return LLVMConstPointerCast(ptr, llvm_type_info_ptr);
+		return giant_const_values[index];
 	};
 
 	for_array(type_info_type_index, info->type_info_types) {
@@ -366,7 +355,10 @@ gb_internal void lb_setup_type_info_data_giant_packed_struct(lbModule *m, i64 gl
 		entries_handled[entry_index] = true;
 
 
-		LLVMTypeRef stype = LLVMStructGetTypeAtIndex(giant_struct_type, cast(unsigned)entry_index);
+		LLVMTypeRef stype = modified_types[0];
+		if (t->kind != Type_Named) {
+			stype = modified_types[lb_typeid_kind(m, t)];
+		}
 
 		i64 size = type_size_of(t);
 		i64 align = type_align_of(t);
@@ -375,6 +367,10 @@ gb_internal void lb_setup_type_info_data_giant_packed_struct(lbModule *m, i64 gl
 		GB_ASSERT_MSG(align != 0, "%lld %s", align, type_to_string(t));
 
 		lbValue type_info_flags = lb_const_int(m, t_type_info_flags, flags);
+
+		for (isize i = 0; i < 6; i++) {
+			small_const_values[i] = nullptr;
+		}
 
 		small_const_values[0] = LLVMConstInt(lb_type(m, t_int), size, true);
 		small_const_values[1] = LLVMConstInt(lb_type(m, t_int), align, true);
@@ -994,6 +990,7 @@ gb_internal void lb_setup_type_info_data_giant_packed_struct(lbModule *m, i64 gl
 		if (tag_type != nullptr) {
 			tag_index = union_variant_index(ut, tag_type);
 		}
+		GB_ASSERT(tag_index <= Typeid__COUNT);
 
 		LLVMValueRef full_variant_values[3] = {};
 
@@ -1024,11 +1021,16 @@ gb_internal void lb_setup_type_info_data_giant_packed_struct(lbModule *m, i64 gl
 
 		small_const_values[variant_index] = full_variant_value;
 
-		giant_const_values[entry_index] = LLVMConstNamedStruct(stype, small_const_values, variant_index+1);
+		LLVMSetInitializer(giant_const_values[entry_index], LLVMConstNamedStruct(stype, small_const_values, variant_index+1));
+	}
+	for (isize i = 0; i < global_type_info_data_entity_count; i++) {
+		giant_const_values[i] = LLVMConstPointerCast(giant_const_values[i], lb_type(m, t_type_info_ptr));
 	}
 
-	LLVMValueRef giant_const = LLVMConstNamedStruct(giant_struct_type, giant_const_values, cast(unsigned)global_type_info_data_entity_count);
-	LLVMSetInitializer(giant_struct, giant_const);
+
+	LLVMValueRef giant_const = LLVMConstArray(lb_type(m, t_type_info_ptr), giant_const_values, cast(unsigned)global_type_info_data_entity_count);
+	LLVMValueRef giant_array = lb_global_type_info_data_ptr(m).value;
+	LLVMSetInitializer(giant_array, giant_const);
 }
 
 
@@ -1038,845 +1040,25 @@ gb_internal void lb_setup_type_info_data(lbProcedure *p) { // NOTE(bill): Setup 
 	}
 
 	lbModule *m = p->module;
-	CheckerInfo *info = m->info;
 
 	i64 global_type_info_data_entity_count = 0;
-	{
-		// NOTE(bill): Set the type_table slice with the global backing array
-		lbValue global_type_table = lb_find_runtime_value(m, str_lit("type_table"));
-		Type *type = base_type(lb_global_type_info_data_entity->type);
-		GB_ASSERT(type->kind == Type_Array);
-		global_type_info_data_entity_count = type->Array.count;
 
-		LLVMValueRef data = lb_global_type_info_data_ptr(m).value;
-		data = LLVMConstPointerCast(data, lb_type(m, alloc_type_pointer(type->Array.elem)));
-		LLVMValueRef len = LLVMConstInt(lb_type(m, t_int), type->Array.count, true);
-		Type *t = type_deref(global_type_table.type);
-		GB_ASSERT(is_type_slice(t));
-		LLVMValueRef slice = llvm_const_slice_internal(m, data, len);
+	// NOTE(bill): Set the type_table slice with the global backing array
+	lbValue global_type_table = lb_find_runtime_value(m, str_lit("type_table"));
+	Type *type = base_type(lb_global_type_info_data_entity->type);
+	GB_ASSERT(type->kind == Type_Array);
+	global_type_info_data_entity_count = type->Array.count;
 
-		LLVMSetInitializer(global_type_table.value, slice);
+	if (true) {
+		lb_setup_type_info_data_giant_array(m, global_type_info_data_entity_count, p);
 	}
 
-	if (LB_USE_GIANT_PACKED_STRUCT) {
-		lb_setup_type_info_data_giant_packed_struct(m, global_type_info_data_entity_count, p);
-		return;
-	}
-
-	// Useful types
-	Entity *type_info_flags_entity = find_core_entity(info->checker, str_lit("Type_Info_Flags"));
-	Type *t_type_info_flags = type_info_flags_entity->type;
-
-	
-	auto entries_handled = slice_make<bool>(heap_allocator(), cast(isize)global_type_info_data_entity_count);
-	defer (gb_free(heap_allocator(), entries_handled.data));
-	entries_handled[0] = true;
-	
-	for_array(type_info_type_index, info->type_info_types) {
-		Type *t = info->type_info_types[type_info_type_index];
-		if (t == nullptr || t == t_invalid) {
-			continue;
-		}
-
-		isize entry_index = lb_type_info_index(info, t, false);
-		if (entry_index <= 0) {
-			continue;
-		}
-
-		if (entries_handled[entry_index]) {
-			continue;
-		}
-		entries_handled[entry_index] = true;
-
-		lbValue global_data_ptr = lb_global_type_info_data_ptr(m);
-		lbValue tag = {};
-		lbValue ti_ptr = lb_emit_array_epi(p, global_data_ptr, cast(i32)entry_index);
-		
-		i64 size = type_size_of(t);
-		i64 align = type_align_of(t);
-		u32 flags = type_info_flags_of_type(t);
-		lbValue id = lb_typeid(m, t);
-		GB_ASSERT_MSG(align != 0, "%lld %s", align, type_to_string(t));
-		
-		lbValue type_info_flags = lb_const_int(p->module, t_type_info_flags, flags);
-		
-		lbValue size_ptr  = lb_emit_struct_ep(p, ti_ptr, 0);
-		lbValue align_ptr = lb_emit_struct_ep(p, ti_ptr, 1);
-		lbValue flags_ptr = lb_emit_struct_ep(p, ti_ptr, 2);
-		lbValue id_ptr    = lb_emit_struct_ep(p, ti_ptr, 3);
-				
-		lb_emit_store(p, size_ptr,  lb_const_int(m, t_int, size));
-		lb_emit_store(p, align_ptr, lb_const_int(m, t_int, align));
-		lb_emit_store(p, flags_ptr, type_info_flags);
-		lb_emit_store(p, id_ptr,    id);
-		
-		lbValue variant_ptr = lb_emit_struct_ep(p, ti_ptr, 4);
-
-		switch (t->kind) {
-		case Type_Named: {
-			tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_named_ptr);
-
-			LLVMValueRef pkg_name = nullptr;
-			if (t->Named.type_name->pkg) {
-				pkg_name = lb_const_string(m, t->Named.type_name->pkg->name).value;
-			} else {
-				pkg_name = LLVMConstNull(lb_type(m, t_string));
-			}
-
-			String proc_name = {};
-			if (t->Named.type_name->parent_proc_decl) {
-				DeclInfo *decl = t->Named.type_name->parent_proc_decl;
-				if (decl->entity && decl->entity->kind == Entity_Procedure) {
-					proc_name = decl->entity->token.string;
-				}
-			}
-			TokenPos pos = t->Named.type_name->token.pos;
-
-			lbValue loc = lb_emit_source_code_location_const(p, proc_name, pos);
-
-			LLVMValueRef vals[4] = {
-				lb_const_string(p->module, t->Named.type_name->token.string).value,
-				lb_type_info(m, t->Named.base).value,
-				pkg_name,
-				loc.value
-			};
-
-			lbValue res = {};
-			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-			lb_emit_store(p, tag, res);
-			break;
-		}
-
-		case Type_Basic:
-			switch (t->Basic.kind) {
-			case Basic_bool:
-			case Basic_b8:
-			case Basic_b16:
-			case Basic_b32:
-			case Basic_b64:
-				tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_boolean_ptr);
-				break;
-
-			case Basic_i8:
-			case Basic_u8:
-			case Basic_i16:
-			case Basic_u16:
-			case Basic_i32:
-			case Basic_u32:
-			case Basic_i64:
-			case Basic_u64:
-			case Basic_i128:
-			case Basic_u128:
-
-			case Basic_i16le:
-			case Basic_u16le:
-			case Basic_i32le:
-			case Basic_u32le:
-			case Basic_i64le:
-			case Basic_u64le:
-			case Basic_i128le:
-			case Basic_u128le:
-			case Basic_i16be:
-			case Basic_u16be:
-			case Basic_i32be:
-			case Basic_u32be:
-			case Basic_i64be:
-			case Basic_u64be:
-			case Basic_i128be:
-			case Basic_u128be:
-
-			case Basic_int:
-			case Basic_uint:
-			case Basic_uintptr: {
-				tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_integer_ptr);
-
-				lbValue is_signed = lb_const_bool(m, t_bool, (t->Basic.flags & BasicFlag_Unsigned) == 0);
-				// NOTE(bill): This is matches the runtime layout
-				u8 endianness_value = 0;
-				if (t->Basic.flags & BasicFlag_EndianLittle) {
-					endianness_value = 1;
-				} else if (t->Basic.flags & BasicFlag_EndianBig) {
-					endianness_value = 2;
-				}
-				lbValue endianness = lb_const_int(m, t_u8, endianness_value);
-
-				LLVMValueRef vals[2] = {
-					is_signed.value,
-					endianness.value,
-				};
-
-				lbValue res = {};
-				res.type = type_deref(tag.type);
-				res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-				lb_emit_store(p, tag, res);
-				break;
-			}
-
-			case Basic_rune:
-				tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_rune_ptr);
-				break;
-
-			case Basic_f16:
-			case Basic_f32:
-			case Basic_f64:
-			case Basic_f16le:
-			case Basic_f32le:
-			case Basic_f64le:
-			case Basic_f16be:
-			case Basic_f32be:
-			case Basic_f64be:
-				{
-					tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_float_ptr);
-
-					// NOTE(bill): This is matches the runtime layout
-					u8 endianness_value = 0;
-					if (t->Basic.flags & BasicFlag_EndianLittle) {
-						endianness_value = 1;
-					} else if (t->Basic.flags & BasicFlag_EndianBig) {
-						endianness_value = 2;
-					}
-					lbValue endianness = lb_const_int(m, t_u8, endianness_value);
-
-					LLVMValueRef vals[1] = {
-						endianness.value,
-					};
-
-					lbValue res = {};
-					res.type = type_deref(tag.type);
-					res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-					lb_emit_store(p, tag, res);
-				}
-				break;
-
-			case Basic_complex32:
-			case Basic_complex64:
-			case Basic_complex128:
-				tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_complex_ptr);
-				break;
-
-			case Basic_quaternion64:
-			case Basic_quaternion128:
-			case Basic_quaternion256:
-				tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_quaternion_ptr);
-				break;
-
-			case Basic_rawptr:
-				tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_pointer_ptr);
-				break;
-
-			case Basic_string:
-				tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_string_ptr);
-				break;
-
-			case Basic_cstring:
-				{
-					tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_string_ptr);
-					LLVMValueRef vals[1] = {
-						lb_const_bool(m, t_bool, true).value,
-					};
-
-					lbValue res = {};
-					res.type = type_deref(tag.type);
-					res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-					lb_emit_store(p, tag, res);
-				}
-				break;
-
-			case Basic_any:
-				tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_any_ptr);
-				break;
-
-			case Basic_typeid:
-				tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_typeid_ptr);
-				break;
-			}
-			break;
-
-		case Type_Pointer: {
-			tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_pointer_ptr);
-			lbValue gep = lb_type_info(m, t->Pointer.elem);
-
-			LLVMValueRef vals[1] = {
-				gep.value,
-			};
-
-			lbValue res = {};
-			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-			lb_emit_store(p, tag, res);
-			break;
-		}
-		case Type_MultiPointer: {
-			tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_multi_pointer_ptr);
-			lbValue gep = lb_type_info(m, t->MultiPointer.elem);
-
-			LLVMValueRef vals[1] = {
-				gep.value,
-			};
-
-			lbValue res = {};
-			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-			lb_emit_store(p, tag, res);
-			break;
-		}
-		case Type_SoaPointer: {
-			tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_soa_pointer_ptr);
-			lbValue gep = lb_type_info(m, t->SoaPointer.elem);
-
-			LLVMValueRef vals[1] = {
-				gep.value,
-			};
-
-			lbValue res = {};
-			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-			lb_emit_store(p, tag, res);
-			break;
-		}
-		case Type_Array: {
-			tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_array_ptr);
-			i64 ez = type_size_of(t->Array.elem);
-
-			LLVMValueRef vals[3] = {
-				lb_type_info(m, t->Array.elem).value,
-				lb_const_int(m, t_int, ez).value,
-				lb_const_int(m, t_int, t->Array.count).value,
-			};
-
-			lbValue res = {};
-			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-			lb_emit_store(p, tag, res);
-			break;
-		}
-		case Type_EnumeratedArray: {
-			tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_enumerated_array_ptr);
-
-			LLVMValueRef vals[7] = {
-				lb_type_info(m, t->EnumeratedArray.elem).value,
-				lb_type_info(m, t->EnumeratedArray.index).value,
-				lb_const_int(m, t_int, type_size_of(t->EnumeratedArray.elem)).value,
-				lb_const_int(m, t_int, t->EnumeratedArray.count).value,
-
-				// Unions
-				LLVMConstNull(lb_type(m, t_type_info_enum_value)),
-				LLVMConstNull(lb_type(m, t_type_info_enum_value)),
-
-				lb_const_bool(m, t_bool, t->EnumeratedArray.is_sparse).value,
-			};
-
-			lbValue res = {};
-			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-			lb_emit_store(p, tag, res);
-
-			// NOTE(bill): Union assignment
-			lbValue min_value = lb_emit_struct_ep(p, tag, 4);
-			lbValue max_value = lb_emit_struct_ep(p, tag, 5);
-
-			lbValue min_v = lb_const_value(m, t_i64, *t->EnumeratedArray.min_value);
-			lbValue max_v = lb_const_value(m, t_i64, *t->EnumeratedArray.max_value);
-
-			lb_emit_store(p, min_value, min_v);
-			lb_emit_store(p, max_value, max_v);
-			break;
-		}
-		case Type_DynamicArray: {
-			tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_dynamic_array_ptr);
-
-			LLVMValueRef vals[2] = {
-				lb_type_info(m, t->DynamicArray.elem).value,
-				lb_const_int(m, t_int, type_size_of(t->DynamicArray.elem)).value,
-			};
-
-			lbValue res = {};
-			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-			lb_emit_store(p, tag, res);
-			break;
-		}
-		case Type_Slice: {
-			tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_slice_ptr);
-
-			LLVMValueRef vals[2] = {
-				lb_type_info(m, t->Slice.elem).value,
-				lb_const_int(m, t_int, type_size_of(t->Slice.elem)).value,
-			};
-
-			lbValue res = {};
-			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-			lb_emit_store(p, tag, res);
-			break;
-		}
-		case Type_Proc: {
-			tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_procedure_ptr);
-
-			LLVMValueRef params = LLVMConstNull(lb_type(m, t_type_info_ptr));
-			LLVMValueRef results = LLVMConstNull(lb_type(m, t_type_info_ptr));
-			if (t->Proc.params != nullptr) {
-				params = lb_type_info(m, t->Proc.params).value;
-			}
-			if (t->Proc.results != nullptr) {
-				results = lb_type_info(m, t->Proc.results).value;
-			}
-
-			LLVMValueRef vals[4] = {
-				params,
-				results,
-				lb_const_bool(m, t_bool, t->Proc.variadic).value,
-				lb_const_int(m, t_u8, t->Proc.calling_convention).value,
-			};
-
-			lbValue res = {};
-			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-			lb_emit_store(p, tag, res);
-			break;
-		}
-		case Type_Tuple: {
-			tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_parameters_ptr);
-
-			lbValue memory_types = lb_type_info_member_types_offset(m, t->Tuple.variables.count);
-			lbValue memory_names = lb_type_info_member_names_offset(m, t->Tuple.variables.count);
-
-
-			for_array(i, t->Tuple.variables) {
-				// NOTE(bill): offset is not used for tuples
-				Entity *f = t->Tuple.variables[i];
-
-				lbValue index     = lb_const_int(m, t_int, i);
-				lbValue type_info = lb_emit_ptr_offset(p, memory_types, index);
-
-				// TODO(bill): Make this constant if possible, 'lb_const_store' does not work
-				lb_emit_store(p, type_info, lb_type_info(m, f->type));
-				if (f->token.string.len > 0) {
-					lbValue name = lb_emit_ptr_offset(p, memory_names, index);
-					lb_emit_store(p, name, lb_const_string(m, f->token.string));
-				}
-			}
-
-			lbValue count = lb_const_int(m, t_int, t->Tuple.variables.count);
-
-			LLVMValueRef types_slice = llvm_const_slice(m, memory_types, count);
-			LLVMValueRef names_slice = llvm_const_slice(m, memory_names, count);
-
-			LLVMValueRef vals[2] = {
-				types_slice,
-				names_slice,
-			};
-
-			lbValue res = {};
-			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-			lb_emit_store(p, tag, res);
-
-			break;
-		}
-
-		case Type_Enum:
-			tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_enum_ptr);
-
-			{
-				GB_ASSERT(t->Enum.base_type != nullptr);
-				// GB_ASSERT_MSG(type_size_of(t_type_info_enum_value) == 16, "%lld == 16", cast(long long)type_size_of(t_type_info_enum_value));
-
-
-				LLVMValueRef vals[3] = {};
-				vals[0] = lb_type_info(m, t->Enum.base_type).value;
-				if (t->Enum.fields.count > 0) {
-					auto fields = t->Enum.fields;
-					lbValue name_array  = lb_generate_global_array(m, t_string, fields.count,
-					                                        str_lit("$enum_names"), cast(i64)entry_index);
-					lbValue value_array = lb_generate_global_array(m, t_type_info_enum_value, fields.count,
-					                                        str_lit("$enum_values"), cast(i64)entry_index);
-
-
-					LLVMValueRef *name_values = gb_alloc_array(temporary_allocator(), LLVMValueRef, fields.count);
-					LLVMValueRef *value_values = gb_alloc_array(temporary_allocator(), LLVMValueRef, fields.count);
-
-					GB_ASSERT(is_type_integer(t->Enum.base_type));
-
-					for_array(i, fields) {
-						name_values[i] = lb_const_string(m, fields[i]->token.string).value;
-						value_values[i] = lb_const_value(m, t_i64, fields[i]->Constant.value).value;
-					}
-
-					LLVMValueRef name_init  = llvm_const_array(lb_type(m, t_string),               name_values,  cast(unsigned)fields.count);
-					LLVMValueRef value_init = llvm_const_array(lb_type(m, t_type_info_enum_value), value_values, cast(unsigned)fields.count);
-					LLVMSetInitializer(name_array.value,  name_init);
-					LLVMSetInitializer(value_array.value, value_init);
-					LLVMSetGlobalConstant(name_array.value, true);
-					LLVMSetGlobalConstant(value_array.value, true);
-
-					lbValue v_count = lb_const_int(m, t_int, fields.count);
-
-					vals[1] = llvm_const_slice(m, lb_array_elem(p, name_array), v_count);
-					vals[2] = llvm_const_slice(m, lb_array_elem(p, value_array), v_count);
-				} else {
-					vals[1] = LLVMConstNull(lb_type(m, base_type(t_type_info_enum)->Struct.fields[1]->type));
-					vals[2] = LLVMConstNull(lb_type(m, base_type(t_type_info_enum)->Struct.fields[2]->type));
-				}
-
-
-				lbValue res = {};
-				res.type = type_deref(tag.type);
-				res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-				lb_emit_store(p, tag, res);
-			}
-			break;
-
-		case Type_Union: {
-			tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_union_ptr);
-
-			{
-				LLVMValueRef vals[7] = {};
-
-				isize variant_count = gb_max(0, t->Union.variants.count);
-				lbValue memory_types = lb_type_info_member_types_offset(m, variant_count);
-
-				// NOTE(bill): Zeroth is nil so ignore it
-				for (isize variant_index = 0; variant_index < variant_count; variant_index++) {
-					Type *vt = t->Union.variants[variant_index];
-					lbValue tip = lb_type_info(m, vt);
-
-					lbValue index     = lb_const_int(m, t_int, variant_index);
-					lbValue type_info = lb_emit_ptr_offset(p, memory_types, index);
-					lb_emit_store(p, type_info, lb_type_info(m, vt));
-				}
-
-				lbValue count = lb_const_int(m, t_int, variant_count);
-				vals[0] = llvm_const_slice(m, memory_types, count);
-
-				i64 tag_size = union_tag_size(t);
-				if (tag_size > 0) {
-					i64 tag_offset = align_formula(t->Union.variant_block_size, tag_size);
-					vals[1] = lb_const_int(m, t_uintptr, tag_offset).value;
-					vals[2] = lb_type_info(m, union_tag_type(t)).value;
-				} else {
-					vals[1] = lb_const_int(m, t_uintptr, 0).value;
-					vals[2] = LLVMConstNull(lb_type(m, t_type_info_ptr));
-				}
-
-				if (is_type_comparable(t) && !is_type_simple_compare(t)) {
-					vals[3] = lb_equal_proc_for_type(m, t).value;
-				}
-
-				vals[4] = lb_const_bool(m, t_bool, t->Union.custom_align != 0).value;
-				vals[5] = lb_const_bool(m, t_bool, t->Union.kind == UnionType_no_nil).value;
-				vals[6] = lb_const_bool(m, t_bool, t->Union.kind == UnionType_shared_nil).value;
-
-				for (isize i = 0; i < gb_count_of(vals); i++) {
-					if (vals[i] == nullptr) {
-						vals[i]  = LLVMConstNull(lb_type(m, get_struct_field_type(tag.type, i)));
-					}
-				}
-
-				lbValue res = {};
-				res.type = type_deref(tag.type);
-				res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-				lb_emit_store(p, tag, res);
-			}
-
-			break;
-		}
-
-		case Type_Struct: {
-			tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_struct_ptr);
-
-			LLVMValueRef vals[13] = {};
-
-
-			{
-				lbValue is_packed       = lb_const_bool(m, t_bool, t->Struct.is_packed);
-				lbValue is_raw_union    = lb_const_bool(m, t_bool, t->Struct.is_raw_union);
-				lbValue is_no_copy      = lb_const_bool(m, t_bool, t->Struct.is_no_copy);
-				lbValue is_custom_align = lb_const_bool(m, t_bool, t->Struct.custom_align != 0);
-				vals[5] = is_packed.value;
-				vals[6] = is_raw_union.value;
-				vals[7] = is_no_copy.value;
-				vals[8] = is_custom_align.value;
-				if (is_type_comparable(t) && !is_type_simple_compare(t)) {
-					vals[9] = lb_equal_proc_for_type(m, t).value;
-				}
-
-
-				if (t->Struct.soa_kind != StructSoa_None) {
-					lbValue kind = lb_emit_struct_ep(p, tag, 10);
-					Type *kind_type = type_deref(kind.type);
-
-					lbValue soa_kind = lb_const_value(m, kind_type, exact_value_i64(t->Struct.soa_kind));
-					lbValue soa_type = lb_type_info(m, t->Struct.soa_elem);
-					lbValue soa_len = lb_const_int(m, t_int, t->Struct.soa_count);
-
-					vals[10] = soa_kind.value;
-					vals[11] = soa_type.value;
-					vals[12] = soa_len.value;
-				}
-			}
-			
-			isize count = t->Struct.fields.count;
-			if (count > 0) {
-				lbValue memory_types   = lb_type_info_member_types_offset  (m, count);
-				lbValue memory_names   = lb_type_info_member_names_offset  (m, count);
-				lbValue memory_offsets = lb_type_info_member_offsets_offset(m, count);
-				lbValue memory_usings  = lb_type_info_member_usings_offset (m, count);
-				lbValue memory_tags    = lb_type_info_member_tags_offset   (m, count);
-
-				type_set_offsets(t); // NOTE(bill): Just incase the offsets have not been set yet
-				for (isize source_index = 0; source_index < count; source_index++) {
-					Entity *f = t->Struct.fields[source_index];
-					lbValue tip = lb_type_info(m, f->type);
-					i64 foffset = 0;
-					if (!t->Struct.is_raw_union) {
-						GB_ASSERT(t->Struct.offsets != nullptr);
-						GB_ASSERT(0 <= f->Variable.field_index && f->Variable.field_index < count);
-						foffset = t->Struct.offsets[source_index];
-					}
-					GB_ASSERT(f->kind == Entity_Variable && f->flags & EntityFlag_Field);
-
-					lbValue index     = lb_const_int(m, t_int, source_index);
-					lbValue type_info = lb_emit_ptr_offset(p, memory_types,   index);
-					lbValue offset    = lb_emit_ptr_offset(p, memory_offsets, index);
-					lbValue is_using  = lb_emit_ptr_offset(p, memory_usings,  index);
-
-					lb_emit_store(p, type_info, lb_type_info(m, f->type));
-					if (f->token.string.len > 0) {
-						lbValue name = lb_emit_ptr_offset(p, memory_names,   index);
-						lb_emit_store(p, name, lb_const_string(m, f->token.string));
-					}
-					lb_emit_store(p, offset, lb_const_int(m, t_uintptr, foffset));
-					lb_emit_store(p, is_using, lb_const_bool(m, t_bool, (f->flags&EntityFlag_Using) != 0));
-
-					if (t->Struct.tags != nullptr) {
-						String tag_string = t->Struct.tags[source_index];
-						if (tag_string.len > 0) {
-							lbValue tag_ptr = lb_emit_ptr_offset(p, memory_tags, index);
-							lb_emit_store(p, tag_ptr, lb_const_string(m, tag_string));
-						}
-					}
-
-				}
-
-				lbValue cv = lb_const_int(m, t_int, count);
-				vals[0] = llvm_const_slice(m, memory_types,   cv);
-				vals[1] = llvm_const_slice(m, memory_names,   cv);
-				vals[2] = llvm_const_slice(m, memory_offsets, cv);
-				vals[3] = llvm_const_slice(m, memory_usings,  cv);
-				vals[4] = llvm_const_slice(m, memory_tags,    cv);
-			}
-			for (isize i = 0; i < gb_count_of(vals); i++) {
-				if (vals[i] == nullptr) {
-					vals[i]  = LLVMConstNull(lb_type(m, get_struct_field_type(tag.type, i)));
-				}
-			}
-			
-			lbValue res = {};
-			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-			lb_emit_store(p, tag, res);
-
-			break;
-		}
-
-		case Type_Map: {
-			tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_map_ptr);
-			init_map_internal_types(t);
-
-			LLVMValueRef vals[3] = {
-				lb_type_info(m, t->Map.key).value,
-				lb_type_info(m, t->Map.value).value,
-				lb_gen_map_info_ptr(p->module, t).value
-			};
-
-			lbValue res = {};
-			res.type = type_deref(tag.type);
-			res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-			lb_emit_store(p, tag, res);
-			break;
-		}
-
-		case Type_BitSet:
-			{
-				tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_bit_set_ptr);
-
-				GB_ASSERT(is_type_typed(t->BitSet.elem));
-
-
-				LLVMValueRef vals[4] = {
-					lb_type_info(m, t->BitSet.elem).value,
-					LLVMConstNull(lb_type(m, t_type_info_ptr)),
-					lb_const_int(m, t_i64, t->BitSet.lower).value,
-					lb_const_int(m, t_i64, t->BitSet.upper).value,
-				};
-				if (t->BitSet.underlying != nullptr) {
-					vals[1] =lb_type_info(m, t->BitSet.underlying).value;
-				}
-
-				lbValue res = {};
-				res.type = type_deref(tag.type);
-				res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-				lb_emit_store(p, tag, res);
-			}
-			break;
-
-		case Type_SimdVector:
-			{
-				tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_simd_vector_ptr);
-
-				LLVMValueRef vals[3] = {};
-
-				vals[0] = lb_type_info(m, t->SimdVector.elem).value;
-				vals[1] = lb_const_int(m, t_int, type_size_of(t->SimdVector.elem)).value;
-				vals[2] = lb_const_int(m, t_int, t->SimdVector.count).value;
-
-				lbValue res = {};
-				res.type = type_deref(tag.type);
-				res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-				lb_emit_store(p, tag, res);
-			}
-			break;
-
-		case Type_RelativePointer:
-			{
-				tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_relative_pointer_ptr);
-				LLVMValueRef vals[2] = {
-					lb_type_info(m, t->RelativePointer.pointer_type).value,
-					lb_type_info(m, t->RelativePointer.base_integer).value,
-				};
-
-				lbValue res = {};
-				res.type = type_deref(tag.type);
-				res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-				lb_emit_store(p, tag, res);
-			}
-			break;
-
-		case Type_RelativeMultiPointer:
-			{
-				tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_relative_multi_pointer_ptr);
-				LLVMValueRef vals[2] = {
-					lb_type_info(m, t->RelativeMultiPointer.pointer_type).value,
-					lb_type_info(m, t->RelativeMultiPointer.base_integer).value,
-				};
-
-				lbValue res = {};
-				res.type = type_deref(tag.type);
-				res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-				lb_emit_store(p, tag, res);
-			}
-			break;
-
-		case Type_Matrix: 
-			{
-				tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_matrix_ptr);
-				i64 ez = type_size_of(t->Matrix.elem);
-
-				LLVMValueRef vals[5] = {
-					lb_type_info(m, t->Matrix.elem).value,
-					lb_const_int(m, t_int, ez).value,
-					lb_const_int(m, t_int, matrix_type_stride_in_elems(t)).value,
-					lb_const_int(m, t_int, t->Matrix.row_count).value,
-					lb_const_int(m, t_int, t->Matrix.column_count).value,
-				};
-
-				lbValue res = {};
-				res.type = type_deref(tag.type);
-				res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-				lb_emit_store(p, tag, res);
-			}
-			break;
-
-		case Type_BitField:
-			{
-				tag = lb_const_ptr_cast(m, variant_ptr, t_type_info_bit_field_ptr);
-				LLVMValueRef vals[6] = {};
-
-				vals[0] = lb_type_info(m, t->BitField.backing_type).value;
-				isize count = t->BitField.fields.count;
-				if (count > 0) {
-					i64 names_offset       = 0;
-					i64 types_offset       = 0;
-					i64 bit_sizes_offset   = 0;
-					i64 bit_offsets_offset = 0;
-					i64 tags_offset        = 0;
-					lbValue memory_names       = lb_type_info_member_names_offset  (m, count, &names_offset);
-					lbValue memory_types       = lb_type_info_member_types_offset  (m, count, &types_offset);
-					lbValue memory_bit_sizes   = lb_type_info_member_offsets_offset(m, count, &bit_sizes_offset);
-					lbValue memory_bit_offsets = lb_type_info_member_offsets_offset(m, count, &bit_offsets_offset);
-					lbValue memory_tags        = lb_type_info_member_tags_offset   (m, count, &tags_offset);
-
-					u64 bit_offset = 0;
-					for (isize source_index = 0; source_index < count; source_index++) {
-						Entity *f = t->BitField.fields[source_index];
-						u64 bit_size = cast(u64)t->BitField.bit_sizes[source_index];
-
-						lbValue index = lb_const_int(m, t_int, source_index);
-						if (f->token.string.len > 0) {
-							lbValue name_ptr = lb_emit_ptr_offset(p, memory_names, index);
-							lb_emit_store(p, name_ptr, lb_const_string(m, f->token.string));
-						}
-						lbValue type_ptr       = lb_emit_ptr_offset(p, memory_types, index);
-						lbValue bit_size_ptr   = lb_emit_ptr_offset(p, memory_bit_sizes, index);
-						lbValue bit_offset_ptr = lb_emit_ptr_offset(p, memory_bit_offsets, index);
-
-						lb_emit_store(p, type_ptr,       lb_type_info(m, f->type));
-						lb_emit_store(p, bit_size_ptr,   lb_const_int(m, t_uintptr, bit_size));
-						lb_emit_store(p, bit_offset_ptr, lb_const_int(m, t_uintptr, bit_offset));
-
-						if (t->BitField.tags) {
-							String tag = t->BitField.tags[source_index];
-							if (tag.len > 0) {
-								lbValue tag_ptr = lb_emit_ptr_offset(p, memory_tags, index);
-								lb_emit_store(p, tag_ptr, lb_const_string(m, tag));
-							}
-						}
-
-						bit_offset += bit_size;
-					}
-
-					lbValue cv = lb_const_int(m, t_int, count);
-					vals[1] = llvm_const_slice(m, memory_names,       cv);
-					vals[2] = llvm_const_slice(m, memory_types,       cv);
-					vals[3] = llvm_const_slice(m, memory_bit_sizes,   cv);
-					vals[4] = llvm_const_slice(m, memory_bit_offsets, cv);
-					vals[5] = llvm_const_slice(m, memory_tags,        cv);
-				}
-
-				for (isize i = 0; i < gb_count_of(vals); i++) {
-					if (vals[i] == nullptr) {
-						vals[i]  = LLVMConstNull(lb_type(m, get_struct_field_type(tag.type, i)));
-					}
-				}
-
-				lbValue res = {};
-				res.type = type_deref(tag.type);
-				res.value = llvm_const_named_struct(m, res.type, vals, gb_count_of(vals));
-				lb_emit_store(p, tag, res);
-
-				break;
-			}
-
-		}
-
-
-		if (tag.value != nullptr) {
-			Type *tag_type = type_deref(tag.type);
-			GB_ASSERT(is_type_named(tag_type));
-			// lb_emit_store_union_variant(p, variant_ptr, lb_emit_load(p, tag), tag_type);
-			lb_emit_store_union_variant_tag(p, variant_ptr, tag_type);
-		} else {
-			if (t != t_llvm_bool) {
-				GB_PANIC("Unhandled Type_Info variant: %s", type_to_string(t));
-			}
-		}
-	}
-	
-	for_array(i, entries_handled) {
-		if (!entries_handled[i]) {
-			GB_PANIC("UNHANDLED ENTRY %td (%td)", i, entries_handled.count);
-		}
-	}
+	LLVMValueRef data = lb_global_type_info_data_ptr(m).value;
+	data = LLVMConstPointerCast(data, lb_type(m, alloc_type_pointer(type->Array.elem)));
+	LLVMValueRef len = LLVMConstInt(lb_type(m, t_int), type->Array.count, true);
+	Type *t = type_deref(global_type_table.type);
+	GB_ASSERT(is_type_slice(t));
+	LLVMValueRef slice = llvm_const_slice_internal(m, data, len);
+
+	LLVMSetInitializer(global_type_table.value, slice);
 }

--- a/src/llvm_backend_type.cpp
+++ b/src/llvm_backend_type.cpp
@@ -111,22 +111,19 @@ gb_internal lbValue lb_typeid(lbModule *m, Type *type) {
 	return res;
 }
 
-gb_internal lbValue lb_type_info(lbModule *m, Type *type) {
+gb_internal lbValue lb_type_info(lbProcedure *p, Type *type) {
 	GB_ASSERT(!build_context.no_rtti);
 
 	type = default_type(type);
+	lbModule *m = p->module;
 
 	isize index = lb_type_info_index(m->info, type);
 	GB_ASSERT(index >= 0);
 
-	LLVMValueRef global = lb_global_type_info_data_ptr(m).value;
+	lbValue global = lb_global_type_info_data_ptr(m);
 
-	LLVMValueRef global_array = LLVMGetInitializer(global);
-	LLVMValueRef index_value = LLVMConstInt(lb_type(m, t_int), index, false);
-	lbValue res = {};
-	res.value = LLVMConstPointerCast(LLVMConstExtractElement(global_array, index_value), lb_type(m, t_type_info_ptr));
-	res.type = t_type_info_ptr;
-	return res;
+	lbValue ptr = lb_emit_array_epi(p, global, index);
+	return lb_emit_load(p, ptr);
 }
 
 gb_internal LLVMTypeRef lb_get_procedure_raw_type(lbModule *m, Type *type) {

--- a/src/llvm_backend_type.cpp
+++ b/src/llvm_backend_type.cpp
@@ -119,8 +119,14 @@ gb_internal lbValue lb_type_info(lbModule *m, Type *type) {
 	isize index = lb_type_info_index(m->info, type);
 	GB_ASSERT(index >= 0);
 
-	lbValue data = lb_global_type_info_data_ptr(m);
-	return lb_emit_array_epi(m, data, index);
+	LLVMValueRef global = lb_global_type_info_data_ptr(m).value;
+
+	LLVMValueRef global_array = LLVMGetInitializer(global);
+	LLVMValueRef index_value = LLVMConstInt(lb_type(m, t_int), index, false);
+	lbValue res = {};
+	res.value = LLVMConstPointerCast(LLVMConstExtractElement(global_array, index_value), lb_type(m, t_type_info_ptr));
+	res.type = t_type_info_ptr;
+	return res;
 }
 
 gb_internal LLVMTypeRef lb_get_procedure_raw_type(lbModule *m, Type *type) {

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -365,6 +365,9 @@ enum Typeid_Kind : u8 {
 	Typeid_Matrix,
 	Typeid_SoaPointer,
 	Typeid_Bit_Field,
+
+	Typeid__COUNT
+
 };
 
 // IMPORTANT NOTE(bill): This must match the same as the in core.odin


### PR DESCRIPTION
Change `runtime.type_table` layout to allow RTTI to be constantly initialized.

Previously, we had to initialize this table at runtime because LLVM does not support arrays of unions as a type. In order to emulate an array of unions, you have to great a giant packed struct containing packed structs of the specific union types. This experiment was tried but it wasn't working on all platforms for an unknown reason.

This change keeps the same idea of using a packed-struct to represent the union value, but each type info element is now its own separate global value instead, which is then referenced by point in the `type_table` backing array.

Using these modified packed-struct, means we can now initialize everything constantly in the read-only data section too!

This also removes the internal startup runtime type info procedure call done before `main`.