### PR TITLE
Wasm fixes

### DIFF
--- a/base/intrinsics/intrinsics.odin
+++ b/base/intrinsics/intrinsics.odin
@@ -293,7 +293,9 @@ wasm_memory_size :: proc(index: uintptr)        -> int ---
 // 0 - indicates that the thread blocked and then was woken up
 // 1 - the loaded value from `ptr` did not match `expected`, the thread did not block
 // 2 - the thread blocked, but the timeout
+@(enable_target_feature="atomics")
 wasm_memory_atomic_wait32   :: proc(ptr: ^u32, expected: u32, timeout_ns: i64) -> u32 ---
+@(enable_target_feature="atomics")
 wasm_memory_atomic_notify32 :: proc(ptr: ^u32, waiters: u32) -> (waiters_woken_up: u32) ---
 
 // x86 Targets (i386, amd64)

--- a/core/time/time_js.odin
+++ b/core/time/time_js.odin
@@ -24,9 +24,9 @@ _sleep :: proc "contextless" (d: Duration) {
 
 _tick_now :: proc "contextless" () -> Tick {
 	foreign odin_env {
-		tick_now :: proc "contextless" () -> i64 ---
+		tick_now :: proc "contextless" () -> f32 ---
 	}
-	return Tick{tick_now()*1e6}
+	return Tick{i64(tick_now()*1e6)}
 }
 
 _yield :: proc "contextless" () {

--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -6014,6 +6014,8 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 				return false;
 			}
 
+			enable_target_feature({}, str_lit("atomics"));
+
 			Operand ptr = {};
 			Operand expected = {};
 			Operand timeout = {};
@@ -6065,6 +6067,8 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 				error(call, "'%.*s' is only allowed on wasm targets", LIT(builtin_name));
 				return false;
 			}
+
+			enable_target_feature({}, str_lit("atomics"));
 
 			Operand ptr = {};
 			Operand waiters = {};

--- a/vendor/wasm/js/runtime.js
+++ b/vendor/wasm/js/runtime.js
@@ -1335,7 +1335,7 @@ function odinSetupDefaultImports(wasmMemoryInterface, consoleElement) {
 
 			// return a bigint to be converted to i64
 			time_now: () => BigInt(Date.now()),
-			tick_now: () => BigInt(performance.now()),
+			tick_now: () => performance.now(),
 			time_sleep: (duration_ms) => {
 				if (duration_ms > 0) {
 					// TODO(bill): Does this even make any sense?

--- a/vendor/wasm/js/runtime.js
+++ b/vendor/wasm/js/runtime.js
@@ -1676,6 +1676,9 @@ async function runWasm(wasmPath, consoleElement, extraForeignImports) {
 
 	exports._start();
 
+	// Define a `@export step :: proc(dt: f32) -> (continue: bool) {`
+	// in your app and it will get called every frame.
+	// return `false` to stop the execution of the module.
 	if (exports.step) {
 		const odin_ctx = exports.default_context_ptr();
 
@@ -1687,14 +1690,19 @@ async function runWasm(wasmPath, consoleElement, extraForeignImports) {
 
 			const dt = (currTimeStamp - prevTimeStamp)*0.001;
 			prevTimeStamp = currTimeStamp;
-			exports.step(dt, odin_ctx);
+
+			if (!exports.step(dt, odin_ctx)) {
+				exports._end();
+				return;
+			}
+
 			window.requestAnimationFrame(step);
 		};
 
 		window.requestAnimationFrame(step);
+	} else {
+		exports._end();
 	}
-
-	exports._end();
 
 	return;
 };


### PR DESCRIPTION
1. I don't think the `tick_now` implementation has ever worked, it returns a float and we were converting it to an integer which causes an error
2. The `_end` export was being ran before the end of the program when using the `step` functionality, `requestAnimationFrame` is not blocking and would return, executing `_end` and then executing the `step` function each frame
3. To use the atomics in wasm the target feature for it is required, it is currently emitting an llvm error when used without it