### PR TITLE
Quality of Life changes to wgpu/js

### DIFF
--- a/vendor/wasm/js/events.odin
+++ b/vendor/wasm/js/events.odin
@@ -33,6 +33,7 @@ Event_Kind :: enum u32 {
 	Submit,
 	Blur,
 	Change,
+	HashChange,
 	Select,
 
 	Animation_Start,
@@ -112,6 +113,7 @@ event_kind_string := [Event_Kind]string{
 	.Submit       = "submit",
 	.Blur         = "blur",
 	.Change       = "change",
+	.HashChange   = "hashchange",
 	.Select       = "select",
 
 	.Animation_Start     = "animationstart",

--- a/vendor/wgpu/wgpu.odin
+++ b/vendor/wgpu/wgpu.odin
@@ -716,7 +716,7 @@ BufferDescriptor :: struct {
 	mappedAtCreation: b32,
 }
 
-Color :: [4]f32
+Color :: [4]f64
 
 CommandBufferDescriptor :: struct {
 	nextInChain: ^ChainedStruct,

--- a/vendor/wgpu/wgpu.odin
+++ b/vendor/wgpu/wgpu.odin
@@ -716,12 +716,7 @@ BufferDescriptor :: struct {
 	mappedAtCreation: b32,
 }
 
-Color :: struct {
-	r: f64,
-	g: f64,
-	b: f64,
-	a: f64,
-}
+Color :: [4]f32
 
 CommandBufferDescriptor :: struct {
 	nextInChain: ^ChainedStruct,


### PR DESCRIPTION
Makes `wgpu.Color`  a `[4]f32` to be more nice for odin (get all the fancy `color.rggg` stuff including `wgpu.Color(1)`)

Also a tiny addition to js/events so you can do:
```odin
js.add_window_event_listener(.HashChange, nil, proc(e: js.Event) {
        buf := [256]u8{};
        val := js_ext.get_current_url(buf[:])
        fmt.println("Current URL:", val)
    })
```