### PR TITLE
[core/os2]: Fix read_entire_file for reads from pipe and console.

### DIFF
--- a/core/os/os2/errors.odin
+++ b/core/os/os2/errors.odin
@@ -13,6 +13,10 @@ General_Error :: enum u32 {
 
 	Timeout,
 
+	// Indicates that an attempt to retrieve a file's size was made, but the
+	// file doesn't have a size.
+	No_Size,
+
 	Invalid_File,
 	Invalid_Dir,
 	Invalid_Path,
@@ -22,9 +26,15 @@ General_Error :: enum u32 {
 
 Platform_Error :: enum i32 {None=0}
 
+Read_Error :: enum u32 {
+	None,
+	Broken_Pipe,
+}
+
 Error :: union #shared_nil {
 	General_Error,
 	io.Error,
+	Read_Error,
 	runtime.Allocator_Error,
 	Platform_Error,
 }
@@ -51,6 +61,7 @@ error_string :: proc(ferr: Error) -> string {
 		case .Not_Exist:         return "file does not exist"
 		case .Closed:            return "file already closed"
 		case .Timeout:           return "i/o timeout"
+		case .No_Size:           return "file has no definite size"
 		case .Invalid_File:      return "invalid file"
 		case .Invalid_Dir:       return "invalid directory"
 		case .Invalid_Path:      return "invalid path"
@@ -81,6 +92,11 @@ error_string :: proc(ferr: Error) -> string {
 		case .Invalid_Pointer:      return "invalid allocator pointer"
 		case .Invalid_Argument:     return "invalid allocator argument"
 		case .Mode_Not_Implemented: return "allocator mode not implemented"
+		}
+	case Read_Error:
+		switch e {
+			case .None:             return ""
+			case .Broken_Pipe:      return "Broken pipe"
 		}
 	case Platform_Error:
 		return _error_string(i32(e))

--- a/core/os/os2/errors.odin
+++ b/core/os/os2/errors.odin
@@ -13,6 +13,8 @@ General_Error :: enum u32 {
 
 	Timeout,
 
+	Broken_Pipe,
+
 	// Indicates that an attempt to retrieve a file's size was made, but the
 	// file doesn't have a size.
 	No_Size,
@@ -26,15 +28,9 @@ General_Error :: enum u32 {
 
 Platform_Error :: enum i32 {None=0}
 
-Read_Error :: enum u32 {
-	None,
-	Broken_Pipe,
-}
-
 Error :: union #shared_nil {
 	General_Error,
 	io.Error,
-	Read_Error,
 	runtime.Allocator_Error,
 	Platform_Error,
 }
@@ -61,6 +57,7 @@ error_string :: proc(ferr: Error) -> string {
 		case .Not_Exist:         return "file does not exist"
 		case .Closed:            return "file already closed"
 		case .Timeout:           return "i/o timeout"
+		case .Broken_Pipe:       return "Broken pipe"
 		case .No_Size:           return "file has no definite size"
 		case .Invalid_File:      return "invalid file"
 		case .Invalid_Dir:       return "invalid directory"
@@ -92,11 +89,6 @@ error_string :: proc(ferr: Error) -> string {
 		case .Invalid_Pointer:      return "invalid allocator pointer"
 		case .Invalid_Argument:     return "invalid allocator argument"
 		case .Mode_Not_Implemented: return "allocator mode not implemented"
-		}
-	case Read_Error:
-		switch e {
-			case .None:             return ""
-			case .Broken_Pipe:      return "Broken pipe"
 		}
 	case Platform_Error:
 		return _error_string(i32(e))

--- a/core/os/os2/file_util.odin
+++ b/core/os/os2/file_util.odin
@@ -117,7 +117,7 @@ read_entire_file_from_file :: proc(f: ^File, allocator: runtime.Allocator) -> (d
 		}
 	} else {
 		buffer: [1024]u8
-		out_buffer := make([dynamic]u8)
+		out_buffer := make([dynamic]u8, 0, 0, allocator)
 		total := 0
 		for {
 			n: int = ---

--- a/core/os/os2/file_util.odin
+++ b/core/os/os2/file_util.odin
@@ -87,26 +87,50 @@ read_entire_file_from_path :: proc(name: string, allocator: runtime.Allocator) -
 
 read_entire_file_from_file :: proc(f: ^File, allocator: runtime.Allocator) -> (data: []byte, err: Error) {
 	size: int
+	has_size := true
 	if size64, err := file_size(f); err == nil {
 		if i64(int(size64)) != size64 {
 			size = int(size64)
 		}
+	} else if err == .No_Size {
+		has_size = false
+	} else {
+		return
 	}
 	size += 1 // for EOF
 
 	// TODO(bill): Is this correct logic?
-	total: int
-	data = make([]byte, size, allocator) or_return
-	for {
-		n: int
-		n, err = read(f, data[total:])
-		total += n
-		if err != nil {
-			if err == .EOF {
-				err = nil
+	if has_size {
+		total: int
+		data = make([]byte, size, allocator) or_return
+		for {
+			n: int
+			n, err = read(f, data[total:])
+			total += n
+			if err != nil {
+				if err == .EOF {
+					err = nil
+				}
+				data = data[:total]
+				return
 			}
-			data = data[:total]
-			return
+		}
+	} else {
+		buffer: [1024]u8
+		out_buffer := make([dynamic]u8)
+		total := 0
+		for {
+			n: int = ---
+			n, err = read(f, buffer[:])
+			total += n
+			append_elems(&out_buffer, ..buffer[:total])
+			if err != nil {
+				if err == .EOF || err == .Broken_Pipe {
+					err = nil
+				}
+				data = out_buffer[:total]
+				return
+			}
 		}
 	}
 }

--- a/core/os/os2/file_windows.odin
+++ b/core/os/os2/file_windows.odin
@@ -434,6 +434,9 @@ _write_at :: proc(f: ^File, p: []byte, offset: i64) -> (n: i64, err: Error) {
 
 _file_size :: proc(f: ^File) -> (n: i64, err: Error) {
 	length: win32.LARGE_INTEGER
+	if f.impl.kind == .Pipe {
+		return 0, .No_Size
+	}
 	handle := _handle(f)
 	if !win32.GetFileSizeEx(handle, &length) {
 		err = _get_platform_error()
@@ -766,7 +769,6 @@ _is_dir :: proc(path: string) -> bool {
 _file_stream_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, offset: i64, whence: io.Seek_From) -> (n: i64, err: io.Error) {
 	f := (^File)(stream_data)
 	ferr: Error
-	i: int
 	switch mode {
 	case .Read:
 		n, ferr = _read(f, p)


### PR DESCRIPTION
In before the logic for reading from a file was as follows:

- Get the size of the file
- Allocate a buffer of that size
- Read all the data into the buffer

This ignores files that don't have a definite size (`/dev/std*`, `/dev/null`, named and anonymous pipes). In this PR I've added `.No_Size` error to package io and used it to tell whether we should read entire buffer at once (i.e. the old logic) or read it chunk by chunk.