### PR TITLE
wgpu_native fixes

### DIFF
--- a/vendor/wgpu/wgpu_native.odin
+++ b/vendor/wgpu/wgpu_native.odin
@@ -29,10 +29,9 @@ foreign {
 	RawQueueSubmitForIndex :: proc(queue: Queue, commandCount: uint, commands: [^]CommandBuffer) -> SubmissionIndex ---
 
 	// Returns true if the queue is empty, or false if there are more queue submissions still in flight.
-	@(link_name="wgpuDevicePoll")
-	RawDevicePoll :: proc(device: Device, wait: b32, /* NULLABLE */ wrappedSubmissionIndex: /* const */ ^WrappedSubmissionIndex) -> b32 ---
+	DevicePoll :: proc(device: Device, wait: b32, /* NULLABLE */ wrappedSubmissionIndex: /* const */ ^WrappedSubmissionIndex = nil) -> b32 ---
 
-	SetLogCallback :: proc "odin" (callback: LogCallback) ---
+	SetLogCallback :: proc(callback: LogCallback, userdata: rawptr) ---
 
 	SetLogLevel :: proc(level: LogLevel) ---
 
@@ -67,9 +66,3 @@ InstanceEnumerateAdapters :: proc(instance: Instance, options: ^InstanceEnumerat
 QueueSubmitForIndex :: proc(queue: Queue, commands: []CommandBuffer) -> SubmissionIndex {
 	return RawQueueSubmitForIndex(queue, len(commands), raw_data(commands))
 }
-
-DevicePoll :: proc(device: Device, wait: b32) -> (wrappedSubmissionIndex: WrappedSubmissionIndex, ok: bool) {
-	ok = bool(RawDevicePoll(device, wait, &wrappedSubmissionIndex))
-	return
-}
-

--- a/vendor/wgpu/wgpu_native_types.odin
+++ b/vendor/wgpu/wgpu_native_types.odin
@@ -79,7 +79,7 @@ RequiredLimitsExtras :: struct {
 }
 
 SupportedLimitsExtras :: struct {
-	using chain: ChainedStruct,
+	using chain: ChainedStructOut,
 	limits: NativeLimits,
 }
 

--- a/vendor/wgpu/wgpu_native_types.odin
+++ b/vendor/wgpu/wgpu_native_types.odin
@@ -182,7 +182,7 @@ SurfaceConfigurationExtras :: struct {
 	desiredMaximumFrameLatency: i32,
 }
 
-LogCallback :: #type proc "odin" (level: LogLevel, message: cstring)
+LogCallback :: #type proc "c" (level: LogLevel, message: cstring, userdata: rawptr)
 
 // Wrappers
 


### PR DESCRIPTION
1. `LogCallback` should have the "c" calling convention and takes a userdata pointer like other callbacks.
2. `DevicePoll`'s `wrappedSubmissionIndex` argument is an optional in/out parameter. When not specified the function does not query the status of any queue, but if specified the function polls the status of the passed (valid) queue. The previous wrapper method was broken since it passed a non-nil structure to the underlying API with invalid members.
3. `SupportedLimitsExtras.chain` should be a `ChainedStructOut` to properly chain from `SupportedLimits`