### PR TITLE
Fix typo for core:math/big.INT_MINUS_INF

### DIFF
--- a/core/math/big/helpers.odin
+++ b/core/math/big/helpers.odin
@@ -788,7 +788,7 @@ initialize_constants :: proc() -> (res: int) {
 	*/
 	internal_set(      INT_NAN,  1);       INT_NAN.flags = {.Immutable, .NaN}
 	internal_set(      INT_INF,  1);       INT_INF.flags = {.Immutable, .Inf}
-	internal_set(      INT_INF, -1); INT_MINUS_INF.flags = {.Immutable, .Inf}
+	internal_set(INT_MINUS_INF, -1); INT_MINUS_INF.flags = {.Immutable, .Inf}
 
 	return _DEFAULT_MUL_KARATSUBA_CUTOFF
 }


### PR DESCRIPTION
Found this typo/mistake while trying to fix https://github.com/odin-lang/Odin/issues/3243. This is not directly related but should be fixed anyways.