### PR TITLE
Fix race between find and add of new polymorphic type.

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -93,9 +93,11 @@ gb_internal void     check_init_constant            (CheckerContext *c, Entity *
 gb_internal bool     check_representable_as_constant(CheckerContext *c, ExactValue in_value, Type *type, ExactValue *out_value);
 gb_internal bool     check_procedure_type           (CheckerContext *c, Type *type, Ast *proc_type_node, Array<Operand> const *operands = nullptr);
 gb_internal void     check_struct_type              (CheckerContext *c, Type *struct_type, Ast *node, Array<Operand> *poly_operands,
-                                                     Type *named_type = nullptr, Type *original_type_for_poly = nullptr);
+                                                     Type *named_type = nullptr, Type *original_type_for_poly = nullptr,
+                                                     bool local_gen_types_locked = false);
 gb_internal void     check_union_type               (CheckerContext *c, Type *union_type, Ast *node, Array<Operand> *poly_operands,
-                                                     Type *named_type = nullptr, Type *original_type_for_poly = nullptr);
+                                                     Type *named_type = nullptr, Type *original_type_for_poly = nullptr,
+                                                     bool local_gen_types_locked = false);
 
 gb_internal Type *   check_init_variable            (CheckerContext *c, Entity *e, Operand *operand, String context_name);
 
@@ -7196,7 +7198,7 @@ gb_internal CallArgumentError check_polymorphic_record_type(CheckerContext *c, O
 			set_base_type(named_type, struct_type);
 
 			check_open_scope(&ctx, node);
-			check_struct_type(&ctx, struct_type, node, &ordered_operands, named_type, original_type);
+			check_struct_type(&ctx, struct_type, node, &ordered_operands, named_type, original_type, true);
 			check_close_scope(&ctx);
 		} else if (bt->kind == Type_Union) {
 			Ast *node = clone_ast(bt->Union.node);
@@ -7206,7 +7208,7 @@ gb_internal CallArgumentError check_polymorphic_record_type(CheckerContext *c, O
 			set_base_type(named_type, union_type);
 
 			check_open_scope(&ctx, node);
-			check_union_type(&ctx, union_type, node, &ordered_operands, named_type, original_type);
+			check_union_type(&ctx, union_type, node, &ordered_operands, named_type, original_type, true);
 			check_close_scope(&ctx);
 		} else {
 			GB_PANIC("Unsupported parametric polymorphic record type");


### PR DESCRIPTION
# Explanation of the PR

Partially fixes #2679, #2814, #2949, and #3291.

This PR fixes a race condition that exists across multiple threads, between calling `find_polymorhic_record_entity` and `add_polymorphic_record_entity`. Two or more threads can create the same type independantly because they may both call `find_polymorphic_record_entity` around the same time, don't find it, and then both proceed to create and then add the same type with `add_polymorphic_record_entity`.

The proposed solution here is for a lock to be held between looking up an entity (and not finding it) and subsequently adding the entity. This will lock out other threads and when another thread finally gets the lock to lookup the entity, it
will already be added and it won't attempt to add the entity again.

Specifically, if `find_polymorphic_record_entity` does not find the entity it leaves the the relevant (local) `gen_types` mutex locked. In combination, if the caller must subsequenty call `add_polymorphic_record_entity` and pass the flag
`local_gen_types_locked = true` so that `add_polymorphic_record_entity` knows that locking the local `gen_types` mutex has already been done.

Note that in `find_polymorphic_record_entity` the global lock must be released before locking the local lock. Otherwise, a deadlock can occur if:
1. Thread 1 takes the local lock in `find_polymorphic_record_entity`
2. Thread 2 goes into `find_polymorphic_record_entity` takes the global lock but can't get the local lock so it stops, holding the global lock.
3. Thread 1 goes into `add_polymorphic_record_entity`, and attempts to get the global lock. But it can't because Thread 1 has it. So thread 1 can't finish its work and then release the local lock. This is a deadlock.

While this is a relatively small fix, the downside is that dividing the lock and unlock into separate functions does make the code a bit more difficult to reason about. Perhaps a better solution can be identified, but from my testing it 100%
fixes this problem which has ben reported several times and at least demonstrates that the problem has been correctly diagnosed.