### PR TITLE
Strike incorrect note from `parse_f64_prefix` doc

### DIFF
--- a/core/strconv/strconv.odin
+++ b/core/strconv/strconv.odin
@@ -835,17 +835,21 @@ Example:
 
 		n, _, ok = strconv.parse_f64_prefix("12.34e2")
 		fmt.printfln("%.3f %v", n, ok)
+
+		n, _, ok = strconv.parse_f64_prefix("13.37 hellope")
+		fmt.printfln("%.3f %v", n, ok)
 	}
 
 Output:
 
 	0.000 false
 	1234.000 true
+	13.370 true
 
 **Returns**  
 - value: The parsed 64-bit floating point number.
 - nr: The length of the parsed substring.
-- ok: `false` if a base 10 float could not be found, or if the input string contained more than just the number.
+- ok: `false` if a base 10 float could not be found
 */
 parse_f64_prefix :: proc(str: string) -> (value: f64, nr: int, ok: bool) {
 	common_prefix_len_ignore_case :: proc "contextless" (s, prefix: string) -> int {


### PR DESCRIPTION
During the development of #3677, I followed the API doc for `parse_f64_prefix` as described, but I eventually found that something like "32.0 hellope" would return true, despite what the `returns` comment said. I thought this was a bug and saved it for later. When I started digging around, I got the sense that it was the documentation that was in error and not the procedure itself.

Of course, I then recalled that the name of the proc ends in `_prefix`.

I've fixed the documentation comment and added a test case to show that it's supposed to return true in that case. Hopefully this brings a bit of clarity to the situation.