### PR TITLE
wasm: allow `-default-to-nil-allocator`

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1583,8 +1583,10 @@ gb_internal void init_build_context(TargetMetrics *cross_target, Subtarget subta
 		if (bc->metrics.os == TargetOs_js || bc->metrics.os == TargetOs_wasi) {
 			// TODO(bill): Should these even have a default "heap-like" allocator?
 		}
-		bc->ODIN_DEFAULT_TO_PANIC_ALLOCATOR = true;
-		bc->ODIN_DEFAULT_TO_NIL_ALLOCATOR = !bc->ODIN_DEFAULT_TO_PANIC_ALLOCATOR;
+
+		if (!bc->ODIN_DEFAULT_TO_NIL_ALLOCATOR && !bc->ODIN_DEFAULT_TO_PANIC_ALLOCATOR) {
+			bc->ODIN_DEFAULT_TO_PANIC_ALLOCATOR = true;
+		}
 	}
 }
 


### PR DESCRIPTION
This is pretty necessary when you are using a package that allocates in its `@(init)` procedure, you are just going to panic and there is nothing you can do about it.