### PR TITLE
debug info fixes/refactor

### DIFF
--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -1978,12 +1978,6 @@ gb_internal void lb_debug_info_complete_types_and_finalize(lbGenerator *gen) {
 	for (auto const &entry : gen->modules) {
 		lbModule *m = entry.value;
 		if (m->debug_builder != nullptr) {
-			lb_debug_complete_types(m);
-		}
-	}
-	for (auto const &entry : gen->modules) {
-		lbModule *m = entry.value;
-		if (m->debug_builder != nullptr) {
 			LLVMDIBuilderFinalize(m->debug_builder);
 		}
 	}

--- a/src/llvm_backend.hpp
+++ b/src/llvm_backend.hpp
@@ -199,8 +199,6 @@ struct lbModule {
 	RecursiveMutex debug_values_mutex;
 	PtrMap<void *, LLVMMetadataRef> debug_values; 
 
-	Array<lbIncompleteDebugType> debug_incomplete_types;
-
 	StringMap<lbAddr> objc_classes;
 	StringMap<lbAddr> objc_selectors;
 

--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -81,7 +81,6 @@ gb_internal void lb_init_module(lbModule *m, Checker *c) {
 	array_init(&m->global_procedures_and_types_to_create, a, 0, 1024);
 	array_init(&m->missing_procedures_to_check, a, 0, 16);
 	map_init(&m->debug_values);
-	array_init(&m->debug_incomplete_types, a, 0, 1024);
 
 	string_map_init(&m->objc_classes);
 	string_map_init(&m->objc_selectors);


### PR DESCRIPTION
Fixes #3340
Fixes #3117
Fixes #2945
Fixes #2922
Fixes #2762

A general refactor of debug info generation in order to fix issues and increase stability.

What I believe is the root cause of a bunch of issues is that we use the temporary metadata/forward declarations too much (/ hold onto them for too long). It seems to cause problems with the reference counting inside LLVM.

This PR reduces the use of these forward declarations to a minimum, it creates it, fills in the fields, and resolves it, instead of waiting until the end of generating code.

Some smaller issues I came across have also been solved.