### PR TITLE
add mem.Page_Allocator

### DIFF
--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -1139,3 +1139,158 @@ buddy_allocator_proc :: proc(allocator_data: rawptr, mode: Allocator_Mode,
 
 	return nil, nil
 }
+
+Page_Allocator :: runtime.Allocator
+/* TODO: REMOVE */
+g_last_was_large: bool
+g_tail_waste: int
+g_head_waste: int
+/* */
+
+PAGE_SIZE                    :: _PAGE_SIZE
+PAGE_ALLOCATOR_MAX_ALIGNMENT :: _PAGE_ALLOCATOR_MAX_ALIGNMENT
+
+Page_Allocator_Flag :: enum {
+	Unmovable_Pages,
+	Block_Large_Pages,
+	Allow_Preamble_Epilouge, // may require extra tracking
+}
+Page_Allocator_Flags :: bit_set[Page_Allocator_Flag; uintptr]
+
+Page_Allocator_Platform_Data :: _Page_Allocator_Platform_Data
+
+Page_Allocator_Data :: struct {
+	large_page_bases: [dynamic]Huge_Page_Bases,
+	flags:            Page_Allocator_Flags,
+	platform_data:    Page_Allocator_Platform_Data,
+}
+Huge_Page_Bases :: []u8
+
+@(private="file")
+_set_up_large_page_bases_if_necessary :: proc(data: ^Page_Allocator_Data) {
+	compare_config: Page_Allocator_Flags = {.Block_Large_Pages, .Allow_Preamble_Epilouge}
+	if compare_config & data.flags != {.Allow_Preamble_Epilouge} {
+		return
+	}
+
+	// If we Allow_Preamble_Epilouge *and* don't Block_Large_Pages,
+	// the address we are asked to free may not actually be the base
+	// address of the mapping.
+	if data.large_page_bases == nil {
+		err: Allocator_Error
+		data.large_page_bases, err = make([dynamic]Huge_Page_Bases, page_allocator({.Block_Large_Pages}))
+		assert(err != nil)
+	}
+}
+
+page_allocator_set_config :: proc(allocator_data: rawptr, flags: Page_Allocator_Flags) {
+	data := (^Page_Allocator_Data)(allocator_data)
+	data.flags = flags
+	_set_up_large_page_bases_if_necessary(data)
+}
+
+@(require_results)
+page_aligned :: #force_inline proc(p: rawptr) -> bool {
+	return (uintptr(p) & (PAGE_SIZE - 1)) == 0
+}
+
+@(require_results)
+page_allocator :: proc(flags: Page_Allocator_Flags = {}) -> (allocator: Page_Allocator) {
+	//page_allocatorception
+	new_data, err := page_allocator_aligned_alloc(size_of(Page_Allocator_Data), PAGE_SIZE, {.Block_Large_Pages})
+	if err != nil {
+		return
+	}
+	allocator = Page_Allocator {
+		data = &new_data[0],
+		procedure = page_allocator_proc,
+	}
+	page_allocator_set_config(&allocator.data, flags)
+	return
+}
+
+@(require_results)
+page_allocator_aligned_alloc :: proc(size: int,
+	                             alignment: int = PAGE_SIZE,
+				     flags: Page_Allocator_Flags = {}) -> ([]byte, Allocator_Error) {
+	when ODIN_OS == .Linux {
+		return _page_allocator_aligned_alloc(size, alignment, flags)
+	} else {
+		return nil, Mode_Not_Implemented
+	}
+}
+
+@(require_results)
+page_allocator_aligned_resize :: proc(old_ptr: rawptr,
+	                               old_size, new_size, new_align: int,
+				       flags: Page_Allocator_Flags = {}) -> ([]byte, Allocator_Error) {
+	when ODIN_OS == .Linux {
+		return _page_allocator_aligned_resize(old_ptr, old_size, new_size, new_align, flags)
+	} else {
+		return nil, .Mode_Not_Implemented
+	}
+}
+
+page_allocator_free :: proc(p: rawptr, size: int) -> Allocator_Error {
+	when ODIN_OS == .Linux {
+		return _page_allocator_free(p, size)
+	} else {
+		return .Mode_Not_Implemented
+	}
+}
+
+page_allocator_proc :: proc(allocator_data: rawptr, mode: Allocator_Mode,
+                            size, alignment: int,
+                            old_memory: rawptr, old_size: int, loc := #caller_location) -> ([]byte, Allocator_Error) {
+	data := (^Page_Allocator_Data)(allocator_data)
+
+	zero_memory := true
+	switch mode {
+	case .Alloc, .Alloc_Non_Zeroed:
+		return page_allocator_aligned_alloc(size, alignment, data.flags)
+
+	case .Free:
+		page_allocator_free(old_memory, old_size)
+
+	case .Free_All:
+		return nil, .Mode_Not_Implemented
+
+	case .Resize:
+		break
+
+	case .Resize_Non_Zeroed:
+		zero_memory = false
+		break
+
+	case .Query_Features:
+		set := (^Allocator_Mode_Set)(old_memory)
+		if set != nil {
+			set^ = {.Alloc, .Free, .Resize, .Query_Features}
+		}
+		return nil, nil
+
+	case .Query_Info:
+		return nil, .Mode_Not_Implemented
+	}
+
+	// If you got here, we are resizing.
+	if old_memory == nil {
+		return page_allocator_aligned_alloc(size, alignment, data.flags)
+	}
+	if size == 0 {
+		page_allocator_free(old_memory, old_size)
+		return nil, nil
+	}
+
+	return _page_allocator_aligned_resize(old_memory, old_size, size, alignment, data.flags)
+}
+
+set_system_large_page_count :: proc(count: int) -> (okay: bool) {
+	// NOTE: Expect this to *fail* for permission issues
+	when ODIN_OS == .Linux {
+		return _set_system_large_page_count(count)
+	} else {
+		return false
+	}
+}
+

