### PR TITLE
darwin: fix amd64 f16 emulation

### DIFF
--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -1115,7 +1115,16 @@ gb_internal void init_universal(void) {
 
 	add_global_constant("ODIN_COMPILE_TIMESTAMP", t_untyped_integer, exact_value_i64(odin_compile_timestamp()));
 
-	add_global_bool_constant("__ODIN_LLVM_F16_SUPPORTED", lb_use_new_pass_system() && !is_arch_wasm());
+	{
+		bool f16_supported = lb_use_new_pass_system();
+		if (is_arch_wasm()) {
+			f16_supported = false;
+		} else if (build_context.metrics.os == TargetOs_darwin && build_context.metrics.arch == TargetArch_amd64) {
+			// NOTE(laytan): See #3222 for my ramblings on this.
+			f16_supported = false;
+		}
+		add_global_bool_constant("__ODIN_LLVM_F16_SUPPORTED", f16_supported);
+	}
 
 	{
 		GlobalEnumValue values[3] = {


### PR DESCRIPTION
Fixes #3222

Bunch of rambling in the linked issue but it comes down to llvm generating calls to __extendhfsf2 with the half/f16 in edi and returning in xmm0, our implementation would be fixed with this change by also doing that.

I checked on WindowsLlinux and curiously code generated by llvm for that target does use the float register for both arguments and returns. Couldn't get to the bottom of why.

These calls are only generated on older microarches (older than haswell ~2013) because later on it has native support.

I also looked into being able to ask llvm what was expected for an architecture but it seems to not have this ability, at least not in llvm-c.