### PR TITLE
Get the compiler to build and work on arm32 Linux

### DIFF
--- a/base/runtime/internal.odin
+++ b/base/runtime/internal.odin
@@ -801,6 +801,10 @@ truncsfhf2 :: proc "c" (value: f32) -> __float16 {
 	}
 }
 
+@(link_name="__aeabi_d2h", linkage=RUNTIME_LINKAGE, require=RUNTIME_REQUIRE)
+aeabi_d2h :: proc "c" (value: f64) -> __float16 {
+	return truncsfhf2(f32(value))
+}
 
 @(link_name="__truncdfhf2", linkage=RUNTIME_LINKAGE, require=RUNTIME_REQUIRE)
 truncdfhf2 :: proc "c" (value: f64) -> __float16 {

--- a/src/bug_report.cpp
+++ b/src/bug_report.cpp
@@ -251,7 +251,7 @@ gb_internal void report_ram_info() {
 		int result = sysinfo(&info);
 
 		if (result == 0x0) {
-			gb_printf("%lu MiB\n", info.totalram * info.mem_unit / gb_megabytes(1));
+			gb_printf("%lu MiB\n", (unsigned long)(info.totalram * info.mem_unit / gb_megabytes(1)));
 		} else {
 			gb_printf("Unknown.\n");
 		}

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -972,7 +972,7 @@ gb_global TargetMetrics target_linux_arm32 = {
 	TargetOs_linux,
 	TargetArch_arm32,
 	4, 4, 4, 8,
-	str_lit("arm-linux-gnu"),
+	str_lit("arm-unknown-linux-gnueabihf"),
 };
 
 gb_global TargetMetrics target_darwin_amd64 = {
@@ -1889,6 +1889,16 @@ gb_internal void init_build_context(TargetMetrics *cross_target, Subtarget subta
 			metrics = &target_linux_arm64;
 		#else
 			metrics = &target_linux_amd64;
+		#endif
+	#elif defined(GB_CPU_ARM)
+		#if defined(GB_SYSTEM_WINDOWS)
+			#error "Build Error: Unsupported architecture"
+		#elif defined(GB_SYSTEM_OSX)
+			#error "Build Error: Unsupported architecture"
+		#elif defined(GB_SYSTEM_FREEBSD)
+			#error "Build Error: Unsupported architecture"
+		#else
+			metrics = &target_linux_arm32;
 		#endif
 	#else
 		#if defined(GB_SYSTEM_WINDOWS)

--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -2643,6 +2643,10 @@ gb_internal void generate_minimum_dependency_set(Checker *c, Entity *start) {
 		str_lit("memmove"),
 	);
 
+	FORCE_ADD_RUNTIME_ENTITIES(build_context.metrics.arch == TargetArch_arm32,
+		str_lit("aeabi_d2h")
+	);
+
 	FORCE_ADD_RUNTIME_ENTITIES(is_arch_wasm() && !build_context.tilde_backend,
 	// 	// Extended data type internal procedures
 	// 	str_lit("umodti3"),

--- a/src/gb/gb.h
+++ b/src/gb/gb.h
@@ -6220,11 +6220,12 @@ gb_no_inline isize gb_snprintf_va(char *text, isize max_len, char const *fmt, va
 #elif defined(__aarch64__)
 	gb_inline u64 gb_rdtsc(void) {
 		int64_t virtual_timer_value;
- 		asm volatile("mrs %0, cntvct_el0" : "=r"(virtual_timer_value));
- 		return virtual_timer_value;
+		asm volatile("mrs %0, cntvct_el0" : "=r"(virtual_timer_value));
+		return virtual_timer_value;
 	}
 #else
-#error "gb_rdtsc not supported"
+#warning "gb_rdtsc not supported"
+	gb_inline u64 gb_rdtsc(void) { return 0; }
 #endif
 
 #if defined(GB_SYSTEM_WINDOWS)

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -2909,7 +2909,6 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 				break;
 			case TargetArch_arm32:
 				{
-					// TODO(bill): Check this is correct
 					GB_ASSERT(arg_count <= 7);
 
 					char asm_string[] = "svc #0";
@@ -2917,13 +2916,14 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 					for (unsigned i = 0; i < arg_count; i++) {
 						constraints = gb_string_appendc(constraints, ",{");
 						static char const *regs[] = {
-							"r8",
+							"r7",
 							"r0",
 							"r1",
 							"r2",
 							"r3",
 							"r4",
 							"r5",
+							"r6",
 						};
 						constraints = gb_string_appendc(constraints, regs[i]);
 						constraints = gb_string_appendc(constraints, "}");


### PR DESCRIPTION
This fixes #3529.  I had to change the `target_triple` for the arm32 Linux target.  32-bit arm is weird with `target_triple`, so we may want to consider adding the ability to override it or we could just add targets for stuff like `arm-none-eabi` or `arm-linux-gnu-eabi`.
