### PR TITLE
Fix `core:odin/parser` not parsing `label: #reverse`

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -3514,9 +3514,21 @@ parse_simple_stmt :: proc(p: ^Parser, flags: Stmt_Allow_Flags) -> ^ast.Stmt {
 		}
 	case op.kind == .Colon:
 		expect_token_after(p, .Colon, "identifier list")
-		if .Label in flags && len(lhs) == 1 {
+		colon_label_block: if .Label in flags && len(lhs) == 1 {
 			#partial switch p.curr_tok.kind {
-			case .Open_Brace, .If, .For, .Switch:
+			case .Open_Brace, .If, .For, .Switch, .Hash:
+				if p.curr_tok.kind == .Hash {
+					name := peek_token(p)
+					switch name.text {
+					case "reverse":
+						expect_token(p, .Hash)
+						expect_token(p, .Ident)
+						break
+					case:
+						break colon_label_block
+					}
+				}
+
 				label := lhs[0]
 				stmt := parse_stmt(p)
 


### PR DESCRIPTION
I had a look at the AST with `ast.inspect` using print statements to make sure the loop is parsed as a `reverse` loop on the right line and column, tried something like `label: #force_inline` to make sure it still erred out, and I think it's working properly - as in no unexpected errors, but I haven't a good way to visualize and verify that the AST is in a precisely correct construction, just as an advisory.

Fixes #3715

**EDIT**: Well, that's unfortunate. I didn't run tests locally. I suppose it was too good to be true to be so easy to fix.