### PR TITLE
fix named arguments and untyped nil with #c_vararg

### DIFF
--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -3359,6 +3359,9 @@ gb_internal lbValue lb_build_call_expr_internal(lbProcedure *p, Ast *expr) {
 					for (Ast *var_arg : variadic) {
 						lbValue arg = lb_build_expr(p, var_arg);
 						if (is_type_any(elem_type)) {
+							if (is_type_untyped_nil(arg.type)) {
+								arg = lb_const_nil(p->module, t_rawptr);
+							}
 							array_add(&args, lb_emit_conv(p, arg, c_vararg_promote_type(default_type(arg.type))));
 						} else {
 							array_add(&args, lb_emit_conv(p, arg, c_vararg_promote_type(elem_type)));
@@ -3434,6 +3437,9 @@ gb_internal lbValue lb_build_call_expr_internal(lbProcedure *p, Ast *expr) {
 				for (Ast *var_arg : literal->elems) {
 					lbValue arg = lb_build_expr(p, var_arg);
 					if (is_type_any(elem_type)) {
+						if (is_type_untyped_nil(arg.type)) {
+							arg = lb_const_nil(p->module, t_rawptr);
+						}
 						array_add(&args, lb_emit_conv(p, arg, c_vararg_promote_type(default_type(arg.type))));
 					} else {
 						array_add(&args, lb_emit_conv(p, arg, c_vararg_promote_type(elem_type)));

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -3423,6 +3423,27 @@ gb_internal lbValue lb_build_call_expr_internal(lbProcedure *p, Ast *expr) {
 		if (e->kind == Entity_TypeName) {
 			lbValue value = lb_const_nil(p->module, e->type);
 			args[param_index] = value;
+		} else if (is_c_vararg && pt->variadic && pt->variadic_index == param_index) {
+			GB_ASSERT(param_index == pt->param_count-1);
+			Type *slice_type = e->type;
+			GB_ASSERT(slice_type->kind == Type_Slice);
+			Type *elem_type = slice_type->Slice.elem;
+
+			if (fv->value->kind == Ast_CompoundLit) {
+				ast_node(literal, CompoundLit, fv->value);
+				for (Ast *var_arg : literal->elems) {
+					lbValue arg = lb_build_expr(p, var_arg);
+					if (is_type_any(elem_type)) {
+						array_add(&args, lb_emit_conv(p, arg, c_vararg_promote_type(default_type(arg.type))));
+					} else {
+						array_add(&args, lb_emit_conv(p, arg, c_vararg_promote_type(elem_type)));
+					}
+				}
+			} else {
+				lbValue value = lb_build_expr(p, fv->value);
+				GB_ASSERT(!is_type_tuple(value.type));
+				array_add(&args, lb_emit_conv(p, value, c_vararg_promote_type(value.type)));
+			}
 		} else {
 			lbValue value = lb_build_expr(p, fv->value);
 			GB_ASSERT(!is_type_tuple(value.type));


### PR DESCRIPTION
Previously `args=1`, `args={}`, `args={1, 2, 3}` would all crash the compiler. Now it passes them correctly, and if given a compound literal, the values are expanded into the call so you can use a named arg while passing multiple values.

Also makes sure untyped nil is supported in c varargs.

Fixes #3168
Fixes #2842 