### PR TITLE
commonmark: add missing on_exit api

### DIFF
--- a/vendor/commonmark/cmark.odin
+++ b/vendor/commonmark/cmark.odin
@@ -366,6 +366,16 @@ foreign lib {
 	// Returns `true` on success, `false`on failure.
 	node_set_on_enter :: proc(node: ^Node, on_enter: cstring) -> (success: b32) ---
 
+	// Returns the literal "on exit" text for a custom 'node', or
+	// an empty string if no on_exit is set.  Returns NULL if
+	// called on a non-custom node.
+	node_get_on_exit :: proc(node: ^Node) -> (on_exit: cstring) ---
+
+	// Sets the literal text to render "on exit" for a custom 'node'.
+	// Any children of the node will be rendered before this text.
+	// Returns 1 on success 0 on failure.
+	node_set_on_exit :: proc(node: ^Node, on_exit: cstring) -> (success: b32) ---
+
 	// Returns the line on which `node` begins.
 	node_get_start_line :: proc(node: ^Node) -> (line: c.int) ---
 


### PR DESCRIPTION
See: https://github.com/commonmark/cmark/blob/a8da5a2f252b96eca60ae8bada1a9ba059a38401/src/cmark.h#L386