### PR TITLE
Require results for non-buffered `print` procs

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -124,8 +124,7 @@ register_user_formatter :: proc(id: typeid, formatter: User_Formatter) -> Regist
 aprint :: proc(args: ..any, sep := " ", allocator := context.allocator) -> string {
 	str: strings.Builder
 	strings.builder_init(&str, allocator)
-	sbprint(&str, ..args, sep=sep)
-	return strings.to_string(str)
+	return sbprint(&str, ..args, sep=sep)
 }
 // 	Creates a formatted string with a newline character at the end
 //
@@ -141,8 +140,7 @@ aprint :: proc(args: ..any, sep := " ", allocator := context.allocator) -> strin
 aprintln :: proc(args: ..any, sep := " ", allocator := context.allocator) -> string {
 	str: strings.Builder
 	strings.builder_init(&str, allocator)
-	sbprintln(&str, ..args, sep=sep)
-	return strings.to_string(str)
+	return sbprintln(&str, ..args, sep=sep)
 }
 // 	Creates a formatted string using a format string and arguments
 //
@@ -159,8 +157,7 @@ aprintln :: proc(args: ..any, sep := " ", allocator := context.allocator) -> str
 aprintf :: proc(fmt: string, args: ..any, allocator := context.allocator, newline := false) -> string {
 	str: strings.Builder
 	strings.builder_init(&str, allocator)
-	sbprintf(&str, fmt, ..args, newline=newline)
-	return strings.to_string(str)
+	return sbprintf(&str, fmt, ..args, newline=newline)
 }
 // 	Creates a formatted string using a format string and arguments, followed by a newline.
 //
@@ -190,8 +187,7 @@ aprintfln :: proc(fmt: string, args: ..any, allocator := context.allocator) -> s
 tprint :: proc(args: ..any, sep := " ") -> string {
 	str: strings.Builder
 	strings.builder_init(&str, context.temp_allocator)
-	sbprint(&str, ..args, sep=sep)
-	return strings.to_string(str)
+	return sbprint(&str, ..args, sep=sep)
 }
 // 	Creates a formatted string with a newline character at the end
 //
