### PR TITLE
Add missing `Raw_*` complex and quaternion types

### DIFF
--- a/base/runtime/core.odin
+++ b/base/runtime/core.odin
@@ -470,6 +470,12 @@ Raw_Soa_Pointer :: struct {
 	index: int,
 }
 
+Raw_Complex64     :: struct {real, imag: f32}
+Raw_Complex128    :: struct {real, imag: f64}
+Raw_Quaternion128 :: struct {imag, jmag, kmag: f32, real: f32}
+Raw_Quaternion256 :: struct {imag, jmag, kmag: f64, real: f64}
+Raw_Quaternion128_Vector_Scalar :: struct {vector: [3]f32, scalar: f32}
+Raw_Quaternion256_Vector_Scalar :: struct {vector: [3]f64, scalar: f64}
 
 
 /*

--- a/base/runtime/core.odin
+++ b/base/runtime/core.odin
@@ -470,10 +470,13 @@ Raw_Soa_Pointer :: struct {
 	index: int,
 }
 
+Raw_Complex32     :: struct {real, imag: f16}
 Raw_Complex64     :: struct {real, imag: f32}
 Raw_Complex128    :: struct {real, imag: f64}
+Raw_Quaternion64  :: struct {imag, jmag, kmag: f16, real: f16}
 Raw_Quaternion128 :: struct {imag, jmag, kmag: f32, real: f32}
 Raw_Quaternion256 :: struct {imag, jmag, kmag: f64, real: f64}
+Raw_Quaternion64_Vector_Scalar  :: struct {vector: [3]f16, scalar: f16}
 Raw_Quaternion128_Vector_Scalar :: struct {vector: [3]f32, scalar: f32}
 Raw_Quaternion256_Vector_Scalar :: struct {vector: [3]f64, scalar: f64}
 

--- a/core/math/linalg/general.odin
+++ b/core/math/linalg/general.odin
@@ -3,6 +3,7 @@ package linalg
 import "core:math"
 import "base:builtin"
 import "base:intrinsics"
+import "base:runtime"
 
 // Generic
 
@@ -223,33 +224,27 @@ quaternion_mul_quaternion :: proc "contextless" (q1, q2: $Q) -> Q where IS_QUATE
 
 @(require_results)
 quaternion64_mul_vector3 :: proc "contextless" (q: $Q/quaternion64, v: $V/[3]$F/f16) -> V {
-	Raw_Quaternion :: struct {xyz: [3]f16, r: f16}
-
-	q := transmute(Raw_Quaternion)q
+	q := transmute(runtime.Raw_Quaternion64_Vector_Scalar)q
 	v := v
 
-	t := cross(2*q.xyz, v)
-	return V(v + q.r*t + cross(q.xyz, t))
+	t := cross(2*q.vector, v)
+	return V(v + q.scalar*t + cross(q.vector, t))
 }
 @(require_results)
 quaternion128_mul_vector3 :: proc "contextless" (q: $Q/quaternion128, v: $V/[3]$F/f32) -> V {
-	Raw_Quaternion :: struct {xyz: [3]f32, r: f32}
-
-	q := transmute(Raw_Quaternion)q
+	q := transmute(runtime.Raw_Quaternion128_Vector_Scalar)q
 	v := v
 
-	t := cross(2*q.xyz, v)
-	return V(v + q.r*t + cross(q.xyz, t))
+	t := cross(2*q.vector, v)
+	return V(v + q.scalar*t + cross(q.vector, t))
 }
 @(require_results)
 quaternion256_mul_vector3 :: proc "contextless" (q: $Q/quaternion256, v: $V/[3]$F/f64) -> V {
-	Raw_Quaternion :: struct {xyz: [3]f64, r: f64}
-
-	q := transmute(Raw_Quaternion)q
+	q := transmute(runtime.Raw_Quaternion256_Vector_Scalar)q
 	v := v
 
-	t := cross(2*q.xyz, v)
-	return V(v + q.r*t + cross(q.xyz, t))
+	t := cross(2*q.vector, v)
+	return V(v + q.scalar*t + cross(q.vector, t))
 }
 quaternion_mul_vector3 :: proc{quaternion64_mul_vector3, quaternion128_mul_vector3, quaternion256_mul_vector3}
 

--- a/core/mem/raw.odin
+++ b/core/mem/raw.odin
@@ -11,13 +11,6 @@ Raw_Dynamic_Array :: runtime.Raw_Dynamic_Array
 Raw_Map           :: runtime.Raw_Map
 Raw_Soa_Pointer   :: runtime.Raw_Soa_Pointer
 
-Raw_Complex64     :: struct {real, imag: f32}
-Raw_Complex128    :: struct {real, imag: f64}
-Raw_Quaternion128 :: struct {imag, jmag, kmag: f32, real: f32}
-Raw_Quaternion256 :: struct {imag, jmag, kmag: f64, real: f64}
-Raw_Quaternion128_Vector_Scalar :: struct {vector: [3]f32, scalar: f32}
-Raw_Quaternion256_Vector_Scalar :: struct {vector: [3]f64, scalar: f64}
-
 make_any :: proc "contextless" (data: rawptr, id: typeid) -> any {
 	return transmute(any)Raw_Any{data, id}
 }

--- a/core/mem/raw.odin
+++ b/core/mem/raw.odin
@@ -11,6 +11,16 @@ Raw_Dynamic_Array :: runtime.Raw_Dynamic_Array
 Raw_Map           :: runtime.Raw_Map
 Raw_Soa_Pointer   :: runtime.Raw_Soa_Pointer
 
+Raw_Complex32     :: runtime.Raw_Complex32
+Raw_Complex64     :: runtime.Raw_Complex64
+Raw_Complex128    :: runtime.Raw_Complex128
+Raw_Quaternion64  :: runtime.Raw_Quaternion64
+Raw_Quaternion128 :: runtime.Raw_Quaternion128
+Raw_Quaternion256 :: runtime.Raw_Quaternion256
+Raw_Quaternion64_Vector_Scalar  :: runtime.Raw_Quaternion64_Vector_Scalar
+Raw_Quaternion128_Vector_Scalar :: runtime.Raw_Quaternion128_Vector_Scalar
+Raw_Quaternion256_Vector_Scalar :: runtime.Raw_Quaternion256_Vector_Scalar
+
 make_any :: proc "contextless" (data: rawptr, id: typeid) -> any {
 	return transmute(any)Raw_Any{data, id}
 }


### PR DESCRIPTION
I'm not sure why those types were defined in `core:mem`, but I moved them to `base:runtime` where the other `Raw_*` types live.

To be clear, this adds the following types to `base:runtime`:
```odin
Raw_Complex32     :: struct {real, imag: f16}
Raw_Quaternion64  :: struct {imag, jmag, kmag: f16, real: f16}
Raw_Quaternion64_Vector_Scalar  :: struct {vector: [3]f16, scalar: f16}
```