### PR TITLE
Add to_cstring for Builders

### DIFF
--- a/core/strings/builder.odin
+++ b/core/strings/builder.odin
@@ -286,6 +286,33 @@ to_string :: proc(b: Builder) -> (res: string) {
 	return string(b.buf[:])
 }
 /*
+Appends a trailing null byte if missing and then casts the Builder byte buffer to cstring
+
+Inputs:
+- b: A pointer to builder
+
+Returns:
+- res: A cstring of the Builder's buffer
+*/
+to_cstring :: proc(b: ^Builder) -> (res: cstring) {
+	if b.buf[len(b.buf)-1] != 0 {
+		append(&b.buf, 0)
+	}
+	return cstring(raw_data(b.buf))
+}
+/*
+Casts the Builder byte buffer to cstring, assuming it is already null-terminated
+
+Inputs:
+- b: A pointer to builder
+
+Returns:
+- res: A cstring of the Builder's buffer
+*/
+to_cstring_unsafe :: proc(b: Builder) -> (res: cstring) {
+	return cstring(raw_data(b.buf))
+}
+/*
 Returns the length of the Builder's buffer, in bytes
 
 Inputs:


### PR DESCRIPTION
When using external libs that use cstrings a lot, it can be very helpful to be able to output cstrings from a builder.

It's not straightforward to think about the null terminator manually and then feed it through a series of non-allocating casts.