### PR TITLE
Clearer function parameters for core:os:read_dir()

### DIFF
--- a/core/os/dir_bsd.odin
+++ b/core/os/dir_bsd.odin
@@ -3,7 +3,7 @@ package os
 
 import "core:mem"
 
-read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []File_Info, err: Errno) {
+read_dir :: proc(fd: Handle, fi_size: int = 100, allocator := context.allocator) -> (fi: []File_Info, err: Errno) {
 	dirp: Dir
 	dirp, err = _fdopendir(fd)
 	if err != ERROR_NONE {
@@ -21,14 +21,11 @@ read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []F
 
 	defer delete(dirpath)
 
-	n := n
-	size := n
-	if n <= 0 {
-		n = -1
-		size = 100
+	if fi_size <= 0 {
+		fi_size = 100
 	}
 
-	dfi := make([dynamic]File_Info, 0, size, allocator)
+	dfi := make([dynamic]File_Info, 0, fi_size, allocator)
 
 	for {
 		entry: Dirent

--- a/core/os/dir_darwin.odin
+++ b/core/os/dir_darwin.odin
@@ -3,7 +3,7 @@ package os
 import "core:strings"
 import "core:mem"
 
-read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []File_Info, err: Errno) {
+read_dir :: proc(fd: Handle, fi_size: int = 100, allocator := context.allocator) -> (fi: []File_Info, err: Errno) {
 	dirp: Dir
 	dirp, err = _fdopendir(fd)
 	if err != ERROR_NONE {
@@ -20,14 +20,11 @@ read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []F
 
 	defer delete(dirpath)
 
-	n := n
-	size := n
-	if n <= 0 {
-		n = -1
-		size = 100
+	if fi_size <= 0 {
+		fi_size = 100
 	}
 
-	dfi := make([dynamic]File_Info, 0, size, allocator)
+	dfi := make([dynamic]File_Info, 0, fi_size, allocator)
 
 	for {
 		entry: Dirent

--- a/core/os/dir_linux.odin
+++ b/core/os/dir_linux.odin
@@ -4,7 +4,7 @@ import "core:strings"
 import "core:mem"
 import "base:runtime"
 
-read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []File_Info, err: Errno) {
+read_dir :: proc(fd: Handle, fi_size: int = 100, allocator := context.allocator) -> (fi: []File_Info, err: Errno) {
 	dirp: Dir
 	dirp, err = _fdopendir(fd)
 	if err != ERROR_NONE {
@@ -22,14 +22,11 @@ read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []F
 
 	defer delete(dirpath)
 
-	n := n
-	size := n
-	if n <= 0 {
-		n = -1
-		size = 100
+	if fi_size <= 0 {
+		fi_size = 100
 	}
 
-	dfi := make([dynamic]File_Info, 0, size, allocator)
+	dfi := make([dynamic]File_Info, 0, fi_size, allocator)
 
 	for {
 		entry: Dirent

--- a/core/os/dir_openbsd.odin
+++ b/core/os/dir_openbsd.odin
@@ -3,7 +3,7 @@ package os
 import "core:strings"
 import "core:mem"
 
-read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []File_Info, err: Errno) {
+read_dir :: proc(fd: Handle, fi_size: int = 100, allocator := context.allocator) -> (fi: []File_Info, err: Errno) {
 	dirp: Dir
 	dirp, err = _fdopendir(fd)
 	if err != ERROR_NONE {
@@ -22,14 +22,11 @@ read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []F
 
 	defer delete(dirpath)
 
-	n := n
-	size := n
-	if n <= 0 {
-		n = -1
-		size = 100
+	if fi_size <= 0 {
+		fi_size = 100
 	}
 
-	dfi := make([dynamic]File_Info, 0, size, allocator)
+	dfi := make([dynamic]File_Info, 0, fi_size, allocator)
 
 	for {
 		entry: Dirent

--- a/core/os/dir_windows.odin
+++ b/core/os/dir_windows.odin
@@ -4,7 +4,7 @@ import win32 "core:sys/windows"
 import "core:strings"
 import "base:runtime"
 
-read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []File_Info, err: Errno) {
+read_dir :: proc(fd: Handle, fi_size: int = 100, allocator := context.allocator) -> (fi: []File_Info, err: Errno) {
 	find_data_to_file_info :: proc(base_path: string, d: ^win32.WIN32_FIND_DATAW) -> (fi: File_Info) {
 		// Ignore "." and ".."
 		if d.cFileName[0] == '.' && d.cFileName[1] == 0 {
@@ -60,11 +60,8 @@ read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []F
 		return nil, ERROR_FILE_IS_NOT_DIR
 	}
 
-	n := n
-	size := n
-	if n <= 0 {
-		n = -1
-		size = 100
+	if fi_size <= 0 {
+		fi_size = 100
 	}
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD(ignore = context.temp_allocator == allocator)
 
@@ -74,7 +71,7 @@ read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []F
 		return
 	}
 
-	dfi := make([dynamic]File_Info, 0, size)
+	dfi := make([dynamic]File_Info, 0, fi_size)
 
 	wpath_search := make([]u16, len(wpath)+3, context.temp_allocator)
 	copy(wpath_search, wpath)

--- a/core/os/os_js.odin
+++ b/core/os/os_js.odin
@@ -155,7 +155,7 @@ pipe :: proc() -> (r, w: Handle, err: Errno) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
-read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []File_Info, err: Errno) {
+read_dir :: proc(fd: Handle, fi_size: int = 100, allocator := context.allocator) -> (fi: []File_Info, err: Errno) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 


### PR DESCRIPTION
I was confused when initially using read_dir and had to read the code to figure out what n controlled. Decided to make it more explicit that n was the size of the fi return array and display the default size.