### PR TITLE
Fix mistaken 1TBS error

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -114,7 +114,7 @@ call build_vendor.bat
 if %errorlevel% neq 0 goto end_of_build
 
 rem If the demo doesn't run for you and your CPU is more than a decade old, try -microarch:native
-if %release_mode% EQU 0 odin run examples/demo -- Hellope World
+if %release_mode% EQU 0 odin run examples/demo -vet -strict-style -- Hellope World
 
 del *.obj > NUL 2> NUL
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1507,6 +1507,13 @@ gb_internal bool skip_possible_newline_for_literal(AstFile *f, bool ignore_stric
 		if (curr.pos.line+1 >= next.pos.line) {
 			switch (next.kind) {
 			case Token_OpenBrace:
+				if (build_context.strict_style && !ignore_strict_style) {
+					Token prev = f->prev_token;
+					if (prev.kind == Token_if || prev.kind == Token_else) {
+						syntax_error(next, "With '-strict-style' the attached brace style (1TBS) is enforced");
+					}
+				}
+				break;
 			case Token_else:
 				if (build_context.strict_style && !ignore_strict_style) {
 					syntax_error(next, "With '-strict-style' the attached brace style (1TBS) is enforced");


### PR DESCRIPTION
And also compile `examples\demo` with `-vet -strict-style` going forward.

```odin
if true {
	fmt.println("Foo")
}
{ // complains about this one
	fmt.println("Bar")
}
```