### PR TITLE
Fix memory leak in encoding/ini

### DIFF
--- a/core/encoding/ini/ini.odin
+++ b/core/encoding/ini/ini.odin
@@ -92,7 +92,6 @@ load_map_from_string :: proc(src: string, allocator: runtime.Allocator, options 
 			}
 		}
 		return strings.clone(val)
-
 	}
 
 	context.allocator = allocator
@@ -114,7 +113,10 @@ load_map_from_string :: proc(src: string, allocator: runtime.Allocator, options 
 			new_key = strings.to_lower(key) or_return
 			delete(old_key) or_return
 		}
-		pairs[new_key] = unquote(value) or_return
+		pairs[new_key], err = unquote(value)
+		if err != nil {
+			return
+		}
 	}
 	return
 }
@@ -144,6 +146,7 @@ delete_map :: proc(m: Map) {
 			delete(value, allocator)
 		}
 		delete(section)
+		delete(pairs)
 	}
 	delete(m)
 }

--- a/core/encoding/ini/ini.odin
+++ b/core/encoding/ini/ini.odin
@@ -113,10 +113,7 @@ load_map_from_string :: proc(src: string, allocator: runtime.Allocator, options 
 			new_key = strings.to_lower(key) or_return
 			delete(old_key) or_return
 		}
-		pairs[new_key], err = unquote(value)
-		if err != nil {
-			return
-		}
+		pairs[new_key], err = unquote(value) or_return
 	}
 	return
 }


### PR DESCRIPTION
A simple change that fixes a memory leak caused by not deleting all the values in the ini.map.  The type that is returned when parsing an ini file/string.