### PR TITLE
fix large ints amd64 sysv abi

### DIFF
--- a/src/llvm_abi.cpp
+++ b/src/llvm_abi.cpp
@@ -900,7 +900,15 @@ namespace lbAbiAmd64SysV {
 		}
 
 		switch (LLVMGetTypeKind(t)) {
-		case LLVMIntegerTypeKind:
+		case LLVMIntegerTypeKind: {
+			i64 s = t_size;
+			while (s > 0) {
+				unify(cls, ix + off/8, RegClass_Int);
+				off += 8;
+				s   -= 8;
+			}
+			break;
+		}
 		case LLVMPointerTypeKind:
 		case LLVMHalfTypeKind:
 			unify(cls, ix + off/8, RegClass_Int);


### PR DESCRIPTION
Fixes #3707

This seems to match what clang does, (pass a 128 bit int as two 64 bit ints).