### PR TITLE
[os2] Add missing temp_file implementation for Linux

### DIFF
--- a/core/os/os2/temp_file_linux.odin
+++ b/core/os/os2/temp_file_linux.odin
@@ -3,8 +3,11 @@ package os2
 
 import "base:runtime"
 
-
-_temp_dir :: proc(allocator: runtime.Allocator) -> (string, Error) {
-	//TODO
-	return "", nil
+_temp_dir :: proc(allocator: runtime.Allocator) -> (string, runtime.Allocator_Error) {
+	TEMP_ALLOCATOR_GUARD()
+	tmpdir := get_env("TMPDIR", temp_allocator())
+	if tmpdir == "" {
+		tmpdir = "/tmp"
+	}
+	return clone_string(tmpdir, allocator)
 }


### PR DESCRIPTION
According the POSIX specification, this implementation should be possible to share between Linux, OSX and the BSDs.

References:
* https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s18.html
* https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap10.html
* https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html
