### PR TITLE
Attempt to automatically resolve the sysroot on build_odin.sh on macOS

### DIFF
--- a/build_odin.sh
+++ b/build_odin.sh
@@ -64,7 +64,16 @@ Darwin)
 		fi
 	fi
 
-	CXXFLAGS="$CXXFLAGS $($LLVM_CONFIG --cxxflags --ldflags)"
+	darwin_sysroot=
+	if [ $(which xcode-select) ]; then
+		darwin_sysroot="--sysroot $(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+	elif [[ -e "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" ]]; then
+		darwin_sysroot="--sysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+	else
+		echo "Warning: MacOSX.sdk not found."
+	fi
+
+	CXXFLAGS="$CXXFLAGS $($LLVM_CONFIG --cxxflags --ldflags) ${darwin_sysroot}"
 	LDFLAGS="$LDFLAGS -liconv -ldl -framework System -lLLVM"
 	;;
 FreeBSD)


### PR DESCRIPTION
Since 30ff15e53805590ac48560080aa56a5e540ea22e , `build_odin.sh` defaults to using the `clang++` provided by the selected `LLVM_CONFIG`, instead of the one in `PATH`. This can cause compilation to not work  on macOS where it is not able to find required headers and libraries. This attempts to resolve the macOS SDK automatically and set it as the sysroot.