### PR TITLE
Fix `omitempty` in `json.marshal`

### DIFF
--- a/core/encoding/json/marshal.odin
+++ b/core/encoding/json/marshal.odin
@@ -420,7 +420,7 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 				data := rawptr(uintptr(v.data) + info.offsets[i])
 				the_value := any{data, id}
 
-				if is_omitempty(the_value) {
+				if omitempty && is_omitempty(the_value) {
 					continue
 				}
 

--- a/core/encoding/json/unmarshal.odin
+++ b/core/encoding/json/unmarshal.odin
@@ -348,7 +348,7 @@ json_name_from_tag_value :: proc(value: string) -> (json_name, extra: string) {
 	json_name = value
 	if comma_index := strings.index_byte(json_name, ','); comma_index >= 0 {
 		json_name = json_name[:comma_index]
-		extra = json_name[comma_index:]
+		extra = value[1 + comma_index:]
 	}
 	return
 }


### PR DESCRIPTION
The `omitempty` tag was not being checked in the relevant conditional, and `json_name_from_tag_value` was setting `extra` to a slice of `json_name` after it had already been sliced. Added 1 to the comma index in order to skip the comma, too.