### PR TITLE
Suggest `-all-packages` flag when testing empty directory

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -5508,10 +5508,14 @@ gb_internal AstPackage *try_add_import_path(Parser *p, String path, String const
 		}
 	}
 	if (files_with_ext == 0 || files_to_reserve == 1) {
+		ERROR_BLOCK();
 		if (files_with_ext != 0) {
 			syntax_error(pos, "Directory contains no .odin files for the specified platform: %.*s", LIT(rel_path));
 		} else {
 			syntax_error(pos, "Empty directory that contains no .odin files: %.*s", LIT(rel_path));
+		}
+		if (build_context.command_kind == Command_test) {
+			error_line("\tSuggestion: Make an .odin file that imports packages to test and use the `-all-packages` flag.");
 		}
 		return nullptr;
 	}

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -400,16 +400,13 @@ gb_internal ReadDirectoryError read_directory(String path, Array<FileInfo> *fi) 
 			continue;
 		}
 
-		if (S_ISDIR(dir_stat.st_mode)) {
-			continue;
-		}
-
 		i64 size = dir_stat.st_size;
 
 		FileInfo info = {};
 		info.name = copy_string(a, name);
 		info.fullpath = path_to_full_path(a, filepath);
 		info.size = size;
+		info.is_dir = S_ISDIR(dir_stat.st_mode);
 		array_add(fi, info);
 	}
 


### PR DESCRIPTION
I have a project that has a directory with subdirectories containing tests. I've used a shell script until now to test all of them sequentially. I was almost finished implementing recursive imports for the `odin test` command when I noticed in the source code that the `-all-packages` flag exists. Oops.

I have in the past tried `odin test ./tests/` and gotten the usual syntax error. This suggestion should help people who fall into the same trap in the future. I think having a main tests file with `-all-packages` is better than recursive imports, since it gives the developer the ability to toggle what should run.

While doing that, I found that `read_directory` (which is used in `try_add_import_path`, which is where I was hacking up recursion), skips directories (as in, does not add them to the output file list) on UNIX-likes, which looks to be inconsistent with its behavior on Windows.

Here's what the suggestion looks like now with a directory that has no .odin files but has subdirectories:
```
Syntax Error: Empty directory that contains no .odin files: /tmp/tests
	Suggestion: Make an .odin file that imports all the packages to test and use the `-all-packages` flag.
```
Note that this suggestion won't appear if the directory is _totally_ empty.
