### PR TITLE
fix for using .rc files

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1822,6 +1822,7 @@ gb_internal bool init_build_paths(String init_filename) {
 		if (bc->resource_filepath.len > 0) {
 			bc->build_paths[BuildPath_RES] = path_from_string(ha, bc->resource_filepath);
 			if (!string_ends_with(bc->resource_filepath, str_lit(".res"))) {
+				bc->build_paths[BuildPath_RES].ext = copy_string(ha, STR_LIT("res"));
 				bc->build_paths[BuildPath_RC]      = path_from_string(ha, bc->resource_filepath);
 				bc->build_paths[BuildPath_RC].ext  = copy_string(ha, STR_LIT("rc"));
 			}


### PR DESCRIPTION
I've made a small tool for setting up odin (for windows) and ran into trouvle using a .rc file after compiling the .rc file was overwritten.
The command i use:
```
>odin run examples/setup -resource:examples/setup/setup.rc -vet -- -nologo -DV1=2024 -DV2=07 -DV3=30 -DV4=0 -DVF=2024.07.30.0 -DGIT_SHA=744d7f7ef -DVP=dev-2024-07:744d7f7ef -D_DEBUG
```
Forcing the BuildPath_RES path to use .res fixed it.