### PR TITLE
core:math/fixed Removed undefined & usused vars in init_from_parts

### DIFF
--- a/core/math/fixed/fixed.odin
+++ b/core/math/fixed/fixed.odin
@@ -39,7 +39,6 @@ init_from_f64 :: proc(x: ^$T/Fixed($Backing, $Fraction_Width), val: f64) {
 }
 
 init_from_parts :: proc(x: ^$T/Fixed($Backing, $Fraction_Width), integer, fraction: Backing) {
-	i, f := math.modf(val)
 	x.i  = fraction
 	x.i &= 1<<Fraction_Width - 1
 	x.i |= integer


### PR DESCRIPTION
Removed undefined & usused vars in `init_from_parts` that I assume are just a copy paste mistake.

Fixes: https://github.com/odin-lang/Odin/issues/3384