### PR TITLE
Avoid loop index shadowing in vendor:OpenGL

### DIFF
--- a/vendor/OpenGL/wrappers.odin
+++ b/vendor/OpenGL/wrappers.odin
@@ -787,8 +787,8 @@ when !GL_DEBUG {
 			fmt.printf("   call: gl%s(", loc.procedure)
 			{
 				// add input arguments
-				for arg, i in args[num_ret:] {
-				if i > 0 { fmt.printf(", ") }
+				for arg, arg_index in args[num_ret:] {
+				if arg_index > 0 { fmt.printf(", ") }
 
 				if v, ok := arg.(u32); ok { // TODO: Assumes all u32 are GLenum (they're not, GLbitfield and GLuint are also mapped to u32), fix later by better typing
 					if err == .INVALID_ENUM {
@@ -806,8 +806,8 @@ when !GL_DEBUG {
 					fmt.printf(") -> %v \n", args[0])
 				} else if num_ret > 1 {
 					fmt.printf(") -> (")
-					for arg, i in args[1:num_ret] {
-						if i > 0 { fmt.printf(", ") }
+					for arg, arg_index in args[1:num_ret] {
+						if arg_index > 0 { fmt.printf(", ") }
 						fmt.printf("%v", arg)
 					}
 					fmt.printf(")\n")


### PR DESCRIPTION
The inner loop uses the same index variable name "i" as the parent.

This causes an error message with -vet -strict-style

I made a comment about this in #3399, however it might be better to raise it here separately.

When compilig this simple test file with `odin build main.odin -file -debug -vet -strict-style` 

```
package main

import gl "vendor:OpenGL"

main :: proc() {
    gl.ClearColor(0.0, 0.0, 0.0, 0.0)
}

```

I'm getting

```
PS C:\work\odin\ogltest> odin build main.odin -file -debug -vet -strict-style
C:/odin/vendor/OpenGL/wrappers.odin(790:14) Error: Declaration of 'i' shadows declaration at line 780
        for arg, i in args[num_ret:] {
                 ^
C:/odin/vendor/OpenGL/wrappers.odin(809:15) Error: Declaration of 'i' shadows declaration at line 780
        for arg, i in args[1:num_ret] {
                 ^
```

Note that `-debug` is required to hit this code path.