### PR TITLE
Allow commas and spaces in the link section names

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1965,6 +1965,8 @@ gb_internal bool is_foreign_name_valid(String const &name) {
 			case '$':
 			case '.':
 			case '_':
+			case ',':
+			case ' ':
 				break;
 			default:
 				if (!gb_char_is_alphanumeric(cast(char)rune)) {


### PR DESCRIPTION
In the Mach-O object format, a segment can be specified in addition to the section.

The format for such declaration is "SEGMENT,SECTION" which LLVM understands. So, simply allowing commas and spaces we get support for these link section names. Spaces are not strictly required, but the underlying tooling supports it and that's what people would expect, I believe.

This is required, for example, to do symbol interposition, as it mandates placing the interposition table in the "__DATA,__interpose" section.