### PR TITLE
Fix `%p` pointers not printing leading `0x`

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -1495,7 +1495,7 @@ fmt_pointer :: proc(fi: ^Info, p: rawptr, verb: rune) {
 	u := u64(uintptr(p))
 	switch verb {
 	case 'p', 'v', 'w':
-		if !fi.hash && verb == 'v' {
+		if !fi.hash {
 			io.write_string(fi.writer, "0x", &fi.n)
 		}
 		_fmt_int(fi, u, 16, false, 8*size_of(rawptr), __DIGITS_UPPER)

--- a/tests/core/fmt/test_core_fmt.odin
+++ b/tests/core/fmt/test_core_fmt.odin
@@ -259,7 +259,7 @@ test_pointers :: proc(t: ^testing.T) {
 }
 
 @(private)
-check :: proc(t: ^testing.T, exp: string, format: string, args: ..any) {
+check :: proc(t: ^testing.T, exp: string, format: string, args: ..any, loc := #caller_location) {
 	got := fmt.tprintf(format, ..args)
-	testing.expectf(t, got == exp, "(%q, %v): %q != %q", format, args, got, exp)
+	testing.expectf(t, got == exp, "(%q, %v): %q != %q", format, args, got, exp, loc = loc)
 }

--- a/tests/core/fmt/test_core_fmt.odin
+++ b/tests/core/fmt/test_core_fmt.odin
@@ -221,6 +221,43 @@ test_fmt_python_syntax :: proc(t: ^testing.T) {
 	check(t, "%!(MISSING CLOSE BRACE)%!(EXTRA 1)",          "{0", 1 )
 }
 
+@(test)
+test_pointers :: proc(t: ^testing.T) {
+	S :: struct { i: int }
+	a: rawptr
+	b: ^int
+	c: ^S
+	d: ^S = cast(^S)cast(uintptr)0xFFFF
+
+	check(t, "0x0", "%p", a)
+	check(t, "0x0", "%p", b)
+	check(t, "0x0", "%p", c)
+	check(t, "0xFFFF", "%p", d)
+
+	check(t, "0x0", "%#p", a)
+	check(t, "0x0", "%#p", b)
+	check(t, "0x0", "%#p", c)
+	check(t, "0xFFFF", "%#p", d)
+
+	check(t, "0x0",   "%v", a)
+	check(t, "0x0",   "%v", b)
+	check(t, "<nil>", "%v", c)
+
+	check(t, "0x0",   "%#v", a)
+	check(t, "0x0",   "%#v", b)
+	check(t, "<nil>", "%#v", c)
+
+	check(t, "0x0000", "%4p", a)
+	check(t, "0x0000", "%4p", b)
+	check(t, "0x0000", "%4p", c)
+	check(t, "0xFFFF", "%4p", d)
+
+	check(t, "0x0000", "%#4p", a)
+	check(t, "0x0000", "%#4p", b)
+	check(t, "0x0000", "%#4p", c)
+	check(t, "0xFFFF", "%#4p", d)
+}
+
 @(private)
 check :: proc(t: ^testing.T, exp: string, format: string, args: ..any) {
 	got := fmt.tprintf(format, ..args)


### PR DESCRIPTION
The documentation says that they should, but they do not.