### PR TITLE
Fix syscall_munmap in darwin

### DIFF
--- a/core/sys/darwin/xnu_system_call_wrappers.odin
+++ b/core/sys/darwin/xnu_system_call_wrappers.odin
@@ -367,7 +367,7 @@ syscall_execve :: #force_inline proc "contextless" (path: cstring, argv: [^]cstr
 }
 
 syscall_munmap :: #force_inline proc "contextless" (addr: rawptr, len: u64) -> c.int {
-	return cast(c.int)intrinsics.syscall(unix_offset_syscall(.mmap), uintptr(addr), uintptr(len))
+	return cast(c.int)intrinsics.syscall(unix_offset_syscall(.munmap), uintptr(addr), uintptr(len))
 }
 
 syscall_mmap :: #force_inline proc "contextless" (addr: ^u8, len: u64, port: c.int, flags: c.int, fd: int, offset: off_t) -> ^u8 {


### PR DESCRIPTION
this was using the .mmap syscall number when it should be using the .munmap syscall number