### PR TITLE
Fix the format of some `doc.odin` files of the `core` library…

### DIFF
--- a/core/c/frontend/tokenizer/doc.odin
+++ b/core/c/frontend/tokenizer/doc.odin
@@ -1,34 +1,31 @@
 /*
-package demo
+Example:
+	package demo
 
-import tokenizer "core:c/frontend/tokenizer"
-import preprocessor "core:c/frontend/preprocessor"
-import "core:fmt"
+	import tokenizer "core:c/frontend/tokenizer"
+	import preprocessor "core:c/frontend/preprocessor"
+	import "core:fmt"
 
-main :: proc() {
-	t := &tokenizer.Tokenizer{};
-	tokenizer.init_defaults(t);
+	main :: proc() {
+		t := &tokenizer.Tokenizer{};
+		tokenizer.init_defaults(t);
 
-	cpp := &preprocessor.Preprocessor{};
-	cpp.warn, cpp.err = t.warn, t.err;
-	preprocessor.init_lookup_tables(cpp);
-	preprocessor.init_default_macros(cpp);
-	cpp.include_paths = {"my/path/to/include"};
+		cpp := &preprocessor.Preprocessor{};
+		cpp.warn, cpp.err = t.warn, t.err;
+		preprocessor.init_lookup_tables(cpp);
+		preprocessor.init_default_macros(cpp);
+		cpp.include_paths = {"my/path/to/include"};
 
-	tok := tokenizer.tokenize_file(t, "the/source/file.c", 1);
+		tok := tokenizer.tokenize_file(t, "the/source/file.c", 1);
 
-	tok = preprocessor.preprocess(cpp, tok);
-	if tok != nil {
-		for t := tok; t.kind != .EOF; t = t.next {
-			fmt.println(t.lit);
+		tok = preprocessor.preprocess(cpp, tok);
+		if tok != nil {
+			for t := tok; t.kind != .EOF; t = t.next {
+				fmt.println(t.lit);
+			}
 		}
+
+		fmt.println("[Done]");
 	}
-
-	fmt.println("[Done]");
-}
 */
-
-
 package c_frontend_tokenizer
-
-

--- a/core/container/bit_array/doc.odin
+++ b/core/container/bit_array/doc.odin
@@ -1,53 +1,52 @@
-package dynamic_bit_array
-
 /*
-	The Bit Array can be used in several ways:
+The Bit Array can be used in several ways:
 
-	-- By default you don't need to instantiate a Bit Array:
+- By default you don't need to instantiate a Bit Array:
 
-		package test
+	package test
 
-		import "core:fmt"
-		import "core:container/bit_array"
+	import "core:fmt"
+	import "core:container/bit_array"
 
-		main :: proc() {
-			using bit_array
+	main :: proc() {
+		using bit_array
 
-			bits: Bit_Array
+		bits: Bit_Array
 
-			// returns `true`
-			fmt.println(set(&bits, 42))
+		// returns `true`
+		fmt.println(set(&bits, 42))
 
-			// returns `false`, `false`, because this Bit Array wasn't created to allow negative indices.
-			was_set, was_retrieved := get(&bits, -1)
-			fmt.println(was_set, was_retrieved) 
-			destroy(&bits)
+		// returns `false`, `false`, because this Bit Array wasn't created to allow negative indices.
+		was_set, was_retrieved := get(&bits, -1)
+		fmt.println(was_set, was_retrieved) 
+		destroy(&bits)
+	}
+
+- A Bit Array can optionally allow for negative indices, if the minimum value was given during creation:
+
+	package test
+
+	import "core:fmt"
+	import "core:container/bit_array"
+
+	main :: proc() {
+		Foo :: enum int {
+			Negative_Test = -42,
+			Bar           = 420,
+			Leaves        = 69105,
 		}
 
-	-- A Bit Array can optionally allow for negative indices, if the mininum value was given during creation:
+		using bit_array
 
-		package test
+		bits := create(int(max(Foo)), int(min(Foo)))
+		defer destroy(bits)
 
-		import "core:fmt"
-		import "core:container/bit_array"
-
-		main :: proc() {
-			Foo :: enum int {
-				Negative_Test = -42,
-				Bar           = 420,
-				Leaves        = 69105,
-			}
-
-			using bit_array
-
-			bits := create(int(max(Foo)), int(min(Foo)))
-			defer destroy(bits)
-
-			fmt.printf("Set(Bar):           %v\n",     set(bits, Foo.Bar))
-			fmt.printf("Get(Bar):           %v, %v\n", get(bits, Foo.Bar))
-			fmt.printf("Set(Negative_Test): %v\n",     set(bits, Foo.Negative_Test))
-			fmt.printf("Get(Leaves):        %v, %v\n", get(bits, Foo.Leaves))
-			fmt.printf("Get(Negative_Test): %v, %v\n", get(bits, Foo.Negative_Test))
-			fmt.printf("Freed.\n")
-		}
+		fmt.printf("Set(Bar):           %v\n",     set(bits, Foo.Bar))
+		fmt.printf("Get(Bar):           %v, %v\n", get(bits, Foo.Bar))
+		fmt.printf("Set(Negative_Test): %v\n",     set(bits, Foo.Negative_Test))
+		fmt.printf("Get(Leaves):        %v, %v\n", get(bits, Foo.Leaves))
+		fmt.printf("Get(Negative_Test): %v, %v\n", get(bits, Foo.Negative_Test))
+		fmt.printf("Freed.\n")
+	}
 */
