### PR TITLE
[core:strings] split_by_byte_iterator add nil pointer & empty string check

### DIFF
--- a/core/strings/strings.odin
+++ b/core/strings/strings.odin
@@ -1059,6 +1059,11 @@ Output:
 
 */
 split_by_byte_iterator :: proc(s: ^string, sep: u8) -> (res: string, ok: bool) {
+	// stop once the string is empty or nil
+	if s == nil || len(s^) == 0 {
+		return
+	}
+	
 	m := index_byte(s^, sep)
 	if m < 0 {
 		// not found


### PR DESCRIPTION
add nil check to prevent deferring a nil pointer and empty string check to stop iterating early.