### PR TITLE
Add support for iOS/iPhoneSimulator target

### DIFF
--- a/base/runtime/core.odin
+++ b/base/runtime/core.odin
@@ -531,6 +531,7 @@ Odin_Endian_Type :: type_of(ODIN_ENDIAN)
 	Odin_Platform_Subtarget_Type :: enum int {
 		Default,
 		iOS,
+		iPhoneSimulator,
 	}
 */
 Odin_Platform_Subtarget_Type :: type_of(ODIN_PLATFORM_SUBTARGET)

--- a/base/runtime/heap_allocator_unix.odin
+++ b/base/runtime/heap_allocator_unix.odin
@@ -3,7 +3,7 @@
 package runtime
 
 when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/complex.odin
+++ b/core/c/libc/complex.odin
@@ -5,7 +5,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/ctype.odin
+++ b/core/c/libc/ctype.odin
@@ -3,7 +3,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/errno.odin
+++ b/core/c/libc/errno.odin
@@ -5,7 +5,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/math.odin
+++ b/core/c/libc/math.odin
@@ -7,7 +7,7 @@ import "base:intrinsics"
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/setjmp.odin
+++ b/core/c/libc/setjmp.odin
@@ -5,7 +5,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/signal.odin
+++ b/core/c/libc/signal.odin
@@ -5,7 +5,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/stdio.odin
+++ b/core/c/libc/stdio.odin
@@ -8,7 +8,7 @@ when ODIN_OS == .Windows {
 		"system:legacy_stdio_definitions.lib",
 	}
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/stdlib.odin
+++ b/core/c/libc/stdlib.odin
@@ -5,7 +5,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/string.odin
+++ b/core/c/libc/string.odin
@@ -7,7 +7,7 @@ import "base:runtime"
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/time.odin
+++ b/core/c/libc/time.odin
@@ -5,7 +5,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/uchar.odin
+++ b/core/c/libc/uchar.odin
@@ -5,7 +5,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/wchar.odin
+++ b/core/c/libc/wchar.odin
@@ -5,7 +5,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/wctype.odin
+++ b/core/c/libc/wctype.odin
@@ -5,7 +5,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/mem/virtual/virtual_darwin.odin
+++ b/core/mem/virtual/virtual_darwin.odin
@@ -2,7 +2,7 @@
 //+private
 package mem_virtual
 
-foreign import libc "system:System.framework"
+foreign import libc "system:System"
 import "core:c"
 
 PROT_NONE  :: 0x0 /* [MC2] no permissions */

--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -1,8 +1,8 @@
 package os
 
 foreign import dl   "system:dl"
-foreign import libc "system:System.framework"
-foreign import pthread "system:System.framework"
+foreign import libc "system:System"
+foreign import pthread "system:System"
 
 import "base:runtime"
 import "core:strings"

--- a/core/path/filepath/path_unix.odin
+++ b/core/path/filepath/path_unix.odin
@@ -2,7 +2,7 @@
 package filepath
 
 when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/prof/spall/spall_unix.odin
+++ b/core/prof/spall/spall_unix.odin
@@ -6,7 +6,7 @@ package spall
 import "core:os"
 
 when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/sync/futex_darwin.odin
+++ b/core/sync/futex_darwin.odin
@@ -6,7 +6,7 @@ import "core:c"
 import "core:sys/darwin"
 import "core:time"
 
