### PR TITLE
Fix vendor dynamic libraries not working on Linux

### DIFF
--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -432,7 +432,7 @@ gb_internal i32 linker_stage(LinkerData *gen) {
 							if (string_ends_with(lib, str_lit(".a")) || string_ends_with(lib, str_lit(".o"))) {
 								// static libs and object files, absolute full path relative to the file in which the lib was imported from
 								lib_str = gb_string_append_fmt(lib_str, " -l:\"%.*s\" ", LIT(lib));
-							} else if (string_ends_with(lib, str_lit(".so"))) {
+							} else if (string_ends_with(lib, str_lit(".so")) || string_contains_string(lib, str_lit(".so."))) {
 								// dynamic lib, relative path to executable
 								// NOTE(vassvik): it is the user's responsibility to make sure the shared library files are visible
 								//                at runtime to the executable

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -5710,7 +5710,7 @@ gb_internal bool determine_path_from_string(BlockingMutex *file_mutex, Ast *node
 		//                 working directory of the exe to the library search paths.
 		//                 Static libraries can be linked directly with the full pathname
 		//
-		if (node->kind == Ast_ForeignImportDecl && string_ends_with(file_str, str_lit(".so"))) {
+		if (node->kind == Ast_ForeignImportDecl && (string_ends_with(file_str, str_lit(".so")) || string_contains_string(file_str, str_lit(".so.")))) {
 			*path = file_str;
 			return true;
 		}

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -323,6 +323,25 @@ gb_internal bool string_contains_char(String const &s, u8 c) {
 	return false;
 }
 
+gb_internal bool string_contains_string(String const &haystack, String const &needle) {
+    if (needle.len == 0) return true;
+    if (needle.len > haystack.len) return false;
+
+    for (isize i = 0; i <= haystack.len - needle.len; i++) {
+        bool found = true;
+        for (isize j = 0; j < needle.len; j++) {
+            if (haystack[i + j] != needle[j]) {
+                found = false;
+                break;
+            }
+        }
+        if (found) {
+            return true;
+        }
+    }
+    return false;
+}
+
 gb_internal String filename_from_path(String s) {
 	isize i = string_extension_position(s);
 	if (i >= 0) {


### PR DESCRIPTION
Fixes https://github.com/odin-lang/Odin/issues/3368

Dynamic libraries like libraylib.so.5.0.0 in vendor aren't working on linux, because the name doesn't end in `.so` like the code expected.