### PR TITLE
darwin: fix ld warnings and set minimum os version

### DIFF
--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -502,7 +502,6 @@ gb_internal i32 linker_stage(LinkerData *gen) {
 					platform_lib_str = gb_string_appendc(platform_lib_str, "-L/opt/local/lib ");
 				}
 
-				// This sets a requirement of Mountain Lion and up, but the compiler doesn't work without this limit.
 				if (build_context.minimum_os_version_string.len) {
 					link_settings = gb_string_append_fmt(link_settings, "-mmacosx-version-min=%.*s ", LIT(build_context.minimum_os_version_string));
 				}
@@ -513,7 +512,9 @@ gb_internal i32 linker_stage(LinkerData *gen) {
 			if (!build_context.no_crt) {
 				platform_lib_str = gb_string_appendc(platform_lib_str, "-lm ");
 				if (build_context.metrics.os == TargetOs_darwin) {
-					platform_lib_str = gb_string_appendc(platform_lib_str, "-lSystem ");
+					// NOTE: adding this causes a warning about duplicate libraries, I think it is
+					// automatically assumed/added by clang when you don't do `-nostdlib`.
+					// platform_lib_str = gb_string_appendc(platform_lib_str, "-lSystem ");
 				} else {
 					platform_lib_str = gb_string_appendc(platform_lib_str, "-lc ");
 				}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1925,7 +1925,7 @@ gb_internal void print_show_help(String const arg0, String const &command) {
 	if (run_or_build) {
 		print_usage_line(1, "-minimum-os-version:<string>");
 		print_usage_line(2, "Sets the minimum OS version targeted by the application.");
-		print_usage_line(2, "Example: -minimum-os-version:12.0.0");
+		print_usage_line(2, "Default: -minimum-os-version:11.0.0");
 		print_usage_line(2, "(Only used when target is Darwin.)");
 		print_usage_line(0, "");
 


### PR DESCRIPTION
- we were basically hardcoding macosx11 as a target regardless of the -minimum-os-version flag (the flag was only passed on to the linker before)
- not setting a version in the triplet (like we did on amd64) results in a linker warning: `ld: warning: no platform load command found in '/Users/agostino/repos/odin/game/game.o', assuming: macOS`
- another linker warning `ld: warning: ignoring duplicate libraries: '-lSystem'` was showing up, I believe this is because clang automatically adds this if you don't specify `-nostdlib` and we should leave it out