### PR TITLE
Add `field_name` parameter to `flags.Custom_Type_Setter`

### DIFF
--- a/core/flags/internal_assignment.odin
+++ b/core/flags/internal_assignment.odin
@@ -48,6 +48,7 @@ push_positional :: #force_no_inline proc (model: ^$T, parser: ^Parser, arg: stri
 	args_tag, _ := reflect.struct_tag_lookup(field.tag, TAG_ARGS)
 	field_name := get_field_name(field)
 	error = parse_and_set_pointer_by_type(ptr, arg, field.type, args_tag)
+
 	#partial switch &specific_error in error {
 	case Parse_Error:
 		specific_error.message = fmt.tprintf("Unable to set positional #%i (%s) of type %v to `%s`.%s%s",
@@ -160,6 +161,7 @@ set_option :: proc(model: ^$T, parser: ^Parser, name, option: string) -> (error:
 	ptr := cast(rawptr)(cast(uintptr)model + field.offset)
 	args_tag := reflect.struct_tag_get(field.tag, TAG_ARGS)
 	error = parse_and_set_pointer_by_type(ptr, option, field.type, args_tag)
+
 	#partial switch &specific_error in error {
 	case Parse_Error:
 		specific_error.message = fmt.tprintf("Unable to set `%s` of type %v to `%s`.%s%s",

--- a/core/flags/internal_assignment.odin
+++ b/core/flags/internal_assignment.odin
@@ -47,7 +47,7 @@ push_positional :: #force_no_inline proc (model: ^$T, parser: ^Parser, arg: stri
 	ptr := cast(rawptr)(cast(uintptr)model + field.offset)
 	args_tag, _ := reflect.struct_tag_lookup(field.tag, TAG_ARGS)
 	field_name := get_field_name(field)
-	error = parse_and_set_pointer_by_type(ptr, arg, field.type, args_tag)
+	error = parse_and_set_pointer_by_type(ptr, arg, field.type, field.name, args_tag)
 
 	#partial switch &specific_error in error {
 	case Parse_Error:
@@ -160,7 +160,7 @@ set_option :: proc(model: ^$T, parser: ^Parser, name, option: string) -> (error:
 
 	ptr := cast(rawptr)(cast(uintptr)model + field.offset)
 	args_tag := reflect.struct_tag_get(field.tag, TAG_ARGS)
-	error = parse_and_set_pointer_by_type(ptr, option, field.type, args_tag)
+	error = parse_and_set_pointer_by_type(ptr, option, field.type, field.name, args_tag)
 
 	#partial switch &specific_error in error {
 	case Parse_Error:
@@ -230,7 +230,7 @@ set_key_value :: proc(model: ^$T, parser: ^Parser, name, key, value: string) -> 
 		}
 
 		args_tag, _ := reflect.struct_tag_lookup(field.tag, TAG_ARGS)
-		error = parse_and_set_pointer_by_type(value_ptr, value, specific_type_info.value, args_tag)
+		error = parse_and_set_pointer_by_type(value_ptr, value, specific_type_info.value, field.name, args_tag)
 		#partial switch &specific_error in error {
 		case Parse_Error:
 			specific_error.message = fmt.tprintf("Unable to set `%s` of type %v with key=value: `%s`=`%s`.%s%s",

--- a/core/flags/internal_rtti.odin
+++ b/core/flags/internal_rtti.odin
@@ -486,16 +486,12 @@ get_field_name :: proc(field: reflect.Struct_Field) -> string {
 	return name
 }
 
-get_field_pos :: proc(field: reflect.Struct_Field) -> (int, bool) {
-	if args_tag, ok := reflect.struct_tag_lookup(field.tag, TAG_ARGS); ok {
-		if pos_subtag, pos_ok := get_struct_subtag(args_tag, SUBTAG_POS); pos_ok {
-			if value, parse_ok := strconv.parse_u64_of_base(pos_subtag, 10); parse_ok {
-				return int(value), true
-			}
-		}
-	}
-
-	return 0, false
+get_field_pos :: proc(field: reflect.Struct_Field) -> (pos: int, ok: bool) {
+	args_tag := reflect.struct_tag_lookup(field.tag, TAG_ARGS) or_return
+	pos_subtag := get_struct_subtag(args_tag, SUBTAG_POS) or_return
+	value := strconv.parse_u64_of_base(pos_subtag, 10) or_return
+	pos, ok = int(value), true
+	return
 }
 
 // Get a struct field by its field name or `name` subtag.

--- a/core/flags/rtti.odin
+++ b/core/flags/rtti.odin
@@ -20,7 +20,7 @@ Returns:
 Custom_Type_Setter :: #type proc(
 	data:           rawptr,
 	data_type:      typeid,
-	field_name:		string,
+	field_name:			string,
 	unparsed_value: string,
 	args_tag:       string,
 ) -> (

--- a/core/flags/rtti.odin
+++ b/core/flags/rtti.odin
@@ -20,7 +20,7 @@ Returns:
 Custom_Type_Setter :: #type proc(
 	data:           rawptr,
 	data_type:      typeid,
-	field_name:			string,
+	field_name:     string,
 	unparsed_value: string,
 	args_tag:       string,
 ) -> (

--- a/core/flags/rtti.odin
+++ b/core/flags/rtti.odin
@@ -8,6 +8,7 @@ Handle setting custom data types.
 Inputs:
 - data: A raw pointer to the field where the data will go.
 - data_type: Type information on the underlying field.
+- field_name: The name of the underlying field.
 - unparsed_value: The unparsed string that the flag is being set to.
 - args_tag: The `args` tag from the struct's field.
 
@@ -19,6 +20,7 @@ Returns:
 Custom_Type_Setter :: #type proc(
 	data:           rawptr,
 	data_type:      typeid,
+	field_name:		string,
 	unparsed_value: string,
 	args_tag:       string,
 ) -> (


### PR DESCRIPTION
Motivation:
I found it quite difficult to provide an accurate error message in a type setter when the field name is not known.