### PR TITLE
makes raylib and stb_rect_pack free of libc

### DIFF
--- a/core/c/c.odin
+++ b/core/c/c.odin
@@ -104,3 +104,13 @@ NULL           :: rawptr(uintptr(0))
 NDEBUG         :: !ODIN_DEBUG
 
 CHAR_BIT :: 8
+
+// Since there are no types in C with an alignment larger than that of
+// max_align_t, which cannot be larger than sizeof(long double) as any other
+// exposed type wouldn't be valid C, the maximum alignment possible in a
+// strictly conformant C implementation is 16 on the platforms we care about.
+// The choice of 4096 bytes for storage of this type is more than enough on all
+// relevant platforms.
+va_list :: struct #align(16) {
+	_: [4096]u8,
+}

--- a/core/c/libc/stdarg.odin
+++ b/core/c/libc/stdarg.odin
@@ -4,6 +4,8 @@ package libc
 
 import "base:intrinsics"
 
+import "core:c"
+
 @(private="file")
 @(default_calling_convention="none")
 foreign _ {
@@ -12,15 +14,7 @@ foreign _ {
 	@(link_name="llvm.va_copy")  _va_copy  :: proc(dst, src: ^i8) ---
 }
 
-// Since there are no types in C with an alignment larger than that of
-// max_align_t, which cannot be larger than sizeof(long double) as any other
-// exposed type wouldn't be valid C, the maximum alignment possible in a
-// strictly conformant C implementation is 16 on the platforms we care about.
-// The choice of 4096 bytes for storage of this type is more than enough on all
-// relevant platforms.
-va_list :: struct #align(16) {
-	_: [4096]u8,
-}
+va_list :: c.va_list
 
 va_start :: #force_inline proc(ap: ^va_list, _: any) {
 	_va_start(cast(^i8)ap)

--- a/vendor/raylib/raygui.odin
+++ b/vendor/raylib/raygui.odin
@@ -1,6 +1,6 @@
 package raylib
 
-import c "core:c/libc"
+import c "core:c"
 
 RAYGUI_SHARED :: #config(RAYGUI_SHARED, false)
 
@@ -240,7 +240,10 @@ SCROLLBAR_RIGHT_SIDE :: 1
 
 @(default_calling_convention="c")
 foreign lib {
-	@(link_name="raylib_version") version: cstring
+	// WASM does not have foreign variable declarations.
+	when ODIN_ARCH != .wasm32 && ODIN_ARCH != .wasm64p32 {
+		@(link_name="raylib_version") version: cstring
+	}
 	// Global gui state control functions
 	
 	GuiEnable           :: proc() ---                                                                         // Enable gui controls (global state)

--- a/vendor/raylib/raygui.odin
+++ b/vendor/raylib/raygui.odin
@@ -1,6 +1,6 @@
 package raylib
 
-import c "core:c"
+import "core:c"
 
 RAYGUI_SHARED :: #config(RAYGUI_SHARED, false)
 

--- a/vendor/raylib/raylib.odin
+++ b/vendor/raylib/raylib.odin
@@ -81,7 +81,7 @@ Package vendor:raylib implements bindings for version 5.0 of the raylib library 
 */
 package raylib
 
-import c "core:c"
+import "core:c"
 import "core:fmt"
 import "core:mem"
 import "core:strings"

--- a/vendor/raylib/raylib.odin
+++ b/vendor/raylib/raylib.odin
@@ -81,7 +81,7 @@ Package vendor:raylib implements bindings for version 5.0 of the raylib library 
 */
 package raylib
 
-import c "core:c/libc"
+import c "core:c"
 import "core:fmt"
 import "core:mem"
 import "core:strings"
@@ -925,13 +925,17 @@ NPatchLayout :: enum c.int {
 	THREE_PATCH_HORIZONTAL,  // Npatch layout: 3x1 tiles
 }
 
-
+// NOTE: Castable to `core:c/libc`'s `va_list`.
+// But some use cases of raylib do not want `libc` imported.
+va_list :: struct #align(16) {
+	_: [4096]u8,
+}
 
 // Callbacks to hook some internal functions
 // WARNING: This callbacks are intended for advance users
