### PR TITLE
Clarify when the arena in base:runtime should be used

### DIFF
--- a/base/runtime/default_temp_allocator_arena.odin
+++ b/base/runtime/default_temp_allocator_arena.odin
@@ -12,7 +12,8 @@ Memory_Block :: struct {
 	capacity:  uint,
 }
 
-// NOTE: This is for internal use, prefer `Arena` from `core:mem/virtual` if necessary
+// NOTE: This is a growing arena that is only used for the default temp allocator.
+// For your own growing arena needs, prefer `Arena` from `core:mem/virtual`.
 Arena :: struct {
 	backing_allocator:  Allocator,
 	curr_block:         ^Memory_Block,


### PR DESCRIPTION
This PR clarifies that the arena in `base:runtime` shouldn't be used for anything but the default temp allocator. This is done by:
- Renaming the file in which it lives: `default_allocators_arena.odin => default_temp_allocator_arena.odin`
- Improve the comment above `Arena :: struct {`.

This should avoid some confusion where people end up using the Arena in`base:runtime` because they thought it was the 'default arena', as the old file name `default_allocators_arena.odin` might have lured them into believing.