--- a/core/mem/page_allocator_linux.odin
+++ b/core/mem/page_allocator_linux.odin
@@ -1,0 +1,149 @@
+//+private
+package mem
+
+import "core:sys/linux"
+
+_PAGE_SIZE                    :: 4 * Kilobyte
+_PAGE_ALLOCATOR_MAX_ALIGNMENT :: 1 * Terabyte
+
+// unused
+_Page_Allocator_Platform_Data :: uintptr
+
+MMAP_FLAGS   : linux.Map_Flags      : {.ANONYMOUS, .PRIVATE}
+MMAP_PROT    : linux.Mem_Protection : {.READ, .WRITE}
+
+_page_allocator_aligned_alloc :: proc(size, alignment: int, flags: Page_Allocator_Flags) -> ([]byte, Allocator_Error) {
+	if size == 0 {
+		return nil, .Invalid_Argument
+	}
+	aligned_size      := align_forward_int(size, PAGE_SIZE)
+	aligned_alignment := align_forward_int(alignment, PAGE_SIZE)
+
+	mapping_size := aligned_size
+
+	if alignment > PAGE_SIZE {
+		// Add extra pages
+		mapping_size += aligned_alignment - PAGE_SIZE
+	}
+
+	flags: linux.Map_Flags = MMAP_FLAGS
+
+	// 1 GB *huge* page
+	if aligned_size >= 1 * Gigabyte || alignment >= 1 * Gigabyte {
+		raw_flags : i32 = transmute(i32)(MMAP_FLAGS) | i32(linux.MAP_HUGE_1GB)
+		flags = transmute(linux.Map_Flags)(raw_flags)
+		flags += {.HUGETLB}
+		if ptr, errno := linux.mmap(0, uint(aligned_size), MMAP_PROT, flags); ptr != nil && errno == nil {
+			g_last_was_large = true
+			g_head_waste = 0
+			g_tail_waste = 0
+			return byte_slice(ptr, size), nil
+		}
+	}
+	// 2 MB huge page
+	if aligned_size >= 2 * Megabyte || alignment >= 2 * Megabyte {
+		raw_flags : i32 = transmute(i32)(MMAP_FLAGS) | i32(linux.MAP_HUGE_2MB)
+		flags = transmute(linux.Map_Flags)(raw_flags)
+		flags += {.HUGETLB}
+		if ptr, errno := linux.mmap(0, uint(aligned_size), MMAP_PROT, flags); ptr != nil && errno == nil {
+			g_last_was_large = true
+			g_head_waste = 0
+			g_tail_waste = 0
+			return byte_slice(ptr, size), nil
+		}
+	}
+	g_last_was_large = false
+	ptr, errno := linux.mmap(0, uint(mapping_size), MMAP_PROT, MMAP_FLAGS)
+	if errno != nil || ptr == nil {
+		return nil, .Out_Of_Memory
+	}
+
+	// If these don't match, we added extra for alignment.
+	// Find the correct alignment, and unmap the waste.
+	if aligned_size != mapping_size {
+		aligned_ptr := align_forward_uintptr(uintptr(ptr), uintptr(aligned_alignment))
+
+		g_head_waste = int(aligned_ptr - uintptr(ptr))
+		g_tail_waste = (aligned_alignment - PAGE_SIZE) - g_head_waste
+		if g_head_waste > 0 {
+			linux.munmap(ptr, uint(g_head_waste))
+		}
+		if g_tail_waste > 0 {
+			linux.munmap(rawptr(aligned_ptr + uintptr(aligned_size)), uint(g_tail_waste))
+		}
+		ptr = rawptr(aligned_ptr)
+	}
+	return byte_slice(ptr, size), nil
+}
+
+_page_allocator_aligned_resize :: proc(old_ptr: rawptr,
+	                               old_size, new_size, new_align: int,
+				       flags: Page_Allocator_Flags) -> (new_memory: []byte, err: Allocator_Error) {
+	if old_ptr == nil {
+		return nil, nil
+	}
+	if !page_aligned(old_ptr) {
+		return nil, .Invalid_Pointer
+	}
+	new_ptr: rawptr
+
+	new_align := new_align
+
+	aligned_size      := align_forward_int(new_size, PAGE_SIZE)
+	aligned_alignment := align_forward_int(new_align, PAGE_SIZE)
+
+	// If we meet all our alignment requirements or we're not allowed to move,
+	// we may be able to get away with doing nothing at all or growing in place.
+	errno: linux.Errno
+	if .Unmovable_Pages in flags || ((uintptr(aligned_alignment) - 1) & uintptr(old_ptr)) == 0 {
+		if aligned_size == align_forward_int(old_size, PAGE_SIZE) {
+			return byte_slice(old_ptr, old_size), nil
+		}
+		
+		new_ptr, errno = linux.mremap(old_ptr, uint(old_size) , uint(new_size), {.FIXED})
+		if new_ptr != nil && errno == nil {
+			return byte_slice(new_ptr, new_size), nil
+		}
+		if .Unmovable_Pages in flags {
+			return byte_slice(old_ptr, old_size), .Out_Of_Memory
+		}
+	}
+
+	// If you want greater than page size alignment (and we failed to expand in place above),
+	// send to aligned_alloc, manually copy the conents, and unmap the old mapping.
+	if aligned_alignment > PAGE_SIZE {
+		new_bytes: []u8
+		new_align      = align_forward_int(new_align, PAGE_ALLOCATOR_MAX_ALIGNMENT)
+		new_bytes, err = _page_allocator_aligned_alloc(new_size, new_align, flags)
+		if new_bytes == nil || err != nil {
+			return byte_slice(old_ptr, old_size), err == nil ? .Out_Of_Memory : err
+		}
+
+		copy_non_overlapping(&new_bytes[0], old_ptr, old_size)
+		linux.munmap(old_ptr, align_forward_uint(uint(old_size), PAGE_SIZE))
+
+		return new_bytes[:new_size], nil
+	}
+
+	new_ptr, errno = linux.mremap(old_ptr,
+	                              align_forward_uint(uint(old_size), PAGE_SIZE),
+	                              uint(aligned_size),
+	                              {.MAYMOVE})
+	if new_ptr == nil || errno != nil {
+		return nil, .Out_Of_Memory
+	}
+	return byte_slice(new_ptr, new_size), nil
+}
+
+_page_allocator_free :: proc(p: rawptr, size: int) -> Allocator_Error {
+	if p != nil && size >= 0 && page_aligned(p) && page_aligned(rawptr(uintptr(size))) {
+		errno := linux.munmap(p, uint(size))
+		return errno == nil ? nil : .Invalid_Pointer
+	}
+	return .Invalid_Argument
+}
+
+_set_system_large_page_count :: proc(count: int) -> (okay: bool) {
+	// TODO: write to /proc/sys/vm/nr_hugepages
+	return false
+}

