### PR TITLE
ARM64 support for NetBSD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build, Check, and Test
-      timeout-minutes: 25
+      timeout-minutes: 15
       uses: vmactions/netbsd-vm@v1
       with:
         release: "10.0"
@@ -31,6 +31,7 @@ jobs:
           ./odin version
           ./odin report
           ./odin check examples/all -vet -strict-style -target:netbsd_amd64
+          ./odin check examples/all -vet -strict-style -target:netbsd_arm64
           (cd tests/core; gmake all_bsd)
           (cd tests/internal; gmake all_bsd)
           (cd tests/issues; ./run.sh)

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1039,6 +1039,13 @@ gb_global TargetMetrics target_netbsd_amd64 = {
 	str_lit("x86_64-unknown-netbsd-elf"),
 };
 
+gb_global TargetMetrics target_netbsd_arm64 = {
+	TargetOs_netbsd,
+	TargetArch_arm64,
+	8, 8, 16, 16,
+	str_lit("aarch64-unknown-netbsd-elf"),
+};
+
 gb_global TargetMetrics target_haiku_amd64 = {
 	TargetOs_haiku,
 	TargetArch_amd64,
@@ -1154,8 +1161,10 @@ gb_global NamedTargetMetrics named_targets[] = {
 	{ str_lit("freebsd_amd64"),       &target_freebsd_amd64  },
 	{ str_lit("freebsd_arm64"),       &target_freebsd_arm64  },
 
-	{ str_lit("openbsd_amd64"),       &target_openbsd_amd64  },
 	{ str_lit("netbsd_amd64"),        &target_netbsd_amd64   },
+	{ str_lit("netbsd_arm64"),        &target_netbsd_arm64   },
+
+	{ str_lit("openbsd_amd64"),       &target_openbsd_amd64  },
 	{ str_lit("haiku_amd64"),         &target_haiku_amd64    },
 
 	{ str_lit("freestanding_wasm32"), &target_freestanding_wasm32 },
@@ -1916,7 +1925,11 @@ gb_internal void init_build_context(TargetMetrics *cross_target, Subtarget subta
 		#elif defined(GB_SYSTEM_OPENBSD)
 			metrics = &target_openbsd_amd64;
 		#elif defined(GB_SYSTEM_NETBSD)
-			metrics = &target_netbsd_amd64;
+			#if defined(GB_CPU_ARM)
+				metrics = &target_netbsd_arm64;
+			#else
+				metrics = &target_netbsd_amd64;
+			#endif
 		#elif defined(GB_SYSTEM_HAIKU)
 			metrics = &target_haiku_amd64;
 		#elif defined(GB_CPU_ARM)

--- a/src/gb/gb.h
+++ b/src/gb/gb.h
@@ -256,6 +256,7 @@ extern "C" {
 
 #if defined(GB_SYSTEM_NETBSD)
 	#include <stdio.h>
+	#include <lwp.h>
 	#define lseek64 lseek
 #endif
 
@@ -3027,6 +3028,8 @@ gb_inline u32 gb_thread_current_id(void) {
 	thread_id = find_thread(NULL);
 #elif defined(GB_SYSTEM_FREEBSD)
 	thread_id = pthread_getthreadid_np();
+#elif defined(GB_SYSTEM_NETBSD)
+	thread_id = (u32)_lwp_self();
 #else
 	#error Unsupported architecture for gb_thread_current_id()
 #endif

--- a/src/threading.cpp
+++ b/src/threading.cpp
@@ -494,6 +494,8 @@ gb_internal u32 thread_current_id(void) {
 	thread_id = find_thread(NULL);
 #elif defined(GB_SYSTEM_FREEBSD)
 	thread_id = pthread_getthreadid_np();
+#elif defined(GB_SYSTEM_NETBSD)
+	thread_id = (u32)_lwp_self();
 #else
 	#error Unsupported architecture for thread_current_id()
 #endif


### PR DESCRIPTION
First pass of arm64 support for NetBSD.
Tested with NetBSD 10.0 in QEMU using LLVM17 built from source.