### PR TITLE
fix 6 argument syscall on i386

### DIFF
--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -2835,8 +2835,7 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 				{
 					GB_ASSERT(arg_count <= 7);
 
-					char asm_string_default[] = "int $$0x80";
-					char *asm_string = asm_string_default;
+					char asm_string[] = "int $$0x80";
 					gbString constraints = gb_string_make(heap_allocator(), "={eax}");
 
 					for (unsigned i = 0; i < gb_min(arg_count, 6); i++) {
@@ -2848,15 +2847,10 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 							"edx",
 							"esi",
 							"edi",
+							"ebp",
 						};
 						constraints = gb_string_appendc(constraints, regs[i]);
 						constraints = gb_string_appendc(constraints, "}");
-					}
-					if (arg_count == 7) {
-						char asm_string7[] = "push %[arg6]\npush %%ebp\nmov 4(%%esp), %%ebp\nint $0x80\npop %%ebp\nadd $4, %%esp";
-						asm_string = asm_string7;
-
-						constraints = gb_string_appendc(constraints, ",rm");
 					}
 
 					inline_asm = llvm_get_inline_asm(func_type, make_string_c(asm_string), make_string_c(constraints));


### PR DESCRIPTION
It looks like the routine where we put the rest of the arguments (>6) on the stack and pass their address in `ebp` wouldn't apply until `arg_count == 8` which fails `GB_ASSERT(arg_count <= 7);` anyway.  I don't know about the other systems, but there currently exists no system call with more than 6 arguments in Linux (Fixes #3512).

From `linux/arch/x86/entry/entry_32.S`:
```asm
/*
...
 *
 * Arguments:
 * eax  system call number
 * ebx  arg1
 * ecx  arg2
 * edx  arg3
 * esi  arg4
 * edi  arg5
 * ebp  arg6
 */
SYM_FUNC_START(entry_INT80_32)
        ASM_CLAC
        pushl   %eax                    /* pt_regs->orig_ax */

        SAVE_ALL pt_regs_ax=$-ENOSYS switch_stacks=1    /* save rest */

        movl    %esp, %eax
        call    do_int80_syscall_32
.Lsyscall_32_done:
```