### PR TITLE
Fix thread deadlock

### DIFF
--- a/core/sync/futex_darwin.odin
+++ b/core/sync/futex_darwin.odin
@@ -52,7 +52,7 @@ _futex_wait_with_timeout :: proc "contextless" (f: ^Futex, expected: u32, durati
 		}
 	} else {
 
-	timeout_ns := u32(duration) * 1000
+	timeout_ns := u32(duration)
 	s := __ulock_wait(UL_COMPARE_AND_WAIT | ULF_NO_ERRNO, f, u64(expected), timeout_ns)
 	if s >= 0 {
 		return true


### PR DESCRIPTION
I debugged a deadlock that was rarely happening running the demo, this fixes that on my end, I also added a few more atomic operations (mainly to the flags) because -sanitize:thread was complaining about those.

Also it seems like the duration on darwin is calculated wrong, `time.Duration` is already in nanoseconds but it still does a `* 1000`.