### PR TITLE
Fix discrepancy with pthread cancelability state

### DIFF
--- a/core/thread/thread_unix.odin
+++ b/core/thread/thread_unix.odin
@@ -25,7 +25,7 @@ _create :: proc(procedure: Thread_Proc, priority: Thread_Priority) -> ^Thread {
 
 		when ODIN_OS != .Darwin {
 			// We need to give the thread a moment to start up before we enable cancellation.
-			can_set_thread_cancel_state := unix.pthread_setcancelstate(unix.PTHREAD_CANCEL_DISABLE, nil) == 0
+			can_set_thread_cancel_state := unix.pthread_setcancelstate(unix.PTHREAD_CANCEL_ENABLE, nil) == 0
 		}
 
 		sync.lock(&t.mutex)
@@ -40,7 +40,7 @@ _create :: proc(procedure: Thread_Proc, priority: Thread_Priority) -> ^Thread {
 			// Enable thread's cancelability.
 			if can_set_thread_cancel_state {
 				unix.pthread_setcanceltype (unix.PTHREAD_CANCEL_ASYNCHRONOUS, nil)
-				unix.pthread_setcancelstate(unix.PTHREAD_CANCEL_DISABLE,      nil)
+				unix.pthread_setcancelstate(unix.PTHREAD_CANCEL_ENABLE,       nil)
 			}
 		}
 


### PR DESCRIPTION
I am not 100% sure if this is a bug or a system-dependent quirk, so I'm outlining my thoughts ahead. This _does_ fix my issue.

I was having an issue with cancelling a long-running thread on Linux via `thread.terminate` and noticed this discrepancy in the thread package. The comment says it's going to enable cancellation, but I referenced the man pages on my system, and it says `PTHREAD_CANCEL_ENABLE` should be used to signify that the thread is cancellable.

```
    PTHREAD_CANCEL_ENABLE
           The  thread  is  cancelable.   This  is the default cancelability
           state in all new threads,  including  the  initial  thread.   The
           thread's  cancelability  type determines when a cancelable thread
           will respond to a cancelation request.

    PTHREAD_CANCEL_DISABLE
           The thread is not cancelable.  If a cancelation  request  is  re‐
           ceived, it is blocked until cancelability is enabled.
```

According to the manual, the second argument to `pthread_setcancelstate` (which here is being supplied with nil) refers to a pointer that would receive the old state, so it doesn't appear to be a situation where setting "disable" to nil/0x0 would indicate enabled.

Was this a typo? I noticed @Kelimion implemented this, so I'm looking forward to hearing more about this.

Output of `odin report` just in case:

	Odin:    dev-2024-04:2416380f3
	OS:      Arch Linux, Linux 6.8.7-arch1-1
	CPU:     12th Gen Intel(R) Core(TM) i7-12700K
	RAM:     31916 MiB
	Backend: LLVM 14.0.6