### PR TITLE
darwin: be less annoying about "incompatible" library versions

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -436,7 +436,9 @@ struct BuildContext {
 	BlockingMutex target_features_mutex;
 	StringSet target_features_set;
 	String target_features_string;
+
 	String minimum_os_version_string;
+	bool   minimum_os_version_string_given;
 };
 
 gb_global BuildContext build_context = {0};
@@ -1419,7 +1421,7 @@ gb_internal void init_build_context(TargetMetrics *cross_target, Subtarget subta
 
 	bc->metrics = *metrics;
 	if (metrics->os == TargetOs_darwin) {
-		if (bc->minimum_os_version_string.len == 0) {
+		if (!bc->minimum_os_version_string_given) {
 			bc->minimum_os_version_string = str_lit("11.0.0");
 		}
 

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -502,9 +502,12 @@ gb_internal i32 linker_stage(LinkerData *gen) {
 					platform_lib_str = gb_string_appendc(platform_lib_str, "-L/opt/local/lib ");
 				}
 
-				if (build_context.minimum_os_version_string.len) {
+				// Only specify this flag if the user has given a minimum version to target.
+				// This will cause warnings to show up for mismatched libraries.
+				if (build_context.minimum_os_version_string_given) {
 					link_settings = gb_string_append_fmt(link_settings, "-mmacosx-version-min=%.*s ", LIT(build_context.minimum_os_version_string));
 				}
+
 				// This points the linker to where the entry point is
 				link_settings = gb_string_appendc(link_settings, "-e _main ");
 			}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1066,6 +1066,7 @@ gb_internal bool parse_build_flags(Array<String> args) {
 						case BuildFlag_MinimumOSVersion: {
 							GB_ASSERT(value.kind == ExactValue_String);
 							build_context.minimum_os_version_string = value.value_string;
+							build_context.minimum_os_version_string_given = true;
 							break;
 						}
 						case BuildFlag_RelocMode: {
@@ -1926,7 +1927,7 @@ gb_internal void print_show_help(String const arg0, String const &command) {
 		print_usage_line(1, "-minimum-os-version:<string>");
 		print_usage_line(2, "Sets the minimum OS version targeted by the application.");
 		print_usage_line(2, "Default: -minimum-os-version:11.0.0");
-		print_usage_line(2, "(Only used when target is Darwin.)");
+		print_usage_line(2, "Only used when target is Darwin, if given, linking mismatched versions will emit a warning.");
 		print_usage_line(0, "");
 
 		print_usage_line(1, "-extra-linker-flags:<string>");


### PR DESCRIPTION
After #3316 we set a default minimum version, now this will warn if you link with a library that is targeting later versions.

This might be a bit annoying, especially when the user hasn't actually given Odin a minimum target.

So this PR makes these warnings only show when you explicitly give a target version (afaik that is the only thing that -mmacosx-min-version actually does for us because we don't use it to compile anything, just to link).