### PR TITLE
Fix race condition in `error_va`

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -376,11 +376,11 @@ gb_internal void error_out_coloured(char const *str, TerminalStyle style, Termin
 
 gb_internal void error_va(TokenPos const &pos, TokenPos end, char const *fmt, va_list va) {
 	global_error_collector.count.fetch_add(1);
+	mutex_lock(&global_error_collector.mutex);
 	if (global_error_collector.count > MAX_ERROR_COLLECTOR_COUNT()) {
 		print_all_errors();
 		gb_exit(1);
 	}
-	mutex_lock(&global_error_collector.mutex);
 
 	push_error_value(pos, ErrorValue_Error);
 	// NOTE(bill): Duplicate error, skip it


### PR DESCRIPTION
If the error count exceeded `MAX_ERROR_COLLECTOR_COUNT`, multiple threads could print and exit simultaneously, causing a segfault.

This change moves the mutex lock back before the conditional.

Related to #3500 