### PR TITLE
reduce dynamic library dependencies for macos release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -83,7 +83,9 @@ jobs:
           TMP_PATH=$(xcrun --show-sdk-path)/user/include
           echo "CPATH=$TMP_PATH" >> $GITHUB_ENV
       - name: build odin
-        run: make nightly
+        # These -L makes the linker prioritize system libraries over LLVM libraries, this is mainly to
+        # not link with libunwind bundled with LLVM but link with libunwind on the system.
+        run: CXXFLAGS="-L/usr/lib/system -L/usr/lib" make nightly
       - name: Bundle
         run: |
           mkdir dist
@@ -117,7 +119,9 @@ jobs:
           TMP_PATH=$(xcrun --show-sdk-path)/user/include
           echo "CPATH=$TMP_PATH" >> $GITHUB_ENV
       - name: build odin
-        run: make nightly
+        # These -L makes the linker prioritize system libraries over LLVM libraries, this is mainly to
+        # not link with libunwind bundled with LLVM but link with libunwind on the system.
+        run: CXXFLAGS="-L/usr/lib/system -L/usr/lib" make nightly
       - name: Bundle
         run: |
           mkdir dist

--- a/build_odin.sh
+++ b/build_odin.sh
@@ -63,8 +63,7 @@ Darwin)
 	fi
 
 	CXXFLAGS="$CXXFLAGS $($LLVM_CONFIG --cxxflags --ldflags)"
-	LDFLAGS="$LDFLAGS -liconv -ldl -framework System"
-	LDFLAGS="$LDFLAGS -lLLVM-C"
+	LDFLAGS="$LDFLAGS -liconv -ldl -framework System -lLLVM"
 	;;
 FreeBSD)
 	CXXFLAGS="$CXXFLAGS $($LLVM_CONFIG --cxxflags --ldflags)"


### PR DESCRIPTION
With the current releases we bundle 3 dynamic libraries:
- `libLLVM-C.dylib`
- `libLLVM.dylib`
- `libunwind.1.0.dylib`

After this change it will just be `libLLVM.dylib`. I tested and everything still works, I think `libLLVM-C.dylib` is just a subset of `libLLVM.dylib`, and `libunwind` is a system library on macos, but because it also comes with llvm, it was given priority by the linker.

You might say this doesn't matter but it reduces the amount of annoying privacy popups you get (macos shows one for each library).