### PR TITLE
fixed slice.unique and slice.unique_proc

### DIFF
--- a/core/slice/slice.odin
+++ b/core/slice/slice.odin
@@ -497,8 +497,8 @@ unique :: proc(s: $S/[]$T) -> S where intrinsics.type_is_comparable(T) #no_bound
 	for j in 1..<len(s) {
 		if s[j] != s[j-1] && i != j {
 			s[i] = s[j]
+			i += 1
 		}
-		i += 1
 	}
 
 	return s[:i]
@@ -515,8 +515,8 @@ unique_proc :: proc(s: $S/[]$T, eq: proc(T, T) -> bool) -> S #no_bounds_check {
 	for j in 1..<len(s) {
 		if !eq(s[j], s[j-1]) && i != j {
 			s[i] = s[j]
+			i += 1
 		}
-		i += 1
 	}
 
 	return s[:i]


### PR DESCRIPTION
Fixed issue #3276 regarding `slice.unique` and `slice.unique_proc` returning incorrect slices.


Below is a small test of `slice.unique` and `slice.unique_proc` that failed, and are now fixed with this patch.
``` odin
package demo 

import "core:fmt"
import "core:slice"
main :: proc() {
	s := []int{2,2,2}
	res := slice.unique(s)
	assert(slice.equal(res,[]int{2}))

	res = slice.unique([]int{1,1,1,2,2,3,3,3,3})
	assert(slice.equal(res, []int{1,2,3}))

	equal := proc(a,b: int) -> bool{
		return a == b
	}
	res = slice.unique_proc([]int{1,1,1,2,2,3,3,3,3}, equal)
	assert(slice.equal(res, []int{1,2,3}))
}
```