### PR TITLE
Base/runtime (darwin): Incorrect write syscall on Darwin - fixes stderr output.

### DIFF
--- a/base/runtime/os_specific_darwin.odin
+++ b/base/runtime/os_specific_darwin.odin
@@ -5,7 +5,7 @@ package runtime
 import "base:intrinsics"
 
 _stderr_write :: proc "contextless" (data: []byte) -> (int, _OS_Errno) {
-	WRITE  :: 0x20000004
+	WRITE  :: 0x2000004
 	STDERR :: 2
 	ret := intrinsics.syscall(WRITE, STDERR, uintptr(raw_data(data)), uintptr(len(data)))
 	if ret < 0 {


### PR DESCRIPTION
On macos, Odin was previously swallowing errors that would be reported via stderr. 

I've confirmed with @laytan on Discord that this fixes the issue.