### PR TITLE
Take logger itself, not a pointer to logger in multi-logger destructor.

### DIFF
--- a/core/log/multi_logger.odin
+++ b/core/log/multi_logger.odin
@@ -12,11 +12,10 @@ create_multi_logger :: proc(logs: ..Logger) -> Logger {
 	return Logger{multi_logger_proc, data, Level.Debug, nil}
 }
 
-destroy_multi_logger :: proc(log : ^Logger) {
+destroy_multi_logger :: proc(log: Logger) {
 	data := (^Multi_Logger_Data)(log.data)
 	delete(data.loggers)
-	free(log.data)
-	log^ = nil_logger()
+	free(data)
 }
 
 multi_logger_proc :: proc(logger_data: rawptr, level: Level, text: string,


### PR DESCRIPTION
Related to https://github.com/odin-lang/Odin/pull/3639

```odin
file_logger := log.create_file_logger(handle)
defer log.destroy_file_logger(file_logger)

console_logger := log.create_console_logger()
defer log.destroy_console_logger(console_logger)

context.logger = log.create_multi_logger(file_logger, console_logger)
defer log.destroy_multi_logger(context.logger) // <--- this now works
```