### PR TITLE
Remove unused code in `internal_random_prime`

### DIFF
--- a/core/math/big/prime.odin
+++ b/core/math/big/prime.odin
@@ -1188,9 +1188,6 @@ internal_random_prime :: proc(a: ^Int, size_in_bits: int, trials: int, flags := 
 	flags  := flags
 	trials := trials
 
-	t := &Int{}
-	defer internal_destroy(t)
-
 	/*
 		Sanity check the input.
 	*/


### PR DESCRIPTION
It looks like it's there for a reason, but it's never referred to again.