### PR TITLE
Fixed issue #3264 regarding `core:odin/parser` compound literal not allowing a newline

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -2947,6 +2947,7 @@ parse_literal_value :: proc(p: ^Parser, type: ^ast.Expr) -> ^ast.Comp_Lit {
 	}
 	p.expr_level -= 1
 
+	skip_possible_newline(p)
 	close := expect_token_after(p, .Close_Brace, "compound literal")
 
 	pos := type.pos if type != nil else open.pos


### PR DESCRIPTION
Fixes issue #3264 