### PR TITLE
Setup `context.random_generator` in test runner

### DIFF
--- a/core/testing/runner.odin
+++ b/core/testing/runner.odin
@@ -9,6 +9,7 @@ import "core:encoding/ansi"
 import "core:fmt"
 import "core:io"
 @require import pkg_log "core:log"
+import "core:math/rand"
 import "core:mem"
 import "core:os"
 import "core:slice"
@@ -107,6 +108,9 @@ run_test_task :: proc(task: thread.Task) {
 	}
 
 	free_all(context.temp_allocator)
+
+	random_generator_state := rand.create(data.t.seed)
+	context.random_generator = rand.default_random_generator(&random_generator_state)
 
 	data.it.p(&data.t)
 

--- a/core/testing/runner.odin
+++ b/core/testing/runner.odin
@@ -107,10 +107,14 @@ run_test_task :: proc(task: thread.Task) {
 		options = Default_Test_Logger_Opts,
 	}
 
-	free_all(context.temp_allocator)
+	random_generator_state: runtime.Default_Random_State
+	context.random_generator = {
+		procedure = runtime.default_random_generator_proc,
+		data = &random_generator_state,
+	}
+	rand.reset(data.t.seed)
 
-	random_generator_state := rand.create(data.t.seed)
-	context.random_generator = rand.default_random_generator(&random_generator_state)
+	free_all(context.temp_allocator)
 
 	data.it.p(&data.t)
 

