### PR TITLE
Uses correct `clang++` binary for non-standard versions

### DIFF
--- a/build_odin.sh
+++ b/build_odin.sh
@@ -2,7 +2,6 @@
 set -eu
 
 : ${CPPFLAGS=}
-: ${CXX=clang++}
 : ${CXXFLAGS=}
 : ${LDFLAGS=}
 : ${LLVM_CONFIG=}
@@ -43,6 +42,8 @@ if [ -z "$LLVM_CONFIG" ]; then
 		error "No llvm-config command found. Set LLVM_CONFIG to proceed."
 	fi
 fi
+
+: ${CXX=$($LLVM_CONFIG --bindir)/clang++}
 
 LLVM_VERSION="$($LLVM_CONFIG --version)"
 LLVM_VERSION_MAJOR="$(echo $LLVM_VERSION | awk -F. '{print $1}')"


### PR DESCRIPTION
Define `CXX` after `LLVM_CONFIG` to use `$LLVM_CONFIG --bindir` to choose the correct binary from the specified version.

In my case using Fedora 40, the command for compilation using `master`:
```
clang++ src/main.cpp src/libtommath.cpp -Wno-switch -Wno-macro-redefined -Wno-unused-value '-DODIN_VERSION_RAW="dev-2024-04"' '-DGIT_SHA="58e12f0b1"' -std= c++14 -I/usr/lib64/llvm17/in
clude -std=c++17 -fno-exceptions -funwind-tables -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -L/usr/lib64/llvm17/lib -O3 -march=native -pthread -lm
-lstdc++ -ldl /usr/lib64/llvm17/lib/libLLVM-17.so '-Wl,-rpath=$ORIGIN' -o odin
```
However, the version of `clang++` in my case is `18.1.1` which resulted in a `SIGSEGV`.

Using `PR`:
```
/usr/lib64/llvm17/bin/clang++ src/main.cpp src/libtommath.cpp -Wno-switch -Wno-macro-redefined -Wno-unused-value '-DODIN_VERSION_RAW="dev-2024-04"' '- DGIT_SHA="58e12f0b1"' -std= c++14 -I/usr/lib64/llvm17/in
clude -std=c++17 -fno-exceptions -funwind-tables -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -L/usr/lib64/llvm17/lib -O3 -march=native -pthread -lm
-lstdc++ -ldl /usr/lib64/llvm17/lib/libLLVM-17.so '-Wl,-rpath=$ORIGIN' -o odin
```

This change should work on all systems, but I only tested mine, anyone who can carry out tests on the others would help validate this `PR`.

---

Odin:    dev-2024-04:d1f3a4974
OS:      Fedora Linux 40 (KDE Plasma), Linux 6.8.7-300.fc40.x86_64
CPU:     AMD Ryzen 7 5700X 8-Core Processor
RAM:     32010 MiB
Backend: LLVM 17.0.6