### PR TITLE
time.accurate_sleep Windows Doc update

### DIFF
--- a/core/time/time.odin
+++ b/core/time/time.odin
@@ -240,7 +240,7 @@ time_add :: proc "contextless" (t: Time, d: Duration) -> Time {
 // On Windows it depends but is comparable with regular sleep in the worst case.
 // To get the same kind of accuracy as on Linux, have your program call `windows.timeBeginPeriod(1)` to
 // tell Windows to use a more accurate timer for your process.
-// Additionally your program should call `windows.timeEndPeriod(1)` when you're done.
+// Additionally your program should call `windows.timeEndPeriod(1)` once you're done. 
 accurate_sleep :: proc "contextless" (d: Duration) {
 	to_sleep, estimate, mean, m2, count: Duration
 

--- a/core/time/time.odin
+++ b/core/time/time.odin
@@ -238,8 +238,9 @@ time_add :: proc "contextless" (t: Time, d: Duration) -> Time {
 //
 // Accuracy seems to be pretty good out of the box on Linux, to within around 4µs worst case.
 // On Windows it depends but is comparable with regular sleep in the worst case.
-// To get the same kind of accuracy as on Linux, have your program call `win32.time_begin_period(1)` to
+// To get the same kind of accuracy as on Linux, have your program call `windows.timeBeginPeriod(1)` to
 // tell Windows to use a more accurate timer for your process.
+// Additionally your program should call `windows.timeEndPeriod(1)` when you're done.
 accurate_sleep :: proc "contextless" (d: Duration) {
 	to_sleep, estimate, mean, m2, count: Duration
 

--- a/core/time/time.odin
+++ b/core/time/time.odin
@@ -240,7 +240,7 @@ time_add :: proc "contextless" (t: Time, d: Duration) -> Time {
 // On Windows it depends but is comparable with regular sleep in the worst case.
 // To get the same kind of accuracy as on Linux, have your program call `windows.timeBeginPeriod(1)` to
 // tell Windows to use a more accurate timer for your process.
-// Additionally your program should call `windows.timeEndPeriod(1)` once you're done. 
+// Additionally your program should call `windows.timeEndPeriod(1)` once you're done with `accurate_sleep`. 
 accurate_sleep :: proc "contextless" (d: Duration) {
 	to_sleep, estimate, mean, m2, count: Duration
 


### PR DESCRIPTION
Updated `win32.time_begin_period` to `windows.timeBeginPeriod`
Added a note about calling `windows.timeEndPeriod` once you don't need accurate_sleep, as per [MS's docs](https://learn.microsoft.com/en-us/windows/win32/api/timeapi/nf-timeapi-timebeginperiod#remarks).
Spelling & grammar checking are appreciated.

Fixes https://github.com/odin-lang/Odin/issues/3259