### PR TITLE
Make destroy_file_logger take logger instead of logger pointer.

### DIFF
--- a/core/log/file_console_logger.odin
+++ b/core/log/file_console_logger.odin
@@ -42,7 +42,7 @@ create_file_logger :: proc(h: os.Handle, lowest := Level.Debug, opt := Default_F
 	return Logger{file_console_logger_proc, data, lowest, opt}
 }
 
-destroy_file_logger :: proc(log: ^Logger) {
+destroy_file_logger :: proc(log: Logger) {
 	data := cast(^File_Console_Logger_Data)log.data
 	if data.file_handle != os.INVALID_HANDLE {
 		os.close(data.file_handle)


### PR DESCRIPTION
![Screenshot 2024-05-27 162004](https://github.com/odin-lang/Odin/assets/1799756/989ac624-7c89-40c4-8706-79aa5bc22abe)
