### PR TITLE
Add NSApplication.activate to Foundation bindings.

### DIFF
--- a/vendor/darwin/Foundation/NSApplication.odin
+++ b/vendor/darwin/Foundation/NSApplication.odin
@@ -79,9 +79,20 @@ Application_setActivationPolicy :: proc "c" (self: ^Application, activationPolic
 	return msgSend(BOOL, self, "setActivationPolicy:", activationPolicy)
 }
 
+@(deprecated="Use NSApplication method activate instead.")
 @(objc_type=Application, objc_name="activateIgnoringOtherApps")
 Application_activateIgnoringOtherApps :: proc "c" (self: ^Application, ignoreOtherApps: BOOL) {
 	msgSend(nil, self, "activateIgnoringOtherApps:", ignoreOtherApps)
+}
+
+@(objc_type=Application, objc_name="activate")
+Application_activate :: proc "c" (self: ^Application) {
+	msgSend(nil, self, "activate")
+}
+
+@(objc_type=Application, objc_name="setTitle")
+Application_setTitle :: proc "c" (self: ^Application, title: ^String) {
+	msgSend(nil, self, "setTitle", title)
 }
 
 @(objc_type=Application, objc_name="setMainMenu")


### PR DESCRIPTION
Old: https://developer.apple.com/documentation/appkit/nsapplication/1428468-activateignoringotherapps
New: https://developer.apple.com/documentation/appkit/nsapplication/4168336-activate?language=objc