### PR TITLE
Expose internal invmod and int_exponent_mod with more consistent naming

### DIFF
--- a/core/math/big/internal.odin
+++ b/core/math/big/internal.odin
@@ -2047,6 +2047,7 @@ internal_int_inverse_modulo :: proc(dest, a, b: ^Int, allocator := context.alloc
 
 	return _private_inverse_modulo(dest, a, b)
 }
+internal_int_invmod :: internal_int_inverse_modulo
 internal_invmod :: proc{ internal_int_inverse_modulo, }
 
 /*

--- a/core/math/big/prime.odin
+++ b/core/math/big/prime.odin
@@ -44,7 +44,7 @@ internal_int_prime_is_divisible :: proc(a: ^Int, allocator := context.allocator)
 	Computes res == G**X mod P.
 	Assumes `res`, `G`, `X` and `P` to not be `nil` and for `G`, `X` and `P` to have been initialized.
 */
-internal_int_exponent_mod :: proc(res, G, X, P: ^Int, allocator := context.allocator) -> (err: Error) {
+internal_int_power_modulo :: proc(res, G, X, P: ^Int, allocator := context.allocator) -> (err: Error) {
 	context.allocator = allocator
 
 	dr: int
@@ -112,6 +112,9 @@ internal_int_exponent_mod :: proc(res, G, X, P: ^Int, allocator := context.alloc
 	*/
 	return _private_int_exponent_mod(res, G, X, P, 0)
 }
+internal_int_exponent_mod :: internal_int_power_modulo
+internal_int_powmod :: internal_int_power_modulo
+internal_powmod :: proc { internal_int_power_modulo, }
 
 /*
 	Kronecker/Legendre symbol (a|p)


### PR DESCRIPTION
A simple patch to expose
existing `internal_invmod` also as `internal_int_invmod` just like all the other `mod` functions such as `addmod`, `divmod`, `mulmod`, `submod` etc.

And more importantly,
expose `internal_int_exponent_mod` as `internal_int_powmod` as the word `pow` is preferred in existing library with all the `pow_f16`, `pow_small`, `int_pow` etc. 

I also renamed `internal_int_exponent_mod` to `internal_int_exponent_modulus` since if we are spelling out exponent already, might as well spell out `mod` as `modulus` like how it is done in `internal_int_inverse_modulus`.
Of course, `internal_int_exponent_mod` now refers to `internal_int_exponent_modulus` to maintain backward compatibility.