### PR TITLE
Fix `or_or_<branch>` error message

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -516,7 +516,7 @@ gb_internal void syntax_error_with_verbose_va(TokenPos const &pos, TokenPos end,
 
 	if (pos.line == 0) {
 		error_out_empty();
-		error_out_coloured("Syntax_Error: ", TerminalStyle_Normal, TerminalColour_Red);
+		error_out_coloured("Syntax Error: ", TerminalStyle_Normal, TerminalColour_Red);
 		error_out_va(fmt, va);
 		error_out("\n");
 	} else {
@@ -527,7 +527,7 @@ gb_internal void syntax_error_with_verbose_va(TokenPos const &pos, TokenPos end,
 			error_out_pos(pos);
 		}
 		if (has_ansi_terminal_colours()) {
-			error_out_coloured("Syntax_Error: ", TerminalStyle_Normal, TerminalColour_Red);
+			error_out_coloured("Syntax Error: ", TerminalStyle_Normal, TerminalColour_Red);
 		}
 		error_out_va(fmt, va);
 		error_out("\n");

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -555,7 +555,7 @@ gb_internal Ast *ast_unary_expr(AstFile *f, Token op, Ast *expr) {
 		syntax_error_with_verbose(expr, "'or_return' within an unary expression not wrapped in parentheses (...)");
 		break;
 	case Ast_OrBranchExpr:
-		syntax_error_with_verbose(expr, "'or_%.*s' within an unary expression not wrapped in parentheses (...)", LIT(expr->OrBranchExpr.token.string));
+		syntax_error_with_verbose(expr, "'%.*s' within an unary expression not wrapped in parentheses (...)", LIT(expr->OrBranchExpr.token.string));
 		break;
 	}
 
@@ -583,7 +583,7 @@ gb_internal Ast *ast_binary_expr(AstFile *f, Token op, Ast *left, Ast *right) {
 		syntax_error_with_verbose(left, "'or_return' within a binary expression not wrapped in parentheses (...)");
 		break;
 	case Ast_OrBranchExpr:
-		syntax_error_with_verbose(left, "'or_%.*s' within a binary expression not wrapped in parentheses (...)", LIT(left->OrBranchExpr.token.string));
+		syntax_error_with_verbose(left, "'%.*s' within a binary expression not wrapped in parentheses (...)", LIT(left->OrBranchExpr.token.string));
 		break;
 	}
 	if (right) switch (right->kind) {
@@ -591,7 +591,7 @@ gb_internal Ast *ast_binary_expr(AstFile *f, Token op, Ast *left, Ast *right) {
 		syntax_error_with_verbose(right, "'or_return' within a binary expression not wrapped in parentheses (...)");
 		break;
 	case Ast_OrBranchExpr:
-		syntax_error_with_verbose(right, "'or_%.*s' within a binary expression not wrapped in parentheses (...)", LIT(right->OrBranchExpr.token.string));
+		syntax_error_with_verbose(right, "'%.*s' within a binary expression not wrapped in parentheses (...)", LIT(right->OrBranchExpr.token.string));
 		break;
 	}
 
@@ -3102,7 +3102,7 @@ gb_internal void parse_check_or_return(Ast *operand, char const *msg) {
 		syntax_error_with_verbose(operand, "'or_return' use within %s is not wrapped in parentheses (...)", msg);
 		break;
 	case Ast_OrBranchExpr:
-		syntax_error_with_verbose(operand, "'or_%.*s' use within %s is not wrapped in parentheses (...)", msg, LIT(operand->OrBranchExpr.token.string));
+		syntax_error_with_verbose(operand, "'%.*s' use within %s is not wrapped in parentheses (...)", msg, LIT(operand->OrBranchExpr.token.string));
 		break;
 	}
 }


### PR DESCRIPTION
I got an odd error message while trying out some of the `or_<branch>` features.

```
/tmp/odin/a.odin(5:12) Syntax_Error: 'or_or_break' within a binary expression not wrapped in parentheses (...)
	i % 2 == 0 or_break
	         ^~~~~~~~~^
```

```odin
package main

main :: proc() {
	for i in 0 ..< 10 {
		i % 2 == 0 or_break
	}
}
```

This PR fixes two problems. One is that `Syntax Error` is being printed with an underscore in this particular `syntax_error_with_verbose` function, and the other is the `or_or_` bit.