### PR TITLE
Fix raygui not using the GuiIconName enum type for icon related functionality

### DIFF
--- a/vendor/raylib/raygui.odin
+++ b/vendor/raylib/raygui.odin
@@ -278,11 +278,11 @@ foreign lib {
 	
 	// Icons functionality
 	
-	GuiIconText         :: proc(iconId: c.int, text: cstring) -> cstring ---                                  // Get text with icon id prepended (if supported)
-	GuiSetIconScale     :: proc(scale: c.int) ---                                                             // Set default icon drawing size
-	GuiGetIcons         :: proc() -> [^]u32 ---                                                               // Get raygui icons data pointer
-	GuiLoadIcons        :: proc(fileName: cstring, loadIconsName: bool) -> [^]cstring ---                     // Load raygui icons file (.rgi) into internal icons data
-	GuiDrawIcon         :: proc(iconId: c.int, posX: c.int, posY: c.int, pixelSize: c.int, color: Color) ---  // Draw icon using pixel size at specified position
+	GuiIconText         :: proc(iconId: GuiIconName, text: cstring) -> cstring ---                                  // Get text with icon id prepended (if supported)
+	GuiSetIconScale     :: proc(scale: c.int) ---                                                                   // Set default icon drawing size
+	GuiGetIcons         :: proc() -> [^]u32 ---                                                                     // Get raygui icons data pointer
+	GuiLoadIcons        :: proc(fileName: cstring, loadIconsName: bool) -> [^]cstring ---                           // Load raygui icons file (.rgi) into internal icons data
+	GuiDrawIcon         :: proc(iconId: GuiIconName, posX: c.int, posY: c.int, pixelSize: c.int, color: Color) ---  // Draw icon using pixel size at specified position
 	
 	
 	// Controls


### PR DESCRIPTION
While experimenting with raygui, I noticed that the corresponding icon enum isn't compatible with the associated icon functions, necessitating the casting of the icon to an int. Given that in other instances where raylib employs int flags as an enum, they are passed as the enum directly I assumed this was an oversight and therefore made this change :).