### PR TITLE
Fix core:odin/parser crashing on empty and/or no package files

### DIFF
--- a/core/odin/parser/parse_files.odin
+++ b/core/odin/parser/parse_files.odin
@@ -6,6 +6,7 @@ import "core:path/filepath"
 import "core:fmt"
 import "core:os"
 import "core:slice"
+import "core:strings"
 
 collect_package :: proc(path: string) -> (pkg: ^ast.Package, success: bool) {
 	NO_POS :: tokenizer.Pos{}
@@ -32,11 +33,17 @@ collect_package :: proc(path: string) -> (pkg: ^ast.Package, success: bool) {
 		if !ok {
 			return
 		}
+
 		src, ok = os.read_entire_file(fullpath)
 		if !ok {
 			delete(fullpath)
 			return
 		}
+        if strings.trim_space(string(src)) == "" {
+            delete(fullpath)
+            continue
+        }
+
 		file := ast.new(ast.File, NO_POS, NO_POS)
 		file.pkg = pkg
 		file.src = string(src)
@@ -69,7 +76,9 @@ parse_package :: proc(pkg: ^ast.Package, p: ^Parser = nil) -> bool {
 		if !parse_file(p, file) {
 			ok = false
 		}
-		if pkg.name == "" {
+        if file.pkg_decl == nil {
+            error(p, p.curr_tok.pos, "Expected pacakge declaration at the start of the file")
+        } else if pkg.name == "" {
 			pkg.name = file.pkg_decl.name
 		} else if pkg.name != file.pkg_decl.name {
 			error(p, file.pkg_decl.pos, "different package name, expected '%s', got '%s'", pkg.name, file.pkg_decl.name)

--- a/core/odin/parser/parse_files.odin
+++ b/core/odin/parser/parse_files.odin
@@ -39,10 +39,10 @@ collect_package :: proc(path: string) -> (pkg: ^ast.Package, success: bool) {
 			delete(fullpath)
 			return
 		}
-        if strings.trim_space(string(src)) == "" {
-            delete(fullpath)
-            continue
-        }
+		if strings.trim_space(string(src)) == "" {
+			delete(fullpath)
+			continue
+		}
 
 		file := ast.new(ast.File, NO_POS, NO_POS)
 		file.pkg = pkg
@@ -76,9 +76,9 @@ parse_package :: proc(pkg: ^ast.Package, p: ^Parser = nil) -> bool {
 		if !parse_file(p, file) {
 			ok = false
 		}
-        if file.pkg_decl == nil {
-            error(p, p.curr_tok.pos, "Expected pacakge declaration at the start of the file")
-        } else if pkg.name == "" {
+		if file.pkg_decl == nil {
+			error(p, p.curr_tok.pos, "Expected pacakge declaration at the start of the file")
+		} else if pkg.name == "" {
 			pkg.name = file.pkg_decl.name
 		} else if pkg.name != file.pkg_decl.name {
 			error(p, file.pkg_decl.pos, "different package name, expected '%s', got '%s'", pkg.name, file.pkg_decl.name)

--- a/core/odin/parser/parse_files.odin
+++ b/core/odin/parser/parse_files.odin
@@ -41,6 +41,7 @@ collect_package :: proc(path: string) -> (pkg: ^ast.Package, success: bool) {
 		}
 		if strings.trim_space(string(src)) == "" {
 			delete(fullpath)
+			delete(src)
 			continue
 		}
 
@@ -77,7 +78,7 @@ parse_package :: proc(pkg: ^ast.Package, p: ^Parser = nil) -> bool {
 			ok = false
 		}
 		if file.pkg_decl == nil {
-			error(p, p.curr_tok.pos, "Expected pacakge declaration at the start of the file")
+			error(p, p.curr_tok.pos, "Expected a package declaration at the start of the file")
 		} else if pkg.name == "" {
 			pkg.name = file.pkg_decl.name
 		} else if pkg.name != file.pkg_decl.name {


### PR DESCRIPTION
Fix for #3543 
`collect_package` now ignores empty files. `parse_package` reports errors on files without package declaration