### PR TITLE
ci: fix macOS versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         timeout-minutes: 10
   build_macOS:
     name: MacOS Build, Check, and Test
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v1
       - name: Download LLVM, and setup PATH

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,7 +77,7 @@ jobs:
   build_macos:
     name: MacOS Build
     if: github.repository == 'odin-lang/Odin'
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v1
       - name: Download LLVM and setup PATH


### PR DESCRIPTION
GitHub updated `macos-latest` to be `macos-14`, which is an ARM runner. ~~`-large` seems to mean Intel.~~