### PR TITLE
Correct the Array_Type.len comment and assign tok when making Ellipsis node

### DIFF
--- a/core/odin/ast/ast.odin
+++ b/core/odin/ast/ast.odin
@@ -757,7 +757,7 @@ Array_Type :: struct {
 	using node: Expr,
 	open:  tokenizer.Pos,
 	tag:   ^Expr,
-	len:   ^Expr, // Ellipsis node for [?]T array types, nil for slice types
+	len:   ^Expr, // Unary_Expr node for [?]T array types, nil for slice types
 	close: tokenizer.Pos,
 	elem:  ^Expr,
 }

--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -1778,6 +1778,7 @@ parse_var_type :: proc(p: ^Parser, flags: ast.Field_Flags) -> ^ast.Expr {
 			type = ast.new(ast.Bad_Expr, tok.pos, end_pos(tok))
 		}
 		e := ast.new(ast.Ellipsis, type.pos, type)
+		e.tok = tok.kind
 		e.expr = type
 		return e
 	}


### PR DESCRIPTION
Correct the `Array_Type.len` comment and assign `Ellipsis.tok` when making the node

The unary expression is used to annotate a `[?]T` array: https://github.com/odin-lang/Odin/blob/7f17d4eb7fa0b95dfed3a42211d9188479bfd820/core/odin/parser/parser.odin#L2533