### PR TITLE
Handle empty structs in hash (#v) fmt

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -1973,11 +1973,13 @@ fmt_struct :: proc(fi: ^Info, v: any, the_verb: rune, info: runtime.Type_Info_St
 	// fi.hash = false;
 	fi.indent += 1
 
-	if !is_soa && hash {
+	is_empty := len(info.names) == 0
+
+	if !is_soa && hash && !is_empty {
 		io.write_byte(fi.writer, '\n', &fi.n)
 	}
 	defer {
-		if hash {
+		if !is_soa && hash && !is_empty {
 			for _ in 0..<indent { io.write_byte(fi.writer, '\t', &fi.n) }
 		}
 		io.write_byte(fi.writer, ']' if is_soa && the_verb == 'v' else '}', &fi.n)
@@ -2025,9 +2027,9 @@ fmt_struct :: proc(fi: ^Info, v: any, the_verb: rune, info: runtime.Type_Info_St
 			}
 			io.write_string(fi.writer, base_type_name, &fi.n)
 			io.write_byte(fi.writer, '{', &fi.n)
-			if hash { io.write_byte(fi.writer, '\n', &fi.n) }
+			if hash && !is_empty { io.write_byte(fi.writer, '\n', &fi.n) }
 			defer {
-				if hash {
+				if hash && !is_empty {
 					fi.indent -= 1
 					fmt_write_indent(fi)
 					fi.indent += 1
@@ -2074,6 +2076,10 @@ fmt_struct :: proc(fi: ^Info, v: any, the_verb: rune, info: runtime.Type_Info_St
 
 				if hash { io.write_string(fi.writer, ",\n", &fi.n) }
 			}
+		}
+
+		if hash && n > 0 {
+			for _ in 0..<indent { io.write_byte(fi.writer, '\t', &fi.n) }
 		}
 	} else {
 		field_count := -1


### PR DESCRIPTION
Added a few checks to handle hash formatting empty structs. They now behave the same as empty arrays.

P.S. Cursed(?) Bonus: Now you can use empty structs as headers in your mega thicc structs. :)
P.P.S. `fmt_struct` might benefit from a refactor now that we have a better understanding of its requirements.

```odin
package main

import "core:fmt"

o: struct {

	__EMPTY_STRUCTS_____________________________________: struct {},

	empty: struct {},
	empty_one: struct { one: struct{} },
	empty_two: struct { one: struct{}, two: struct{} },

	__EMPTY_STRUCT_ARRAYS_______________________________: struct {},

	empty_array_zero: [0]struct{},
	empty_array_one: [1]struct{},
	empty_array_two: [2]struct{},

	__EMPTY_STRUCT_SOA_ARRAYS___________________________: struct {},

	empty_soa_array_zero: #soa [0]struct{},
	empty_soa_array_one: #soa [1]struct{},
	empty_soa_array_two: #soa [2]struct{},

	__STRUCTS___________________________________________: struct {},

	one: struct { one: u32 },
	two: struct { one: u32, two: u32 },

	__STRUCT_ARRAYS_____________________________________: struct {},

	array_one: [0]struct{ one: u32 },
	array_two: [2]struct{ one: u32, two: u32 },

	__STRUCT_SOA_ARRAYS_________________________________: struct {},

	soa_array_one: #soa [1]struct{ one: u32 },
	soa_array_two: #soa [2]struct{ one: u32, two: u32 },
}

main :: proc() {
	fmt.printf("%#v\n", o)
}

// OUTPUT BEFORE:
// {
// 	__EMPTY_STRUCTS_____________________________________ = {
// 	},
// 	empty = {
// 	},
// 	empty_one = {
// 		one = {
// 		},
// 	},
// 	empty_two = {
// 		one = {
// 		},
// 		two = {
// 		},
// 	},
// 	__EMPTY_STRUCT_ARRAYS_______________________________ = {
// 	},
// 	empty_array_zero = [],
// 	empty_array_one = [
// 		{
// 		},
// 	],
// 	empty_array_two = [
// 		{
// 		},
// 		{
// 		},
// 	],
// 	__EMPTY_STRUCT_SOA_ARRAYS___________________________ = {
// 	},
// 	empty_soa_array_zero = [	],
// 	empty_soa_array_one = [
// 		{
// 		},
// 	],
// 	empty_soa_array_two = [
// 		{
// 		},
// 		{
// 		},
// 	],
// 	__STRUCTS___________________________________________ = {
// 	},
// 	one = {
// 		one = 0,
// 	},
// 	two = {
// 		one = 0,
// 		two = 0,
// 	},
// 	__STRUCT_ARRAYS_____________________________________ = {
// 	},
// 	array_one = [],
// 	array_two = [
// 		{
// 			one = 0,
// 			two = 0,
// 		},
// 		{
// 			one = 0,
// 			two = 0,
// 		},
// 	],
// 	__STRUCT_SOA_ARRAYS_________________________________ = {
// 	},
// 	soa_array_one = [
// 		{
// 			one = 0,
// 		},
// 	],
// 	soa_array_two = [
// 		{
// 			one = 0,
// 			two = 0,
// 		},
// 		{
// 			one = 0,
// 			two = 0,
// 		},
// 	],
// }

// OUTPUT AFTER:
// {
// 	__EMPTY_STRUCTS_____________________________________ = {},
// 	empty = {},
// 	empty_one = {
// 		one = {},
// 	},
// 	empty_two = {
// 		one = {},
// 		two = {},
// 	},
// 	__EMPTY_STRUCT_ARRAYS_______________________________ = {},
// 	empty_array_zero = [],
// 	empty_array_one = [
// 		{},
// 	],
// 	empty_array_two = [
// 		{},
// 		{},
// 	],
// 	__EMPTY_STRUCT_SOA_ARRAYS___________________________ = {},
// 	empty_soa_array_zero = [],
// 	empty_soa_array_one = [
// 		{},
// 	],
// 	empty_soa_array_two = [
// 		{},
// 		{},
// 	],
// 	__STRUCTS___________________________________________ = {},
// 	one = {
// 		one = 0,
// 	},
// 	two = {
// 		one = 0,
// 		two = 0,
// 	},
// 	__STRUCT_ARRAYS_____________________________________ = {},
// 	array_one = [],
// 	array_two = [
// 		{
// 			one = 0,
// 			two = 0,
// 		},
// 		{
// 			one = 0,
// 			two = 0,
// 		},
// 	],
// 	__STRUCT_SOA_ARRAYS_________________________________ = {},
// 	soa_array_one = [
// 		{
// 			one = 0,
// 		},
// 	],
// 	soa_array_two = [
// 		{
// 			one = 0,
// 			two = 0,
// 		},
// 		{
// 			one = 0,
// 			two = 0,
// 		},
// 	],
// }
```