### PR TITLE
allow `core:mem/virtual` import on more targets by expanding the `other` implementation

### DIFF
--- a/core/mem/virtual/virtual_other.odin
+++ b/core/mem/virtual/virtual_other.odin
@@ -1,5 +1,7 @@
-//+build freebsd, openbsd, netbsd
 //+private
+//+build !darwin
+//+build !linux
+//+build !windows
 package mem_virtual
 
 _reserve :: proc "contextless" (size: uint) -> (data: []byte, err: Allocator_Error) {


### PR DESCRIPTION
Was trying to use `core:text/table` on wasm and I think the best solution is solving it at this level instead of there, as the bsds also had it solved at this level already.