### PR TITLE
Consistent dynamic array default capacity and avoid unnecessary dynamic array allocations

### DIFF
--- a/base/runtime/core_builtin.odin
+++ b/base/runtime/core_builtin.odin
@@ -268,7 +268,7 @@ new_clone :: proc(data: $T, allocator := context.allocator, loc := #caller_locat
 	return
 }
 
-DEFAULT_RESERVE_CAPACITY :: 16
+DEFAULT_DYNAMIC_ARRAY_CAPACITY :: 8
 
 @(require_results)
 make_aligned :: proc($T: typeid/[]$E, #any_int len: int, alignment: int, allocator := context.allocator, loc := #caller_location) -> (T, Allocator_Error) #optional_allocator_error {
@@ -295,7 +295,7 @@ make_slice :: proc($T: typeid/[]$E, #any_int len: int, allocator := context.allo
 // Note: Prefer using the procedure group `make`.
 @(builtin, require_results)
 make_dynamic_array :: proc($T: typeid/[dynamic]$E, allocator := context.allocator, loc := #caller_location) -> (T, Allocator_Error) #optional_allocator_error {
-	return make_dynamic_array_len_cap(T, 0, DEFAULT_RESERVE_CAPACITY, allocator, loc)
+	return make_dynamic_array_len_cap(T, 0, 0, allocator, loc)
 }
 // `make_dynamic_array_len` allocates and initializes a dynamic array. Like `new`, the first argument is a type, not a value.
 // Unlike `new`, `make`'s return value is the same as the type of its argument, not a pointer to it.
@@ -423,8 +423,8 @@ _append_elem :: #force_inline proc(array: ^$T/[dynamic]$E, arg: E, should_zero: 
 		return 1, nil
 	} else {
 		if cap(array) < len(array)+1 {
-			// Same behavior as _append_elems but there's only one arg, so we always just add 8.
-			cap := 2 * cap(array) + 8
+			// Same behavior as _append_elems but there's only one arg, so we always just add DEFAULT_DYNAMIC_ARRAY_CAPACITY.
+			cap := 2 * cap(array) + DEFAULT_DYNAMIC_ARRAY_CAPACITY
 
 			// do not 'or_return' here as it could be a partial success
 			if should_zero {
@@ -473,7 +473,7 @@ _append_elems :: #force_inline proc(array: ^$T/[dynamic]$E, should_zero: bool, l
 		return arg_len, nil
 	} else {
 		if cap(array) < len(array)+arg_len {
-			cap := 2 * cap(array) + max(8, arg_len)
+			cap := 2 * cap(array) + max(DEFAULT_DYNAMIC_ARRAY_CAPACITY, arg_len)
 
 			// do not 'or_return' here as it could be a partial success
 			if should_zero {

--- a/base/runtime/core_builtin_soa.odin
+++ b/base/runtime/core_builtin_soa.odin
@@ -147,7 +147,7 @@ make_soa_slice :: proc($T: typeid/#soa[]$E, length: int, allocator := context.al
 @(builtin, require_results)
 make_soa_dynamic_array :: proc($T: typeid/#soa[dynamic]$E, allocator := context.allocator, loc := #caller_location) -> (array: T, err: Allocator_Error) #optional_allocator_error {
 	context.allocator = allocator
-	reserve_soa(&array, DEFAULT_RESERVE_CAPACITY, loc) or_return
+	reserve_soa(&array, 0, loc) or_return
 	return array, nil
 }
 
@@ -280,7 +280,8 @@ append_soa_elem :: proc(array: ^$T/#soa[dynamic]$E, arg: E, loc := #caller_locat
 	}
 
 	if cap(array) <= len(array) + 1 {
-		cap := 2 * cap(array) + 8
+		// Same behavior as append_soa_elems but there's only one arg, so we always just add DEFAULT_DYNAMIC_ARRAY_CAPACITY.
+		cap := 2 * cap(array) + DEFAULT_DYNAMIC_ARRAY_CAPACITY
 		err = reserve_soa(array, cap, loc) // do not 'or_return' here as it could be a partial success
 	}
 
@@ -337,7 +338,7 @@ append_soa_elems :: proc(array: ^$T/#soa[dynamic]$E, args: ..E, loc := #caller_l
 	}
 
 	if cap(array) <= len(array)+arg_len {
-		cap := 2 * cap(array) + max(8, arg_len)
+		cap := 2 * cap(array) + max(DEFAULT_DYNAMIC_ARRAY_CAPACITY, arg_len)
 		err = reserve_soa(array, cap, loc) // do not 'or_return' here as it could be a partial success
 	}
 	arg_len = min(cap(array)-len(array), arg_len)

--- a/core/strings/builder.odin
+++ b/core/strings/builder.odin
@@ -24,7 +24,7 @@ Builder :: struct {
 	buf: [dynamic]byte,
 }
 /*
-Produces a Builder with a default length of 0 and cap of 16
+Produces an empty Builder
 
 *Allocates Using Provided Allocator*
 
@@ -39,7 +39,7 @@ builder_make_none :: proc(allocator := context.allocator, loc := #caller_locatio
 	return Builder{buf=make([dynamic]byte, allocator, loc) or_return }, nil
 }
 /*
-Produces a Builder with a specified length and cap of max(16,len) byte buffer
+Produces a Builder with specified length and capacity `len`.
 
 *Allocates Using Provided Allocator*
 
@@ -55,7 +55,7 @@ builder_make_len :: proc(len: int, allocator := context.allocator, loc := #calle
 	return Builder{buf=make([dynamic]byte, len, allocator, loc) or_return }, nil
 }
 /*
-Produces a Builder with a specified length and cap
+Produces a Builder with specified length `len` and capacity `cap`.
 
 *Allocates Using Provided Allocator*
 
@@ -103,7 +103,7 @@ builder_make :: proc{
 	builder_make_len_cap,
 }
 /*
-Initializes a Builder with a length of 0 and cap of 16
+Initializes an empty Builder
 It replaces the existing `buf`
 
 *Allocates Using Provided Allocator*
@@ -121,7 +121,7 @@ builder_init_none :: proc(b: ^Builder, allocator := context.allocator, loc := #c
 	return b, nil
 }
 /*
-Initializes a Builder with a specified length and cap, which is max(len,16)
+Initializes a Builder with specified length and capacity `len`.
 It replaces the existing `buf`
 
 *Allocates Using Provided Allocator*
@@ -140,7 +140,7 @@ builder_init_len :: proc(b: ^Builder, len: int, allocator := context.allocator, 
 	return b, nil
 }
 /*
-Initializes a Builder with a specified length and cap
+Initializes a Builder with specified length `len` and capacity `cap`.
 It replaces the existing `buf`
 
 Inputs:


### PR DESCRIPTION
## Behavior before
Before these changes, if you did:
```
arr: [dynamic]int
```
and then append to arr, then `arr` will have capacity `8`.

But if you did
```
arr := make([dynamic]int, context.temp_allocator)
```
then `arr` would have capacity `16`.

## Behavior now
Now both `arr: [dynamic]int` and `arr := make([dynamic]int, context.temp_allocator)` will result in arr having cap 0.

The only reason to use `make` without an explicit len or cap now is because you want to set it up for a non-default allocator. After the first call to `append` it will now in both cases have capacity 8.

There was a hard-coded 8 in `append` and then there was a default reserve capacity constant set to 16. The constant has been changed to 8 and is used in append now, while `make` uses capacity 0.

I have updated the documentation in the strings builder to reflect this. There were also some inaccuracies in there that weren't true even before these changes (such as len being `max(16, len)` when you specify len for a builder).

## Positive side effects of this
Say you have a proc like this, that fetches all trees that are near a video game player within a certain distance:
```
find_all_nearby_trees :: proc(max_distance: f32, allocator := context.allocator) -> []^Tree {
	trees := make([dynamic]^Tree, allocator)

	for &t in world.trees {
		if linalg.length(t.pos - player.pos) < max_distance {
			append(&trees, &t)
		}
	}

	return trees[:]
}
```
Then if there are no trees nearby, then with the new code no allocation at all will happen. With the old code there would always be an allocation of capacity 16.

## Tests done

I tested this using this program

```
package dyn_arr_cap

import "core:fmt"
import "core:strings"

test :: proc() {
	fmt.println("Testing dynamic array")
	dyn_arr := make([dynamic]int, context.temp_allocator)
	fmt.println(cap(dyn_arr)) // 0
	append(&dyn_arr, 7)
	append(&dyn_arr, 8, 9, 10)
	fmt.println(cap(dyn_arr)) // 8

	fmt.println(dyn_arr) // [7, 8, 9, 10]
}

test_soa :: proc() {
	fmt.println("Testing soa dynamic array")
	My_Struct :: struct {
		v1: int,
		v2: int,
		v3: int,
		v4: int,
		v5: int,
		v6: int,
	}

	dyn_arr := make_soa(#soa[dynamic]My_Struct, context.temp_allocator)
	fmt.println(cap(dyn_arr)) // 0
	append_soa(&dyn_arr, My_Struct{1,2,3,4,5,6})
	append_soa(&dyn_arr, My_Struct{1,2,3,4,5,6}, My_Struct{1,2,3,4,5,6}, My_Struct{1,2,3,4,5,6})
	fmt.println(cap(dyn_arr)) // 8

	fmt.println(dyn_arr) // [My_Struct{v1 = 1, v2 = 2, v3 = 3, v4 = 4, v5 = 5, v6 = 6}, My_Struct{v1 = 1, v2 = 2, v3 = 3, v4 = 4, v5 = 5, v6 = 6}, My_Struct{v1 = 1, v2 = 2, v3 = 3, v4 = 4, v5 = 5, v6 = 6}, My_Struct{v1 = 1, v2 = 2, v3 = 3, v4 = 4, v5 = 5, v6 = 6}]
}

test_builder :: proc() {
	fmt.println("Testing builder")
	b := strings.builder_make(context.temp_allocator)
	fmt.println(cap(b.buf)) // 0
	strings.write_string(&b, "Hellope!")
	fmt.println(cap(b.buf)) // 8
	strings.write_string(&b, " Bye!")
	fmt.println(cap(b.buf)) // 24 (8 * 2 + 8)
	fmt.println(strings.to_string(b)) // "Hellope! Bye!"
}

main :: proc() {
	test()
	test_soa()
	test_builder()
}
```

Output:
```
Testing dynamic array
0
8
[7, 8, 9, 10]
Testing soa dynamic array
0
8
[My_Struct{v1 = 1, v2 = 2, v3 = 3, v4 = 4, v5 = 5, v6 = 6}, My_Struct{v1 = 1, v2 = 2, v3 = 3, v4 = 4, v5 = 5, v6 = 6}, My_Struct{v1 = 1, v2 = 2, v3 = 3, v4 = 4, v5 = 5, v6 = 6}, My_Struct{v1 = 1, v2 = 2, v3 = 3, v4 = 4, v5 = 5, v6 = 6}]
Testing builder
0
8
24
Hellope! Bye!
```

I also tested this with my current game prototype, it all worked fine.