### PR TITLE
darwin: fix sysroot retrieval for some systems

### DIFF
--- a/build_odin.sh
+++ b/build_odin.sh
@@ -71,8 +71,8 @@ Darwin)
 	fi
 
 	darwin_sysroot=
-	if [ $(which xcode-select) ]; then
-		darwin_sysroot="--sysroot $(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+	if [ $(which xcrun) ]; then
+		darwin_sysroot="--sysroot $(xcrun --sdk macosx --show-sdk-path)"
 	elif [[ -e "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" ]]; then
 		darwin_sysroot="--sysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
 	else


### PR DESCRIPTION
Got a report on Discord that the current way didn't work for a user, this change did work and I confirmed with @harold-b (who initially added this) that it also works for them and is actually a better way.