### PR TITLE
add error message for unknown test log level

### DIFF
--- a/core/testing/runner.odin
+++ b/core/testing/runner.odin
@@ -53,6 +53,9 @@ get_log_level :: #force_inline proc() -> runtime.Logger_Level {
 		else when LOG_LEVEL == "warning" { return .Warning }
 		else when LOG_LEVEL == "error"   { return .Error   }
 		else when LOG_LEVEL == "fatal"   { return .Fatal   }
+		else {
+			#panic("Unknown `ODIN_TEST_LOG_LEVEL`: \"" + LOG_LEVEL + "\", possible levels are: \"debug\", \"info\", \"warning\", \"error\", or \"fatal\".")
+		}
 	}
 }
 


### PR DESCRIPTION
It would previously just be a compilation error about a missing return statement.