### PR TITLE
[vendor:raylib] Remove GuiStyleProp

### DIFF
--- a/vendor/raylib/raygui.odin
+++ b/vendor/raylib/raygui.odin
@@ -28,13 +28,6 @@ when ODIN_OS == .Windows {
 
 RAYGUI_VERSION :: "4.0"
 
-// Style property
-GuiStyleProp :: struct {
-	controlId:     u16,
-	propertyId:    u16,
-	propertyValue: c.int,
-}
-
 // Gui control state
 GuiState :: enum c.int {
 	STATE_NORMAL = 0,

--- a/vendor/raylib/raygui.odin
+++ b/vendor/raylib/raygui.odin
@@ -236,8 +236,8 @@ foreign lib {
 	
 	// Style set/get functions
 	
-	GuiSetStyle         :: proc(control: GuiControl, property: GuiStyleProp, value: c.int) ---                // Set one style property
-	GuiGetStyle         :: proc(control: GuiControl, property: GuiStyleProp) -> c.int ---                     // Get one style property
+	GuiSetStyle         :: proc(control: GuiControl, property: c.int, value: c.int) ---                       // Set one style property
+	GuiGetStyle         :: proc(control: GuiControl, property: c.int) -> c.int ---                            // Get one style property
 	
 	// Styles loading functions
 	

--- a/vendor/raylib/raygui.odin
+++ b/vendor/raylib/raygui.odin
@@ -229,8 +229,8 @@ foreign lib {
 	
 	// Style set/get functions
 	
-	GuiSetStyle         :: proc(control: GuiControl, property: c.int, value: c.int) ---                       // Set one style property
-	GuiGetStyle         :: proc(control: GuiControl, property: c.int) -> c.int ---                            // Get one style property
+	GuiSetStyle         :: proc(control: GuiControl, property: GuiControlProperty, value: c.int) ---          // Set one style property
+	GuiGetStyle         :: proc(control: GuiControl, property: GuiControlProperty) -> c.int ---               // Get one style property
 	
 	// Styles loading functions
 	


### PR DESCRIPTION
Removed GuiStyleProp and updated GuiSetStyle & GuiGetStyle to accept an i32 as the property as GuiStyleProp is not needed. Original raygui accepts integer as shown below:

```c
// Styles loading functions
RAYGUIAPI void GuiLoadStyle(const char *fileName);              // Load style file over global style variable (.rgs)
RAYGUIAPI void GuiLoadStyleDefault(void);                       // Load style default over global style
```

Styles can now be changed without a segmentation fault and called as shown below:
```odin
rl.GuiSetStyle(.LISTVIEW, .TEXT_ALIGNMENT, i32(rl.GuiTextAlignment.TEXT_ALIGN_RIGHT))
```