### PR TITLE
Add `raw_data` proc to `base/builtin/builtin.odin`

### DIFF
--- a/base/builtin/builtin.odin
+++ b/base/builtin/builtin.odin
@@ -129,9 +129,9 @@ soa_unzip :: proc(value: $S/#soa[]$E) -> (slices: ...) ---
 
 unreachable :: proc() -> ! ---
 
-@private _raw_data_string  :: proc (v: string)      -> [^]u8 ---
-@private _raw_data_slice   :: proc (v: []$E)        -> [^]E  ---
-@private _raw_data_dynamic :: proc (v: [dynamic]$E) -> [^]E  ---
-@private _raw_data_array   :: proc (v: ^[$N]$E)     -> [^]E  ---
+@private _raw_data_string  :: proc(value: string)      -> [^]u8 ---
+@private _raw_data_slice   :: proc(value: []$E)        -> [^]E  ---
+@private _raw_data_dynamic :: proc(value: [dynamic]$E) -> [^]E  ---
+@private _raw_data_array   :: proc(value: ^[$N]$E)     -> [^]E  ---
 
-raw_data :: proc {_raw_data_string, _raw_data_slice, _raw_data_dynamic, _raw_data_array}
+raw_data :: proc{_raw_data_string, _raw_data_slice, _raw_data_dynamic, _raw_data_array}

--- a/base/builtin/builtin.odin
+++ b/base/builtin/builtin.odin
@@ -128,3 +128,10 @@ soa_zip :: proc(slices: ...) -> #soa[]Struct ---
 soa_unzip :: proc(value: $S/#soa[]$E) -> (slices: ...) ---
 
 unreachable :: proc() -> ! ---
+
+@private _raw_data_string  :: proc (v: string)      -> [^]u8 ---
+@private _raw_data_slice   :: proc (v: []$E)        -> [^]E  ---
+@private _raw_data_dynamic :: proc (v: [dynamic]$E) -> [^]E  ---
+@private _raw_data_array   :: proc (v: ^[$N]$E)     -> [^]E  ---
+
+raw_data :: proc {_raw_data_string, _raw_data_slice, _raw_data_dynamic, _raw_data_array}


### PR DESCRIPTION
`raw_data` was missing, but it's nice to be able to see it's rough definition.
Had to split it into a proc group, so the other procs are made private *because they are not real anyway*