### PR TITLE
Fix `bit_set` construction crash on constant non-integer field

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -9819,7 +9819,9 @@ gb_internal ExprKind check_compound_literal(CheckerContext *c, Operand *o, Ast *
 				if (tav.mode != Addressing_Constant) {
 					continue;
 				}
-				GB_ASSERT(tav.value.kind == ExactValue_Integer);
+				if (tav.value.kind != ExactValue_Integer) {
+					continue;
+				}
 				i64 v = big_int_to_i64(&tav.value.value_integer);
 				i64 lower = bt->BitSet.lower;
 				u64 index = cast(u64)(v-lower);


### PR DESCRIPTION
Found this when I switched a `struct` to be a `bit_set`. The following program fails an assertion:
```odin
package main

main :: proc() {
	E :: enum {
		Alpha,
		Beta,
	}

	BS :: bit_set[E]

	f := BS{ true }
}
```