### PR TITLE
fix `add_sat` and `sub_sat` intrinsics

### DIFF
--- a/base/intrinsics/intrinsics.odin
+++ b/base/intrinsics/intrinsics.odin
@@ -38,9 +38,9 @@ count_leading_zeros  :: proc(x: $T) -> T where type_is_integer(T) || type_is_sim
 reverse_bits         :: proc(x: $T) -> T where type_is_integer(T) || type_is_simd_vector(T) ---
 byte_swap            :: proc(x: $T) -> T where type_is_integer(T) || type_is_float(T) ---
 
-overflow_add :: proc(lhs, rhs: $T) -> (T, bool) where type_is_integer(T) ---
-overflow_sub :: proc(lhs, rhs: $T) -> (T, bool) where type_is_integer(T) ---
-overflow_mul :: proc(lhs, rhs: $T) -> (T, bool) where type_is_integer(T) ---
+overflow_add :: proc(lhs, rhs: $T) -> (T, bool) where type_is_integer(T) #optional_ok ---
+overflow_sub :: proc(lhs, rhs: $T) -> (T, bool) where type_is_integer(T) #optional_ok ---
+overflow_mul :: proc(lhs, rhs: $T) -> (T, bool) where type_is_integer(T) #optional_ok ---
 
 add_sat :: proc(lhs, rhs: $T) -> T where type_is_integer(T) ---
 sub_sat :: proc(lhs, rhs: $T) -> T where type_is_integer(T) ---

--- a/base/intrinsics/intrinsics.odin
+++ b/base/intrinsics/intrinsics.odin
@@ -38,9 +38,12 @@ count_leading_zeros  :: proc(x: $T) -> T where type_is_integer(T) || type_is_sim
 reverse_bits         :: proc(x: $T) -> T where type_is_integer(T) || type_is_simd_vector(T) ---
 byte_swap            :: proc(x: $T) -> T where type_is_integer(T) || type_is_float(T) ---
 
-overflow_add :: proc(lhs, rhs: $T) -> (T, bool) ---
-overflow_sub :: proc(lhs, rhs: $T) -> (T, bool) ---
-overflow_mul :: proc(lhs, rhs: $T) -> (T, bool) ---
+overflow_add :: proc(lhs, rhs: $T) -> (T, bool) where type_is_integer(T) ---
+overflow_sub :: proc(lhs, rhs: $T) -> (T, bool) where type_is_integer(T) ---
+overflow_mul :: proc(lhs, rhs: $T) -> (T, bool) where type_is_integer(T) ---
+
+add_sat :: proc(lhs, rhs: $T) -> T where type_is_integer(T) ---
+sub_sat :: proc(lhs, rhs: $T) -> T where type_is_integer(T) ---
 
 sqrt :: proc(x: $T) -> T where type_is_float(T) || (type_is_simd_vector(T) && type_is_float(type_elem_type(T))) ---
 

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -2290,9 +2290,6 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 		{
 			Type *main_type = tv.type;
 			Type *type = main_type;
-			if (is_type_tuple(main_type)) {
-				type = main_type->Tuple.variables[0]->type;
-			}
 
 			lbValue x = lb_build_expr(p, ce->args[0]);
 			lbValue y = lb_build_expr(p, ce->args[1]);


### PR DESCRIPTION
These were using the same codepath as the overflowing intrinsics but these do not return an (optional) boolean too.