### PR TITLE
Retain copies of `dirent->name` for .odin files when using `read_directory`

### DIFF
--- a/src/path.cpp
+++ b/src/path.cpp
@@ -407,7 +407,7 @@ gb_internal ReadDirectoryError read_directory(String path, Array<FileInfo> *fi) 
 		i64 size = dir_stat.st_size;
 
 		FileInfo info = {};
-		info.name = name;
+		info.name = copy_string(a, name);
 		info.fullpath = path_to_full_path(a, filepath);
 		info.size = size;
 		array_add(fi, info);


### PR DESCRIPTION
I ran into a bug this weekend on macOS where where certain types 
were not being found when compiling, even though the type in question was
present in the package and was even visible by ols when going to its definition
from the compiler error site.

I narrowed it down where it only happened when there were a certain amount of files in a package/folder with a combination of a certain file name length.

Digging into it further, I found the issue in [read_directory](https://github.com/odin-lang/Odin/blob/master/src/path.cpp#L348) 
where the pointers to `readdir`'s returned `dirent->name` are [kept without making a copy](https://github.com/odin-lang/Odin/blob/master/src/path.cpp#L410)
(wrapped [here](https://github.com/odin-lang/Odin/blob/master/src/path.cpp#L382C10-L382C14)).


When the issue happened the output would look like this (I added some `debugf` calls in [try_add_import_path](https://github.com/odin-lang/Odin/blob/master/src/parser.cpp#L5367) when investigating the issue. The file name printed is from [fi.name](https://github.com/odin-lang/Odin/blob/master/src/parser.cpp#L5432):

```bash
[DEBUG]   PACKAGE: /Users/.../projects/apps/darwodin/darwodin/Foundation
[DEBUG] F:
[DEBUG] F: NSOperationQueue.odin
[DEBUG] F: NSOrderedCollectionChange.odin
[DEBUG] F: NSObject.odin
[DEBUG] F: NSPortNameServer.odin
...
```


The first entry should be the file `NSPredicate.odin`, however at this point the memory it points to has been zeroed-out, as it seems the system reclaimed the `dirent` instance.

This caused errors during the checker step, where it could not find the type `Predicate`:

```bash
/Users/.../projects/apps/darwodin/darwodin/Foundation/NSArray.odin(328:89) Error: Undeclared name: Predicate
	... icate: ^Predicate) -> ^Array { ...
	            ^~~~~~~~^
/Users/.../projects/apps/darwodin/darwodin/Foundation/NSMutableArray.odin(163:96) Error: Undeclared name: Predicate
	... icate: ^Predicate) { ...
...
```

After applying this fix, the `NSPredicate.odin` entry appears and the compilation succeeds:

```bash
[DEBUG]   PACKAGE: /Users/.../projects/apps/darwodin/darwodin/Foundation
[DEBUG] F: NSPredicate.odin
[DEBUG] F: NSOperationQueue.odin
[DEBUG] F: NSOrderedCollectionChange.odin
[DEBUG] F: NSObject.odin
[DEBUG] F: NSPortNameServer.odin

...

[DEBUG] [Section] LLVM Generate Object: main.o
[DEBUG] Generated File: /Users/.../projects/apps/darwodin/.bin/main.o
[DEBUG] Linking /Users/.../projects/apps/darwodin/.bin/main
```
