### PR TITLE
fix(core/encoding/json): remove Unsupported_Type return when marshalling bit_set

### DIFF
--- a/core/encoding/json/marshal.odin
+++ b/core/encoding/json/marshal.odin
@@ -539,8 +539,6 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 		case: panic("unknown bit_size size")
 		}
 		io.write_u64(w, bit_data) or_return
-
-		return .Unsupported_Type
 	}
 
 	return


### PR DESCRIPTION
This seems to have been left here accidentally