+package dynamic_bit_array

--- a/core/dynlib/doc.odin
+++ b/core/dynlib/doc.odin
@@ -1,6 +1,5 @@
-//+build ignore
 /*
-Package core:dynlib implements loading of shared libraries/DLLs and their symbols.
+Package `core:dynlib` implements loading of shared libraries/DLLs and their symbols.
 
 The behaviour of dynamically loaded libraries is specific to the target platform of the program.
 For in depth detail on the underlying behaviour please refer to your target platform's documentation.

--- a/core/image/netpbm/doc.odin
+++ b/core/image/netpbm/doc.odin
@@ -1,5 +1,6 @@
 /*
 Formats:
+
 	PBM (P1, P4): Portable Bit Map,       stores black and white images   (1 channel)
 	PGM (P2, P5): Portable Gray Map,      stores greyscale images         (1 channel, 1 or 2 bytes per value)
 	PPM (P3, P6): Portable Pixel Map,     stores colour images            (3 channel, 1 or 2 bytes per value)
@@ -7,27 +8,29 @@ Formats:
 	PFM (Pf, PF): Portable Float Map,     stores floating-point images    (Pf: 1 channel, PF: 3 channel)
 
 Reading:
-	All formats fill out header fields `format`, `width`, `height`, `channels`, `depth`
-	Specific formats use more fields
-		PGM, PPM, and PAM set `maxval` (maximum of 65535)
-		PAM sets `tupltype` if there is one, and can set `channels` to any value (not just 1 or 3)
-		PFM sets `scale` (float equivalent of `maxval`) and `little_endian` (endianness of stored floats)
-	Currently doesn't support reading multiple images from one binary-format file
+
+- All formats fill out header fields `format`, `width`, `height`, `channels`, `depth`.
+- Specific formats use more fields:
+	PGM, PPM, and PAM set `maxval` (maximum of 65535)
+	PAM sets `tupltype` if there is one, and can set `channels` to any value (not just 1 or 3)
+	PFM sets `scale` (float equivalent of `maxval`) and `little_endian` (endianness of stored floats)
+- Currently doesn't support reading multiple images from one binary-format file.
 
 Writing:
-	You can use your own `Netpbm_Info` struct to control how images are written
-	All formats require the header field `format` to be specified
-	Additional header fields are required for specific formats
-		PGM, PPM, and PAM require `maxval` (maximum of 65535)
-		PAM also uses `tupltype`, though it may be left as default (empty or nil string)
-		PFM requires `scale`, and optionally `little_endian`
+
+- You can use your own `Netpbm_Info` struct to control how images are written.
+- All formats require the header field `format` to be specified.
+- Additional header fields are required for specific formats:
+	PGM, PPM, and PAM require `maxval` (maximum of 65535)
+	PAM also uses `tupltype`, though it may be left as default (empty or nil string)
+	PFM requires `scale`, and optionally `little_endian`
 
 Some syntax differences from the specifications:
-	`channels` stores the number of values per pixel, what the PAM specification calls `depth`
-	`depth` instead is the number of bits for a single value (32 for PFM, 16 or 8 otherwise)
-	`scale` and `little_endian` are separated, so the `header` will always store a positive `scale`
-	`little_endian` will only be true for a negative `scale` PFM, every other format will be false
-	`little_endian` only describes the netpbm data being read/written, the image buffer will be native
-*/
 
