### PR TITLE
Fix invalid rune literal reported twice

### DIFF
--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -767,9 +767,8 @@ gb_internal void tokenizer_get_token(Tokenizer *t, Token *token, int repeat=0) {
 				}
 			}
 
-			// TODO(bill): Better Error Handling
 			if (valid && n != 1) {
-				tokenizer_err(t, "Invalid rune literal");
+				tokenizer_err(t, token->pos, "Invalid rune literal");
 			}
 			token->string.len = t->curr - token->string.text;
 			goto semicolon_check;


### PR DESCRIPTION
The tokenizer and the parser were reporting it in different positions. This way, they'll report in the same spot.

I removed the `TODO(bill)` comment under the assumption that since it was from 2016 and the `tokenizer_err()` function with the specifiable `TokenPos` argument option is from ~2021, that we have Better Error Handling now.


Program:
```odin
package main

main :: proc() {
	a := 'aa'
}
```

Before:
```
/tmp/2rune.odin(4:7) Syntax Error: Invalid rune literal
	a := 'aa'
	     ^
/tmp/2rune.odin(4:11) Syntax Error: Invalid rune literal
	}
	^
```

After:
```
/tmp/2rune.odin(4:7) Syntax Error: Invalid rune literal
	a := 'aa'
	     ^
```