### PR TITLE
Fix half-implemented features in the test runner

### DIFF
--- a/core/testing/runner.odin
+++ b/core/testing/runner.odin
@@ -604,10 +604,10 @@ runner :: proc(internal_tests: []Internal_Test) -> bool {
 			})
 			fmt.assertf(alloc_error == nil, "Error appending to log messages: %v", alloc_error)
 
-			find_task_data: for &data in task_data_slots {
+			find_task_data_for_timeout: for &data in task_data_slots {
 				if data.it.pkg == it.pkg && data.it.name == it.name {
 					end_t(&data.t)
-					break find_task_data
+					break find_task_data_for_timeout
 				}
 			}
 		}
@@ -653,6 +653,13 @@ runner :: proc(internal_tests: []Internal_Test) -> bool {
 				failed_test_reason_map[test_index] = fmt.aprintf("Signal caught: %v", reason, allocator = shared_log_allocator)
 				pkg_log.fatalf("Caught signal to stop test #%i %s.%s for: %v.", test_index, it.pkg, it.name, reason)
 
+			}
+
+			find_task_data_for_stop_signal: for &data in task_data_slots {
+				if data.it.pkg == it.pkg && data.it.name == it.name {
+					end_t(&data.t)
+					break find_task_data_for_stop_signal
+				}
 			}
 
 			when FANCY_OUTPUT {

--- a/tests/core/slice/test_core_slice.odin
+++ b/tests/core/slice/test_core_slice.odin
@@ -3,6 +3,7 @@ package test_core_slice
 import "core:slice"
 import "core:testing"
 import "core:math/rand"
+import "core:log"
 
 @test
 test_sort_with_indices :: proc(t: ^testing.T) {
@@ -205,7 +206,7 @@ test_permutation_iterator :: proc(t: ^testing.T) {
 			n += item
 		}
 		if n in seen {
-			testing.fail_now(t, "Permutation iterator made a duplicate permutation.")
+			log.error("Permutation iterator made a duplicate permutation.")
 			return
 		}
 		seen[n] = true


### PR DESCRIPTION
I'm working on documentation for the website, and I found a couple things in the test runner were half-implemented. `fail_now` will now always diverge, just like the old Windows behavior. `cleanups` will now be called even if the test fails due to a raised signal. Documentation has been added to warn about the case in which a `cleanup` proc will run in the main thread and can take out the runner if it also fails.