+- `channels` stores the number of values per pixel, what the PAM specification calls `depth`
+- `depth` instead is the number of bits for a single value (32 for PFM, 16 or 8 otherwise)
+- `scale` and `little_endian` are separated, so the `header` will always store a positive `scale`
+- `little_endian` will only be true for a negative `scale` PFM, every other format will be false
+- `little_endian` only describes the netpbm data being read/written, the image buffer will be native
+*/
 package netpbm

--- a/core/sys/info/doc.odin
+++ b/core/sys/info/doc.odin
@@ -1,78 +1,78 @@
 /*
-	Copyright 2022 Jeroen van Rijn <nom@duclavier.com>.
-	Made available under Odin's BSD-3 license.
+Copyright 2022 Jeroen van Rijn <nom@duclavier.com>.
+Made available under Odin's BSD-3 license.
 
-	Package `core:sys/info` gathers system information on:
-	Windows, Linux, macOS, FreeBSD & OpenBSD.
+Package `core:sys/info` gathers system information on:
+Windows, Linux, macOS, FreeBSD & OpenBSD.
 
-	Simply import the package and you'll have access to the OS version, RAM amount
-	and CPU information.
+Simply import the package and you'll have access to the OS version, RAM amount
+and CPU information.
 
-	On Windows, GPUs will also be enumerated using the registry.
+On Windows, GPUs will also be enumerated using the registry.
 
-	CPU feature flags can be tested against `cpu_features`, where applicable, e.g.
-	`if .aes in si.aes { ... }`
-*/
-//+build ignore
-package sysinfo
+CPU feature flags can be tested against `cpu_features`, where applicable, e.g.
+`if .aes in si.aes { ... }`
 
-import "core:fmt"
-import si "core:sys/info"
+Example:
 
