### PR TITLE
Handle fixed soa arrays

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -102,6 +102,7 @@ gb_internal Type *   check_init_variable            (CheckerContext *c, Entity *
 gb_internal void check_assignment_error_suggestion(CheckerContext *c, Operand *o, Type *type, i64 max_bit_size=0);
 gb_internal void add_map_key_type_dependencies(CheckerContext *ctx, Type *key);
 
+gb_internal Type *make_soa_struct_fixed(CheckerContext *ctx, Ast *array_typ_expr, Ast *elem_expr, Type *elem, i64 count, Type *generic_type);
 gb_internal Type *make_soa_struct_slice(CheckerContext *ctx, Ast *array_typ_expr, Ast *elem_expr, Type *elem);
 gb_internal Type *make_soa_struct_dynamic_array(CheckerContext *ctx, Ast *array_typ_expr, Ast *elem_expr, Type *elem);
 
@@ -1409,11 +1410,19 @@ gb_internal bool is_polymorphic_type_assignable(CheckerContext *c, Type *poly, T
 			    poly->Struct.soa_kind != StructSoa_None) {
 				bool ok = is_polymorphic_type_assignable(c, poly->Struct.soa_elem, source->Struct.soa_elem, true, modify_type);
 				if (ok) switch (source->Struct.soa_kind) {
-				case StructSoa_Fixed:
 				default:
 					GB_PANIC("Unhandled SOA Kind");
 					break;
-
+				case StructSoa_Fixed:
+					if (modify_type) {
+						bool breakpoint = true;
+						Type *type = make_soa_struct_fixed(
+							c, nullptr, poly->Struct.node,
+							poly->Struct.soa_elem, poly->Struct.soa_count,
+							nullptr);
+						gb_memmove(poly, type, gb_size_of(*type));
+					}
+					break;
 				case StructSoa_Slice:
 					if (modify_type) {
 						Type *type = make_soa_struct_slice(c, nullptr, poly->Struct.node, poly->Struct.soa_elem);

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -1416,10 +1416,7 @@ gb_internal bool is_polymorphic_type_assignable(CheckerContext *c, Type *poly, T
 				case StructSoa_Fixed:
 					if (modify_type) {
 						bool breakpoint = true;
-						Type *type = make_soa_struct_fixed(
-							c, nullptr, poly->Struct.node,
-							poly->Struct.soa_elem, poly->Struct.soa_count,
-							nullptr);
+						Type *type = make_soa_struct_fixed(c, nullptr, poly->Struct.node, poly->Struct.soa_elem, poly->Struct.soa_count, nullptr);
 						gb_memmove(poly, type, gb_size_of(*type));
 					}
 					break;

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -1410,6 +1410,7 @@ gb_internal bool is_polymorphic_type_assignable(CheckerContext *c, Type *poly, T
 			    poly->Struct.soa_kind != StructSoa_None) {
 				bool ok = is_polymorphic_type_assignable(c, poly->Struct.soa_elem, source->Struct.soa_elem, true, modify_type);
 				if (ok) switch (source->Struct.soa_kind) {
+				case StructSoa_None:
 				default:
 					GB_PANIC("Unhandled SOA Kind");
 					break;

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -1416,7 +1416,6 @@ gb_internal bool is_polymorphic_type_assignable(CheckerContext *c, Type *poly, T
 					break;
 				case StructSoa_Fixed:
 					if (modify_type) {
-						bool breakpoint = true;
 						Type *type = make_soa_struct_fixed(c, nullptr, poly->Struct.node, poly->Struct.soa_elem, poly->Struct.soa_count, nullptr);
 						gb_memmove(poly, type, gb_size_of(*type));
 					}


### PR DESCRIPTION
The panic was being hit on #soa types of fixed length in a procedure type arguments and variable declaration. Tested on Linux.

This is to fix the following case:
```odin
package main;

import "core:fmt"

Bar :: struct
{
	a: i32,
	b: f32,
}

main :: proc()
{
	foo: #soa[8]Bar;
	fmt.printfln("%#v", foo);
	baz(#soa[8]Bar, foo);
}

baz :: proc($T: typeid/#soa[$N]$E, param: T)
{
	fmt.printfln("%#v", param);
}
```
This does not manifest when you manually resolve the polyparametric.