### PR TITLE
Proper thread identification on NetBSD

### DIFF
--- a/core/os/os_netbsd.odin
+++ b/core/os/os_netbsd.odin
@@ -328,6 +328,11 @@ foreign dl {
 	@(link_name="dlerror")          _unix_dlerror       :: proc() -> cstring ---
 }
 
+@(private)
+foreign libc {
+	_lwp_self :: proc() -> i32 ---
+}
+
 // NOTE(phix): Perhaps share the following functions with FreeBSD if they turn out to be the same in the end.
 
 is_path_separator :: proc(r: rune) -> bool {
@@ -721,7 +726,7 @@ exit :: proc "contextless" (code: int) -> ! {
 }
 
 current_thread_id :: proc "contextless" () -> int {
-	return cast(int) unix.pthread_self()
+	return int(_lwp_self())
 }
 
 dlopen :: proc(filename: string, flags: int) -> rawptr {

--- a/core/os/os_netbsd.odin
+++ b/core/os/os_netbsd.odin
@@ -5,7 +5,6 @@ foreign import libc "system:c"
 
 import "base:runtime"
 import "core:strings"
-import "core:sys/unix"
 import "core:c"
 
 Handle :: distinct i32

--- a/core/sync/primitives_netbsd.odin
+++ b/core/sync/primitives_netbsd.odin
@@ -1,8 +1,12 @@
 //+private
 package sync
 
-import "core:sys/unix"
+foreign import libc "system:c"
+
+foreign libc {
+	_lwp_self :: proc "c" () -> i32 ---
+}
 
 _current_thread_id :: proc "contextless" () -> int {
-	return cast(int) unix.pthread_self()
+	return int(_lwp_self())
 }


### PR DESCRIPTION
This is the properer way of getting the thread id as an integer on NetBSD.