### PR TITLE
wasm: fix target wasm64p32 runtime procs

### DIFF
--- a/base/runtime/procs.odin
+++ b/base/runtime/procs.odin
@@ -26,12 +26,18 @@ when ODIN_NO_CRT && ODIN_OS == .Windows {
 		return dst
 	}
 } else when ODIN_NO_CRT || (ODIN_ARCH == .wasm32 || ODIN_ARCH == .wasm64p32) {
+	// NOTE: on wasm, calls to these procs are generated (by LLVM) with type `i32` instead of `int`.
+	//
+	// NOTE: `#any_int` is also needed, because calls that we generate (and package code)
+	//       will be using `int` and need to be converted.
+	int_t :: i32 when ODIN_ARCH == .wasm64p32 else int
+
 	@(link_name="memset", linkage="strong", require)
-	memset :: proc "c" (ptr: rawptr, val: i32, len: int) -> rawptr {
+	memset :: proc "c" (ptr: rawptr, val: i32, #any_int len: int_t) -> rawptr {
 		if ptr != nil && len != 0 {
 			b := byte(val)
 			p := ([^]byte)(ptr)
-			for i := 0; i < len; i += 1 {
+			for i := int_t(0); i < len; i += 1 {
 				p[i] = b
 			}
 		}
@@ -39,10 +45,10 @@ when ODIN_NO_CRT && ODIN_OS == .Windows {
 	}
 
 	@(link_name="bzero", linkage="strong", require)
-	bzero :: proc "c" (ptr: rawptr, len: int) -> rawptr {
+	bzero :: proc "c" (ptr: rawptr, #any_int len: int_t) -> rawptr {
 		if ptr != nil && len != 0 {
 			p := ([^]byte)(ptr)
-			for i := 0; i < len; i += 1 {
+			for i := int_t(0); i < len; i += 1 {
 				p[i] = 0
 			}
 		}
@@ -50,7 +56,7 @@ when ODIN_NO_CRT && ODIN_OS == .Windows {
 	}
 
 	@(link_name="memmove", linkage="strong", require)
-	memmove :: proc "c" (dst, src: rawptr, len: int) -> rawptr {
+	memmove :: proc "c" (dst, src: rawptr, #any_int len: int_t) -> rawptr {
 		d, s := ([^]byte)(dst), ([^]byte)(src)
 		if d == s || len == 0 {
 			return dst
@@ -63,7 +69,7 @@ when ODIN_NO_CRT && ODIN_OS == .Windows {
 		}
 
 		if s > d && uintptr(s)-uintptr(d) < uintptr(len) {
-			for i := 0; i < len; i += 1 {
+			for i := int_t(0); i < len; i += 1 {
 				d[i] = s[i]
 			}
 			return dst
@@ -71,10 +77,10 @@ when ODIN_NO_CRT && ODIN_OS == .Windows {
 		return memcpy(dst, src, len)
 	}
 	@(link_name="memcpy", linkage="strong", require)
-	memcpy :: proc "c" (dst, src: rawptr, len: int) -> rawptr {
+	memcpy :: proc "c" (dst, src: rawptr, #any_int len: int_t) -> rawptr {
 		d, s := ([^]byte)(dst), ([^]byte)(src)
 		if d != s {
-			for i := 0; i < len; i += 1 {
+			for i := int_t(0); i < len; i += 1 {
 				d[i] = s[i]
 			}
 		}


### PR DESCRIPTION
LLVM generates calls with `i32` regardless of target, so if a call to any of these procs was generated this failed to compile (I mean it compiled, but `wasm-validate` fails and any wasm runners like the browser won't run it).

I opted to fix by changing from `int` to `i32` on wasm64p32 and adding `#any_int` so existing code calling with `int` keeps working.