### PR TITLE
Fix lack of adding to `total_bit_size`

### DIFF
--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -1080,6 +1080,8 @@ gb_internal void check_bit_field_type(CheckerContext *ctx, Type *bit_field_type,
 			array_add(&tags, tag);
 
 			add_entity_use(ctx, field, e);
+
+			total_bit_size += bit_size_u8;
 		}
 	}
 
@@ -1094,7 +1096,7 @@ gb_internal void check_bit_field_type(CheckerContext *ctx, Type *bit_field_type,
 
 	if (total_bit_size > maximum_bit_size) {
 		gbString s = type_to_string(backing_type);
-		error(node, "The numbers required %llu exceeds the backing type's (%s) bit size %llu",
+		error(node, "The total bit size of a bit_field's fields (%llu) must fit into its backing type's (%s) bit size of %llu",
 		      cast(unsigned long long)total_bit_size,
 		      s,
 		      cast(unsigned long long)maximum_bit_size);


### PR DESCRIPTION
`total_bit_size` was checked, but nothing was ever added to it. I made the error message more explicit and hopefully more helpful.

Fixes #3531 

Before:
`The numbers required 66 exceeds the backing type's (u64) bit size 64`
After:
`The total bit size of a bit_field's fields (66) must fit into its backing type's (u64) bit size of 64`