### PR TITLE
Clear unused `global_error_collector.curr_error`

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -403,6 +403,8 @@ gb_internal void error_va(TokenPos const &pos, TokenPos end, char const *fmt, va
 		error_out("\n");
 		show_error_on_line(pos, end);
 	} else {
+		global_error_collector.curr_error_value = {};
+		global_error_collector.curr_error_value_set.store(false);
 		global_error_collector.count.fetch_sub(1);
 	}
 	try_pop_error_value();


### PR DESCRIPTION
This should cleanly prevent acknowledging duplicate errors on the same position as seems to be the intent based on the prior `else if` condition.

Fixes #3481 