### PR TITLE
Remove entry point when compiled with no-entry-point as shared library

### DIFF
--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -6320,6 +6320,8 @@ gb_internal void check_parsed_files(Checker *c) {
 
 			error(token, "Undefined entry point procedure 'main'");
 		}
+	} else if (build_context.build_mode == BuildMode_DynamicLibrary && build_context.no_entry_point) {
+		c->info.entry_point = nullptr;
 	}
 
 	thread_pool_wait();


### PR DESCRIPTION
Currently the `-no-entry-point` flag gets ignored when building as dynamic library.