-foreign import System "system:System.framework"
+foreign import System "system:System"
 
 foreign System {
 	// __ulock_wait is not available on 10.15

--- a/core/sync/primitives_darwin.odin
+++ b/core/sync/primitives_darwin.odin
@@ -5,7 +5,7 @@ package sync
 import "core:c"
 import "base:intrinsics"
 
-foreign import pthread "system:System.framework"
+foreign import pthread "system:System"
 
 _current_thread_id :: proc "contextless" () -> int {
 	tid: u64

--- a/core/sys/darwin/Foundation/NSBlock.odin
+++ b/core/sys/darwin/Foundation/NSBlock.odin
@@ -58,7 +58,7 @@ global_block_descriptor := Block_Descriptor{
 	size     = size_of(Internal_Block_Literal),
 }
 
-foreign import libSystem "system:System.framework"
+foreign import libSystem "system:System"
 foreign libSystem {
 	_NSConcreteGlobalBlock: intrinsics.objc_class
 	_NSConcreteStackBlock: intrinsics.objc_class

--- a/core/sys/darwin/darwin.odin
+++ b/core/sys/darwin/darwin.odin
@@ -3,7 +3,7 @@ package darwin
 
 import "core:c"
 
-foreign import system "system:System.framework"
+foreign import system "system:System"
 
 Bool :: b8
 

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -1,6 +1,6 @@
 package darwin
 
-foreign import pthread "system:System.framework"
+foreign import pthread "system:System"
 
 import "core:c"
 

--- a/core/sys/darwin/sync.odin
+++ b/core/sys/darwin/sync.odin
@@ -1,11 +1,11 @@
 package darwin
 
-foreign import system "system:System.framework"
+foreign import system "system:System"
 
 // #define OS_WAIT_ON_ADDR_AVAILABILITY \
 // 	__API_AVAILABLE(macos(14.4), ios(17.4), tvos(17.4), watchos(10.4))
 when ODIN_OS == .Darwin {
-	when ODIN_PLATFORM_SUBTARGET == .iOS && ODIN_MINIMUM_OS_VERSION > 17_04_00 {
+	when (ODIN_PLATFORM_SUBTARGET == .iOS || ODIN_PLATFORM_SUBTARGET == .iPhoneSimulator ) && ODIN_MINIMUM_OS_VERSION > 17_04_00 {
 		WAIT_ON_ADDRESS_AVAILABLE :: true
 	} else when ODIN_MINIMUM_OS_VERSION > 14_04_00 {
 		WAIT_ON_ADDRESS_AVAILABLE :: true

--- a/core/sys/unix/pthread_darwin.odin
+++ b/core/sys/unix/pthread_darwin.odin
@@ -86,7 +86,7 @@ PTHREAD_CANCEL_DISABLE      :: 1
 PTHREAD_CANCEL_DEFERRED     :: 0
 PTHREAD_CANCEL_ASYNCHRONOUS :: 1
 
-foreign import pthread "system:System.framework"
+foreign import pthread "system:System"
 
 @(default_calling_convention="c")
 foreign pthread {

--- a/core/sys/unix/time_unix.odin
+++ b/core/sys/unix/time_unix.odin
@@ -2,7 +2,7 @@
 package unix
 
 when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else  {
 	foreign import libc "system:c"
 }

--- a/core/time/tsc_darwin.odin
+++ b/core/time/tsc_darwin.odin
@@ -4,7 +4,7 @@ package time
 
 import "core:c"
 
-foreign import libc "system:System.framework"
+foreign import libc "system:System"
 foreign libc {
 	@(link_name="sysctlbyname") _sysctlbyname    :: proc(path: cstring, oldp: rawptr, oldlenp: rawptr, newp: rawptr, newlen: int) -> c.int ---
 }

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -169,6 +169,7 @@ struct TargetMetrics {
 enum Subtarget : u32 {
 	Subtarget_Default,
 	Subtarget_iOS,
+	Subtarget_iPhoneSimulator,
 
 	Subtarget_COUNT,
 };
@@ -176,6 +177,7 @@ enum Subtarget : u32 {
 gb_global String subtarget_strings[Subtarget_COUNT] = {
 	str_lit(""),
 	str_lit("ios"),
+	str_lit("ios-simulator"),
 };
 
 
@@ -1477,10 +1479,17 @@ gb_internal void init_build_context(TargetMetrics *cross_target, Subtarget subta
 		case Subtarget_iOS:
 			if (metrics->arch == TargetArch_arm64) {
 				bc->metrics.target_triplet = str_lit("arm64-apple-ios");
-			} else if (metrics->arch == TargetArch_amd64) {
-				bc->metrics.target_triplet = str_lit("x86_64-apple-ios");
 			} else {
-				GB_PANIC("Unknown architecture for darwin");
+				GB_PANIC("Unknown architecture for ios");
+			}
+			break;
+		case Subtarget_iPhoneSimulator:
+			if (metrics->arch == TargetArch_arm64) {
+				bc->metrics.target_triplet = str_lit("arm64-apple-ios-simulator");
+			} else if (metrics->arch == TargetArch_amd64) {
+				bc->metrics.target_triplet = str_lit("x86_64-apple-ios-simulator");
+			} else {
+				GB_PANIC("Unknown architecture for ios simulator");
 			}
 			break;
 		}

--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -1065,8 +1065,9 @@ gb_internal void init_universal(void) {
 
 	{
 		GlobalEnumValue values[Subtarget_COUNT] = {
-			{"Default", Subtarget_Default},
-			{"iOS",     Subtarget_iOS},
+			{"Default", 		Subtarget_Default},
+			{"iOS",     		Subtarget_iOS},
+			{"iPhoneSimulator", Subtarget_iPhoneSimulator},
 		};
 
 		auto fields = add_global_enum_type(str_lit("Odin_Platform_Subtarget_Type"), values, gb_count_of(values));

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -496,22 +496,40 @@ gb_internal i32 linker_stage(LinkerData *gen) {
 			gbString platform_lib_str = gb_string_make(heap_allocator(), "");
 			defer (gb_string_free(platform_lib_str));
 			if (build_context.metrics.os == TargetOs_darwin) {
-				platform_lib_str = gb_string_appendc(platform_lib_str, "-Wl,-syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib ");
+				// NOTE(harold): We should attempt to use `xcrun --sdk <SDK_GIVEN_SUBTARGET> --show-sdk-path`
+				// here to get the SDK path, else fallback to a best-effort default.
+				// -Wl,-ld_classic is added to avoid the "no platform load command found in..." linker warning.
+				if (selected_subtarget == Subtarget_iOS) {
+					platform_lib_str = gb_string_append_fmt(platform_lib_str, "-target %.*s -Wl,-ld_classic -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk ", LIT(build_context.metrics.target_triplet));
 
-				// Homebrew's default library path, checking if it exists to avoid linking warnings.
-				if (gb_file_exists("/opt/homebrew/lib")) {
-					platform_lib_str = gb_string_appendc(platform_lib_str, "-L/opt/homebrew/lib ");
-				}
+					if (build_context.minimum_os_version_string_given) {
+						link_settings = gb_string_append_fmt(link_settings, "-mios-version-min=%.*s ", LIT(build_context.minimum_os_version_string));
+					}
+				
+				} else if (selected_subtarget == Subtarget_iPhoneSimulator) {
+						platform_lib_str = gb_string_append_fmt(platform_lib_str, "-target %.*s -Wl,-ld_classic -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk ", LIT(build_context.metrics.target_triplet));
 
-				// MacPort's default library path, checking if it exists to avoid linking warnings.
-				if (gb_file_exists("/opt/local/lib")) {
-					platform_lib_str = gb_string_appendc(platform_lib_str, "-L/opt/local/lib ");
-				}
+						if (build_context.minimum_os_version_string_given) {
+							link_settings = gb_string_append_fmt(link_settings, "-mios-simulator-version-min=%.*s ", LIT(build_context.minimum_os_version_string));
+						}
+				} else {
+					platform_lib_str = gb_string_appendc(platform_lib_str, "-Wl,-syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib ");
 
-				// Only specify this flag if the user has given a minimum version to target.
-				// This will cause warnings to show up for mismatched libraries.
-				if (build_context.minimum_os_version_string_given) {
-					link_settings = gb_string_append_fmt(link_settings, "-mmacosx-version-min=%.*s ", LIT(build_context.minimum_os_version_string));
+					// Homebrew's default library path, checking if it exists to avoid linking warnings.
+					if (gb_file_exists("/opt/homebrew/lib")) {
+						platform_lib_str = gb_string_appendc(platform_lib_str, "-L/opt/homebrew/lib ");
+					}
+
+					// MacPort's default library path, checking if it exists to avoid linking warnings.
+					if (gb_file_exists("/opt/local/lib")) {
+						platform_lib_str = gb_string_appendc(platform_lib_str, "-L/opt/local/lib ");
+					}
+
+					// Only specify this flag if the user has given a minimum version to target.
+					// This will cause warnings to show up for mismatched libraries.
+					if (build_context.minimum_os_version_string_given) {
+						link_settings = gb_string_append_fmt(link_settings, "-mmacosx-version-min=%.*s ", LIT(build_context.minimum_os_version_string));
+					}
 				}
 
 				if (build_context.build_mode != BuildMode_DynamicLibrary) {


### PR DESCRIPTION
Attempts to add support for building for iOS and iPhoneOS simulator targets.

The basic changes for compiler support are few, mainly on the CLI frontend and on the linker side.

iOS support is only available targeting `17.4` and up because [os_sync_wait_on_address](https://developer.apple.com/documentation/os/4316531-os_sync_wait_on_address?changes=_2_8_8) is only available starting with said version. The fallback `ulock` APIs are disallowed in the Appstore.

Opened in draft mode as an additional layer to avoid syscalls on iOS must be added too, as these would also be disallowed in the Appstore.