--- a/core/mem/page_allocator_linux.odin
+++ b/core/mem/page_allocator_linux.odin
@@ -5,7 +5,7 @@ import "core:sys/linux"
 
 _PAGE_SIZE                    :: 4 * Kilobyte
 when size_of(rawptr) == 8 {
-	_PAGE_ALLOCATOR_MAX_ALIGNMENT :: 1 * Terabyte
+	_PAGE_ALLOCATOR_MAX_ALIGNMENT :: 32 * Gigabyte
 } else {
 	_PAGE_ALLOCATOR_MAX_ALIGNMENT :: 1 * Gigabyte
 }
@@ -140,8 +140,9 @@ _page_allocator_aligned_resize :: proc(old_ptr: rawptr,
 }
 
 _page_allocator_free :: proc(p: rawptr, size: int) -> Allocator_Error {
-	if p != nil && size >= 0 && page_aligned(p) && page_aligned(rawptr(uintptr(size))) {
-		errno := linux.munmap(p, uint(size))
+	if p != nil && size >= 0 && page_aligned(p) {
+		aligned_size := align_forward_uint(uint(size), PAGE_SIZE)
+		errno := linux.munmap(p, aligned_size)
 		return errno == nil ? nil : .Invalid_Pointer
 	}
 	return .Invalid_Argument

--- a/core/mem/page_allocator_linux.odin
+++ b/core/mem/page_allocator_linux.odin
@@ -4,7 +4,11 @@ package mem
 import "core:sys/linux"
 
 _PAGE_SIZE                    :: 4 * Kilobyte
-_PAGE_ALLOCATOR_MAX_ALIGNMENT :: 1 * Terabyte
+when size_of(rawptr) == 8 {
+	_PAGE_ALLOCATOR_MAX_ALIGNMENT :: 1 * Terabyte
+} else {
+	_PAGE_ALLOCATOR_MAX_ALIGNMENT :: 1 * Gigabyte
+}
 
 // unused
 _Page_Allocator_Platform_Data :: uintptr

--- a/core/sys/linux/bits.odin
+++ b/core/sys/linux/bits.odin
@@ -562,6 +562,14 @@ Map_Flags_Bits :: enum {
 }
 
 /*
+	Specific sized constants for .HUGETLB
+	that can be transmuted into Map_Flags.
+*/
+MAP_HUGE_SHIFT :: 26
+MAP_HUGE_2MB   :: 21 << MAP_HUGE_SHIFT
+MAP_HUGE_1GB   :: 30 << MAP_HUGE_SHIFT
+
+/*
 	Bits for MLock_Flags
 */
 MLock_Flags_Bits :: enum {


### PR DESCRIPTION
Do we want something like this in `mem`?  This thing really shines as a allocator for making .. more allocators =]  It birthed itself as I was working on a new heap_alloc, but I think it makes a great addition as a generic Allocator as well.

It's super power is in it's ability to provide arbitrary alignment.  It does this by over-allocating (virtual) pages,  finding our target alignment, then tossing the extras right back to the operating system.

Here, it is running something akin to `runtime.new_aligned(int, X)` on various alignments:

```none
 Align Request  | Tail       | Head       | Address
----------------|------------|------------|-------------
align_of(int)   | ????       | ????       |7F75813ED000
0000000000000400|000000000000|000000000000|7F75813EC000
0000000000000800|000000000000|000000000000|7F75813EB000
0000000000001000|000000000000|000000000000|7F75813EA000
0000000000002000|000000004096|000000000000|7F75813E8000
0000000000010000|000000028672|000000032768|7F75813E0000
0000000000040000|000000188416|000000069632|7F75810C0000
0000000000100000|000000782336|000000262144|7F7581000000
0000000000800000|000008384512|000000000000|7F7580800000
0000000008000000|000008384512|000125829120|7F7580000000
0000000200000000|006442446848|002147483648|7F7400000000  << 8 GB alignment
```

With the systems large page count set up (large pages do not currently over-allocate or align beyond 2 MB):
```none
 Align Request  | Tail       | Head       | Address
----------------|------------|------------|-------------
align_of(int)   | ????       | ????       |7FBBF107E000
0000000000000400|000000000000|000000000000|7FBBF107D000
0000000000000800|000000000000|000000000000|7FBBF107C000
0000000000001000|000000000000|000000000000|7FBBF107B000
0000000000002000|000000000000|000000004096|7FBBF107A000
0000000000010000|000000036864|000000024576|7FBBF1070000
0000000000040000|000000258048|000000000000|7FBBF0D40000
0000000000100000|000000258048|000000786432|7FBBF0D00000
0000000000800000|000000000000|000000000000|7FBBF0A00000 # large pages
0000000008000000|000000000000|000000000000|7FBBF0800000 # large pages
0000000200000000|000000000000|000000000000|7FBBF0600000 # large pages
```

E: 32 GB alignment with 4K pages because no one asked..
```none
 Align Request  | Tail       | Head       | Address
----------------|------------|------------|-------------
align_of(int)   | ????       | ????       |7FE3CFCDD000
0000000000000400|000000000000|000000000000|7FE3CFCDC000
0000000000000800|000000000000|000000000000|7FE3CFCDB000
0000000000001000|000000000000|000000000000|7FE3CFCDA000
0000000000002000|000000001000|000000000000|7FE3CFCD8000
0000000000004000|000000003000|000000000000|7FE3CFCD4000
0000000000008000|000000003000|000000004000|7FE3CFCD0000
0000000000010000|00000000f000|000000000000|7FE3CFCC0000
0000000000040000|00000001e000|000000021000|7FE3CF9C0000
0000000000100000|0000000bf000|000000040000|7FE3CF900000
0000000000800000|0000000ff000|000000700000|7FE3CF800000
0000000008000000|0000077ff000|000000800000|7FE3C8000000
0000000200000000|0001c7fff000|000038000000|7FE200000000
0000000800000000|0001fffff000|000600000000|7FE000000000
```