### PR TITLE
Implement Fisher-Yates shuffle

### DIFF
--- a/core/math/rand/rand.odin
+++ b/core/math/rand/rand.odin
@@ -789,8 +789,8 @@ shuffle :: proc(array: $T/[]$E, r: ^Rand = nil) {
 		return
 	}
 
-	for i := i64(0); i < n; i += 1 {
-		j := int63_max(n, r)
+	for i := i64(n - 1); i > 0; i -= 1 {
+		j := int63_max(i + 1, r)
 		array[i], array[j] = array[j], array[i]
 	}
 }


### PR DESCRIPTION
`rand.shuffle` currently implements a naive algorithm prone to bias due to its consideration of already-shuffled elements (taking a random number by `n` instead of `i`). This PR implements the Fisher-Yates shuffle as described [here](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm).