### PR TITLE
Fix fields_wait_signal futex.

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -3393,6 +3393,7 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 			elem->Struct.tags = gb_alloc_array(permanent_allocator(), String, fields.count);
 			elem->Struct.node = dummy_node_struct;
 			type_set_offsets(elem);
+			wait_signal_set(&elem->Struct.fields_wait_signal);
 		}
 
 		Type *soa_type = make_soa_struct_slice(c, dummy_node_soa, nullptr, elem);
@@ -3766,6 +3767,7 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 				soa_struct->Struct.tags[i] = old_struct->Struct.tags[i];
 			}
 		}
+		wait_signal_set(&soa_struct->Struct.fields_wait_signal);
 
 		Token token = {};
 		token.string = str_lit("Base_Type");

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -8873,6 +8873,7 @@ gb_internal ExprKind check_compound_literal(CheckerContext *c, Operand *o, Ast *
 			break;
 		}
 
+		wait_signal_until_available(&t->Struct.fields_wait_signal);
 		isize field_count = t->Struct.fields.count;
 		isize min_field_count = t->Struct.fields.count;
 		for (isize i = min_field_count-1; i >= 0; i--) {

--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -2490,6 +2490,7 @@ gb_internal Type *get_map_cell_type(Type *type) {
 	s->Struct.fields[0] = alloc_entity_field(scope, make_token_ident("v"), alloc_type_array(type, len), false, 0, EntityState_Resolved);
 	s->Struct.fields[1] = alloc_entity_field(scope, make_token_ident("_"), alloc_type_array(t_u8, padding), false, 1, EntityState_Resolved);
 	s->Struct.scope = scope;
+	wait_signal_set(&s->Struct.fields_wait_signal);
 	gb_unused(type_size_of(s));
 
 	return s;
@@ -2520,6 +2521,7 @@ gb_internal void init_map_internal_types(Type *type) {
 	metadata_type->Struct.fields[4] = alloc_entity_field(metadata_scope, make_token_ident("value_cell"), value_cell, false, 4, EntityState_Resolved);
 	metadata_type->Struct.scope = metadata_scope;
 	metadata_type->Struct.node = nullptr;
+	wait_signal_set(&metadata_type->Struct.fields_wait_signal);
 
 	gb_unused(type_size_of(metadata_type));
 
@@ -2537,6 +2539,7 @@ gb_internal void init_map_internal_types(Type *type) {
 	debug_type->Struct.fields[3] = alloc_entity_field(scope, make_token_ident("__metadata"), metadata_type, false, 3, EntityState_Resolved);
 	debug_type->Struct.scope = scope;
 	debug_type->Struct.node = nullptr;
+	wait_signal_set(&debug_type->Struct.fields_wait_signal);
 
 	gb_unused(type_size_of(debug_type));
 
@@ -2832,6 +2835,7 @@ gb_internal Type *make_soa_struct_internal(CheckerContext *ctx, Ast *array_typ_e
 	add_entity(ctx, scope, nullptr, base_type_entity);
 
 	add_type_info_type(ctx, soa_struct);
+	wait_signal_set(&soa_struct->Struct.fields_wait_signal);
 
 	return soa_struct;
 }

--- a/src/threading.cpp
+++ b/src/threading.cpp
@@ -113,7 +113,7 @@ struct Wait_Signal {
 
 gb_internal void wait_signal_until_available(Wait_Signal *ws) {
 	if (ws->futex.load() == 0) {
-		futex_wait(&ws->futex, 1);
+		futex_wait(&ws->futex, 0);
 	}
 }
 


### PR DESCRIPTION
Fixes #2463

Also partially resolves #2679, #2814, #2949, #3200, and #3291.

The missing field problem is a thread concurrency problem with checking structure fields.
One thread is expecting another thread to populate the fields of a structure and the first thread waits until that is done.
But even after waiting, the fields are not populated.

The root cause of this problem is that the function `wait_signal_until_available` which waits for a futex is not functional.

The futex `Struct.fields_wait_signal` is a value that starts at 0 and changes to 1 to indicate completion of `check_struct_fields` for a structure. The futex is waited on by making a `SYS_futex` system call and providing the *current expected* value of the futex. The system call then returns when another thread changes the value. However, if the current futex value is *not* the current expected value that was provided, then the system call returns immediately.

So, the expectation is that the code would call `SYS_futex` with a value of 0.
However, the code is erroneously making the call (via `futex_wait`) with the value of 1 and so the call returns immediately:
https://github.com/odin-lang/Odin/blob/517d7ae0b0fd400ceb6a213e7d644c19b8088bfd/src/threading.cpp#L114-L118

One may wonder how it avoids blocking indefinitely when the futex is already 1. Well, as you can see above, it only makes the system call after checking that the futex is currently zero. I suppose this is an optimization to avoid making an unnecessary system call when the futex is already completed but doing that just so happens to avoid hanging on the completed futex as well.

Unfortunately, fixing the futex reveals that there are problems where the code waits on the futex but the futex is never set. I had to add several calls to set the futex where they were missing. Unfortunately, this means that there may be other situations not yet identified in my testing where a futex wait occurs but the futex is never signaled.

I tried to find any potential lockups by building the demo, running all the tests, and building the [ols](https://github.com/DanielGavin/ols) project. Nevertheless, this fix could possibly reveal new lockups of the compiler. If one experiences a new compiler lockup that is traced to this PR then there is probably another missing `wait_signal_set` call that needs to be tracked down.

Unfortunately, in my testing I identified a design flaw that results in a compiler lock up even when `wait_signal_set` is performed correctly. So, this PR should not be merged until that issue is evaluated.