### PR TITLE
fix `reflect.any_base` and `reflect.any_core` with any's containing nil

### DIFF
--- a/core/reflect/reflect.odin
+++ b/core/reflect/reflect.odin
@@ -143,7 +143,7 @@ when !ODIN_NO_RTTI {
 @(require_results)
 any_base :: proc(v: any) -> any {
 	v := v
-	if v != nil {
+	if v.id != nil {
 		v.id = typeid_base(v.id)
 	}
 	return v
@@ -151,7 +151,7 @@ any_base :: proc(v: any) -> any {
 @(require_results)
 any_core :: proc(v: any) -> any {
 	v := v
-	if v != nil {
+	if v.id != nil {
 		v.id = typeid_core(v.id)
 	}
 	return v


### PR DESCRIPTION
Proper fix that was quick fixed with a workaround here: https://github.com/odin-lang/Odin/commit/fc5ce30f34163ce1dfa7ad8b01e60317c8d43c01

Problem was that if the `.data` of `any` is `nil`, it short-circuited without updating the type.