### PR TITLE
Fix check for too many arguments to a polymorphic record type

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -6847,7 +6847,7 @@ gb_internal CallArgumentError check_polymorphic_record_type(CheckerContext *c, O
 
 	Array<Operand> ordered_operands = operands;
 	if (!named_fields) {
-		ordered_operands = array_make<Operand>(permanent_allocator(), param_count);
+		ordered_operands = array_make<Operand>(permanent_allocator(), operands.count);
 		array_copy(&ordered_operands, operands, 0);
 	} else {
 		TEMPORARY_ALLOCATOR_GUARD();

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -6796,7 +6796,7 @@ gb_internal CallArgumentError check_polymorphic_record_type(CheckerContext *c, O
 					isize index = lookup_polymorphic_record_parameter(original_type, name);
 					if (index >= 0) {
 						TypeTuple *params = get_record_polymorphic_params(original_type);
-						Entity *e = params->variables[i];
+						Entity *e = params->variables[index];
 						if (e->kind == Entity_Constant) {
 							check_expr_with_type_hint(c, &operands[i], fv->value, e->type);
 							continue;


### PR DESCRIPTION
Fixes #1184

The root cause is that there is code in `check_polymorphic_record_type` to check for too many parameters, but it is never activated.

The variable `ordered_operands.count` is used to check the number of parameters:
https://github.com/odin-lang/Odin/blob/23f3898b4efdc3003f8b89d64fcadd638b852bd9/src/check_expr.cpp#L6937-L6939

But for the case of unnamed parameters, ordered_operands always has the same count as `param_count` so the check is never triggered.

So, where does `ordered_operands` come from? The array is constructed here:

https://github.com/odin-lang/Odin/blob/23f3898b4efdc3003f8b89d64fcadd638b852bd9/src/check_expr.cpp#L6850-L6851

Here, `param_count` is used for the size of the array. But `operands.count` should be used instead because on the next line we copy the `operands` array into the new array. Because the array has the wrong size, the `array_copy` is currently unsafe. `param_count` is the number of declared parameters on the polymorphic type, not the number of passed arguments aka operands and `param_count` could be lower than `operands.count`.

(Note that in the case of named parameters, `param_count` is also used, but the array is populated with a completely different algorithm. The algorithm verifies the named parameters are all visited and none are duplicated, so it validates the number of operands correctly using a different method.)

Note that while investigating this, I encountered an index out-of-bounds assertion failure as demonstrated by:
`bar: Foo(A = int, A = int);`.

This is due to using the wrong index variable, which is also fixed in the PR.
Here, the `i` variable comes from the number of arguments, but on line 6799 it is indexing an array of declared parameters which may be smaller. This should be using the `index` variable:
https://github.com/odin-lang/Odin/blob/23f3898b4efdc3003f8b89d64fcadd638b852bd9/src/check_expr.cpp#L6796-L6804

Note that this revealed that `check_expr_with_type_hint`, which is called two lines down, may be called with the wrong type. However, this doesn' cause an error. So, it's not clear for what the purpose this code is.
I couldn't figure it out. Anyway, type mismatches are caught later in the function, so all is well, regardless.
