### PR TITLE
fix(net/linux): add `NOSIGNAL` to `send` options

### DIFF
--- a/core/net/errors_linux.odin
+++ b/core/net/errors_linux.odin
@@ -136,7 +136,6 @@ TCP_Send_Error :: enum c.int {
 	Interrupted               = c.int(linux.Errno.EINTR),        // A signal occurred before any data was transmitted. See signal(7).
 	Timeout                   = c.int(linux.Errno.EWOULDBLOCK),  // The send timeout duration passed before all data was sent. See Socket_Option.Send_Timeout.
 	Not_Socket                = c.int(linux.Errno.ENOTSOCK),     // The so-called socket is not an open socket.
-	Broken_Pipe               = c.int(linux.Errno.EPIPE),        // The peer has disconnected when we are trying to send to it
 }
 
 // TODO

--- a/core/net/errors_linux.odin
+++ b/core/net/errors_linux.odin
@@ -136,6 +136,7 @@ TCP_Send_Error :: enum c.int {
 	Interrupted               = c.int(linux.Errno.EINTR),        // A signal occurred before any data was transmitted. See signal(7).
 	Timeout                   = c.int(linux.Errno.EWOULDBLOCK),  // The send timeout duration passed before all data was sent. See Socket_Option.Send_Timeout.
 	Not_Socket                = c.int(linux.Errno.ENOTSOCK),     // The so-called socket is not an open socket.
+	Broken_Pipe               = c.int(linux.Errno.EPIPE),        // The peer has disconnected when we are trying to send to it
 }
 
 // TODO

--- a/core/net/socket_linux.odin
+++ b/core/net/socket_linux.odin
@@ -258,7 +258,7 @@ _send_tcp :: proc(tcp_sock: TCP_Socket, buf: []byte) -> (int, Network_Error) {
 	for total_written < len(buf) {
 		limit := min(int(max(i32)), len(buf) - total_written)
 		remaining := buf[total_written:][:limit]
-		res, errno := linux.send(linux.Fd(tcp_sock), remaining, {})
+		res, errno := linux.send(linux.Fd(tcp_sock), remaining, {.NOSIGNAL})
 		if errno != .NONE {
 			return total_written, TCP_Send_Error(errno)
 		}

--- a/core/net/socket_linux.odin
+++ b/core/net/socket_linux.odin
@@ -260,7 +260,9 @@ _send_tcp :: proc(tcp_sock: TCP_Socket, buf: []byte) -> (int, Network_Error) {
 		remaining := buf[total_written:][:limit]
 		res, errno := linux.send(linux.Fd(tcp_sock), remaining, {.NOSIGNAL})
 		if errno == .EPIPE {
-			return total_written, TCP_Send_Error.Connection_Closed
+			// If the peer is disconnected when we are trying to send we will get an `EPIPE` error,
+			// so we turn that into a clearer error
+			return total_written, .Connection_Closed
 		} else if errno != .NONE {
 			return total_written, TCP_Send_Error(errno)
 		}

--- a/core/net/socket_linux.odin
+++ b/core/net/socket_linux.odin
@@ -259,7 +259,9 @@ _send_tcp :: proc(tcp_sock: TCP_Socket, buf: []byte) -> (int, Network_Error) {
 		limit := min(int(max(i32)), len(buf) - total_written)
 		remaining := buf[total_written:][:limit]
 		res, errno := linux.send(linux.Fd(tcp_sock), remaining, {.NOSIGNAL})
-		if errno != .NONE {
+		if errno == .EPIPE {
+			return total_written, TCP_Send_Error.Connection_Closed
+		} else if errno != .NONE {
 			return total_written, TCP_Send_Error(errno)
 		}
 		total_written += int(res)

--- a/core/net/socket_linux.odin
+++ b/core/net/socket_linux.odin
@@ -262,7 +262,7 @@ _send_tcp :: proc(tcp_sock: TCP_Socket, buf: []byte) -> (int, Network_Error) {
 		if errno == .EPIPE {
 			// If the peer is disconnected when we are trying to send we will get an `EPIPE` error,
 			// so we turn that into a clearer error
-			return total_written, .Connection_Closed
+			return total_written, TCP_Send_Error.Connection_Closed
 		} else if errno != .NONE {
 			return total_written, TCP_Send_Error(errno)
 		}


### PR DESCRIPTION
This is a better default than not having it, since it turns errors that would be signals into error values instead. We could take these as options but given that we currently don't I think this at the very least improves on the status quo.