### PR TITLE
fix(os2): check for 0 bytes read and return EOF

### DIFF
--- a/core/os/os2/file_linux.odin
+++ b/core/os/os2/file_linux.odin
@@ -121,6 +121,9 @@ _read :: proc(f: ^File, p: []byte) -> (i64, Error) {
 	if n < 0 {
 		return -1, _get_platform_error(n)
 	}
+	if n == 0 {
+		return 0, .EOF
+	}
 	return i64(n), nil
 }
 
@@ -134,6 +137,9 @@ _read_at :: proc(f: ^File, p: []byte, offset: i64) -> (n: i64, err: Error) {
 		m := unix.sys_pread(f.impl.fd, &b[0], len(b), offset)
 		if m < 0 {
 			return -1, _get_platform_error(m)
+		}
+		if m == 0 {
+			return 0, .EOF
 		}
 		n += i64(m)
 		b = b[m:]


### PR DESCRIPTION
Current os2 `file_stream` implementation for `read` on linux never returns an EOF error when reaching the end of file.

Linux's read syscall returns 0 read bytes if the end of file is reached: https://man7.org/linux/man-pages/man2/read.2.html

This also matches the implementation of the `os` package as evident by [`core/os/stream.odin:30`](https://github.com/odin-lang/Odin/blob/f280ba8511b97bb1d2f5173933a6179c2aba231b/core/os/stream.odin#L30)