### PR TITLE
Addition of `core:os2/process` api.

### DIFF
--- a/core/os/os2/process.odin
+++ b/core/os/os2/process.odin
@@ -111,12 +111,25 @@ process_list :: proc(allocator: runtime.Allocator) -> ([]int, Error) {
 	return _process_list(allocator)
 }
 
-
+/*
+	Handle to a process.
+*/
 Process :: struct {
-	pid:          int,
-	handle:       uintptr,
-	is_done:      b32,
-	signal_mutex: sync.RW_Mutex,
+	handle: _Process_Handle,
+}
+
+/*
+	Obtain a process handle.
+*/
+process_open :: proc(pid: int) -> (Process, Error) {
+	return _process_open(pid)
+}
+
+/*
+	Close a process handle
+*/
+process_close :: proc(process: Process) -> (Error) {
+	return _process_close(process)
 }
 
 

--- a/core/os/os2/process.odin
+++ b/core/os/os2/process.odin
@@ -104,6 +104,13 @@ get_ppid :: proc() -> int {
 	return _get_ppid()
 }
 
+/*
+	Obtain ID's of all processes running in the system.
+*/
+process_list :: proc(allocator: runtime.Allocator) -> ([]int, Error) {
+	return _process_list(allocator)
+}
+
 
 Process :: struct {
 	pid:          int,

--- a/core/os/os2/process.odin
+++ b/core/os/os2/process.odin
@@ -133,6 +133,8 @@ Process_Info_Field :: enum {
 	procedure.
 */
 Process_Info :: struct {
+	// The information about a process the struct contains. `pid` is always
+	// stored, no matter what.
 	fields: Process_Info_Fields,
 	// The ID of the process.
 	pid: int,
@@ -157,22 +159,37 @@ Process_Info :: struct {
 /*
 	Obtain information about a process.
 
-	This procedure obtains an information, given by `selection` parameter of
+	This procedure obtains an information, specified by `selection` parameter of
 	a process given by `pid`.
 	
-	Use `free_process_info` to free memory allocated by this function. In case
-	the function returns an error all temporary allocations would be freed and
-	as such, calling `free_process_info()` is not needed.
+	Use `free_process_info` to free the memory allocated by this function. In
+	case the function returns an error all temporary allocations would be freed
+	and as such, calling `free_process_info()` is not needed.
 
 	**Note**: The resulting information may or may not contain the
 	selected fields. Please check the `fields` field of the `Process_Info`
 	struct to see if the struct contains the desired fields **before** checking
-	the error return of this function.
+	the error code returned by this function.
 */
 process_info :: proc(pid: int, selection: Process_Info_Fields, allocator: runtime.Allocator) -> (Process_Info, Error) {
 	return _process_info(pid, selection, allocator)
 }
 
+/*
+	Obtain information about the current process.
+
+	This procedure obtains the information, specified by `selection` parameter
+	about the currently running process.
+
+	Use `free_process_info` to free the memory allocated by this function. In
+	case this function returns an error, all temporary allocations would be
+	freed and as such calling `free_process_info()` is not needed.
+
+	**Note**: The resulting `Process_Info` may or may not contain the selected
+	fields. Check the `fields` field of the `Process_Info` struct to see, if the
+	struct contains the selected fields **before** checking the error code
+	returned by this function.
+*/
 current_process_info :: proc(selection: Process_Info_Fields, allocator: runtime.Allocator) -> (Process_Info, Error) {
 	return _current_process_info(selection, allocator)
 }

--- a/core/os/os2/process.odin
+++ b/core/os/os2/process.odin
@@ -168,17 +168,37 @@ Process_Info :: struct {
 	This procedure obtains an information, specified by `selection` parameter of
 	a process given by `pid`.
 	
-	Use `free_process_info` to free the memory allocated by this function. In
+	Use `free_process_info` to free the memory allocated by this procedure. In
 	case the function returns an error all temporary allocations would be freed
 	and as such, calling `free_process_info()` is not needed.
 
-	**Note**: The resulting information may or may not contain the
-	selected fields. Please check the `fields` field of the `Process_Info`
-	struct to see if the struct contains the desired fields **before** checking
-	the error code returned by this function.
+	**Note**: The resulting information may or may contain the fields specified
+	by the `selection` parameter. Always check whether the returned
+	`Process_Info` struct has the required fields before checking the error code
+	returned by this function.
 */
-process_info :: proc(pid: int, selection: Process_Info_Fields, allocator: runtime.Allocator) -> (Process_Info, Error) {
-	return _process_info(pid, selection, allocator)
+process_info_by_pid :: proc(pid: int, selection: Process_Info_Fields, allocator: runtime.Allocator) -> (Process_Info, Error) {
+	return _process_info_by_pid(pid, selection, allocator)
+}
+
+/*
+	Obtain information about a process.
+
+	This procedure obtains information, specified by `selection` parameter
+	about a process that has been opened by the application, specified in
+	the `process` parameter.
+
+	Use `free_process_info` to free the memory allocated by this procedure. In
+	case the function returns an error, all temporary allocations would be freed
+	and as such, calling `free_process_info` is not needed.
+
+	**Note**: The resulting information may or may contain the fields specified
+	by the `selection` parameter. Always check whether the returned
+	`Process_Info` struct has the required fields before checking the error code
+	returned by this function.
+*/
+process_info_by_handle :: proc(process: Process, selection: Process_Info_Fields, allocator: runtime.Allocator) -> (Process_Info, Error) {
+	return _process_info_by_handle(process, selection, allocator)
 }
 
 /*
@@ -191,13 +211,22 @@ process_info :: proc(pid: int, selection: Process_Info_Fields, allocator: runtim
 	case this function returns an error, all temporary allocations would be
 	freed and as such calling `free_process_info()` is not needed.
 
-	**Note**: The resulting `Process_Info` may or may not contain the selected
-	fields. Check the `fields` field of the `Process_Info` struct to see, if the
-	struct contains the selected fields **before** checking the error code
+	**Note**: The resulting information may or may contain the fields specified
+	by the `selection` parameter. Always check whether the returned
+	`Process_Info` struct has the required fields before checking the error code
 	returned by this function.
 */
 current_process_info :: proc(selection: Process_Info_Fields, allocator: runtime.Allocator) -> (Process_Info, Error) {
 	return _current_process_info(selection, allocator)
+}
+
+/*
+	Obtain information about the specified process.
+*/
+process_info :: proc {
+	process_info_by_pid,
+	process_info_by_handle,
+	current_process_info,
 }
 
 /*

--- a/core/os/os2/process.odin
+++ b/core/os/os2/process.odin
@@ -351,7 +351,8 @@ process_wait :: proc(process: Process, timeout := TIMEOUT_INFINITE) -> (Process_
 
 	This procedure closes the handle associated with a process. It **does not**
 	terminate a process, in case it was running. In case a termination is
-	desired, kill the process first, then close the handle.
+	desired, kill the process first, wait for the process to finish,
+	then close the handle.
 */
 process_close :: proc(process: Process) -> (Error) {
 	return _process_close(process)

--- a/core/os/os2/process.odin
+++ b/core/os/os2/process.odin
@@ -26,11 +26,11 @@ args := get_args()
 	typically is the path to the currently running executable.
 */
 get_args :: proc() -> []string {
-	args := make([]string, len(runtime.args__), allocator = context.allocator)
+	result := make([]string, len(runtime.args__), allocator = context.allocator)
 	for rt_arg, i in runtime.args__ {
-		args[i] = cast(string) rt_arg
+		result[i] = cast(string) rt_arg
 	}
-	return args[:]
+	return result[:]
 }
 
 /*
@@ -387,42 +387,12 @@ process_close :: proc(process: Process) -> (Error) {
 	return _process_close(process)
 }
 
-// Process_Attributes :: struct {
-// 	dir: string,
-// 	env: []string,
-// 	files: []^File,
-// 	sys: ^Process_Attributes_OS_Specific,
-// }
+/*
+	Terminate a process.
 
-// Process_Attributes_OS_Specific :: struct{}
+	This procedure terminates a process, specified by it's handle, `process`.
 
-// Process_Error :: enum {
-// 	None,
-// }
-
-
-
-// Signal :: #type proc()
-
-// Kill:      Signal = nil
-// Interrupt: Signal = nil
-
-// process_start :: proc(name: string, argv: []string, attr: ^Process_Attributes) -> (^Process, Process_Error) {
-// 	return nil, .None
-// }
-
-// process_release :: proc(p: ^Process) -> Process_Error {
-// 	return .None
-// }
-
-// process_kill :: proc(p: ^Process) -> Process_Error {
-// 	return .None
-// }
-
-// process_signal :: proc(p: ^Process, sig: Signal) -> Process_Error {
-// 	return .None
-// }
-
-
-
-
+*/
+process_kill :: proc(process: Process) -> (Error) {
+	return _process_kill(process)
+}

--- a/core/os/os2/process.odin
+++ b/core/os/os2/process.odin
@@ -13,20 +13,12 @@ TIMEOUT_INFINITE :: time.MIN_DURATION // Note(flysand): Any negative duration wi
 
 /*
 	Arguments to the current process.
-
-	See `get_args()` for description of the slice.
 */
 args := get_args()
 
-/*
-	Obtain the process argument array from the OS.
-
-	Slice, containing arguments to the current process. Each element of the
-	slice contains a single argument. The first element of the slice would
-	typically is the path to the currently running executable.
-*/
+@(private="file")
 get_args :: proc() -> []string {
-	result := make([]string, len(runtime.args__), allocator = context.allocator)
+	result := make([]string, len(runtime.args__), heap_allocator())
 	for rt_arg, i in runtime.args__ {
 		result[i] = cast(string) rt_arg
 	}

--- a/core/os/os2/process.odin
+++ b/core/os/os2/process.odin
@@ -3,35 +3,105 @@ package os2
 import "core:sync"
 import "core:time"
 import "base:runtime"
+import "core:strings"
 
-args: []string
+/*
+	Arguments to the current process.
 
+	See `get_args()` for description of the slice.
+*/
+args := get_args()
+
+/*
+	Obtain the process argument array from the OS.
+
+	Slice, containing arguments to the current process. Each element of the
+	slice contains a single argument. The first element of the slice would
+	typically is the path to the currently running executable.
+*/
+get_args :: proc() -> []string {
+	args := make([]string, len(runtime.args__), allocator = context.allocator)
+	for rt_arg, i in runtime.args__ {
+		args[i] = cast(string) rt_arg
+	}
+	return args[:]
+}
+
+/*
+	Exit the current process.
+*/
 exit :: proc "contextless" (code: int) -> ! {
-	runtime.trap()
+	_exit(code)
 }
 
+/*
+	Obtain the UID of the current process.
+
+	**Note(windows)**: Windows doesn't follow the posix permissions model, so
+	the function simply returns -1.
+*/
 get_uid :: proc() -> int {
-	return -1
+	return _get_uid()
 }
 
+/*
+	Obtain the effective UID of the current process.
+
+	The effective UID is typically the same as the UID of the process. In case
+	the process was run by a user with elevated permissions, the process may
+	lower the privilege to perform some tasks without privilege. In these cases
+	the real UID of the process and the effective UID are different.
+	
+	**Note(windows)**: Windows doesn't follow the posix permissions model, so
+	the function simply returns -1.
+*/
 get_euid :: proc() -> int {
-	return -1
+	return _get_euid()
 }
 
+/*
+	Obtain the GID of the current process.
+	
+	**Note(windows)**: Windows doesn't follow the posix permissions model, so
+	the function simply returns -1.
+*/
 get_gid :: proc() -> int {
-	return -1
+	return _get_gid()
 }
 
+/*
+	Obtain the effective GID of the current process.
+	
+	The effective GID is typically the same as the GID of the process. In case
+	the process was run by a user with elevated permissions, the process may
+	lower the privilege to perform some tasks without privilege. In these cases
+	the real GID of the process and the effective GID are different.
+
+	**Note(windows)**: Windows doesn't follow the posix permissions model, so
+	the function simply returns -1.
+*/
 get_egid :: proc() -> int {
-	return -1
+	return _get_egid()
 }
 
+/*
+	Obtain the ID of the current process.
+*/
 get_pid :: proc() -> int {
-	return -1
+	return _get_pid()
 }
 
+/*
+	Obtain the ID of the parent process.
+
+	**Note(windows)**: Windows does not mantain strong relationships between
+	parent and child processes. This function returns the ID of the process
+	that has created the current process. In case the parent has died, the ID
+	returned by this function can identify a non-existent or a different
+	process.
+*/
 get_ppid :: proc() -> int {
-	return -1
+	return _get_ppid()
 }
 
 

--- a/core/os/os2/process_windows.odin
+++ b/core/os/os2/process_windows.odin
@@ -2,6 +2,7 @@
 package os2
 
 import "core:sys/windows"
+import "core:strings"
 import "base:runtime"
 
 _Process_Handle :: windows.HANDLE
@@ -63,18 +64,491 @@ _process_list :: proc(allocator: runtime.Allocator) -> ([]int, Error) {
 	return pid_list[:], nil
 }
 
-_process_open :: proc(pid: int) -> (Process, Error) {
-	handle := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, cast(u32) pid)
-	if handle == windows.INVALID_HANDLE_VALUE {
-		return {}, _get_platform_error()
+_process_info :: proc(pid: int, selection: Process_Info_Fields, allocator: runtime.Allocator) -> (info: Process_Info, err: Error) {
+	info.pid = pid
+	need_snapprocess := \
+		.PPid in selection ||
+		.Priority in selection
+	need_snapmodule := \
+		.Executable_Path in selection
+	need_peb := \
+		.Command_Line in selection ||
+		.Environment in selection ||
+		.CWD in selection
+	need_process_handle := need_peb || .Username in selection
+	// Data obtained from process snapshots
+	if need_snapprocess {
+		snap := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+		if snap == windows.INVALID_HANDLE_VALUE {
+			return info, _get_platform_error()
+		}
+		defer windows.CloseHandle(snap)
+		entry := windows.PROCESSENTRY32W { dwSize = size_of(windows.PROCESSENTRY32W) }
+		status := windows.Process32FirstW(snap, &entry)
+		found := false
+		for status {
+			if u32(pid) == entry.th32ProcessID {
+				found = true
+				break
+			}
+			status = windows.Process32NextW(snap, &entry)
+		}
+		if !found {
+			err = General_Error.Not_Exist
+			return
+		}
+		if .PPid in selection {
+			info.fields |= {.PPid}
+			info.ppid = int(entry.th32ParentProcessID)
+		}
+		if .Priority in selection {
+			info.fields |= {.Priority}
+			info.priority = int(entry.pcPriClassBase)
+		}
 	}
-	return Process {
-		handle = handle,
-	}, nil
+	// Note(flysand): Not sure which way it's better to get the executable path:
+	// via toolhelp snapshots or by reading other process' PEB memory. I have
+	// a slight suspicion that if both exe path and command line are desired,
+	// it's faster to just read both from PEB, but maybe the toolhelp snapshots
+	// are just better...?
+	if need_snapmodule {
+		snap := windows.CreateToolhelp32Snapshot(
+			windows.TH32CS_SNAPMODULE|windows.TH32CS_SNAPMODULE32,
+			u32(pid),
+		)
+		if snap == windows.INVALID_HANDLE_VALUE {
+			err = _get_platform_error()
+			return
+		}
+		defer windows.CloseHandle(snap)
+		entry := windows.MODULEENTRY32W { dwSize = size_of(windows.MODULEENTRY32W) }
+		status := windows.Module32FirstW(snap, &entry)
+		if !status {
+			err = _get_platform_error()
+			return
+		}
+		exe_path: string
+		exe_path, err = windows.wstring_to_utf8(raw_data(entry.szExePath[:]), -1,  allocator)
+		if err != nil {
+			return
+		}
+		info.fields |= {.Executable_Path}
+		info.executable_path = exe_path
+	}
+	defer if .Executable_Path in info.fields && err != nil {
+		delete(info.executable_path, allocator)
+	}
+	ph := windows.INVALID_HANDLE_VALUE
+	if need_process_handle {
+		ph = windows.OpenProcess(
+			windows.PROCESS_QUERY_LIMITED_INFORMATION | windows.PROCESS_VM_READ,
+			false,
+			u32(pid),
+		)
+		if ph == windows.INVALID_HANDLE_VALUE {
+			err = _get_platform_error()
+			return
+		}
+	}
+	defer if ph != windows.INVALID_HANDLE_VALUE {
+		windows.CloseHandle(ph)
+	}
+	defer if .CWD in info.fields && err != nil {
+		delete(info.cwd, allocator)
+	}
+	defer if .Environment in info.fields && err != nil {
+		for s in info.environment {
+			delete(s, allocator)
+		}
+		delete(info.environment, allocator)
+	}
+	defer if .Command_Line in info.fields && err != nil {
+		delete(info.command_line, allocator)
+	}
+	if need_peb {
+		ntdll_lib := windows.LoadLibraryW(windows.L("ntdll.dll"))
+		if ntdll_lib == nil {
+			err = _get_platform_error()
+			return
+		}
+		defer windows.FreeLibrary(ntdll_lib)
+		NtQueryInformationProcess := cast(NtQueryInformationProcess_T) windows.GetProcAddress(ntdll_lib, "NtQueryInformationProcess")
+		if NtQueryInformationProcess == nil {
+			err = _get_platform_error()
+			return
+		}
+		process_info_size: u32 = ---
+		process_info: PROCESS_BASIC_INFORMATION = ---
+		status := NtQueryInformationProcess(ph, .ProcessBasicInformation, &process_info, size_of(process_info), &process_info_size)
+		if status != 0 {
+			// TODO(flysand): There's probably a mismatch between NTSTATUS and
+			// windows userland error codes, I haven't checked.
+			err = Platform_Error(status)
+			return
+		}
+		if process_info.PebBaseAddress == nil {
+			// Not sure what the error is
+			err = General_Error.Unsupported
+			return
+		}
+		process_peb: PEB = ---
+		bytes_read: uint = ---
+		read_struct :: proc(h: windows.HANDLE, addr: rawptr, dest: ^$T, br: ^uint) -> windows.BOOL {
+			return windows.ReadProcessMemory(h, addr, dest, size_of(T), br)
+		}
+		read_slice :: proc(h: windows.HANDLE, addr: rawptr, dest: []$T, br: ^uint) -> windows.BOOL {
+			return windows.ReadProcessMemory(h, addr, raw_data(dest), len(dest)*size_of(T), br)
+		}
+		if !read_struct(ph, process_info.PebBaseAddress, &process_peb, &bytes_read) {
+			err = _get_platform_error()
+			return
+		}
+		process_params: RTL_USER_PROCESS_PARAMETERS = ---
+		if !read_struct(ph, process_peb.ProcessParameters, &process_params, &bytes_read) {
+			err = _get_platform_error()
+			return
+		}
+		if .Command_Line in selection {
+			TEMP_ALLOCATOR_GUARD()
+			cmdline_w := make([]u16, process_params.CommandLine.Length, temp_allocator())
+			if !read_slice(ph, process_params.CommandLine.Buffer, cmdline_w, &bytes_read) {
+				err = _get_platform_error()
+				return
+			}
+			cmdline, cmdline_err := windows.utf16_to_utf8(cmdline_w, allocator)
+			if cmdline_err != nil {
+				err = cmdline_err
+				return
+			}
+			info.fields |= {.Command_Line}
+			info.command_line = cmdline
+		}
+		if .Environment in selection {
+			TEMP_ALLOCATOR_GUARD()
+			env_len := process_params.EnvironmentSize / 2
+			envs_w := make([]u16, env_len, temp_allocator())
+			if !read_slice(ph, process_params.Environment, envs_w, &bytes_read) {
+				err = _get_platform_error()
+				return
+			}
+			envs, envs_err := _parse_environment_block(raw_data(envs_w), allocator)
+			if envs_err != nil {
+				err = envs_err
+				return
+			}
+			info.fields |= {.Environment}
+			info.environment = envs
+		}
+		if .CWD in selection {
+			TEMP_ALLOCATOR_GUARD()
+			cwd_w := make([]u16, process_params.CurrentDirectoryPath.Length, temp_allocator())
+			if !read_slice(ph, process_params.CurrentDirectoryPath.Buffer, cwd_w, &bytes_read) {
+				err = _get_platform_error()
+				return
+			}
+			cwd, cwd_err := windows.utf16_to_utf8(cwd_w, allocator)
+			if cwd_err != nil {
+				err = cwd_err
+				return
+			}
+			info.fields |= {.CWD}
+			info.cwd = cwd
+		}
+	}
+	if .Username in selection {
+		username, username_err := _get_process_user(ph, allocator)
+		if username_err != nil {
+			err = username_err
+			return
+		}
+		info.fields |= {.Username}
+		info.username = username
+	}
+	err = nil
+	return
 }
 
-_process_close :: proc(process: Process) -> (Error) {
-	if !windows.CloseHandle(process.handle) {
-		return _get_platform_error()
+_current_process_info :: proc(selection: Process_Info_Fields, allocator: runtime.Allocator) -> (info: Process_Info, err: Error) {
+	info.pid = cast(int) windows.GetCurrentProcessId()
+	need_snapprocess := .PPid in selection || .Priority in selection
+	if need_snapprocess {
+		snap := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+		if snap == windows.INVALID_HANDLE_VALUE {
+			return
+		}
+		defer windows.CloseHandle(snap)
+		entry := windows.PROCESSENTRY32W { dwSize = size_of(windows.PROCESSENTRY32W) }
+		status := windows.Process32FirstW(snap, &entry)
+		for status {
+			if entry.th32ProcessID == u32(info.pid) {
+				break
+			}
+			status = windows.Process32NextW(snap, &entry)
+		}
+		if entry.th32ProcessID != u32(info.pid) {
+			err = General_Error.Not_Exist
+			return
+		}
+		if .PPid in selection {
+			info.fields += {.PPid}
+			info.ppid = int(entry.th32ProcessID)
+		}
+		if .Priority in selection {
+			info.fields += {.Priority}
+			info.priority = int(entry.pcPriClassBase)
+		}
 	}
+	if .Executable_Path in selection {
+		exe_filename_w: [256]u16
+		path_len := windows.GetModuleFileNameW(nil, raw_data(exe_filename_w[:]), len(exe_filename_w))
+		exe_filename, exe_filename_err := windows.utf16_to_utf8(exe_filename_w[:path_len], allocator)
+		if exe_filename_err != nil {
+			err = exe_filename_err
+			return
+		}
+		info.fields += {.Executable_Path}
+		info.executable_path = exe_filename
+	}
+	defer if .Executable_Path in selection && err != nil {
+		delete(info.executable_path, allocator)
+	}
+	if .Command_Line in selection {
+		command_line_w := windows.GetCommandLineW()
+		command_line, command_line_err := windows.wstring_to_utf8(command_line_w, -1, allocator)
+		if command_line_err != nil {
+			err = command_line_err
+			return
+		}
+		info.fields += {.Command_Line}
+		info.command_line = command_line
+	}
+	defer if .Command_Line in selection && err != nil {
+		delete(info.command_line, allocator)
+	}
+	if .Environment in selection {
+		env_block := windows.GetEnvironmentStringsW()
+		envs, envs_err := _parse_environment_block(env_block, allocator)
+		if envs_err != nil {
+			err = envs_err
+			return
+		}
+		info.fields += {.Environment}
+		info.environment = envs
+	}
+	defer if .Environment in selection && err != nil {
+		for s in info.environment {
+			delete(s, allocator)
+		}
+		delete(info.environment)
+	}
+	if .Username in selection {
+		process_handle := windows.GetCurrentProcess()
+		username, username_err := _get_process_user(process_handle, allocator)
+		if username_err != nil {
+			err = username_err
+			return
+		}
+		info.fields += {.Username}
+		info.username = username
+	}
+	defer if .Username in selection && err != nil {
+		delete(info.username)
+	}
+	err = nil
+	return
+}
+
+
+@(private)
+_get_process_user :: proc(process_handle: windows.HANDLE, allocator: runtime.Allocator) -> (full_username: string, err: Error) {
+	TEMP_ALLOCATOR_GUARD()
+	token_handle: windows.HANDLE = ---
+	if !windows.OpenProcessToken(process_handle, windows.TOKEN_QUERY, &token_handle) {
+		err = _get_platform_error()
+		return
+	}
+	token_user_size: u32 = ---
+	if !windows.GetTokenInformation(token_handle, .TokenUser, nil, 0, &token_user_size) {
+		// Note(flysand): Make sure the buffer too small error comes out, and not any other error
+		err = _get_platform_error()
+		if v, ok := err.(Platform_Error); !ok || int(v) != 0x7a {
+			return
+		}
+	}
+	token_user := cast(^windows.TOKEN_USER) raw_data(make([]u8, token_user_size, temp_allocator()))
+	if !windows.GetTokenInformation(token_handle, .TokenUser, token_user, token_user_size, &token_user_size) {
+		err = _get_platform_error()
+		return
+	}
+	sid_type: windows.SID_NAME_USE = ---
+	username_w: [256]u16 = ---
+	domain_w: [256]u16 = ---
+	username_chrs: u32 = 256
+	domain_chrs: u32 = 256
+	if !windows.LookupAccountSidW(nil, token_user.User.Sid, &username_w[0], &username_chrs, &domain_w[0], &domain_chrs, &sid_type) {
+		err = _get_platform_error()
+		return
+	}
+	username, username_err := windows.utf16_to_utf8(username_w[:username_chrs], temp_allocator())
+	if username_err != nil {
+		err = username_err
+		return
+	}
+	domain, domain_err := windows.utf16_to_utf8(domain_w[:domain_chrs], temp_allocator())
+	if domain_err != nil {
+		err = domain_err
+		return
+	}
+	full_name, full_name_err := strings.concatenate([]string {domain, "\\", username}, allocator)
+	if full_name_err != nil {
+		err = full_name_err
+		return
+	}
+	return full_name, nil
+}
+
+@(private)
+_parse_environment_block :: proc(block: [^]u16, allocator: runtime.Allocator) -> ([]string, Error) {
+	zt_count := 0
+	for idx := 0; true; idx += 1 {
+		if block[idx] == 0x0000 {
+			zt_count += 1
+		}
+		if block[idx] == 0x0000 {
+			zt_count += 1
+			break
+		}
+	}
+	// Note(flysand): Each string in the environment block is terminated
+	// by a NUL character. In addition, the environment block itself is
+	// terminated by a NUL character. So the number of strings in the
+	// environment block is the number of NUL character minus the
+	// block terminator.
+	env_count := zt_count - 1
+	envs := make([]string, env_count, allocator)
+	env_idx := 0
+	last_idx := 0
+	idx := 0
+	for block[idx] != 0x0000 {
+		for block[idx] != 0x0000 {
+			idx += 1
+		}
+		env_w := block[last_idx:idx]
+		env, env_err := windows.utf16_to_utf8(env_w, allocator)
+		if env_err != nil {
+			return nil, env_err
+		}
+		envs[env_idx] = env
+		env_idx += 1
+		idx += 1
+		last_idx = idx
+	}
+	return envs, nil
+}
+
+
+@(private="file")
+PROCESSINFOCLASS :: enum i32 {
+    ProcessBasicInformation = 0,
+	ProcessDebugPort = 7,
+    ProcessWow64Information = 26,
+	ProcessImageFileName = 27,
+	ProcessBreakOnTermination = 29,
+	ProcessTelemetryIdInformation = 64,
+	ProcessSubsystemInformation = 75,
+}
+
+@(private="file")
+NtQueryInformationProcess_T :: #type proc (
+    ProcessHandle: windows.HANDLE,
+    ProcessInformationClass: PROCESSINFOCLASS,
+    ProcessInformation: rawptr,
+    ProcessInformationLength: u32,
+    ReturnLength: ^u32,
+) -> u32
+
+@(private="file")
+PROCESS_BASIC_INFORMATION :: struct {
+    _: rawptr,
+    PebBaseAddress: ^PEB,
+    _: [2]rawptr,
+    UniqueProcessId: ^u32,
+    _: rawptr,
+}
+
+@(private="file")
+PEB :: struct {
+    _: [2]u8,
+    BeingDebugged: u8,
+    _: [1]u8,
+    _: [2]rawptr,
+    Ldr: ^PEB_LDR_DATA,
+    ProcessParameters: ^RTL_USER_PROCESS_PARAMETERS,
+    _: [104]u8,
+    _: [52]rawptr,
+    PostProcessInitRoutine: #type proc "stdcall" (),
+    _: [128]u8,
+    _: [1]rawptr,
+    SessionId: u32,
+}
+
+@(private="file")
+PEB_LDR_DATA :: struct {
+    _: [8]u8,
+    _: [3]rawptr,
+    InMemoryOrderModuleList: LIST_ENTRY,
+}
+
+@(private="file")
+RTL_USER_PROCESS_PARAMETERS :: struct {
+	MaximumLength: u32,
+	Length: u32,
+	Flags: u32,
+	DebugFlags: u32,
+	ConsoleHandle: rawptr,
+	ConsoleFlags: u32,
+	StdInputHandle: rawptr,
+	StdOutputHandle: rawptr,
+	StdErrorHandle: rawptr,
+	CurrentDirectoryPath: UNICODE_STRING,
+	CurrentDirectoryHandle: rawptr,
+	DllPath: UNICODE_STRING,
+    ImagePathName: UNICODE_STRING,
+    CommandLine: UNICODE_STRING,
+	Environment: rawptr,
+	StartingPositionLeft: u32,
+	StartingPositionTop: u32,
+	Width: u32,
+	Height: u32,
+	CharWidth: u32,
+	CharHeight: u32,
+	ConsoleTextAttributes: u32,
+	WindowFlags: u32,
+	ShowWindowFlags: u32,
+	WindowTitle: UNICODE_STRING,
+	DesktopName: UNICODE_STRING,
+	ShellInfo: UNICODE_STRING,
+	RuntimeData: UNICODE_STRING,
+	DLCurrentDirectory: [32]RTL_DRIVE_LETTER_CURDIR,
+	EnvironmentSize: u32,
+}
+
+RTL_DRIVE_LETTER_CURDIR :: struct {
+	Flags: u16,
+	Length: u16,
+	TimeStamp: u32,
+	DosPath: UNICODE_STRING,
+}
+
+@(private="file")
+UNICODE_STRING :: struct {
+    Length: u16,
+    MaximumLength: u16,
+    Buffer: [^]u16,
+}
+
+@(private="file")
+LIST_ENTRY :: struct {
+	Flink: ^LIST_ENTRY,
+	Blink: ^LIST_ENTRY,
 }

--- a/core/os/os2/process_windows.odin
+++ b/core/os/os2/process_windows.odin
@@ -1,0 +1,46 @@
+//+build windows
+package os2
+
+import "core:sys/windows"
+
+_exit :: proc "contextless" (code: int) -> ! {
+	windows.ExitProcess(u32(code))
+}
+
+_get_uid :: proc() -> int {
+	return -1
+}
+
+_get_euid :: proc() -> int {
+	return -1
+}
+
+_get_gid :: proc() -> int {
+	return -1
+}
+
+_get_egid :: proc() -> int {
+	return -1
+}
+
+_get_pid :: proc() -> int {
+	return cast(int) windows.GetCurrentProcessId()
+}
+
+_get_ppid :: proc() -> int {
+	our_pid := windows.GetCurrentProcessId()
+	snap := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if snap == windows.INVALID_HANDLE_VALUE {
+		return -1
+	}
+	defer windows.CloseHandle(snap)
+	entry := windows.PROCESSENTRY32W { dwSize = size_of(windows.PROCESSENTRY32W) }
+	status := windows.Process32FirstW(snap, &entry)
+	for status {
+		if entry.th32ProcessID == our_pid {
+			return cast(int) entry.th32ParentProcessID
+		}
+		status = windows.Process32NextW(snap, &entry)
+	}
+	return -1
+}

--- a/core/os/os2/process_windows.odin
+++ b/core/os/os2/process_windows.odin
@@ -410,14 +410,15 @@ _get_process_user :: proc(process_handle: windows.HANDLE, allocator: runtime.All
 @(private)
 _parse_environment_block :: proc(block: [^]u16, allocator: runtime.Allocator) -> ([]string, Error) {
 	zt_count := 0
-	for idx := 0; true; idx += 1 {
+	for idx := 0; true; {
 		if block[idx] == 0x0000 {
 			zt_count += 1
+			if block[idx+1] == 0x0000 {
+				zt_count += 1
+				break
+			}
 		}
-		if block[idx] == 0x0000 {
-			zt_count += 1
-			break
-		}
+		idx += 1
 	}
 	// Note(flysand): Each string in the environment block is terminated
 	// by a NUL character. In addition, the environment block itself is

--- a/core/os/os2/process_windows.odin
+++ b/core/os/os2/process_windows.odin
@@ -577,6 +577,13 @@ _process_close :: proc(process: Process) -> (Error) {
 	return nil
 }
 
+_process_kill :: proc(process: Process) -> (Error) {
+	if !windows.TerminateProcess(windows.HANDLE(process.handle), 9) {
+		return _get_platform_error()
+	}
+	return nil
+}
+
 @(private)
 _filetime_to_duration :: proc(filetime: windows.FILETIME) -> time.Duration {
 	ticks := u64(filetime.dwHighDateTime)<<32 | u64(filetime.dwLowDateTime)
@@ -695,8 +702,8 @@ _parse_command_line :: proc(cmd_line_w: [^]u16, allocator: runtime.Allocator) ->
 	for arg_w, i in argv_w[:argc] {
 		arg, arg_err := windows.wstring_to_utf8(arg_w, -1, allocator)
 		if arg_err != nil {
-			for arg in argv[:i] {
-				delete(arg, allocator)
+			for s in argv[:i] {
+				delete(s, allocator)
 			}
 			delete(argv, allocator)
 			return nil, arg_err


### PR DESCRIPTION
This is a work-in-progress draft for the `core:os2/process` api. The goal is to provide an API to Odin for creating and running child processes and provide more things one might want from the API than libc provides.

Among some of the features planned:

- [x] Querying information about processes in the system
- [x] Running processes
- [x] Overriding process standard streams

In the scope of this PR I will only implement the functionality for Windows and Linux, hopefully darwin won't be that different in terms of possible API interface.