### PR TITLE
[sys/linux]: change setsid to return Pid

### DIFF
--- a/core/sys/linux/sys.odin
+++ b/core/sys/linux/sys.odin
@@ -1733,9 +1733,9 @@ getpgrp :: proc "contextless" () -> (Pid, Errno) {
 	Create a session and set the process group ID.
 	Available since Linux 2.0.
 */
-setsid :: proc "contextless" () -> (Errno) {
+setsid :: proc "contextless" () -> (Pid, Errno) {
 	ret := syscall(SYS_setsid)
-	return Errno(-ret)
+	return errno_unwrap(ret, Pid)
 }
 
 /*


### PR DESCRIPTION
The `setsid` syscall returns the PID of the calling process upon success. The procedure currently only returns an `Errno`, causing it to return an invalid enum value when it happens. I updated the procedure to return `Pid` as well.