### PR TITLE
Add missing `string_to_int` alias in `core:math/big`

### DIFF
--- a/core/math/big/radix.odin
+++ b/core/math/big/radix.odin
@@ -315,6 +315,7 @@ int_atoi :: proc(res: ^Int, input: string, radix := i8(10), allocator := context
 
 
 atoi :: proc { int_atoi, }
+string_to_int :: int_atoi
 
 /*
 	We size for `string` by default.


### PR DESCRIPTION
The documentation in the header explicitly mentions `string_to_int` but it didn't exist.

I was going to implement `cstring_to_int` for `atoi` but then I realized untyped strings cause compilation confusion with procedure overloading, so I left it as-is.