### PR TITLE
@(link_section): accept a comma in the provided link section

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1943,6 +1943,7 @@ gb_internal bool is_foreign_name_valid(String const &name) {
 			case '$':
 			case '.':
 			case '_':
+			case ',':
 				break;
 			default:
 				if (!gb_char_is_alphanumeric(cast(char)rune)) {


### PR DESCRIPTION
(only if it's not the first character)

In mach-o binaries, link sections are specified with the format `<SEGMENT>,<SECTION>`. Presently the ',' is literally not allowed, which this change fixes.

e.g. for putting a var in read only memory on m-series mac (which uses mach-o)

```c
@(link_section="__TEXT,__const") // the comma isn't allowed, but required by the mach-o format
foo: int = 0
```