### PR TITLE
Remove instrinsics and utf16 imports from os/os_js

### DIFF
--- a/core/os/os_js.odin
+++ b/core/os/os_js.odin
@@ -1,9 +1,7 @@
 //+build js
 package os
 
-import "base:intrinsics"
 import "base:runtime"
-import "core:unicode/utf16"
 
 is_path_separator :: proc(c: byte) -> bool {
 	return c == '/' || c == '\\'


### PR DESCRIPTION
These imports are unused therefore breaking builds with the `-vet-unused` flag.