### PR TITLE
Add `ODIN_TEST_SHORT_LOGS` define

### DIFF
--- a/core/testing/logging.odin
+++ b/core/testing/logging.odin
@@ -8,13 +8,22 @@ import "core:strings"
 import "core:sync/chan"
 import "core:time"
 
-Default_Test_Logger_Opts :: runtime.Logger_Options {
-	.Level,
-	.Terminal_Color,
-	.Short_File_Path,
-	.Line,
-	.Procedure,
-	.Date, .Time,
+when USING_SHORT_LOGS {
+	Default_Test_Logger_Opts :: runtime.Logger_Options {
+		.Level,
+		.Terminal_Color,
+		.Short_File_Path,
+		.Line,
+	}
+} else {
+	Default_Test_Logger_Opts :: runtime.Logger_Options {
+		.Level,
+		.Terminal_Color,
+		.Short_File_Path,
+		.Line,
+		.Procedure,
+		.Date, .Time,
+	}
 }
 
 Log_Message :: struct {

--- a/core/testing/runner.odin
+++ b/core/testing/runner.odin
@@ -41,6 +41,8 @@ PROGRESS_WIDTH        : int    : #config(ODIN_TEST_PROGRESS_WIDTH, 24)
 SHARED_RANDOM_SEED    : u64    : #config(ODIN_TEST_RANDOM_SEED, 0)
 // Set the lowest log level for this test run.
 LOG_LEVEL             : string : #config(ODIN_TEST_LOG_LEVEL, "info")
+// Show only the most necessary logging information.
+USING_SHORT_LOGS      : bool   : #config(ODIN_TEST_SHORT_LOGS, false)
 
 
 get_log_level :: #force_inline proc() -> runtime.Logger_Level {


### PR DESCRIPTION
Strips out the procedure, date, and time information, for when you just need to know the file, line, and message.