### PR TITLE
compiler: fix formatting of large messages

### DIFF
--- a/src/gb/gb.h
+++ b/src/gb/gb.h
@@ -5882,7 +5882,7 @@ gb_internal isize gb__print_string(char *text, isize max_len, gbprivFmtInfo *inf
 			len = info->precision < len ? info->precision : len;
 		}
 
-		res += gb_strlcpy(text, str, len);
+		res += gb_strlcpy(text, str, gb_min(len, max_len));
 
 		if (info->width > res) {
 			isize padding = info->width - len;
@@ -6037,14 +6037,16 @@ gb_internal isize gb__print_f64(char *text, isize max_len, gbprivFmtInfo *info, 
 gb_no_inline isize gb_snprintf_va(char *text, isize max_len, char const *fmt, va_list va) {
 	char const *text_begin = text;
 	isize remaining = max_len, res;
+	remaining--;
 
-	while (*fmt) {
+	while (*fmt && remaining) {
 		gbprivFmtInfo info = {0};
 		isize len = 0;
 		info.precision = -1;
 
 		while (*fmt && *fmt != '%' && remaining) {
 			*text++ = *fmt++;
+			remaining--;
 		}
 
 		if (*fmt == '%') {
@@ -6210,7 +6212,7 @@ gb_no_inline isize gb_snprintf_va(char *text, isize max_len, char const *fmt, va
 
 		text += len;
 		if (len >= remaining) {
-			remaining = gb_min(remaining, 1);
+			remaining = 0;
 		} else {
 			remaining -= len;
 		}
@@ -6218,7 +6220,7 @@ gb_no_inline isize gb_snprintf_va(char *text, isize max_len, char const *fmt, va
 
 	*text++ = '\0';
 	res = (text - text_begin);
-	return (res >= max_len || res < 0) ? -1 : res;
+	return (res > max_len || res < 0) ? -1 : res;
 }
 
 


### PR DESCRIPTION
Was looking at #3970 which crashes because it tries to print a big error message, looks like that code was just extremely busted? Here is an attempt at fixing, after this the actual error for that issue is showing (although truncated).