### PR TITLE
remove extra newline in enumerated array hash fmt

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -2679,7 +2679,6 @@ fmt_value :: proc(fi: ^Info, v: any, verb: rune) {
 			io.write_byte(fi.writer, '[' if verb != 'w' else '{', &fi.n)
 			io.write_byte(fi.writer, '\n', &fi.n)
 			defer {
-				io.write_byte(fi.writer, '\n', &fi.n)
 				fmt_write_indent(fi)
 				io.write_byte(fi.writer, ']' if verb != 'w' else '}', &fi.n)
 			}


### PR DESCRIPTION
```odin
package main

import "core:fmt"

Foo0 :: enum {}

Foo1 :: enum {
	Bar
}

Foo2 :: enum {
	Bar,
	Baz,
}

foo0: [Foo0]int
foo1: [Foo1]int
foo2: [Foo2]int

foo: struct {
	foo0: [Foo0]int,
	foo1: [Foo1]int,
	foo2: [Foo2]int,
}

main :: proc() {
	fmt.printf("%#v\n", foo)
	fmt.printf("%#v\n", foo0)
	fmt.printf("%#v\n", foo1)
	fmt.printf("%#v\n", foo2)
}

/* Before:

{
        foo0 = [

        ],
        foo1 = [
                .Bar = 0,

        ],
        foo2 = [
                .Bar = 0,
                .Baz = 0,

        ],
}
[

]
[
        .Bar = 0,

]
[
        .Bar = 0,
        .Baz = 0,

]

*/

/* After:

{
        foo0 = [
        ],
        foo1 = [
                .Bar = 0,
        ],
        foo2 = [
                .Bar = 0,
                .Baz = 0,
        ],
}
[
]
[
        .Bar = 0,
]
[
        .Bar = 0,
        .Baz = 0,
]

*/

```