### PR TITLE
[os2] Make all handles non-inheritable by default

### DIFF
--- a/core/net/socket_linux.odin
+++ b/core/net/socket_linux.odin
@@ -117,7 +117,7 @@ _wrap_os_addr :: proc "contextless" (addr: linux.Sock_Addr_Any)->(Endpoint) {
 _create_socket :: proc(family: Address_Family, protocol: Socket_Protocol) -> (Any_Socket, Network_Error) {
 	family := _unwrap_os_family(family)
 	proto, socktype := _unwrap_os_proto_socktype(protocol)
-	sock, errno := linux.socket(family, socktype, {}, proto)
+	sock, errno := linux.socket(family, socktype, {.CLOEXEC}, proto)
 	if errno != .NONE {
 		return {}, Create_Socket_Error(errno)
 	}
@@ -132,7 +132,7 @@ _dial_tcp_from_endpoint :: proc(endpoint: Endpoint, options := default_tcp_optio
 	}
 	// Create new TCP socket
 	os_sock: linux.Fd
-	os_sock, errno = linux.socket(_unwrap_os_family(family_from_endpoint(endpoint)), .STREAM, {}, .TCP)
+	os_sock, errno = linux.socket(_unwrap_os_family(family_from_endpoint(endpoint)), .STREAM, {.CLOEXEC}, .TCP)
 	if errno != .NONE {
 		// TODO(flysand): should return invalid file descriptor here casted as TCP_Socket
 		return {}, Create_Socket_Error(errno)
@@ -172,7 +172,7 @@ _listen_tcp :: proc(endpoint: Endpoint, backlog := 1000) -> (TCP_Socket, Network
 	ep_address := _unwrap_os_addr(endpoint)
 	// Create TCP socket
 	os_sock: linux.Fd
-	os_sock, errno = linux.socket(ep_family, .STREAM, {}, .TCP)
+	os_sock, errno = linux.socket(ep_family, .STREAM, {.CLOEXEC}, .TCP)
 	if errno != .NONE {
 		// TODO(flysand): should return invalid file descriptor here casted as TCP_Socket
 		return {}, Create_Socket_Error(errno)

--- a/core/os/os2/file.odin
+++ b/core/os/os2/file.odin
@@ -29,7 +29,7 @@ File_Flag :: enum {
 	Sync,
 	Trunc,
 	Sparse,
-	Close_On_Exec,
+	Inheritable,
 
 	Unbuffered_IO,
 }
@@ -43,7 +43,15 @@ O_EXCL    :: File_Flags{.Excl}
 O_SYNC    :: File_Flags{.Sync}
 O_TRUNC   :: File_Flags{.Trunc}
 O_SPARSE  :: File_Flags{.Sparse}
-O_CLOEXEC :: File_Flags{.Close_On_Exec}
+
+/*
+	If specified, the file handle is inherited upon the creation of a child
+	process. By default all handles are created non-inheritable.
+
+	**Note**: The standard file handles (stderr, stdout and stdin) are always
+	initialized as inheritable.
+*/
+O_INHERITABLE :: File_Flags{.Inheritable}
 
 stdin:  ^File = nil // OS-Specific
 stdout: ^File = nil // OS-Specific

--- a/core/os/os2/file_linux.odin
+++ b/core/os/os2/file_linux.odin
@@ -70,7 +70,7 @@ _open :: proc(name: string, flags: File_Flags, perm: File_Mode) -> (f: ^File, er
 	// Just default to using O_NOCTTY because needing to open a controlling
 	// terminal would be incredibly rare. This has no effect on files while
 	// allowing us to open serial devices.
-	sys_flags: linux.Open_Flags = {.NOCTTY}
+	sys_flags: linux.Open_Flags = {.NOCTTY, .CLOEXEC}
 	switch flags & O_RDONLY|O_WRONLY|O_RDWR {
 	case O_RDONLY:
 	case O_WRONLY: sys_flags += {.WRONLY}
@@ -82,7 +82,7 @@ _open :: proc(name: string, flags: File_Flags, perm: File_Mode) -> (f: ^File, er
 	if .Excl in flags          { sys_flags += {.EXCL} }
 	if .Sync in flags          { sys_flags += {.DSYNC} }
 	if .Trunc in flags         { sys_flags += {.TRUNC} }
-	if .Close_On_Exec in flags { sys_flags += {.CLOEXEC} }
+	if .Inheritable in flags   { sys_flags -= {.CLOEXEC} }
 
 	fd, errno := linux.open(name_cstr, sys_flags, transmute(linux.Mode)(u32(perm)))
 	if errno != .NONE {

--- a/core/os/os2/file_windows.odin
+++ b/core/os/os2/file_windows.odin
@@ -79,7 +79,7 @@ _open_internal :: proc(name: string, flags: File_Flags, perm: File_Mode) -> (han
 	share_mode := u32(win32.FILE_SHARE_READ | win32.FILE_SHARE_WRITE)
 	sa := win32.SECURITY_ATTRIBUTES {
 		nLength = size_of(win32.SECURITY_ATTRIBUTES),
-		bInheritHandle = .Close_On_Exec not_in flags,
+		bInheritHandle = .Inheritable in flags,
 	}
 
 	create_mode: u32 = win32.OPEN_EXISTING

--- a/core/os/os2/pipe_linux.odin
+++ b/core/os/os2/pipe_linux.odin
@@ -5,7 +5,7 @@ import "core:sys/linux"
 
 _pipe :: proc() -> (r, w: ^File, err: Error) {
 	fds: [2]linux.Fd
-	errno := linux.pipe2(&fds, {.CLOEXEC})
+	errno := linux.pipe2(&fds, {})
 	if errno != .NONE {
 		return nil, nil,_get_platform_error(errno)
 	}

--- a/core/os/os2/pipe_windows.odin
+++ b/core/os/os2/pipe_windows.odin
@@ -5,7 +5,11 @@ import win32 "core:sys/windows"
 
 _pipe :: proc() -> (r, w: ^File, err: Error) {
 	p: [2]win32.HANDLE
-	if !win32.CreatePipe(&p[0], &p[1], nil, 0) {
+	sa := win32.SECURITY_ATTRIBUTES {
+		nLength = size_of(win32.SECURITY_ATTRIBUTES),
+		bInheritHandle = true,
+	}
+	if !win32.CreatePipe(&p[0], &p[1], &sa, 0) {
 		return nil, nil, _get_platform_error()
 	}
 	return new_file(uintptr(p[0]), ""), new_file(uintptr(p[1]), ""), nil


### PR DESCRIPTION

Inheritable handles will be put into the child processes' address space, from where they could be accessed and used just as a parent would. If misused, "leaked" handles could be a cause of a vulnerability in a system, which is why it is important to not give child processes any handles that they are not supposed to get. Therefore os2 api will not follow the unix-route

The following handles in os2 have been made non-inheritable:

* sockets (can not be made inheritable)
* files (can be made inheritable with a flag)

Anonymous pipes are made always inheritable by default. To close one of the pipe ends, the `set_inheritable()` procedure needs to be called. This procedure can also be called to make files inheritable.

With `set_inheritable()` there's a concern with race conditions on process creation and setting these values. The burden of serializing all calls to `process_start()`, `pipe()` and `set_inheritable()` currently would fall on the user


