### PR TITLE
disallow non-global foreign import of variables on wasm

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -2053,10 +2053,12 @@ gb_internal void init_build_context(TargetMetrics *cross_target, Subtarget subta
 		gbString link_flags = gb_string_make(heap_allocator(), " ");
 		// link_flags = gb_string_appendc(link_flags, "--export-all ");
 		// link_flags = gb_string_appendc(link_flags, "--export-table ");
-		link_flags = gb_string_appendc(link_flags, "--allow-undefined ");
 		// if (bc->metrics.arch == TargetArch_wasm64) {
 		// 	link_flags = gb_string_appendc(link_flags, "-mwasm64 ");
 		// }
+		if (bc->metrics.os != TargetOs_orca) {
+			link_flags = gb_string_appendc(link_flags, "--allow-undefined ");
+		}
 		if (bc->no_entry_point || bc->metrics.os == TargetOs_orca) {
 			link_flags = gb_string_appendc(link_flags, "--no-entry ");
 		}

--- a/src/check_decl.cpp
+++ b/src/check_decl.cpp
@@ -709,7 +709,7 @@ gb_internal Entity *init_entity_foreign_library(CheckerContext *ctx, Entity *e) 
 	}
 
 	if (ident == nullptr) {
-		error(e->token, "foreign entiies must declare which library they are from");
+		error(e->token, "foreign entities must declare which library they are from");
 	} else if (ident->kind != Ast_Ident) {
 		error(ident, "foreign library names must be an identifier");
 	} else {
@@ -1320,9 +1320,9 @@ gb_internal void check_global_variable_decl(CheckerContext *ctx, Entity *&e, Ast
 			error(e->token, "A foreign variable declaration cannot have a default value");
 		}
 		init_entity_foreign_library(ctx, e);
-		// if (is_arch_wasm()) {
-		// 	error(e->token, "A foreign variable declaration are not allowed for the '%.*s' architecture", LIT(target_arch_names[build_context.metrics.arch]));
-		// }
+		if (is_arch_wasm() && e->Variable.foreign_library != nullptr) {
+			error(e->token, "A foreign variable declaration can not be scoped to a module and must be declared in a 'foreign {' (without a library) block");
+		}
 	}
 	if (ac.link_name.len > 0) {
 		e->Variable.link_name = ac.link_name;

--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -3217,8 +3217,6 @@ gb_internal bool lb_generate_code(lbGenerator *gen) {
 			LLVMSetDLLStorageClass(g.value, LLVMDLLImportStorageClass);
 			LLVMSetExternallyInitialized(g.value, true);
 			lb_add_foreign_library_path(m, e->Variable.foreign_library);
-			
-			// lb_set_wasm_import_attributes(g.value, e, name);
 		} else {
 			LLVMSetInitializer(g.value, LLVMConstNull(lb_type(m, e->type)));
 		}

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -233,7 +233,7 @@ gb_internal lbProcedure *lb_create_procedure(lbModule *m, Entity *entity, bool i
 
 
 	if (p->is_foreign) {
-		lb_set_wasm_import_attributes(p->value, entity, p->name);
+		lb_set_wasm_procedure_import_attributes(p->value, entity, p->name);
 	}
 
 

--- a/src/llvm_backend_utility.cpp
+++ b/src/llvm_backend_utility.cpp
@@ -2018,7 +2018,7 @@ gb_internal LLVMValueRef llvm_get_inline_asm(LLVMTypeRef func_type, String const
 }
 
 
-gb_internal void lb_set_wasm_import_attributes(LLVMValueRef value, Entity *entity, String import_name) {
+gb_internal void lb_set_wasm_procedure_import_attributes(LLVMValueRef value, Entity *entity, String import_name) {
 	if (!is_arch_wasm()) {
 		return;
 	}

--- a/src/tilde.cpp
+++ b/src/tilde.cpp
@@ -363,7 +363,6 @@ gb_internal bool cg_global_variables_create(cgModule *m, Array<cgGlobalVariable>
 		if (is_foreign) {
 			linkage = TB_LINKAGE_PUBLIC;
 			// lb_add_foreign_library_path(m, e->Variable.foreign_library);
-			// lb_set_wasm_import_attributes(g.value, e, name);
 		} else if (is_export) {
 			linkage = TB_LINKAGE_PUBLIC;
 		}


### PR DESCRIPTION
AFAIK (checked with clang, which disallows this) this is not allowed, + we are currently ignoring the module for variables.
```odin
foreign import foo "foo"

foreign foo {
   bar: baz,
}
```
should not be allowed, but (global)
```odin
foreign {
    bar: baz,
}
```
is allowed
just going of what clang and LLVM allow