--- a/tests/core/container/test_core_avl.odin
+++ b/tests/core/container/test_core_avl.odin
@@ -20,9 +20,6 @@ test_avl :: proc(t: ^testing.T) {
 	iter := avl.iterator(&tree, avl.Direction.Forward)
 	testing.expect(t, avl.iterator_get(&iter) == nil, "empty/iterator: first node should be nil")
 
-	r := rand.create(t.seed)
-	context.random_generator = rand.default_random_generator(&r)
-
 	// Test insertion.
 	NR_INSERTS :: 32 + 1 // Ensure at least 1 collision.
 	inserted_map := make(map[int]^avl.Node(int))

--- a/tests/core/container/test_core_rbtree.odin
+++ b/tests/core/container/test_core_rbtree.odin
@@ -14,9 +14,6 @@ test_rbtree_integer :: proc(t: ^testing.T, $Key: typeid, $Value: typeid) {
 	defer mem.tracking_allocator_destroy(&track)
 	context.allocator = mem.tracking_allocator(&track)
 
-	r := rand.create(t.seed)
-	context.random_generator = rand.default_random_generator(&r)
-
 	log.infof("Testing Red-Black Tree($Key=%v,$Value=%v) using random seed %v.", type_info_of(Key), type_info_of(Value), t.seed)
 	tree: rb.Tree(Key, Value)
 	rb.init(&tree)

--- a/tests/core/hash/test_core_hash.odin
+++ b/tests/core/hash/test_core_hash.odin
@@ -53,8 +53,7 @@ test_xxhash_zero_streamed_random_updates :: proc(t: ^testing.T) {
 		testing.expect(t, xxh3_128_err == nil, "Problem initializing XXH3_128 state")
 
 		// XXH3_128_update
-		random_seed := rand.create(t.seed)
-		context.random_generator = rand.default_random_generator(&random_seed)
+		rand.reset(t.seed)
 		for len(b) > 0 {
 			update_size := min(len(b), rand.int_max(8192))
 			if update_size > 4096 {

--- a/tests/core/math/rand/test_core_math_rand.odin
+++ b/tests/core/math/rand/test_core_math_rand.odin
@@ -1,0 +1,35 @@
+package test_core_math_rand
+
+import "core:math/rand"
+import "core:testing"
+
+@test
+test_default_rand_determinism :: proc(t: ^testing.T) {
+	rand.reset(13)
+	first_value := rand.int127()
+	rand.reset(13)
+	second_value := rand.int127()
+
+	testing.expect(t, first_value == second_value, "Context default random number generator is non-deterministic.")
+}
+
+@test
+test_default_rand_determinism_user_set :: proc(t: ^testing.T) {
+	rng_state_1 := rand.create(13)
+	rng_state_2 := rand.create(13)
+
+	rng_1 := rand.default_random_generator(&rng_state_1)
+	rng_2 := rand.default_random_generator(&rng_state_2)
+
+	first_value, second_value: i128
+	{
+		context.random_generator = rng_1
+		first_value = rand.int127()
+	}
+	{
+		context.random_generator = rng_2
+		second_value = rand.int127()
+	}
+
+	testing.expect(t, first_value == second_value, "User-set default random number generator is non-deterministic.")
+}

--- a/tests/core/normal.odin
+++ b/tests/core/normal.odin
@@ -24,6 +24,7 @@ download_assets :: proc() {
 @(require) import "math/big"
 @(require) import "math/linalg/glsl"
 @(require) import "math/noise"
+@(require) import "math/rand"
 @(require) import "mem"
 @(require) import "net"
 @(require) import "odin"

--- a/tests/core/slice/test_core_slice.odin
+++ b/tests/core/slice/test_core_slice.odin
@@ -11,8 +11,7 @@ test_sort_with_indices :: proc(t: ^testing.T) {
 	test_sizes :: []int{7, 13, 347, 1031, 10111, 100003}
 
 	for test_size in test_sizes {
-		r := rand.create(t.seed)
-		context.random_generator = rand.default_random_generator(&r)
+		rand.reset(t.seed)
 
 		vals  := make([]u64, test_size)
 		r_idx := make([]int, test_size) // Reverse index
@@ -63,8 +62,7 @@ test_sort_by_indices :: proc(t: ^testing.T) {
 	test_sizes :: []int{7, 13, 347, 1031, 10111, 100003}
 
 	for test_size in test_sizes {
-		r := rand.create(t.seed)
-		context.random_generator = rand.default_random_generator(&r)
+		rand.reset(t.seed)
 
 		vals  := make([]u64, test_size)
 		r_idx := make([]int, test_size) // Reverse index

--- a/tests/core/slice/test_core_slice.odin
+++ b/tests/core/slice/test_core_slice.odin
@@ -201,7 +201,7 @@ test_permutation_iterator :: proc(t: ^testing.T) {
 	permutations_counted: int
 	for slice.permute(&iter) {
 		n := 0
-		for item, index in s {
+		for item in s {
 			n *= 10
 			n += item
 		}

--- a/tests/internal/test_map.odin
+++ b/tests/internal/test_map.odin
@@ -16,8 +16,7 @@ map_insert_random_key_value :: proc(t: ^testing.T) {
 		defer delete(m)
 
 		unique_keys := 0
-		r := rand.create(t.seed + seed_incr)
-		context.random_generator = rand.default_random_generator(&r)
+		rand.reset(t.seed + seed_incr)
 		for _ in 0..<entries {
 			k := rand.int63()
 			v := rand.int63()
@@ -37,8 +36,7 @@ map_insert_random_key_value :: proc(t: ^testing.T) {
 		testing.expectf(t, len(m)    == unique_keys, "Expected len(map) to equal %v, got %v",  unique_keys, len(m))
 
 		// Reset randomizer and verify
-		r = rand.create(t.seed + seed_incr)
-		context.random_generator = rand.default_random_generator(&r)
+		rand.reset(t.seed + seed_incr)
 
 		num_fails := 0
 		for _ in 0..<entries {
@@ -68,8 +66,7 @@ map_update_random_key_value :: proc(t: ^testing.T) {
 		defer delete(m)
 
 		unique_keys := 0
-		r := rand.create(t.seed + seed_incr)
-		context.random_generator = rand.default_random_generator(&r)
+		rand.reset(t.seed + seed_incr)
 
 		for _ in 0..<entries {
 			k := rand.int63()
@@ -92,8 +89,7 @@ map_update_random_key_value :: proc(t: ^testing.T) {
 		half_entries := entries / 2
 
 		// Reset randomizer and update half the entries
-		r = rand.create(t.seed + seed_incr)
-		context.random_generator = rand.default_random_generator(&r)
+		rand.reset(t.seed + seed_incr)
 
 		for _ in 0..<half_entries {
 			k := rand.int63()
@@ -103,8 +99,7 @@ map_update_random_key_value :: proc(t: ^testing.T) {
 		}
 
 		// Reset randomizer and verify
-		r = rand.create(t.seed + seed_incr)
-		context.random_generator = rand.default_random_generator(&r)
+		rand.reset(t.seed + seed_incr)
 
 		num_fails := 0
 		for i in 0..<entries {
@@ -135,8 +130,7 @@ map_delete_random_key_value :: proc(t: ^testing.T) {
 		defer delete(m)
 
 		unique_keys := 0
-		r := rand.create(t.seed + seed_incr)
-		context.random_generator = rand.default_random_generator(&r)
+		rand.reset(t.seed + seed_incr)
 
 		for _ in 0..<entries {
 			k := rand.int63()
@@ -159,8 +153,7 @@ map_delete_random_key_value :: proc(t: ^testing.T) {
 		half_entries := entries / 2
 
 		// Reset randomizer and delete half the entries
-		r = rand.create(t.seed + seed_incr)
-		context.random_generator = rand.default_random_generator(&r)
+		rand.reset(t.seed + seed_incr)
 
 		for _ in 0..<half_entries {
 			k := rand.int63()
@@ -170,8 +163,7 @@ map_delete_random_key_value :: proc(t: ^testing.T) {
 		}
 
 		// Reset randomizer and verify
-		r = rand.create(t.seed + seed_incr)
-		context.random_generator = rand.default_random_generator(&r)
+		rand.reset(t.seed + seed_incr)
 
 		num_fails := 0
 		for i in 0..<entries {
@@ -218,8 +210,7 @@ set_insert_random_key_value :: proc(t: ^testing.T) {
 		defer delete(m)
 
 		unique_keys := 0
-		r := rand.create(t.seed + seed_incr)
-		context.random_generator = rand.default_random_generator(&r)
+		rand.reset(t.seed + seed_incr)
 
 		for _ in 0..<entries {
 			k := rand.int63()
@@ -238,8 +229,7 @@ set_insert_random_key_value :: proc(t: ^testing.T) {
 		testing.expectf(t, len(m)    == unique_keys, "Expected len(map) to equal %v, got %v",  unique_keys, len(m))
 
 		// Reset randomizer and verify
-		r = rand.create(t.seed + seed_incr)
-		context.random_generator = rand.default_random_generator(&r)
+		rand.reset(t.seed + seed_incr)
 
 		num_fails := 0
 		for _ in 0..<entries {
@@ -268,8 +258,7 @@ set_delete_random_key_value :: proc(t: ^testing.T) {
 		defer delete(m)
 
 		unique_keys := 0
-		r := rand.create(t.seed + seed_incr)
-		context.random_generator = rand.default_random_generator(&r)
+		rand.reset(t.seed + seed_incr)
 
 		for _ in 0..<entries {
 			k := rand.int63()
@@ -291,8 +280,7 @@ set_delete_random_key_value :: proc(t: ^testing.T) {
 		half_entries := entries / 2
 
 		// Reset randomizer and delete half the entries
-		r = rand.create(t.seed + seed_incr)
-		context.random_generator = rand.default_random_generator(&r)
+		rand.reset(t.seed + seed_incr)
 
 		for _ in 0..<half_entries {
 			k := rand.int63()
@@ -300,8 +288,7 @@ set_delete_random_key_value :: proc(t: ^testing.T) {
 		}
 
 		// Reset randomizer and verify
-		r = rand.create(t.seed + seed_incr)
-		context.random_generator = rand.default_random_generator(&r)
+		rand.reset(t.seed + seed_incr)
 
 		num_fails := 0
 		for i in 0..<entries {


### PR DESCRIPTION
I've set it up so the test runner initiates the random generator now, so tests don't have to.