### PR TITLE
Refactor `wprintf`

### DIFF
--- a/core/fmt/doc.odin
+++ b/core/fmt/doc.odin
@@ -1,5 +1,5 @@
 /*
-package fmt implemented formatted I/O with procedures similar to C's printf and Python's format.
+package fmt implements formatted I/O with procedures similar to C's printf and Python's format.
 The format 'verbs' are derived from C's but simpler.
 
 Printing
@@ -33,6 +33,8 @@ Floating-point, complex numbers, and quaternions:
 	%E    scientific notation, e.g. -1.23456E+78
 	%f    decimal point but no exponent, e.g. 123.456
 	%F    synonym for %f
+	%g    synonym for %f with default maximum precision
+	%G    synonym for %g
 	%h    hexadecimal (lower-case) representation with 0h prefix (0h01234abcd)
 	%H    hexadecimal (upper-case) representation with 0H prefix (0h01234ABCD)
 	%m    number of bytes in the best unit of measurement, e.g. 123.45mib
@@ -61,9 +63,9 @@ For compound values, the elements are printed using these rules recursively; lai
 	bit sets           {key0 = elem0, key1 = elem1, ...}
 	pointer to above:  &{}, &[], &map[]
 
-Width is specified by an optional decimal number immediately preceding the verb.
+Width is specified by an optional decimal number immediately after the '%'.
 If not present, the width is whatever is necessary to represent the value.
-Precision is specified after the (optional) width followed by a period followed by a decimal number.
+Precision is specified after the (optional) width by a period followed by a decimal number.
 If no period is present, a default precision is used.
 A period with no following number specifies a precision of 0.
 
@@ -75,7 +77,7 @@ Examples:
 	%8.f   width 8, precision 0
 
 Width and precision are measured in units of Unicode code points (runes).
-n.b. C's printf uses units of bytes
+n.b. C's printf uses units of bytes.
 
 
 Other flags:
@@ -92,7 +94,7 @@ Other flags:
 	0      pad with leading zeros rather than spaces
 
 
-Flags are ignored by verbs that don't expect them
+Flags are ignored by verbs that don't expect them.
 
 
 For each printf-like procedure, there is a print function that takes no
@@ -105,19 +107,20 @@ Explicit argument indices:
 In printf-like procedures, the default behaviour is for each formatting verb to format successive
 arguments passed in the call. However, the notation [n] immediately before the verb indicates that
 the nth zero-index argument is to be formatted instead.
-The same notation before an '*' for a width or precision selecting the argument index holding the value.
-Python-like syntax with argument indices differs for the selecting the argument index: {N:v}
+The same notation before an '*' for a width or precision specifier selects the argument index
+holding the value.
+Python-like syntax with argument indices differs for selecting the argument index: {n:v}
 
 Examples:
-	fmt.printf("%[1]d %[0]d\n", 13, 37); // C-like syntax
-	fmt.printf("{1:d} {0:d}\n", 13, 37); // Python-like syntax
+	fmt.printfln("%[1]d %[0]d", 13, 37) // C-like syntax
+	fmt.printfln("{1:d} {0:d}", 13, 37) // Python-like syntax
 prints "37 13", whilst:
-	fmt.printf("%[2]*.[1]*[0]f\n",  17.0, 2, 6); // C-like syntax
-	fmt.printf("%{0:[2]*.[1]*f}\n", 17.0, 2, 6); // Python-like syntax
-equivalent to:
-	fmt.printf("%6.2f\n",   17.0, 2, 6); // C-like syntax
-	fmt.printf("{:6.2f}\n", 17.0, 2, 6); // Python-like syntax
-prints "17.00"
+	fmt.printfln("%*[2].*[1][0]f", 17.0, 2, 6) // C-like syntax
+	fmt.printfln("{0:*[2].*[1]f}", 17.0, 2, 6) // Python-like syntax
+is equivalent to:
+	fmt.printfln("%6.2f",   17.0) // C-like syntax
+	fmt.printfln("{:6.2f}", 17.0) // Python-like syntax
+and prints "17.00".
 
 Format errors:
 

--- a/core/strconv/generic_float.odin
+++ b/core/strconv/generic_float.odin
@@ -104,8 +104,7 @@ generic_ftoa :: proc(buf: []byte, val: f64, fmt: byte, precision, bit_size: int)
 	} else {
 		switch fmt {
 		case 'e', 'E':
-			prec += 1
-			decimal.round(d, prec)
+			decimal.round(d, prec + 1)
 		case 'f', 'F':
 			decimal.round(d, d.decimal_point+prec)
 		case 'g', 'G':

--- a/tests/core/fmt/test_core_fmt.odin
+++ b/tests/core/fmt/test_core_fmt.odin
@@ -29,6 +29,8 @@ when ODIN_TEST {
 main :: proc() {
 	t := testing.T{}
 	test_fmt_memory(&t)
+	test_fmt_doc_examples(&t)
+	test_fmt_options(&t)
 
 	fmt.printf("%v/%v tests successful.\n", TEST_count - TEST_fail, TEST_count)
 	if TEST_fail > 0 {
@@ -36,12 +38,13 @@ main :: proc() {
 	}
 }
 
-test_fmt_memory :: proc(t: ^testing.T) {
-	check :: proc(t: ^testing.T, exp: string, format: string, args: ..any, loc := #caller_location) {
-		got := fmt.tprintf(format, ..args)
-		expect(t, got == exp, fmt.tprintf("(%q, %v): %q != %q", format, args, got, exp), loc)
-	}
+check :: proc(t: ^testing.T, exp: string, format: string, args: ..any, loc := #caller_location) {
+	got := fmt.tprintf(format, ..args)
+	expect(t, got == exp, fmt.tprintf("(%q, %v): %q != %q", format, args, got, exp), loc)
+}
 
+@(test)
+test_fmt_memory :: proc(t: ^testing.T) {
 	check(t, "5b",        "%m",    5)
 	check(t, "5B",        "%M",    5)
 	check(t, "-5B",       "%M",    -5)
@@ -52,8 +55,129 @@ test_fmt_memory :: proc(t: ^testing.T) {
 	check(t, "3.50 gib",  "%#m",   u32(mem.Gigabyte * 3.5))
 	check(t, "01tib",     "%5.0m", mem.Terabyte)
 	check(t, "-1tib",     "%5.0m", -mem.Terabyte)
-	check(t, "2.50 pib",  "%#5.m", uint(mem.Petabyte * 2.5))
+	check(t, "2 pib",     "%#5.m", uint(mem.Petabyte * 2.5))
 	check(t, "1.00 EiB",  "%#M",   mem.Exabyte)
 	check(t, "255 B",     "%#M",   u8(255))
 	check(t, "0b",        "%m",    u8(0))
+}
+
+@(test)
+test_fmt_doc_examples :: proc(t: ^testing.T) {
+	// C-like syntax
+	check(t, "37 13",  "%[1]d %[0]d",    13,   37)
+	check(t, "017.00", "%*[2].*[1][0]f", 17.0, 2, 6)
+	check(t, "017.00", "%6.2f",          17.0)
+
+	 // Python-like syntax
+	check(t, "37 13",  "{1:d} {0:d}",    13,   37)
+	check(t, "017.00", "{0:*[2].*[1]f}", 17.0, 2, 6)
+	check(t, "017.00", "{:6.2f}",        17.0)
+}
+
+@(test)
+test_fmt_options :: proc(t: ^testing.T) {
+	// Escaping
+	check(t, "% { } 0 { } } {", "%% {{ }} {} {{ }} }} {{", 0 )
+
+	// Prefixes
+	check(t, "+3.000", "%+f",   3.0 )
+	check(t, "0003",   "%04i",  3 )
+	check(t, "3   ",   "% -4i", 3 )
+	check(t, "+3",     "%+i",   3 )
+	check(t, "0b11",   "%#b",   3 )
+	check(t, "0xA",    "%#X",   10 )
+
+	// Specific index formatting
+	check(t, "1 2 3", "%i %i %i",          1, 2, 3)
+	check(t, "1 2 3", "%[0]i %[1]i %[2]i", 1, 2, 3)
+	check(t, "3 2 1", "%[2]i %[1]i %[0]i", 1, 2, 3)
+	check(t, "3 1 2", "%[2]i %i %i",       1, 2, 3)
+	check(t, "1 2 3", "%i %[1]i %i",       1, 2, 3)
+	check(t, "1 3 2", "%i %[2]i %i",       1, 2, 3)
+	check(t, "1 1 1", "%[0]i %[0]i %[0]i", 1)
+
+	// Width
+	check(t, "3.140",  "%f",  3.14)
+	check(t, "3.140",  "%4f", 3.14)
+	check(t, "3.140",  "%5f", 3.14)
+	check(t, "03.140", "%6f", 3.14)
+
+	// Precision
+	check(t, "3",       "%.f",  3.14)
+	check(t, "3",       "%.0f", 3.14)
+	check(t, "3.1",     "%.1f", 3.14)
+	check(t, "3.140",   "%.3f", 3.14)
+	check(t, "3.14000", "%.5f", 3.14)
+
+	check(t, "3.1415",  "%g",   3.1415)
+
+	// Scientific notation
+	check(t, "3.000000e+00", "%e",   3.0)
+
+	check(t, "3e+02",        "%.e",  300.0)
+	check(t, "3e+02",        "%.0e", 300.0)
+	check(t, "3.0e+02",      "%.1e", 300.0)
+	check(t, "3.00e+02",     "%.2e", 300.0)
+	check(t, "3.000e+02",    "%.3e", 300.0)
+
+	check(t, "3e+01",        "%.e",  30.56)
+	check(t, "3e+01",        "%.0e", 30.56)
+	check(t, "3.1e+01",      "%.1e", 30.56)
+	check(t, "3.06e+01",     "%.2e", 30.56)
+	check(t, "3.056e+01",    "%.3e", 30.56)
+
+	// Width and precision
+	check(t, "3.140", "%5.3f",          3.14)
+	check(t, "3.140", "%*[1].3f",       3.14, 5)
+	check(t, "3.140", "%*[1].*[2]f",    3.14, 5, 3)
+	check(t, "3.140", "%*[1].*[2][0]f", 3.14, 5, 3)
+	check(t, "3.140", "%*[2].*[1]f",    3.14, 3, 5)
+	check(t, "3.140", "%5.*[1]f",       3.14, 3)
+
+	// Error checking
+	check(t, "%!(MISSING ARGUMENT)%!(NO VERB)", "%" )
+
+	check(t, "1%!(EXTRA 2, 3)", "%i",    1, 2, 3)
+	check(t, "2%!(EXTRA 1, 3)", "%[1]i", 1, 2, 3)
+
+	check(t, "%!(BAD ARGUMENT NUMBER)%!(EXTRA 0)", "%[1]i", 0)
+
+	check(t, "%!(MISSING ARGUMENT)",               "%f")
+	check(t, "%!(BAD ARGUMENT NUMBER)%!(NO VERB)", "%[0]")
+	check(t, "%!(BAD ARGUMENT NUMBER)",            "%[0]f")
+
+	check(t, "%!(BAD ARGUMENT NUMBER)%!(NO VERB) %!(MISSING ARGUMENT)", "%[0] %i")
+
+	check(t, "%!(NO VERB) 1%!(EXTRA 2)", "%[0] %i", 1, 2)
+
+	check(t, "1 2 %!(MISSING ARGUMENT)",    "%i %i %i",    1, 2)
+	check(t, "1 2 %!(BAD ARGUMENT NUMBER)", "%i %i %[2]i", 1, 2)
+
+	check(t, "%!(BAD ARGUMENT NUMBER)%!(NO VERB)%!(EXTRA 0)", "%[1]", 0)
+
+	check(t, "3.1%!(EXTRA 3.14)", "%.1f", 3.14, 3.14)
+
+	// Python-like syntax
+	check(t, "1 2 3", "{} {} {}",          1, 2, 3)
+	check(t, "3 2 1", "{2} {1} {0}",       1, 2, 3)
+	check(t, "1 2 3", "{:i} {:i} {:i}",    1, 2, 3)
+	check(t, "1 2 3", "{0:i} {1:i} {2:i}", 1, 2, 3)
+	check(t, "3 2 1", "{2:i} {1:i} {0:i}", 1, 2, 3)
+	check(t, "3 1 2", "{2:i} {0:i} {1:i}", 1, 2, 3)
+	check(t, "1 2 3", "{:i} {1:i} {:i}",   1, 2, 3)
+	check(t, "1 3 2", "{:i} {2:i} {:i}",   1, 2, 3)
+	check(t, "1 1 1", "{0:i} {0:i} {0:i}", 1)
+
+	check(t, "1 1%!(EXTRA 2)", "{} {0}", 1, 2)
+	check(t, "2 1", "{1} {}", 1, 2)
+	check(t, "%!(BAD ARGUMENT NUMBER) 1%!(EXTRA 2)", "{2} {}", 1, 2)
+
+	check(t, "%!(BAD ARGUMENT NUMBER)",                       "{1}")
+	check(t, "%!(BAD ARGUMENT NUMBER)%!(NO VERB)",            "{1:}")
+	check(t, "%!(BAD ARGUMENT NUMBER)%!(NO VERB)%!(EXTRA 0)", "{1:}", 0)
+
+	check(t, "%!(MISSING ARGUMENT)",                        "{}" )
+	check(t, "%!(MISSING ARGUMENT)%!(MISSING CLOSE BRACE)", "{" )
+	check(t, "%!(MISSING CLOSE BRACE)%!(EXTRA 1)",          "{",  1)
+	check(t, "%!(MISSING CLOSE BRACE)%!(EXTRA 1)",          "{0", 1 )
 }


### PR DESCRIPTION
I went down a rabbit-hole investigating #3546.

Aiming for consistency, I tried to make sense of the documentation with regards to the code, and this is what I ended up with. I've documented most of the changes in the commit messages themselves, and there's now a larger test suite for `fmt` to verify everything's working well.

I think the most radical change in this set would be making `{}` and `%v` take the next unused argument instead of the argument after the last one used. This made more sense to me, at least.

I noticed a bug with zero-precision scientific notation and fixed that on the way, too.

I also saw this:
https://github.com/odin-lang/Odin/blob/41bd8cf7143902db59c02c56fc5318a7e749d7a5/core/fmt/fmt.odin#L1366-L1368

But I'm not sure what to make of it, since my standard C library gives the same output.

Fixes #3546 