### PR TITLE
Fix Odin to LLVM memory order mapping for .Relaxed and .Consume

### DIFF
--- a/src/llvm_backend_utility.cpp
+++ b/src/llvm_backend_utility.cpp
@@ -2223,8 +2223,8 @@ gb_internal LLVMAtomicOrdering llvm_atomic_ordering_from_odin(ExactValue const &
 	GB_ASSERT(value.kind == ExactValue_Integer);
 	i64 v = exact_value_to_i64(value);
 	switch (v) {
-	case OdinAtomicMemoryOrder_relaxed: return LLVMAtomicOrderingUnordered;
-	case OdinAtomicMemoryOrder_consume: return LLVMAtomicOrderingMonotonic;
+	case OdinAtomicMemoryOrder_relaxed: return LLVMAtomicOrderingMonotonic;
+	case OdinAtomicMemoryOrder_consume: return LLVMAtomicOrderingAcquire;
 	case OdinAtomicMemoryOrder_acquire: return LLVMAtomicOrderingAcquire;
 	case OdinAtomicMemoryOrder_release: return LLVMAtomicOrderingRelease;
 	case OdinAtomicMemoryOrder_acq_rel: return LLVMAtomicOrderingAcquireRelease;


### PR DESCRIPTION
This fixes how Odin's atomic memory order is mapped to LLVM. Now it's the same as Clang.

Before this, .Relaxed threw an LLVM error in some situations and .Consume was more relaxed than it should be.
```rust
sync.atomic_add_explicit(&foo.ref_count, 1, .Relaxed);
```
```llvm
atomicrmw instructions cannot be unordered.
  %31 = atomicrmw volatile add ptr %30, i64 1 unordered, align 8
```

#2974