### PR TITLE
Fix joining non-`Started` threads from blocking main thread

### DIFF
--- a/core/thread/thread_windows.odin
+++ b/core/thread/thread_windows.odin
@@ -24,6 +24,10 @@ _create :: proc(procedure: Thread_Proc, priority: Thread_Priority) -> ^Thread {
 	__windows_thread_entry_proc :: proc "system" (t_: rawptr) -> win32.DWORD {
 		t := (^Thread)(t_)
 
+		if .Joined in t.flags {
+			return 0
+		}
+
 		t.id = sync.current_thread_id()
 
 		{
@@ -93,11 +97,15 @@ _join :: proc(t: ^Thread) {
 		return
 	}
 
+	t.flags += {.Joined}
+
+	if .Started not_in t.flags {
+		_start(t)
+	}
+
 	win32.WaitForSingleObject(t.win32_thread, win32.INFINITE)
 	win32.CloseHandle(t.win32_thread)
 	t.win32_thread = win32.INVALID_HANDLE
-
-	t.flags += {.Joined}
 }
 
 _join_multiple :: proc(threads: ..^Thread) {


### PR DESCRIPTION
While investigating #2746, I noticed this was happening for UNIX threads too. I was able to fix and test it for threads on Linux, but I do not have a Windows machine to test my fix there, so if someone can try it out, that would be great.

Here's the program I tested with:
```odin
package main

import "core:fmt"
import "core:thread"

main :: proc () {
	p: thread.Pool
	fmt.println("pool_init:")
	thread.pool_init(&p, context.allocator, 1)
	fmt.println("pool_destroy:")
	thread.pool_destroy(&p)
	fmt.println("done")
}
```

Fixes #2746 