### PR TITLE
Fix `#warning` directive

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -1727,7 +1727,7 @@ gb_internal bool check_builtin_procedure_directive(CheckerContext *c, Operand *o
 			return false;
 		}
 		warning(call, "%.*s", LIT(operand->value.value_string));
-		if (c->proc_name != "") {
+		if (!global_ignore_warnings() && c->proc_name != "") {
 			gbString str = type_to_string(c->curr_proc_sig);
 			error_line("\tCalled within '%.*s' :: %s\n", LIT(c->proc_name), str);
 			gb_string_free(str);

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -7443,6 +7443,7 @@ gb_internal ExprKind check_call_expr(CheckerContext *c, Operand *operand, Ast *c
 		    name == "exists" ||
 		    name == "assert" || 
 		    name == "panic" || 
+		    name == "warning" ||
 		    name == "defined" || 
 		    name == "config" || 
 		    name == "load" ||

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -1736,6 +1736,8 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 			lb_make_global_private_const(addr);
 
 			return lb_addr_load(p, addr);
+		} else if (name == "warning") {
+			return {};
 		} else {
 			GB_PANIC("UNKNOWN DIRECTIVE: %.*s", LIT(name));
 		}


### PR DESCRIPTION
`#warning` was added in dab3c832e00a3186bddc79585d9ba7ee10d39eaf but cannot actually be used, because it's an unrecognized directive. This should fix it. I did run into one issue though, which is where if I try to assign a `#warning` to a variable, the warning itself shadows the underlying error that would arise. I verified this with `-ignore-warnings` and ran into an assertion failure, which I have also handled in this PR.