### PR TITLE
Fix assertion false negative

### DIFF
--- a/src/llvm_backend_const.cpp
+++ b/src/llvm_backend_const.cpp
@@ -176,7 +176,6 @@ gb_internal LLVMValueRef llvm_const_named_struct_internal(LLVMTypeRef t, LLVMVal
 	for (unsigned i = 0; i < elem_count; i++) {
 		LLVMTypeRef elem_type = LLVMStructGetTypeAtIndex(t, i);
 		values[i] = llvm_const_cast(values[i], elem_type);
-		GB_ASSERT_MSG(elem_type == LLVMTypeOf(values[i]), "%s != %s", LLVMPrintTypeToString(LLVMTypeOf(values[i])), LLVMPrintTypeToString(elem_type));
 	}
 	return LLVMConstNamedStruct(t, values, value_count);
 }


### PR DESCRIPTION
Assertion was added in #3855 - https://github.com/odin-lang/Odin/pull/3855/commits/723314909679b89e159cb4cb05d250d12ac64436 to mimic LLVM's own internal assertion for this, turns out their assertion is more sophisticated than an `==` so lets just remove it.

To be clear their internal assertion is not hit while this one is, which defeats the purpose of ours.

Fixes #3869 