### PR TITLE
darwin: allow cross linking darwin_amd64 from darwin_arm64

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1476,6 +1476,7 @@ gb_internal void init_build_context(TargetMetrics *cross_target, Subtarget subta
 			bc->link_flags = str_lit("/machine:x64 ");
 			break;
 		case TargetOs_darwin:
+			bc->link_flags = str_lit("-arch x86_64 ");
 			break;
 		case TargetOs_linux:
 			bc->link_flags = str_lit("-arch x86-64 ");


### PR DESCRIPTION
This change makes (from an arm machine) using `-target:darwin_amd64` work nicely.