### PR TITLE
Add getrusage syscall for mac/darwin

### DIFF
--- a/core/sys/darwin/darwin.odin
+++ b/core/sys/darwin/darwin.odin
@@ -3,26 +3,27 @@ package darwin
 
 Bool :: b8
 
-timespec :: struct {
-        seconds:      int,
-        microseconds: int,
+timeval :: struct {
+	tv_sec:  int,
+	tv_usec: int,
 }
 
 RUsage :: struct {
-        utime:         timespec,
-        stime:         timespec,
-        maxrss_word:   int,
-        ixrss_word:    int,
-        idrss_word:    int,
-        isrss_word:    int,
-        minflt_word:   int,
-        majflt_word:   int,
-        nswap_word:    int,
-        inblock_word:  int,
-        oublock_word:  int,
-        msgsnd_word:   int,
-        msgrcv_word:   int,
-        nsignals_word: int,
-        nvcsw_word:    int,
-        nivcsw_word:   int,
+	ru_utime:    timeval,
+	ru_stime:    timeval,
+	ru_maxrss:   int,
+	ru_ixrss:    int,
+	ru_idrss:    int,
+	ru_isrss:    int,
+	ru_minflt:   int,
+	ru_majflt:   int,
+	ru_nswap:    int,
+	ru_inblock:  int,
+	ru_oublock:  int,
+	ru_msgsnd:   int,
+	ru_msgrcv:   int,
+	ru_nsignals: int,
+	ru_nvcsw:    int,
+	ru_nivcsw:   int,
 }
+

--- a/core/sys/darwin/darwin.odin
+++ b/core/sys/darwin/darwin.odin
@@ -3,11 +3,6 @@ package darwin
 
 Bool :: b8
 
-timeval :: struct {
-	tv_sec:  int,
-	tv_usec: int,
-}
-
 RUsage :: struct {
 	ru_utime:    timeval,
 	ru_stime:    timeval,

--- a/core/sys/darwin/darwin.odin
+++ b/core/sys/darwin/darwin.odin
@@ -1,24 +1,26 @@
 //+build darwin
 package darwin
 
+import "core:c"
+
 Bool :: b8
 
 RUsage :: struct {
 	ru_utime:    timeval,
 	ru_stime:    timeval,
-	ru_maxrss:   int,
-	ru_ixrss:    int,
-	ru_idrss:    int,
-	ru_isrss:    int,
-	ru_minflt:   int,
-	ru_majflt:   int,
-	ru_nswap:    int,
-	ru_inblock:  int,
-	ru_oublock:  int,
-	ru_msgsnd:   int,
-	ru_msgrcv:   int,
-	ru_nsignals: int,
-	ru_nvcsw:    int,
-	ru_nivcsw:   int,
+	ru_maxrss:   c.long,
+	ru_ixrss:    c.long,
+	ru_idrss:    c.long,
+	ru_isrss:    c.long,
+	ru_minflt:   c.long,
+	ru_majflt:   c.long,
+	ru_nswap:    c.long,
+	ru_inblock:  c.long,
+	ru_oublock:  c.long,
+	ru_msgsnd:   c.long,
+	ru_msgrcv:   c.long,
+	ru_nsignals: c.long,
+	ru_nvcsw:    c.long,
+	ru_nivcsw:   c.long,
 }
 

--- a/core/sys/darwin/darwin.odin
+++ b/core/sys/darwin/darwin.odin
@@ -2,3 +2,27 @@
 package darwin
 
 Bool :: b8
+
+timespec :: struct {
+        seconds:      int,
+        microseconds: int,
+}
+
+RUsage :: struct {
+        utime:         timespec,
+        stime:         timespec,
+        maxrss_word:   int,
+        ixrss_word:    int,
+        idrss_word:    int,
+        isrss_word:    int,
+        minflt_word:   int,
+        majflt_word:   int,
+        nswap_word:    int,
+        inblock_word:  int,
+        oublock_word:  int,
+        msgsnd_word:   int,
+        msgrcv_word:   int,
+        nsignals_word: int,
+        nvcsw_word:    int,
+        nivcsw_word:   int,
+}

--- a/core/sys/darwin/xnu_system_call_wrappers.odin
+++ b/core/sys/darwin/xnu_system_call_wrappers.odin
@@ -125,7 +125,7 @@ DARWIN_MAXCOMLEN :: 16
 /*--==========================================================================--*/
 
 __darwin_ino64_t :: u64
-__darwin_time_t :: u32
+__darwin_time_t :: int
 __darwin_dev_t :: i32
 __darwin_mode_t :: u16
 __darwin_off_t :: i64

--- a/core/sys/darwin/xnu_system_call_wrappers.odin
+++ b/core/sys/darwin/xnu_system_call_wrappers.odin
@@ -417,3 +417,7 @@ syscall_chdir :: #force_inline proc "contextless" (path: cstring) -> c.int {
 syscall_fchdir :: #force_inline proc "contextless" (fd: c.int, path: cstring) -> c.int {
 	return cast(c.int)intrinsics.syscall(unix_offset_syscall(.getentropy), uintptr(fd), transmute(uintptr)path)
 }
+
+syscall_getrusage :: #force_inline proc "contextless" (who: c.int, rusage: ^RUsage) -> c.int {
+	return cast(c.int) intrinsics.syscall(unix_offset_syscall(.getrusage), uintptr(who), uintptr(rusage))
+}

--- a/core/sys/darwin/xnu_system_call_wrappers.odin
+++ b/core/sys/darwin/xnu_system_call_wrappers.odin
@@ -125,7 +125,7 @@ DARWIN_MAXCOMLEN :: 16
 /*--==========================================================================--*/
 
 __darwin_ino64_t :: u64
-__darwin_time_t :: int
+__darwin_time_t :: c.long
 __darwin_dev_t :: i32
 __darwin_mode_t :: u16
 __darwin_off_t :: i64


### PR DESCRIPTION
The syscall number existed but the wrapper for calling it did not. Also adds the `RUsage` struct to receive the data.

Naming is kept the same as in sys/linux and sys/unix though happy to change anything.

Happy to add the RUsage_Who enum like in sys/linux also if desired but the darwin syscall helpers seemed to be using primitives everywhere rather than e.g. in sys/linux where it's a "contextless" proc that feels more odin like and forwards to the syscall