### PR TITLE
Fix open() foreign libc signature on Darwin

### DIFF
--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -442,7 +442,7 @@ F_GETPATH :: 50 // return the full path of the fd
 foreign libc {
 	@(link_name="__error") __error :: proc() -> ^c.int ---
 
-	@(link_name="open")             _unix_open          :: proc(path: cstring, flags: i32, mode: u16) -> Handle ---
+	@(link_name="open")             _unix_open          :: proc(path: cstring, flags: i32, #c_vararg args: ..any) -> Handle ---
 	@(link_name="close")            _unix_close         :: proc(handle: Handle) -> c.int ---
 	@(link_name="read")             _unix_read          :: proc(handle: Handle, buffer: rawptr, count: c.size_t) -> int ---
 	@(link_name="write")            _unix_write         :: proc(handle: Handle, buffer: rawptr, count: c.size_t) -> int ---


### PR DESCRIPTION
Darwin's `open` signature expects a vararg at the end instead of a `mode_t`, even though that's what the third parameter corresponds to:

https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/open.2.html
```c
int     open(const char *, int, ...) __DARWIN_ALIAS_C(open);
```

Currently the binding takes a `mode_t` which yields incorrect file permissions.

For instance, specifiying `os.S_IRUSR | os.S_IWUSR | os.S_IRGRP | os.S_IWGRP | os.S_IROTH | os.S_IWOTH` results in the incorrect file permissions:

```shell
-------r-x   1 ******  staff  93679 May 27 11:47 debug_draw.sdr
```

With this fix it yields the correct permissions, given the systems umask of `022`:

```shell
-rw-r--r--   1 ******  staff  93679 May 27 11:50 debug_draw.sdr

```

