### PR TITLE
Fix print segfault by missing argument in `or_*` shadowed error

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -8727,7 +8727,7 @@ gb_internal ExprKind check_or_branch_expr(CheckerContext *c, Operand *o, Ast *no
 			// okay
 		} else {
 			gbString s = type_to_string(right_type);
-			error(node, "'%.*s' requires a boolean or nil-able type, got %s", s);
+			error(node, "'%.*s' requires a boolean or nil-able type, got %s", LIT(name), s);
 			gb_string_free(s);
 		}
 	}


### PR DESCRIPTION
The error fixed in this PR was shadowed by `check_or_else_right_type`. Just a missing string argument. I verified the fixed error prints correctly by commenting out `check_or_else_right_type`'s error handling to make sure.

Fixes #3794