### PR TITLE
fix releases being a zip of a zip

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -107,7 +107,7 @@ jobs:
   build_macos_arm:
     name: MacOS ARM Build
     if: github.repository == 'odin-lang/Odin'
-    runs-on: macos-14
+    runs-on: macos-14 # ARM machine
     steps:
       - uses: actions/checkout@v1
       - name: Download LLVM and setup PATH
@@ -190,9 +190,9 @@ jobs:
           echo Uploading artifcates to B2
           chmod +x ./ci/upload_create_nightly.sh
           ./ci/upload_create_nightly.sh "$BUCKET" windows-amd64 windows_artifacts/
-          ./ci/upload_create_nightly.sh "$BUCKET" ubuntu-amd64 ubuntu_artifacts/
-          ./ci/upload_create_nightly.sh "$BUCKET" macos-amd64 macos_artifacts/
-          ./ci/upload_create_nightly.sh "$BUCKET" macos-arm64 macos_arm_artifacts/
+          ./ci/upload_create_nightly.sh "$BUCKET" ubuntu-amd64 ubuntu_artifacts/dist.zip
+          ./ci/upload_create_nightly.sh "$BUCKET" macos-amd64 macos_artifacts/dist.zip
+          ./ci/upload_create_nightly.sh "$BUCKET" macos-arm64 macos_arm_artifacts/dist.zip
 
           echo Deleting old artifacts in B2
           python3 ci/delete_old_binaries.py "$BUCKET" "$DAYS_TO_KEEP"

--- a/ci/upload_create_nightly.sh
+++ b/ci/upload_create_nightly.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 bucket=$1
 platform=$2
 artifact=$3
@@ -9,5 +11,15 @@ filename="odin-$platform-nightly+$now.zip"
 
 echo "Creating archive $filename from $artifact and uploading to $bucket"
 
-7z a -bd "output/$filename" -r "$artifact"
+# If this is already zipped up (done before artifact upload to keep permissions in tact), just move it.
+if [ "${artifact: -4}" == ".zip" ]
+then
+	echo "Artifact already a zip"
+	mkdir -p "output"
+	mv "$artifact" "output/$filename"
+else
+	echo "Artifact needs to be zipped"
+	7z a -bd "output/$filename" -r "$artifact"
+fi
+
 b2 upload-file --noProgress "$bucket" "output/$filename" "nightly/$filename"


### PR DESCRIPTION
https://github.com/odin-lang/Odin/pull/3224 made the uploaded releases a zip of a zip, and also changed the name which possibly breaks automated tools. Now we check if it is already a zip file and just move it over and upload that directly.