### PR TITLE
[core/os]: Fix read_console edge case bug

### DIFF
--- a/core/os/file_windows.odin
+++ b/core/os/file_windows.odin
@@ -125,7 +125,7 @@ read_console :: proc(handle: win32.HANDLE, b: []byte) -> (n: int, err: Errno) {
 		src := buf8[:buf8_len]
 
 		ctrl_z := false
-		for i := 0; i < len(src) && n+i < len(b); i += 1 {
+		for i := 0; i < len(src) && n < len(b); i += 1 {
 			x := src[i]
 			if x == 0x1a { // ctrl-z
 				ctrl_z = true


### PR DESCRIPTION

This PR fixes a bug, where the `os.read()` procedure on Windows would fail to finish reading the line, if the size of the output slice was exactly two bytes bigger than the length of the line, excluding the line terminator characters.

The `read_console()` had incorrect bounds checking in the `for` loop that was copying UTF-8 data from a temporary buffer to the output slice.

This PR will fix #1623