### PR TITLE
core/sys/windows: added drag and drop procedures

### DIFF
--- a/core/sys/windows/shell32.odin
+++ b/core/sys/windows/shell32.odin
@@ -30,6 +30,11 @@ foreign shell32 {
 	SHGetKnownFolderIDList :: proc(rfid: REFKNOWNFOLDERID, dwFlags: /* KNOWN_FOLDER_FLAG */ DWORD, hToken: HANDLE, ppidl: rawptr) -> HRESULT ---
 	SHSetKnownFolderPath :: proc(rfid: REFKNOWNFOLDERID, dwFlags: /* KNOWN_FOLDER_FLAG */ DWORD, hToken: HANDLE, pszPath: PCWSTR ) -> HRESULT ---
 	SHGetKnownFolderPath :: proc(rfid: REFKNOWNFOLDERID, dwFlags: /* KNOWN_FOLDER_FLAG */ DWORD, hToken: HANDLE, ppszPath: ^LPWSTR) -> HRESULT ---
+
+	DragAcceptFiles :: proc(hWnd: HWND, fAccept: BOOL) ---
+	DragQueryPoint :: proc(hDrop: HDROP, ppt: ^POINT) -> BOOL ---
+	DragQueryFileW :: proc(hDrop: HDROP, iFile: UINT, lpszFile: LPWSTR, cch: UINT) -> UINT ---
+	DragFinish :: proc(hDrop: HDROP) --- // @New
 }
 
 APPBARDATA :: struct {
@@ -66,6 +71,8 @@ ABE_BOTTOM           :: 3
 
 KNOWNFOLDERID :: GUID
 REFKNOWNFOLDERID :: ^KNOWNFOLDERID
+
+HDROP :: HANDLE
 
 KNOWN_FOLDER_FLAG :: enum u32 {
 	DEFAULT                          = 0x00000000,


### PR DESCRIPTION
`DragQueryFileA` was purposely not added because we prefer the wide procedures over the ascii ones.