### PR TITLE
revert `$(llvm-config --bindir)/clang++` to get the cpp compiler

### DIFF
--- a/build_odin.sh
+++ b/build_odin.sh
@@ -45,7 +45,13 @@ if [ -z "$LLVM_CONFIG" ]; then
 	fi
 fi
 
-: ${CXX=$($LLVM_CONFIG --bindir)/clang++}
+if [ -x "$(which clang++)" ]; then
+	: ${CXX="clang++"}
+elif [ -x "$($LLVM_CONFIG --bindir)/clang++" ]; then
+	: ${CXX=$($LLVM_CONFIG --bindir)/clang++}
+else
+	error "No clang++ command found. Set CXX to proceed."
+fi
 
 LLVM_VERSION="$($LLVM_CONFIG --version)"
 LLVM_VERSION_MAJOR="$(echo $LLVM_VERSION | awk -F. '{print $1}')"


### PR DESCRIPTION
A few reports of either people not having this clang++ or having it but it not finding system headers. On top of that, the reason we added this in the first place was a bug that surfaced on clang-18 which we've since fixed.

Order will now be clang++ from path, then the llvm bindir clang++, then an error.

This can all still be overwritten with `CXX=blah make` like before.