### PR TITLE
Ensure that values in ini map are unquoted

### DIFF
--- a/core/encoding/ini/ini.odin
+++ b/core/encoding/ini/ini.odin
@@ -89,6 +89,8 @@ load_map_from_string :: proc(src: string, allocator: runtime.Allocator, options 
 			}
 			if allocated {
 				return v, nil
+			} else {
+				return strings.clone(v), nil
 			}
 		}
 		return strings.clone(val)

--- a/core/encoding/ini/ini.odin
+++ b/core/encoding/ini/ini.odin
@@ -89,9 +89,8 @@ load_map_from_string :: proc(src: string, allocator: runtime.Allocator, options 
 			}
 			if allocated {
 				return v, nil
-			} else {
-				return strings.clone(v), nil
 			}
+			return strings.clone(v), nil
 		}
 		return strings.clone(val)
 	}


### PR DESCRIPTION
In the ini handler there are times where it will return a value in quotes, this fixes that.  The scenario can be seen using some demo code:
main.odin:
```odin
package main

import "core:fmt"
import "core:encoding/ini"

main :: proc() {
	ini_map, err, ok := ini.load_map_from_path("config.ini", allocator=context.allocator)
	if err != nil {
		fmt.eprintln("Got an error")
	}
	defer ini.delete_map(ini_map)

	fmt.println("ini_map[\"API\"][\"ADDRESS\"]:", ini_map["API"])
}
```

config.ini:
```ini
[LOG]
LEVEL = "DEBUG"

[API]
ADDRESS = "HTTP://127.0.0.1:8000"
```

Output from the above Odin code:
```
odin/ini % odin run .

ini_map["API"]["ADDRESS"]: map[ADDRESS="HTTP://127.0.0.1:8000"]
```