### PR TITLE
Update CommandLineToArgvW return type

### DIFF
--- a/core/sys/windows/shell32.odin
+++ b/core/sys/windows/shell32.odin
@@ -5,7 +5,7 @@ foreign import shell32 "system:Shell32.lib"
 
 @(default_calling_convention="system")
 foreign shell32 {
-	CommandLineToArgvW :: proc(cmd_list: wstring, num_args: ^c_int) -> ^wstring ---
+	CommandLineToArgvW :: proc(cmd_list: wstring, num_args: ^c_int) -> [^]wstring ---
 	ShellExecuteW :: proc(
 		hwnd: HWND,
 		lpOperation: LPCWSTR,


### PR DESCRIPTION
It now returns a multi-pointer so it can be iterated without any casting.