### PR TITLE
error on type_of(value of untyped type)

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -2290,6 +2290,14 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 			error(o.expr, "Invalid argument to 'type_of'");
 			return false;
 		}
+
+		if (is_type_untyped(o.type)) {
+			gbString t = type_to_string(o.type);
+			error(o.expr, "'type_of' of %s cannot be determined", t);
+			gb_string_free(t);
+			return false;
+		}
+
 		// NOTE(bill): Prevent type cycles for procedure declarations
 		if (c->curr_proc_sig == o.type) {
 			gbString s = expr_to_string(o.expr);


### PR DESCRIPTION
Doing `type_of(nil)` or `type_of(5)` now gives a proper error instead of tripping an internal assertion.

This fixes #1180 since `bug := typeid_of(type_of(nil))` cannot get past the `type_of` part anymore.

## Old behavior
`type_of(nil)`
gives:
```
C:\Odin\src\types.cpp(3677): Assertion Failure: `is_type_typed(t)` untyped nil
```

`type_of(5)`
gives:
```
C:\Odin\src\types.cpp(3677): Assertion Failure: `is_type_typed(t)` untyped integer
```

## New behavior
`type_of(nil)`
=>
```
C:/bug_repros/typeid_bug/typeid_bug.odin(6:27) Error: 'type_of' of untyped nil cannot be determined 
	bug := typeid_of(type_of(nil)) 
	                         ^~^ 
```

`type_of(5)`
=>
```
C:/bug_repros/typeid_bug/typeid_bug.odin(7:28) Error: 'type_of' of untyped integer cannot be determined 
	bug2 := typeid_of(type_of(5)) 
	                          ^ 
```