### PR TITLE
Add compilation-related constants

### DIFF
--- a/base/runtime/core.odin
+++ b/base/runtime/core.odin
@@ -560,6 +560,19 @@ Odin_Platform_Subtarget_Type :: type_of(ODIN_PLATFORM_SUBTARGET)
 */
 Odin_Sanitizer_Flags :: type_of(ODIN_SANITIZER_FLAGS)
 
+/*
+	// Defined internally by the compiler
+	Odin_Optimization_Mode :: enum int {
+		None       = -1,
+		Minimal    =  0,
+		Size       =  1,
+		Speed      =  2,
+		Aggressive =  3,
+	}
+
+	ODIN_OPTIMIZATION_MODE // is a constant
+*/
+Odin_Optimization_Mode :: type_of(ODIN_OPTIMIZATION_MODE)
 
 /////////////////////////////
 // Init Startup Procedures //

--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -1040,6 +1040,8 @@ gb_internal void init_universal(void) {
 		add_global_enum_constant(fields, "ODIN_ARCH", bc->metrics.arch);
 		add_global_string_constant("ODIN_ARCH_STRING", target_arch_names[bc->metrics.arch]);
 	}
+
+	add_global_string_constant("ODIN_MICROARCH_STRING", bc->microarch);
 	
 	{
 		GlobalEnumValue values[BuildMode_COUNT] = {
@@ -1131,6 +1133,17 @@ gb_internal void init_universal(void) {
 	add_global_constant("ODIN_COMPILE_TIMESTAMP", t_untyped_integer, exact_value_i64(odin_compile_timestamp()));
 
 	{
+		String version = {};
+
+		#ifdef GIT_SHA
+		version.text = cast(u8 *)GIT_SHA;
+		version.len = gb_strlen(GIT_SHA);
+		#endif
+
+		add_global_string_constant("ODIN_VERSION_HASH", version);
+	}
+
+	{
 		bool f16_supported = lb_use_new_pass_system();
 		if (is_arch_wasm()) {
 			f16_supported = false;
@@ -1167,6 +1180,18 @@ gb_internal void init_universal(void) {
 		add_global_constant("ODIN_SANITIZER_FLAGS", named_type, exact_value_u64(bc->sanitizer_flags));
 	}
 
+	{
+		GlobalEnumValue values[5] = {
+			{"None",      -1},
+			{"Minimal",    0},
+			{"Size",       1},
+			{"Speed",      2},
+			{"Aggressive", 3},
+		};
+
+		auto fields = add_global_enum_type(str_lit("Odin_Optimization_Mode"), values, gb_count_of(values));
+		add_global_enum_constant(fields, "ODIN_OPTIMIZATION_MODE", bc->optimization_level);
+	}
 
 
 // Builtin Procedures


### PR DESCRIPTION
`ODIN_VERSION_HASH` is the `git` SHA hash of the commit the Odin compiler was built with.

`ODIN_MICROARCH_STRING` is the string passed to `-microarch` when the program was built.

`ODIN_OPTIMIZATION_MODE` is an enum value of which optimization mode was used to build the program.

Resolves #2240

(`ODIN_NO_BOUNDS_CHECK` already exists at this time, compared to the then-proposed `ODIN_DISABLE_BOUNDS_CHECK`.)