### PR TITLE
Updated SDL_CreateTexture to take `PixelFormatEnum` instead of `u32`

### DIFF
--- a/vendor/sdl2/sdl_render.odin
+++ b/vendor/sdl2/sdl_render.odin
@@ -76,7 +76,7 @@ foreign lib {
 	GetRenderer                  :: proc(window:   ^Window) -> ^Renderer ---
 	GetRendererInfo              :: proc(renderer: ^Renderer, info: ^RendererInfo) -> c.int ---
 	GetRendererOutputSize        :: proc(renderer: ^Renderer, w, h: ^c.int) -> c.int ---
-	CreateTexture                :: proc(renderer: ^Renderer, format: u32, access: TextureAccess, w, h: c.int) -> ^Texture ---
+	CreateTexture                :: proc(renderer: ^Renderer, format: PixelFormatEnum, access: TextureAccess, w, h: c.int) -> ^Texture ---
 	CreateTextureFromSurface     :: proc(renderer: ^Renderer, surface: ^Surface) -> ^Texture ---
 	QueryTexture                 :: proc(texture:  ^Texture, format: ^u32, access, w, h: ^c.int) -> c.int ---
 	SetTextureColorMod           :: proc(texture:  ^Texture, r, g, b: u8) -> c.int ---


### PR DESCRIPTION
This allows for passing `.RGBA8888` directly instead of `u32(SDL.PixelFormatEnum.RGBA8888)`.