### PR TITLE
fix passing pointer to constant in non-odin cc

### DIFF
--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -1097,15 +1097,7 @@ gb_internal lbValue lb_emit_call(lbProcedure *p, lbValue value, Array<lbValue> c
 						ptr = lb_address_from_load_or_generate_local(p, x);
 					}
 				} else {
-					if (LLVMIsConstant(x.value)) {
-						// NOTE(bill): if the value is already constant, then just it as a global variable
-						// and pass it by pointer
-						lbAddr addr = lb_add_global_generated(p->module, original_type, x);
-						lb_make_global_private_const(addr);
-						ptr = addr.addr;
-					} else {
-						ptr = lb_copy_value_to_ptr(p, x, original_type, 16);
-					}
+					ptr = lb_copy_value_to_ptr(p, x, original_type, 16);
 				}
 				array_add(&processed_args, ptr);
 			}


### PR DESCRIPTION
On calling conventions other than Odin, we can't pass pointers to constant globals to functions

Fixes #2837 