### PR TITLE
Add dxc to all_vendor.odin, fix dxc build on freebsd/openbsd

### DIFF
--- a/examples/all/all_vendor.odin
+++ b/examples/all/all_vendor.odin
@@ -73,10 +73,12 @@ _ :: MTK
 _ :: CA
 
 
+import DXC   "vendor:directx/dxc"
 import D3D11 "vendor:directx/d3d11"
 import D3D12 "vendor:directx/d3d12"
 import DXGI  "vendor:directx/dxgi"
 
+_ :: DXC
 _ :: D3D11
 _ :: D3D12
 _ :: DXGI

--- a/vendor/directx/dxc/dxcdef_unix.odin
+++ b/vendor/directx/dxc/dxcdef_unix.odin
@@ -1,4 +1,4 @@
-//+build linux, darwin
+//+build linux, darwin, freebsd, openbsd
 package directx_dxc
 import "core:c"
 


### PR DESCRIPTION
Adds  dxc to `all_vendor.odin` and fixes the dxc build on freebsd/openbsd.