### PR TITLE
Let Darwin safely panic in a test

### DIFF
--- a/core/c/libc/signal.odin
+++ b/core/c/libc/signal.odin
@@ -34,20 +34,7 @@ when ODIN_OS == .Windows {
 	SIGTERM :: 15
 }
 
-when ODIN_OS == .Linux || ODIN_OS == .FreeBSD || ODIN_OS == .Haiku || ODIN_OS == .OpenBSD || ODIN_OS == .NetBSD {
-	SIG_ERR  :: rawptr(~uintptr(0))
-	SIG_DFL  :: rawptr(uintptr(0))
-	SIG_IGN  :: rawptr(uintptr(1)) 
-
-	SIGABRT  :: 6
-	SIGFPE   :: 8
-	SIGILL   :: 4
-	SIGINT   :: 2
-	SIGSEGV  :: 11
-	SIGTERM  :: 15
-}
-
-when ODIN_OS == .Darwin {
+when ODIN_OS == .Linux || ODIN_OS == .FreeBSD || ODIN_OS == .Haiku || ODIN_OS == .OpenBSD || ODIN_OS == .NetBSD || ODIN_OS == .Darwin {
 	SIG_ERR  :: rawptr(~uintptr(0))
 	SIG_DFL  :: rawptr(uintptr(0))
 	SIG_IGN  :: rawptr(uintptr(1)) 

--- a/core/testing/signal_handler.odin
+++ b/core/testing/signal_handler.odin
@@ -9,6 +9,7 @@ Stop_Reason :: enum {
 	Illegal_Instruction,
 	Arithmetic_Error,
 	Segmentation_Fault,
+	Unhandled_Trap,
 }
 
 test_assertion_failure_proc :: proc(prefix, message: string, loc: runtime.Source_Code_Location) -> ! {

--- a/core/thread/thread_unix.odin
+++ b/core/thread/thread_unix.odin
@@ -23,10 +23,8 @@ _create :: proc(procedure: Thread_Proc, priority: Thread_Priority) -> ^Thread {
 	__unix_thread_entry_proc :: proc "c" (t: rawptr) -> rawptr {
 		t := (^Thread)(t)
 
-		when ODIN_OS != .Darwin {
-			// We need to give the thread a moment to start up before we enable cancellation.
-			can_set_thread_cancel_state := unix.pthread_setcancelstate(unix.PTHREAD_CANCEL_ENABLE, nil) == 0
-		}
+		// We need to give the thread a moment to start up before we enable cancellation.
+		can_set_thread_cancel_state := unix.pthread_setcancelstate(unix.PTHREAD_CANCEL_ENABLE, nil) == 0
 
 		sync.lock(&t.mutex)
 
@@ -42,12 +40,10 @@ _create :: proc(procedure: Thread_Proc, priority: Thread_Priority) -> ^Thread {
 			return nil
 		}
 
-		when ODIN_OS != .Darwin {
-			// Enable thread's cancelability.
-			if can_set_thread_cancel_state {
-				unix.pthread_setcanceltype (unix.PTHREAD_CANCEL_ASYNCHRONOUS, nil)
-				unix.pthread_setcancelstate(unix.PTHREAD_CANCEL_ENABLE,       nil)
-			}
+		// Enable thread's cancelability.
+		if can_set_thread_cancel_state {
+			unix.pthread_setcanceltype (unix.PTHREAD_CANCEL_ASYNCHRONOUS, nil)
+			unix.pthread_setcancelstate(unix.PTHREAD_CANCEL_ENABLE,       nil)
 		}
 
 		{
@@ -169,10 +165,17 @@ _destroy :: proc(t: ^Thread) {
 }
 
 _terminate :: proc(t: ^Thread, exit_code: int) {
-	// `pthread_cancel` is unreliable on Darwin for unknown reasons.
-	when ODIN_OS != .Darwin {
-		unix.pthread_cancel(t.unix_thread)
-	}
+	// NOTE(Feoramund): For thread cancellation to succeed on BSDs and
+	// possibly Darwin systems, the thread must call one of the pthread
+	// cancelation points at some point after this.
+	//
+	// The most obvious one of these is `pthread_cancel`, but there is an
+	// entire list of functions that act as cancelation points available in the
+	// pthreads manual page.
+	//
+	// This is in contrast to behavior I have seen on Linux where the thread is
+	// just terminated.
+	unix.pthread_cancel(t.unix_thread)
 }
 
 _yield :: proc() {


### PR DESCRIPTION
I made sure that even with the signal handler catching `SIGTRAP` that I was able to catch a call to `intrinsics.debug_trap()` with `lldb` and continue on merrily without the runner taking control.

This PR also lets Darwin call `pthread_cancel` again, with an advisory comment based on my experiences working with FreeBSD. It is possible that the previous unreliable behavior was based off of a lack of cancelation points being used.

Fixes #3830 

**EDIT:** One moment while I look up what `SIGTRAP` is on Windows...