### PR TITLE
Normalize ODIN_ROOT path

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -840,13 +840,11 @@ gb_internal String odin_root_dir(void) {
 	char const *found = gb_get_env("ODIN_ROOT", a);
 	if (found) {
 		String path = path_to_full_path(a, make_string_c(found));
-		if (path[path.len-1] != '/' && path[path.len-1] != '\\') {
 		#if defined(GB_SYSTEM_WINDOWS)
-			path = concatenate_strings(a, path, WIN32_SEPARATOR_STRING);
+			path = normalize_path(a, path, WIN32_SEPARATOR_STRING);
 		#else
-			path = concatenate_strings(a, path, NIX_SEPARATOR_STRING);
+			path = normalize_path(a, path, NIX_SEPARATOR_STRING);
 		#endif
-		}
 
 		global_module_path = path;
 		global_module_path_set = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -337,12 +337,12 @@ struct BuildFlag {
 	String             name;
 	BuildFlagParamKind param_kind;
 	u32                command_support;
-	bool               allow_mulitple;
+	bool               allow_multiple;
 };
 
 
-gb_internal void add_flag(Array<BuildFlag> *build_flags, BuildFlagKind kind, String name, BuildFlagParamKind param_kind, u32 command_support, bool allow_mulitple=false) {
-	BuildFlag flag = {kind, name, param_kind, command_support, allow_mulitple};
+gb_internal void add_flag(Array<BuildFlag> *build_flags, BuildFlagKind kind, String name, BuildFlagParamKind param_kind, u32 command_support, bool allow_multiple=false) {
+	BuildFlag flag = {kind, name, param_kind, command_support, allow_multiple};
 	array_add(build_flags, flag);
 }
 
@@ -1358,7 +1358,7 @@ gb_internal bool parse_build_flags(Array<String> args) {
 						}
 					}
 
-					if (!bf.allow_mulitple) {
+					if (!bf.allow_multiple) {
 						set_flags[bf.kind] = ok;
 					}
 				}

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -237,11 +237,16 @@ gb_internal String string_split_iterator(String_Iterator *it, const char sep) {
 	return substring(it->str, start, end);
 }
 
+gb_internal gb_inline bool is_separator(u8 const &ch) {
+	return (ch == '/' || ch == '\\');
+}
+
+
 gb_internal gb_inline isize string_extension_position(String const &str) {
 	isize dot_pos = -1;
 	isize i = str.len;
 	while (i --> 0) {
-		if (str[i] == '\\' || str[i] == '/')
+		if (is_separator(str[i]))
 			break;
 		if (str[i] == '.') {
 			dot_pos = i;
@@ -332,8 +337,7 @@ gb_internal String filename_from_path(String s) {
 	if (i > 0) {
 		isize j = 0;
 		for (j = s.len-1; j >= 0; j--) {
-			if (s[j] == '/' ||
-				s[j] == '\\') {
+			if (is_separator(s[j])) {
 				break;
 			}
 		}
@@ -346,8 +350,7 @@ gb_internal String filename_from_path(String s) {
 gb_internal String filename_without_directory(String s) {
 	isize j = 0;
 	for (j = s.len-1; j >= 0; j--) {
-		if (s[j] == '/' ||
-			s[j] == '\\') {
+		if (is_separator(s[j])) {
 			break;
 		}
 	}
@@ -410,7 +413,26 @@ gb_internal String copy_string(gbAllocator a, String const &s) {
 	return make_string(data, s.len);
 }
 
-
+gb_internal String normalize_path(gbAllocator a, String const &path, String const &sep) {
+	String s;
+	if (sep.len < 1) {
+		return path;
+	}
+	if (path.len < 1) {
+		s = STR_LIT("");
+	} else if (is_separator(path[path.len-1])) {
+		s = copy_string(a, path);
+	} else {
+		s = concatenate_strings(a, path, sep);
+	}
+	isize i;
+	for (i = 0; i < s.len; i++) {
+		if (is_separator(s.text[i])) {
+			s.text[i] = sep.text[0];
+		}
+	}
+	return s;
+}
 
 
 #if defined(GB_SYSTEM_WINDOWS)


### PR DESCRIPTION
Made a fix for the odin root on windows, the seperator was wrong.
`D:/dev/odin/Odin\` --> `D:\dev\odin\Odin\`

+ found a spelling mistake

Before:
```
D:\dev\odin\Odin>build.bat 1
[vcvarsall.bat] Environment initialized for: 'x64'
main.cpp
libtommath.cpp

D:\dev\odin\Odin>odin root
D:/dev/odin/Odin\
```
After:
```
D:\dev\odin\Odin>build.bat 1
[vcvarsall.bat] Environment initialized for: 'x64'
main.cpp
libtommath.cpp

D:\dev\odin\Odin>odin root
D:\dev\odin\Odin\
```