-main :: proc() {
-	fmt.printf("Odin:  %v\n",     ODIN_VERSION)
-	fmt.printf("OS:    %v\n",     si.os_version.as_string)
-	fmt.printf("OS:    %#v\n",    si.os_version)
-	fmt.printf("CPU:   %v\n",     si.cpu_name)
-	fmt.printf("RAM:   %v MiB\n", si.ram.total_ram / 1024 / 1024)
+	import "core:fmt"
+	import si "core:sys/info"
 
-	fmt.println()
-	for gpu, i in si.gpus {
-		fmt.printf("GPU #%v:\n", i)
-		fmt.printf("\tVendor: %v\n",     gpu.vendor_name)
-		fmt.printf("\tModel:  %v\n",     gpu.model_name)
-		fmt.printf("\tVRAM:   %v MiB\n", gpu.total_ram / 1024 / 1024)
+	main :: proc() {
+		fmt.printf("Odin:  %v\n",     ODIN_VERSION)
+		fmt.printf("OS:    %v\n",     si.os_version.as_string)
+		fmt.printf("OS:    %#v\n",    si.os_version)
+		fmt.printf("CPU:   %v\n",     si.cpu_name)
+		fmt.printf("RAM:   %v MiB\n", si.ram.total_ram / 1024 / 1024)
+
+		fmt.println()
+		for gpu, i in si.gpus {
+			fmt.printf("GPU #%v:\n", i)
+			fmt.printf("\tVendor: %v\n",     gpu.vendor_name)
+			fmt.printf("\tModel:  %v\n",     gpu.model_name)
+			fmt.printf("\tVRAM:   %v MiB\n", gpu.total_ram / 1024 / 1024)
+		}
 	}
-}
 
-/*
-	Example Windows output:
-		Odin:  dev-2022-09
-		OS:    Windows 10 Professional (version: 20H2), build: 19042.1466
-		OS:    OS_Version{
-			platform = "Windows",
-			major = 10,
-			minor = 0,
+- Example Windows output:
+
+	Odin:  dev-2022-09
+	OS:    Windows 10 Professional (version: 20H2), build: 19042.1466
+	OS:    OS_Version{
+		platform = "Windows",
+		major = 10,
+		minor = 0,
+		patch = 0,
+		build = [
+			19042,
+			1466,
+		],
+		version = "20H2",
+		as_string = "Windows 10 Professional (version: 20H2), build: 19042.1466",
+	}
+	CPU:   AMD Ryzen 7 1800X Eight-Core Processor
+	RAM:   65469 MiB
+	GPU #0:
+		Vendor: Advanced Micro Devices, Inc.
+		Model:  Radeon RX Vega
+		VRAM:   8176 MiB
+
+- Example macOS output:
+
+	ODIN: dev-2022-09
+	OS:   OS_Version{
+			platform = "MacOS",
+			major = 21,
+			minor = 5,
 			patch = 0,
 			build = [
-				19042,
-				1466,
+					0,
+					0,
 			],
-			version = "20H2",
-			as_string = "Windows 10 Professional (version: 20H2), build: 19042.1466",
-		}
-		CPU:   AMD Ryzen 7 1800X Eight-Core Processor
-		RAM:   65469 MiB
-
-		GPU #0:
-			Vendor: Advanced Micro Devices, Inc.
-			Model:  Radeon RX Vega
-			VRAM:   8176 MiB
-
-	Example macOS output:
-		ODIN: dev-2022-09
-		OS:   OS_Version{
-		        platform = "MacOS",
-		        major = 21,
-		        minor = 5,
-		        patch = 0,
-		        build = [
-		                0,
-		                0,
-		        ],
-		        version = "21F79",
-		        as_string = "macOS Monterey 12.4 (build 21F79, kernel 21.5.0)",
-		}
-		CPU:  Intel(R) Core(TM) i5-7360U CPU @ 2.30GHz
-		RAM:  8192 MiB
+			version = "21F79",
+			as_string = "macOS Monterey 12.4 (build 21F79, kernel 21.5.0)",
+	}
+	CPU:  Intel(R) Core(TM) i5-7360U CPU @ 2.30GHz
+	RAM:  8192 MiB
 */
+package sysinfo

--- a/core/text/i18n/doc.odin
+++ b/core/text/i18n/doc.odin
@@ -1,111 +1,106 @@
-//+build ignore
-package i18n
 
 /*
-	The i18n package is flexible and easy to use.
+The `i18n` package is flexible and easy to use.
 
-	It has one call to get a translation: `get`, which the user can alias into something like `T`.
+It has one call to get a translation: `get`, which the user can alias into something like `T`.
 
-	`get`, referred to as `T` here, has a few different signatures.
-	All of them will return the key if the entry can't be found in the active translation catalog.
+`get`, referred to as `T` here, has a few different signatures.
+All of them will return the key if the entry can't be found in the active translation catalog.
 
-	- `T(key)`              returns the translation of `key`.
-	- `T(key, n)`           returns a pluralized translation of `key` according to value `n`.
+- `T(key)`              returns the translation of `key`.
+- `T(key, n)`           returns a pluralized translation of `key` according to value `n`.
 
-	- `T(section, key)`     returns the translation of `key` in `section`.
-	- `T(section, key, n)`  returns a pluralized translation of `key` in `section` according to value `n`.
+- `T(section, key)`     returns the translation of `key` in `section`.
+- `T(section, key, n)`  returns a pluralized translation of `key` in `section` according to value `n`.
 
-	By default lookup take place in the global `i18n.ACTIVE` catalog for ease of use.
-	If you want to override which translation to use, for example in a language preview dialog, you can use the following:
+By default lookup take place in the global `i18n.ACTIVE` catalog for ease of use.
+If you want to override which translation to use, for example in a language preview dialog, you can use the following:
 
-	- `T(key, n, catalog)`           returns the pluralized version of `key` from explictly supplied catalog.
-	- `T(section, key, n, catalog)`  returns the pluralized version of `key` in `section` from explictly supplied catalog.
+- `T(key, n, catalog)`           returns the pluralized version of `key` from explictly supplied catalog.
+- `T(section, key, n, catalog)`  returns the pluralized version of `key` in `section` from explictly supplied catalog.
 
-	If a catalog has translation contexts or sections, then ommitting it in the above calls looks up in section "".
+If a catalog has translation contexts or sections, then omitting it in the above calls looks up in section "".
 
-	The default pluralization rule is n != 1, which is to say that passing n == 1 (or not passing n) returns the singular form.
-	Passing n != 1 returns plural form 1.
+The default pluralization rule is n != 1, which is to say that passing n == 1 (or not passing n) returns the singular form.
+Passing n != 1 returns plural form 1.
 
-	Should a language not conform to this rule, you can pass a pluralizer procedure to the catalog parser.
-	This is a procedure that maps an integer to an integer, taking a value and returning which plural slot should be used.
+Should a language not conform to this rule, you can pass a pluralizer procedure to the catalog parser.
+This is a procedure that maps an integer to an integer, taking a value and returning which plural slot should be used.
 
-	You can also assign it to a loaded catalog after parsing, of course.
+You can also assign it to a loaded catalog after parsing, of course.
 
-	Some code examples follow.
-*/
+Example:
 
-/*
-```cpp
-import "core:fmt"
-import "core:text/i18n"
+	import "core:fmt"
+	import "core:text/i18n"
 
-T :: i18n.get
+	T :: i18n.get
 
-mo :: proc() {
-	using fmt
+	mo :: proc() {
+		using fmt
 
-	err: i18n.Error
+		err: i18n.Error
 
-	/*
-		Parse MO file and set it as the active translation so we can omit `get`'s "catalog" parameter.
-	*/
-	i18n.ACTIVE, err = i18n.parse_mo(#load("translations/nl_NL.mo"))
-	defer i18n.destroy()
+		/*
+			Parse MO file and set it as the active translation so we can omit `get`'s "catalog" parameter.
+		*/
+		i18n.ACTIVE, err = i18n.parse_mo(#load("translations/nl_NL.mo"))
+		defer i18n.destroy()
 
-	if err != .None { return }
+		if err != .None { return }
 
-	/*
-		These are in the .MO catalog.
-	*/
-	println("-----")
-	println(T(""))
-	println("-----")
-	println(T("There are 69,105 leaves here."))
-	println("-----")
-	println(T("Hellope, World!"))
-	println("-----")
-	// We pass 1 into `T` to get the singular format string, then 1 again into printf.
-	printf(T("There is %d leaf.\n", 1), 1)
-	// We pass 42 into `T` to get the plural format string, then 42 again into printf.
-	printf(T("There is %d leaf.\n", 42), 42)
+		/*
+			These are in the .MO catalog.
+		*/
+		println("-----")
+		println(T(""))
+		println("-----")
+		println(T("There are 69,105 leaves here."))
+		println("-----")
+		println(T("Hellope, World!"))
+		println("-----")
+		// We pass 1 into `T` to get the singular format string, then 1 again into printf.
+		printf(T("There is %d leaf.\n", 1), 1)
+		// We pass 42 into `T` to get the plural format string, then 42 again into printf.
+		printf(T("There is %d leaf.\n", 42), 42)
 
-	/*
-		This isn't in the translation catalog, so the key is passed back untranslated.
-	*/
-	println("-----")
-	println(T("Come visit us on Discord!"))
-}
-
-qt :: proc() {
-	using fmt
-
-	err: i18n.Error
-
-	/*
-		Parse QT file and set it as the active translation so we can omit `get`'s "catalog" parameter.
-	*/
-	i18n.ACTIVE, err = i18n.parse_qt(#load("translations/nl_NL-qt-ts.ts"))
-	defer i18n.destroy()
-
-	if err != .None {
-		return
+		/*
+			This isn't in the translation catalog, so the key is passed back untranslated.
+		*/
+		println("-----")
+		println(T("Come visit us on Discord!"))
 	}
 
-	/*
-		These are in the .TS catalog. As you can see they have sections.
-	*/
-	println("--- Page section ---")
-	println("Page:Text for translation =", T("Page", "Text for translation"))
-	println("-----")
-	println("Page:Also text to translate =", T("Page", "Also text to translate"))
-	println("-----")
-	println("--- installscript section ---")
-	println("installscript:99 bottles of beer on the wall =", T("installscript", "99 bottles of beer on the wall"))
-	println("-----")
-	println("--- apple_count section ---")
-	println("apple_count:%d apple(s) =")
-	println("\t 1  =", T("apple_count", "%d apple(s)", 1))
-	println("\t 42 =", T("apple_count", "%d apple(s)", 42))
-}
-```
+	qt :: proc() {
+		using fmt
+
+		err: i18n.Error
+
+		/*
+			Parse QT file and set it as the active translation so we can omit `get`'s "catalog" parameter.
+		*/
+		i18n.ACTIVE, err = i18n.parse_qt(#load("translations/nl_NL-qt-ts.ts"))
+		defer i18n.destroy()
+
+		if err != .None {
+			return
+		}
+
+		/*
+			These are in the .TS catalog. As you can see they have sections.
+		*/
+		println("--- Page section ---")
+		println("Page:Text for translation =", T("Page", "Text for translation"))
+		println("-----")
+		println("Page:Also text to translate =", T("Page", "Also text to translate"))
+		println("-----")
+		println("--- installscript section ---")
+		println("installscript:99 bottles of beer on the wall =", T("installscript", "99 bottles of beer on the wall"))
+		println("-----")
+		println("--- apple_count section ---")
+		println("apple_count:%d apple(s) =")
+		println("\t 1  =", T("apple_count", "%d apple(s)", 1))
+		println("\t 42 =", T("apple_count", "%d apple(s)", 42))
+	}
 */
+package i18n

--- a/core/text/table/doc.odin
+++ b/core/text/table/doc.odin
@@ -1,11 +1,8 @@
 /*
-	package table implements ascii/markdown/html/custom rendering of tables.
+The package `table` implements ASCII/markdown/HTML/custom rendering of tables.
 
-	---
+**Custom rendering example:**
 
-	Custom rendering example:
-
-	```odin
 	tbl := init(&Table{})
 	padding(tbl, 0, 1)
 	row(tbl, "A_LONG_ENUM", "= 54,", "// A comment about A_LONG_ENUM")
@@ -17,19 +14,14 @@
 		}
 		io.write_byte(stdio_writer(), '\n')
 	}
-	```
 
-	This outputs:
-	```
+This outputs:
+
 	A_LONG_ENUM         = 54, // A comment about A_LONG_ENUM
 	AN_EVEN_LONGER_ENUM = 1,  // A comment about AN_EVEN_LONGER_ENUM
-	```
 
-	---
+**ASCII rendering example:**
 
-	ASCII rendering example:
-
-	```odin
 	tbl := init(&Table{})
 	defer destroy(tbl)
 
@@ -69,10 +61,9 @@
 
 	write_ascii_table(stdio_writer(), tbl)
 	write_markdown_table(stdio_writer(), tbl)
-	```
 
-	This outputs:
-	```
+This outputs:
+
 	+-----------------------------------------------+
 	|  This is a table caption and it is very long  |
 	+------------------+-----------------+----------+
@@ -82,19 +73,15 @@
 	| 000000005        | 6.283185        |          |
 	|        a         | bbb             | c        |
 	+------------------+-----------------+----------+
-	```
 
-	and
+and
 
-	```
 	|    AAAAAAAAA     |        B        |    C     |
 	|:-----------------|:---------------:|---------:|
 	| 123              | foo             |          |
 	| 000000005        | 6.283185        |          |
 	| a                | bbb             | c        |
-	```
 
-	respectively.
+respectively.
 */
-
 package text_table


### PR DESCRIPTION
…which did not made into the documentation.

`c/frontend/tokenizer`:
- add proper "Example:" header to demo example code,
- removed empty lines.

`container/bit_array`:
- moved comment before package;
- aligned narrative lines to left margin;
- converted case lines into bulleted lines ("- ");
- converted individual examples to single-tab-indented preformatted text.

`dynlib`:
- removed "//+build ignore" line;
- added newline at EOF.

`image/netpmb`:
- converted indented lines of "Reading", "Writing" and "Some syntax..." into bulleted lists;
- "Formats" indented lines kept as they are as the preformatted text seems relevant to keep the alignments;
   doubly indented lines kept as single-indented to keep them different (as the format does not allow for two-level bulleted lists);
- removed empty lines.

`os/os2`:	WIP, not modified

`sys/info`:
- removed "//+build ignore" line;
- converted tab-indented initial description into regular left-margin comment;
- moved uncommented sample code within the doc comment as an "Example:" (this also removes any dependency);
- moved simple- and double-tabbed separate comments with sample Windows and macOS outputs within the doc comment as bulleted headlines with preformatted output listings;
- removed now empty comments and blank lines after the package line.
`text/i18n`:
- removed "//+build ignore" line;
- moved the package line at the end;
- de-indented the tab-indented introductory narrative;
- moved sample code comments into the doc comment as tab-indented code with a proper "Example:" heading;
- removed "```" MD attempts at code formatting.

`text/table`:
- unindented the comment lines of a descriptive kind;
- headlines of major subdivisions are marked as bold;
- kept code samples as tab-indented preformatted text (as there are several of them, the standard "Example:" and "Output:" headings cannot be used) removing the "```" MD attempts at code formatting;
- removed in-between blank lines.

As I am currently unable to regenerate the documentation locally, I could not actually test the changes do what they intend to do. So, I primarily followed the  [`pkg.odin-lang.org`](https://github.com/odin-lang/pkg.odin-lang.org?tab=readme-ov-file#markup-rules) documentation as strictly as possible.
