### PR TITLE
Require `base:runtime` import in `core:math/linalg`

### DIFF
--- a/core/math/linalg/general.odin
+++ b/core/math/linalg/general.odin
@@ -3,7 +3,7 @@ package linalg
 import "core:math"
 import "base:builtin"
 import "base:intrinsics"
-import "base:runtime"
+@require import "base:runtime"
 
 // Generic
 


### PR DESCRIPTION
Fixes #3826