### PR TITLE
Fix logic bug in core/encoding/ini/ini.odin

### DIFF
--- a/core/encoding/ini/ini.odin
+++ b/core/encoding/ini/ini.odin
@@ -121,7 +121,7 @@ load_map_from_path :: proc(path: string, allocator: runtime.Allocator, options :
 	data := os.read_entire_file(path, allocator) or_return
 	defer delete(data, allocator)
 	m, err = load_map_from_string(string(data), allocator, options)
-	ok = err != nil
+	ok = err == nil
 	defer if !ok {
 		delete_map(m)
 	}


### PR DESCRIPTION
The load_map_from_path had incorrect logic where it would return false for ok when err was equal to nil and true when there was an error.
This currently fixes the bug and allows people to use the function however as Jason suggested in [Discord](https://discord.com/channels/568138951836172421/568871298428698645/1261749104183083130) the functions would probably change to return a unified error enum instead of those functions returning an err and a ok boolean.