### PR TITLE
Add missing FlushConsoleInputBuffer procedure to core/sys/windows/kernel32.odin

### DIFF
--- a/core/sys/windows/kernel32.odin
+++ b/core/sys/windows/kernel32.odin
@@ -441,6 +441,8 @@ foreign kernel32 {
 	GetConsoleCursorInfo :: proc(hConsoleOutput: HANDLE, lpConsoleCursorInfo: PCONSOLE_CURSOR_INFO) -> BOOL ---
 	SetConsoleCursorInfo :: proc(hConsoleOutput: HANDLE, lpConsoleCursorInfo: PCONSOLE_CURSOR_INFO) -> BOOL ---
 
+	FlushConsoleInputBuffer :: proc(hConsoleInput: HANDLE) -> BOOL ---
+
 	GetDiskFreeSpaceExW :: proc(
 		lpDirectoryName: LPCWSTR,
 		lpFreeBytesAvailableToCaller: PULARGE_INTEGER,


### PR DESCRIPTION
While working on a project, I noticed that the procedure was missing.  The Microsoft documentation for `FlushConsoleInputBuffer` can be found [here](https://learn.microsoft.com/en-us/windows/console/flushconsoleinputbuffer).