-TraceLogCallback     :: #type proc "c" (logLevel: TraceLogLevel, text: cstring, args: c.va_list)        // Logging: Redirect trace log messages
-LoadFileDataCallback :: #type proc "c"(fileName: cstring, dataSize: ^c.int) -> [^]u8                  	// FileIO: Load binary data
-SaveFileDataCallback :: #type proc "c" (fileName: cstring, data: rawptr, dataSize: c.int) -> bool  		// FileIO: Save binary data
+TraceLogCallback     :: #type proc "c" (logLevel: TraceLogLevel, text: cstring, args: va_list)          // Logging: Redirect trace log messages
+LoadFileDataCallback :: #type proc "c"(fileName: cstring, dataSize: ^c.int) -> [^]u8                    // FileIO: Load binary data
+SaveFileDataCallback :: #type proc "c" (fileName: cstring, data: rawptr, dataSize: c.int) -> bool       // FileIO: Save binary data
 LoadFileTextCallback :: #type proc "c" (fileName: cstring) -> [^]u8                                     // FileIO: Load text data
 SaveFileTextCallback :: #type proc "c" (fileName: cstring, text: cstring) -> bool                       // FileIO: Save text data
 

--- a/vendor/raylib/raylib.odin
+++ b/vendor/raylib/raylib.odin
@@ -925,15 +925,9 @@ NPatchLayout :: enum c.int {
 	THREE_PATCH_HORIZONTAL,  // Npatch layout: 3x1 tiles
 }
 
-// NOTE: Castable to `core:c/libc`'s `va_list`.
-// But some use cases of raylib do not want `libc` imported.
-va_list :: struct #align(16) {
-	_: [4096]u8,
-}
-
 // Callbacks to hook some internal functions
 // WARNING: This callbacks are intended for advance users
-TraceLogCallback     :: #type proc "c" (logLevel: TraceLogLevel, text: cstring, args: va_list)          // Logging: Redirect trace log messages
+TraceLogCallback     :: #type proc "c" (logLevel: TraceLogLevel, text: cstring, args: c.va_list)        // Logging: Redirect trace log messages
 LoadFileDataCallback :: #type proc "c"(fileName: cstring, dataSize: ^c.int) -> [^]u8                    // FileIO: Load binary data
 SaveFileDataCallback :: #type proc "c" (fileName: cstring, data: rawptr, dataSize: c.int) -> bool       // FileIO: Save binary data
 LoadFileTextCallback :: #type proc "c" (fileName: cstring) -> [^]u8                                     // FileIO: Load text data

--- a/vendor/raylib/raymath.odin
+++ b/vendor/raylib/raymath.odin
@@ -1,6 +1,5 @@
 package raylib
 
-import c "core:c/libc"
 import "core:math"
 import "core:math/linalg"
 
@@ -45,7 +44,7 @@ Wrap :: proc "c" (value: f32, min, max: f32) -> f32 {
 // Check whether two given floats are almost equal
 @(require_results)
 FloatEquals :: proc "c" (x, y: f32) -> bool {
-	return abs(x - y) <= EPSILON*c.fmaxf(1.0, c.fmaxf(abs(x), abs(y)))
+	return abs(x - y) <= EPSILON*fmaxf(1.0, fmaxf(abs(x), abs(y)))
 }
 
 
@@ -815,4 +814,21 @@ QuaternionEquals :: proc "c" (p, q: Quaternion) -> bool {
 	       FloatEquals(p.y, q.y) &&
 	       FloatEquals(p.z, q.z) &&
 	       FloatEquals(p.w, q.w)
+}
+
+@(private, require_results)
+fmaxf :: proc "contextless" (x, y: f32) -> f32 {
+	if math.is_nan(x) {
+		return y
+	}
+
+	if math.is_nan(y) {
+		return x
+	}
+
+	if math.signbit(x) != math.signbit(y) {
+		return y if math.signbit(x) else x
+	}
+
+	return y if x < y else x
 }

--- a/vendor/stb/rect_pack/stb_rect_pack.odin
+++ b/vendor/stb/rect_pack/stb_rect_pack.odin
@@ -1,6 +1,6 @@
 package stb_rect_pack
 
-import c "core:c/libc"
+import c "core:c"
 
 #assert(size_of(b32) == size_of(c.int))
 

--- a/vendor/stb/rect_pack/stb_rect_pack.odin
+++ b/vendor/stb/rect_pack/stb_rect_pack.odin
@@ -1,6 +1,6 @@
 package stb_rect_pack
 
-import c "core:c"
+import "core:c"
 
 #assert(size_of(b32) == size_of(c.int))
 


### PR DESCRIPTION
May be a bit niche so I would understand not wanting it, but, I was playing around with https://github.com/tsoding/zozlib.js which is a subset of Raylib fully implemented in JS so you don't need emscriptem. With just these changes and some very minor changes in that repo I was able to make it work in Odin.

Also fixed #3144 while I was at it.