### PR TITLE
core:sys/linux - Add support for Unix Domain Socket addresses

### DIFF
--- a/core/sys/linux/sys.odin
+++ b/core/sys/linux/sys.odin
@@ -487,6 +487,7 @@ connect :: proc "contextless" (sock: Fd, addr: ^$T) -> (Errno)
 where
 	T == Sock_Addr_In ||
 	T == Sock_Addr_In6 ||
+	T == Sock_Addr_Un ||
 	T == Sock_Addr_Any
 {
 	ret := syscall(SYS_connect, sock, addr, size_of(T))
@@ -502,6 +503,7 @@ accept :: proc "contextless" (sock: Fd, addr: ^$T, sockflags: Socket_FD_Flags = 
 where
 	T == Sock_Addr_In ||
 	T == Sock_Addr_In6 ||
+	T == Sock_Addr_Un ||
 	T == Sock_Addr_Any
 {
 	addr_len: i32 = size_of(T)
@@ -514,6 +516,7 @@ recvfrom :: proc "contextless" (sock: Fd, buf: []u8, flags: Socket_Msg, addr: ^$
 where
 	T == Sock_Addr_In ||
 	T == Sock_Addr_In6 ||
+	T == Sock_Addr_Un ||
 	T == Sock_Addr_Any
 {
 	addr_len: i32 = size_of(T)
@@ -531,6 +534,7 @@ sendto :: proc "contextless" (sock: Fd, buf: []u8, flags: Socket_Msg, addr: ^$T)
 where
 	T == Sock_Addr_In ||
 	T == Sock_Addr_In6 ||
+	T == Sock_Addr_Un ||
 	T == Sock_Addr_Any
 {
 	ret := syscall(SYS_sendto, sock, raw_data(buf), len(buf), transmute(i32) flags, addr, size_of(T))
@@ -590,6 +594,7 @@ bind :: proc "contextless" (sock: Fd, addr: ^$T) -> (Errno)
 where
 	T == Sock_Addr_In ||
 	T == Sock_Addr_In6 ||
+	T == Sock_Addr_Un ||
 	T == Sock_Addr_Any
 {
 	ret := syscall(SYS_bind, sock, addr, size_of(T))

--- a/core/sys/linux/types.odin
+++ b/core/sys/linux/types.odin
@@ -632,6 +632,14 @@ Sock_Addr_In6 :: struct #packed {
 }
 
 /*
+  Struct representing Unix Domain Socket address
+*/
+Sock_Addr_Un :: struct #packed {
+	sun_family: Address_Family,
+	sun_path:   [108]u8
+}
+
+/*
 	Struct representing an arbitrary socket address.
 */
 Sock_Addr_Any :: struct #raw_union {
@@ -641,6 +649,7 @@ Sock_Addr_Any :: struct #raw_union {
 	},
 	using ipv4: Sock_Addr_In,
 	using ipv6: Sock_Addr_In6,
+	using uds: Sock_Addr_Un,
 }
 
 /*

--- a/core/sys/linux/types.odin
+++ b/core/sys/linux/types.odin
@@ -636,7 +636,7 @@ Sock_Addr_In6 :: struct #packed {
 */
 Sock_Addr_Un :: struct #packed {
 	sun_family: Address_Family,
-	sun_path:   [108]u8
+	sun_path:   [108]u8,
 }
 
 /*


### PR DESCRIPTION
This PR implements the `Sock_Addr_Un` type on the `core:sys/linux` package for convenience when dealing with Unix Domain sockets, and makes it so that the `connect`, `accept`, `bind`, `recvfrom`, `sendto` system call wrappers accept said type as a valid socket address:

```odin
/*
  Struct representing Unix Domain Socket address
*/
Sock_Addr_Un :: struct #packed {
	sun_family: Address_Family,
	sun_path:   [108]u8
}
```