### PR TITLE
Fix incorrect timings on macOS

### DIFF
--- a/src/timings.cpp
+++ b/src/timings.cpp
@@ -44,12 +44,12 @@ gb_internal mach_timebase_info_data_t osx_init_timebase_info(void) {
 }
 
 gb_internal u64 osx_time_stamp_time_now(void) {
-	gb_local_persist mach_timebase_info_data_t data = osx_init_timebase_info();
-	return (mach_absolute_time() * cast(u64)data.numer) / cast(u64)data.denom; // Effectively converts to nanoseconds
+	return mach_absolute_time();
 }
 
 gb_internal u64 osx_time_stamp__freq(void) {
-	return 1000000000ull; // Nanoseconds to seconds
+	gb_local_persist mach_timebase_info_data_t data = osx_init_timebase_info();
+	return 1000000000ull * cast(u64)data.denom / cast(u64)data.numer;
 }
 
 #elif defined(GB_SYSTEM_UNIX)

--- a/src/timings.cpp
+++ b/src/timings.cpp
@@ -33,22 +33,23 @@ gb_internal u64 win32_time_stamp__freq(void) {
 
 #include <mach/mach_time.h>
 
-gb_internal u64 osx_time_stamp_time_now(void) {
-	return mach_absolute_time();
-}
-
-gb_internal u64 osx_time_stamp__freq(void) {
+gb_internal mach_timebase_info_data_t osx_init_timebase_info(void) {
 	mach_timebase_info_data_t data;
 	data.numer = 0;
 	data.denom = 0;
-	mach_timebase_info(&data);
-#if defined(GB_CPU_ARM)
-	// NOTE(bill, 2021-02-25): M1 Chip seems to have a different freq count
-	// TODO(bill): Is this truly correct?
-	return (1000000llu * cast(u64)data.numer) / cast(u64)data.denom;
-#else
-	return (1000000000llu * cast(u64)data.numer) / cast(u64)data.denom;
-#endif
+	kern_return_t r = mach_timebase_info(&data);
+	GB_ASSERT(r == KERN_SUCCESS);
+
+	return data;
+}
+
+gb_internal u64 osx_time_stamp_time_now(void) {
+	gb_local_persist mach_timebase_info_data_t data = osx_init_timebase_info();
+	return (mach_absolute_time() * cast(u64)data.numer) / cast(u64)data.denom; // Effectively converts to nanoseconds
+}
+
+gb_internal u64 osx_time_stamp__freq(void) {
+	return 1000000000ull; // Nanoseconds to seconds
 }
 
 #elif defined(GB_SYSTEM_UNIX)


### PR DESCRIPTION
This fixes incorrect timings being reported on macOS.

macOS raw timing API is a bit of an outlier compared to the other platforms with regards to frequency handling. This change makes it so that the operations to handle the tick conversion is done at the time `mach_absolute_time()` itself is called, returning the ticks as nanoseconds. `osx_time_stamp__freq()` is then changed to return a constant value to convert from nanoseconds to seconds.