### PR TITLE
fix wasm with `-target-features:"simd128"`

### DIFF
--- a/base/runtime/internal.odin
+++ b/base/runtime/internal.odin
@@ -962,9 +962,11 @@ udivmodti4 :: proc "c" (a, b: u128, rem: ^u128) -> u128 {
 	return udivmod128(a, b, rem)
 }
 
-@(link_name="__udivti3", linkage=RUNTIME_LINKAGE, require=RUNTIME_REQUIRE)
-udivti3 :: proc "c" (a, b: u128) -> u128 {
-	return udivmodti4(a, b, nil)
+when !IS_WASM {
+	@(link_name="__udivti3", linkage=RUNTIME_LINKAGE, require=RUNTIME_REQUIRE)
+	udivti3 :: proc "c" (a, b: u128) -> u128 {
+		return udivmodti4(a, b, nil)
+	}
 }
 
 

--- a/base/runtime/procs_wasm.odin
+++ b/base/runtime/procs_wasm.odin
@@ -7,19 +7,25 @@ ti_int :: struct #raw_union {
 	all: i128,
 }
 
+@(private="file")
+ti_uint :: struct #raw_union {
+	using s: struct { lo, hi: u64 },
+	all: u128,
+}
+
 @(link_name="__ashlti3", linkage="strong")
-__ashlti3 :: proc "contextless" (a: i128, b_: u32) -> i128 {
+__ashlti3 :: proc "contextless" (la, ha: u64, b_: u32) -> i128 {
 	bits_in_dword :: size_of(u32)*8
 	b := u32(b_)
 	
 	input, result: ti_int
-	input.all = a
+	input.lo, input.hi = la, ha
 	if b & bits_in_dword != 0 {
 		result.lo = 0
 		result.hi = input.lo << (b-bits_in_dword)
 	} else {
 		if b == 0 {
-			return a
+			return input.all
 		}
 		result.lo = input.lo<<b
 		result.hi = (input.hi<<b) | (input.lo>>(bits_in_dword-b))
@@ -29,12 +35,20 @@ __ashlti3 :: proc "contextless" (a: i128, b_: u32) -> i128 {
 
 
 @(link_name="__multi3", linkage="strong")
-__multi3 :: proc "contextless" (a, b: i128) -> i128 {
+__multi3 :: proc "contextless" (la, ha, lb, hb: u64) -> i128 {
 	x, y, r: ti_int
-	
-	x.all = a
-	y.all = b
+
+	x.lo, x.hi = la, ha
+	y.lo, y.hi = lb, hb
 	r.all = i128(x.lo * y.lo) // TODO this is incorrect
 	r.hi += x.hi*y.lo + x.lo*y.hi
 	return r.all
+}
+
+@(link_name="__udivti3", linkage="strong")
+udivti3 :: proc "c" (la, ha, lb, hb: u64) -> u128 {
+	a, b: ti_uint
+	a.lo, a.hi = la, ha
+	b.lo, b.hi = lb, hb
+	return udivmodti4(a.all, b.all, nil)
 }


### PR DESCRIPTION
the required procs within wasm would compile to take native v128 arguments in, but the procs are supposed to take in i64's causing bad wasm modules.

Fixes #3263