### PR TITLE
Fix big.shrink not actually shrinking

### DIFF
--- a/core/math/big/internal.odin
+++ b/core/math/big/internal.odin
@@ -2178,15 +2178,20 @@ internal_int_grow :: proc(a: ^Int, digits: int, allow_shrink := false, allocator
 	}
 
 	/*
-		If not yet iniialized, initialize the `digit` backing with the allocator we were passed.
+		If not yet initialized, initialize the `digit` backing with the allocator we were passed.
 	*/
 	if cap == 0 {
 		a.digit = make([dynamic]DIGIT, needed, allocator)
-	} else if cap != needed {
+	} else if cap < needed {
 		/*
 			`[dynamic]DIGIT` already knows what allocator was used for it, so resize will do the right thing.
 		*/
 		resize(&a.digit, needed)
+	} else if cap > needed && allow_shrink {
+		/*
+			Same applies to builtin.shrink here as resize above
+		*/
+		builtin.shrink(&a.digit, needed)
 	}
 	/*
 		Let's see if the allocation/resize worked as expected.


### PR DESCRIPTION
Consider this program:
```odin
package main

import "core:fmt"
import "core:math/big"

main :: proc() {
    number := big.Int{}

    big.atoi(&number, "100")
    fmt.println(&number)

    fmt.println("before grow: ", len(number.digit), " / ", cap(number.digit))
    big.grow(&number, 128)
    fmt.println("before shrink: ", len(number.digit), " / ", cap(number.digit))
    big.shrink(&number)
    fmt.println("after shrink: ", len(number.digit), " / ", cap(number.digit))

    e := big.int_sub_digit(&number, &number, 1)
    fmt.println(e, &number)
}
```

Currently, it outputs the below. Notice the capacity after the "shrink". This capacity is checked against during the `big.int_sub_digit` as it calls grow again to ensure it will fit the possible new digit. (This could be replaced by any similar proc or just a `grow` call with the right params).
```
&Int{used = 1, digit = [100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], sign = "Zero_or_Positive", flags = bit_set[Flag; u8]{}}
before grow:  32  /  32
before shrink:  128  /  128
after shrink:  3  /  128
Out_Of_Memory &Int{used = 1, digit = [100, 0, 0], sign = "Zero_or_Positive", flags = bit_set[Flag; u8]{}}
```

After the change:
```
&Int{used = 1, digit = [100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], sign = "Zero_or_Positive", flags = bit_set[Flag; u8]{}}
before grow:  32  /  32
before shrink:  128  /  128
after shrink:  3  /  3
Okay &Int{used = 1, digit = [99, 0, 0], sign = "Zero_or_Positive", flags = bit_set[Flag; u8]{}}
```

(and a typo)