@@ -207,8 +203,7 @@ tprint :: proc(args: ..any, sep := " ") -> string {
 tprintln :: proc(args: ..any, sep := " ") -> string {
 	str: strings.Builder
 	strings.builder_init(&str, context.temp_allocator)
-	sbprintln(&str, ..args, sep=sep)
-	return strings.to_string(str)
+	return sbprintln(&str, ..args, sep=sep)
 }
 // 	Creates a formatted string using a format string and arguments
 //
@@ -225,8 +220,7 @@ tprintln :: proc(args: ..any, sep := " ") -> string {
 tprintf :: proc(fmt: string, args: ..any, newline := false) -> string {
 	str: strings.Builder
 	strings.builder_init(&str, context.temp_allocator)
-	sbprintf(&str, fmt, ..args, newline=newline)
-	return strings.to_string(str)
+	return sbprintf(&str, fmt, ..args, newline=newline)
 }
 // 	Creates a formatted string using a format string and arguments, followed by a newline.
 //

--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -120,6 +120,7 @@ register_user_formatter :: proc(id: typeid, formatter: User_Formatter) -> Regist
 //
 // 	Returns: A formatted string. 
 //
+@(require_results)
 aprint :: proc(args: ..any, sep := " ", allocator := context.allocator) -> string {
 	str: strings.Builder
 	strings.builder_init(&str, allocator)
@@ -136,6 +137,7 @@ aprint :: proc(args: ..any, sep := " ", allocator := context.allocator) -> strin
 //
 // 	Returns: A formatted string with a newline character at the end.
 //
+@(require_results)
 aprintln :: proc(args: ..any, sep := " ", allocator := context.allocator) -> string {
 	str: strings.Builder
 	strings.builder_init(&str, allocator)
@@ -153,6 +155,7 @@ aprintln :: proc(args: ..any, sep := " ", allocator := context.allocator) -> str
 //
 // 	Returns: A formatted string. The returned string must be freed accordingly.
 //
+@(require_results)
 aprintf :: proc(fmt: string, args: ..any, allocator := context.allocator, newline := false) -> string {
 	str: strings.Builder
 	strings.builder_init(&str, allocator)
@@ -169,6 +172,7 @@ aprintf :: proc(fmt: string, args: ..any, allocator := context.allocator, newlin
 //
 // 	Returns: A formatted string. The returned string must be freed accordingly.
 //
+@(require_results)
 aprintfln :: proc(fmt: string, args: ..any, allocator := context.allocator) -> string {
 	return aprintf(fmt, ..args, allocator=allocator, newline=true)
 }
@@ -182,6 +186,7 @@ aprintfln :: proc(fmt: string, args: ..any, allocator := context.allocator) -> s
 //
 // 	Returns: A formatted string.
 //
+@(require_results)
 tprint :: proc(args: ..any, sep := " ") -> string {
 	str: strings.Builder
 	strings.builder_init(&str, context.temp_allocator)
@@ -198,6 +203,7 @@ tprint :: proc(args: ..any, sep := " ") -> string {
 //
 // 	Returns: A formatted string with a newline character at the end.
 //
+@(require_results)
 tprintln :: proc(args: ..any, sep := " ") -> string {
 	str: strings.Builder
 	strings.builder_init(&str, context.temp_allocator)
@@ -215,6 +221,7 @@ tprintln :: proc(args: ..any, sep := " ") -> string {
 //
 // 	Returns: A formatted string.
 //
+@(require_results)
 tprintf :: proc(fmt: string, args: ..any, newline := false) -> string {
 	str: strings.Builder
 	strings.builder_init(&str, context.temp_allocator)
@@ -231,6 +238,7 @@ tprintf :: proc(fmt: string, args: ..any, newline := false) -> string {
 //
 // 	Returns: A formatted string.
 //
+@(require_results)
 tprintfln :: proc(fmt: string, args: ..any) -> string {
 	return tprintf(fmt, ..args, newline=true)
 }
@@ -339,6 +347,7 @@ panicf :: proc(fmt: string, args: ..any, loc := #caller_location) -> ! {
 //
 // Returns: A formatted C string
 //
+@(require_results)
 caprintf :: proc(format: string, args: ..any, newline := false) -> cstring {
 	str: strings.Builder
 	strings.builder_init(&str)
@@ -357,6 +366,7 @@ caprintf :: proc(format: string, args: ..any, newline := false) -> cstring {
 //
 // Returns: A formatted C string
 //
+@(require_results)
 caprintfln :: proc(format: string, args: ..any) -> cstring {
 	return caprintf(format, ..args, newline=true)
 }
@@ -371,6 +381,7 @@ caprintfln :: proc(format: string, args: ..any) -> cstring {
 //
 // Returns: A formatted C string
 //
+@(require_results)
 ctprintf :: proc(format: string, args: ..any, newline := false) -> cstring {
 	str: strings.Builder
 	strings.builder_init(&str, context.temp_allocator)
@@ -389,6 +400,7 @@ ctprintf :: proc(format: string, args: ..any, newline := false) -> cstring {
 //
 // Returns: A formatted C string
 //
+@(require_results)
 ctprintfln :: proc(format: string, args: ..any) -> cstring {
 	return ctprintf(format, ..args, newline=true)
 }

--- a/examples/demo/demo.odin
+++ b/examples/demo/demo.odin
@@ -2385,7 +2385,7 @@ matrix_type :: proc() {
 
 		c := a * b
 		#assert(type_of(c) == matrix[2, 2]f32)
-		fmt.tprintln("c = a * b", c)
+		fmt.println("c = a * b", c)
 	}
 
 	{ // Matrices support multiplication between matrices and arrays


### PR DESCRIPTION
I figure these are all agreeable API changes since they involve the allocator versions.

I avoided requiring results for the `(s)bprint*` procs, as there seems to be a trend to using a few of them consecutively, discarding the return results, then getting the final result at the end. That's probably something discussion-worthy. Though, when I did temporarily make their results required, I realized that a few calls could be combined.

Also fixed a little bug in the demo revealed by this change.