### PR TITLE
Add build flag to export dependencies.

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -694,6 +694,12 @@ enum TimingsExportFormat : i32 {
 	TimingsExportCSV         = 2,
 };
 
+enum DependenciesExportFormat : i32 {
+	DependenciesExportUnspecified = 0,
+	DependenciesExportMake        = 1,
+	DependenciesExportJson        = 2,
+};
+
 enum ErrorPosStyle {
 	ErrorPosStyle_Default, // path(line:column) msg
 	ErrorPosStyle_Unix,    // path:line:column: msg
@@ -831,6 +837,7 @@ struct BuildContext {
 	bool   show_timings;
 	TimingsExportFormat export_timings_format;
 	String export_timings_file;
+	DependenciesExportFormat export_dependencies_format;
 	String export_dependencies_file;
 	bool   show_unused;
 	bool   show_unused_with_location;

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -831,6 +831,7 @@ struct BuildContext {
 	bool   show_timings;
 	TimingsExportFormat export_timings_format;
 	String export_timings_file;
+	String export_dependencies_file;
 	bool   show_unused;
 	bool   show_unused_with_location;
 	bool   show_more_timings;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2951,12 +2951,31 @@ int main(int arg_count, char const **arg_ptr) {
 
 		gb_fprintf(&f, "%.*s:", LIT(exe_name));
 
+		isize current_line_length = exe_name.len + 1;
+
 		for (isize i = parser->packages.count-1; i >= 0; i--) {
 			AstPackage *pkg = parser->packages[i];
 			for (isize j = pkg->files.count-1; j >= 0; j--) {
 				AstFile *file = pkg->files[j];
 
-				gb_fprintf(&f, " \\\n  %.*s", LIT(file->fullpath));
+				/* Arbitrary line break value. Maybe make this better? */
+				if (current_line_length >= 80-2) {
+					gb_file_write(&f, " \\\n ", 4);
+					current_line_length = 1;
+				}
+
+				gb_file_write(&f, " ", 1);
+				current_line_length++;
+
+				for (isize k = 0; k < file->fullpath.len; k++) {
+					char part = file->fullpath.text[k];
+					if (part == ' ') {
+						gb_file_write(&f, "\\", 1);
+						current_line_length++;
+					}
+					gb_file_write(&f, &part, 1);
+					current_line_length++;
+				}
 			}
 		}
 


### PR DESCRIPTION
Adds the `-export-dependencies` build flag. This takes a file to which dependency information about the current build will be written in Make format. This is roughly compatible with GCCs `-MD -MF` flag and help projects which contain multiple independent Odin builds, only some of which should be rebuilt during any given build.