### PR TITLE
`os.Error` to replace `os.Errno`

### DIFF
--- a/core/crypto/rand_windows.odin
+++ b/core/crypto/rand_windows.odin
@@ -10,7 +10,7 @@ HAS_RAND_BYTES :: true
 _rand_bytes :: proc(dst: []byte) {
 	ret := (os.Errno)(win32.BCryptGenRandom(nil, raw_data(dst), u32(len(dst)), win32.BCRYPT_USE_SYSTEM_PREFERRED_RNG))
 	if ret != os.ERROR_NONE {
-		switch ret {
+		#partial switch ret {
 		case os.ERROR_INVALID_HANDLE:
 			// The handle to the first parameter is invalid.
 			// This should not happen here, since we explicitly pass nil to it

--- a/core/crypto/rand_windows.odin
+++ b/core/crypto/rand_windows.odin
@@ -8,8 +8,8 @@ HAS_RAND_BYTES :: true
 
 @(private)
 _rand_bytes :: proc(dst: []byte) {
-	ret := (os.Errno)(win32.BCryptGenRandom(nil, raw_data(dst), u32(len(dst)), win32.BCRYPT_USE_SYSTEM_PREFERRED_RNG))
-	if ret != os.ERROR_NONE {
+	ret := os.Platform_Error(win32.BCryptGenRandom(nil, raw_data(dst), u32(len(dst)), win32.BCRYPT_USE_SYSTEM_PREFERRED_RNG))
+	if ret != nil {
 		#partial switch ret {
 		case os.ERROR_INVALID_HANDLE:
 			// The handle to the first parameter is invalid.

--- a/core/encoding/csv/example.odin
+++ b/core/encoding/csv/example.odin
@@ -38,9 +38,9 @@ iterate_csv_from_stream :: proc(filename: string) {
 	r.reuse_record_buffer = true // Without it you have to each of the fields within it
 	defer csv.reader_destroy(&r)
 
-	handle, errno := os.open(filename)
-	if errno != os.ERROR_NONE {
-		fmt.printfln("Error opening file: %v", filename)
+	handle, err := os.open(filename)
+	if err != nil {
+		fmt.eprintfln("Error opening file: %v", filename)
 		return
 	}
 	defer os.close(handle)

--- a/core/flags/errors.odin
+++ b/core/flags/errors.odin
@@ -28,7 +28,7 @@ Parse_Error :: struct {
 // Provides more granular information than what just a string could hold.
 Open_File_Error :: struct {
 	filename: string,
-	errno: os.Errno,
+	errno: os.Error,
 	mode: int,
 	perms: int,
 }

--- a/core/flags/internal_rtti.odin
+++ b/core/flags/internal_rtti.odin
@@ -254,7 +254,7 @@ parse_and_set_pointer_by_named_type :: proc(ptr: rawptr, str: string, data_type:
 		}
 
 		handle, errno := os.open(str, mode, perms)
-		if errno != 0 {
+		if errno != nil {
 			// NOTE(Feoramund): os.Error is system-dependent, and there's
 			// currently no good way to translate them all into strings.
 			//

--- a/core/flags/internal_rtti.odin
+++ b/core/flags/internal_rtti.odin
@@ -255,7 +255,7 @@ parse_and_set_pointer_by_named_type :: proc(ptr: rawptr, str: string, data_type:
 
 		handle, errno := os.open(str, mode, perms)
 		if errno != 0 {
-			// NOTE(Feoramund): os.Errno is system-dependent, and there's
+			// NOTE(Feoramund): os.Error is system-dependent, and there's
 			// currently no good way to translate them all into strings.
 			//
 			// The upcoming `os2` package will hopefully solve this.

--- a/core/image/general_os.odin
+++ b/core/image/general_os.odin
@@ -27,7 +27,7 @@ which :: proc{
 
 which_file :: proc(path: string) -> Which_File_Type {
 	f, err := os.open(path)
-	if err != 0 {
+	if err != nil {
 		return .Unknown
 	}
 	header: [128]byte

--- a/core/image/png/example.odin
+++ b/core/image/png/example.odin
@@ -213,7 +213,7 @@ write_image_as_ppm :: proc(filename: string, image: ^image.Image) -> (success: b
 	}
 
 	fd, err := open(filename, flags, mode)
-	if err != 0 {
+	if err != nil {
 		return false
 	}
 	defer close(fd)

--- a/core/image/png/helpers.odin
+++ b/core/image/png/helpers.odin
@@ -450,7 +450,7 @@ when false {
 		}
 
 		fd, fderr := open(filename, flags, mode)
-		if fderr != 0 {
+		if fderr != nil {
 			return .Cannot_Open_File
 		}
 		defer close(fd)

--- a/core/mem/virtual/file.odin
+++ b/core/mem/virtual/file.odin
@@ -24,7 +24,7 @@ map_file :: proc{
 
 map_file_from_path :: proc(filename: string, flags: Map_File_Flags) -> (data: []byte, error: Map_File_Error) {
 	fd, err := os.open(filename, os.O_RDWR)
-	if err != 0 {
+	if err != nil {
 		return nil, .Open_Failure
 	}
 	defer os.close(fd)
@@ -34,7 +34,7 @@ map_file_from_path :: proc(filename: string, flags: Map_File_Flags) -> (data: []
 
 map_file_from_file_descriptor :: proc(fd: uintptr, flags: Map_File_Flags) -> (data: []byte, error: Map_File_Error) {
 	size, os_err := os.file_size(os.Handle(fd))
-	if os_err != 0 {
+	if os_err != nil {
 		return nil, .Stat_Failure
 	}
 	if size < 0 {

--- a/core/os/dir_unix.odin
+++ b/core/os/dir_unix.odin
@@ -3,6 +3,7 @@ package os
 
 import "core:strings"
 
+@(require_results)
 read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []File_Info, err: Errno) {
 	dirp := _fdopendir(fd) or_return
 	defer _closedir(dirp)

--- a/core/os/dir_unix.odin
+++ b/core/os/dir_unix.odin
@@ -4,20 +4,10 @@ package os
 import "core:strings"
 
 read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []File_Info, err: Errno) {
-	dirp: Dir
-	dirp, err = _fdopendir(fd)
-	if err != ERROR_NONE {
-		return
-	}
-
+	dirp := _fdopendir(fd) or_return
 	defer _closedir(dirp)
 
-	dirpath: string
-	dirpath, err = absolute_path_from_handle(fd)
-	if err != ERROR_NONE {
-		return
-	}
-
+	dirpath := absolute_path_from_handle(fd) or_return
 	defer delete(dirpath)
 
 	n := n
@@ -27,8 +17,8 @@ read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []F
 		size = 100
 	}
 
-	dfi := make([dynamic]File_Info, 0, size, allocator)
-	defer if err != ERROR_NONE {
+	dfi := make([dynamic]File_Info, 0, size, allocator) or_return
+	defer if err != nil {
 		for fi_ in dfi {
 			file_info_delete(fi_, allocator)
 		}
@@ -39,7 +29,7 @@ read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []F
 		entry: Dirent
 		end_of_stream: bool
 		entry, err, end_of_stream = _readdir(dirp)
-		if err != ERROR_NONE {
+		if err != nil {
 			return
 		} else if end_of_stream {
 			break
@@ -56,7 +46,7 @@ read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []F
 
 		s: OS_Stat
 		s, err = _lstat(fullpath)
-		if err != ERROR_NONE {
+		if err != nil {
 			delete(fullpath, allocator)
 			return
 		}
@@ -67,5 +57,5 @@ read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []F
 		append(&dfi, fi_)
 	}
 
-	return dfi[:], ERROR_NONE
+	return dfi[:], nil
 }

--- a/core/os/dir_unix.odin
+++ b/core/os/dir_unix.odin
@@ -4,7 +4,7 @@ package os
 import "core:strings"
 
 @(require_results)
-read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []File_Info, err: Errno) {
+read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []File_Info, err: Error) {
 	dirp := _fdopendir(fd) or_return
 	defer _closedir(dirp)
 

--- a/core/os/dir_windows.odin
+++ b/core/os/dir_windows.odin
@@ -88,7 +88,7 @@ read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []F
 	find_data := &win32.WIN32_FIND_DATAW{}
 	find_handle := win32.FindFirstFileW(raw_data(wpath_search), find_data)
 	if find_handle == win32.INVALID_HANDLE_VALUE {
-		err = Errno(win32.GetLastError())
+		err = Platform_Error(win32.GetLastError())
 		return dfi[:], err
 	}
 	defer win32.FindClose(find_handle)
@@ -101,7 +101,7 @@ read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []F
 		}
 
 		if !win32.FindNextFileW(find_handle, find_data) {
-			e := Errno(win32.GetLastError())
+			e := Platform_Error(win32.GetLastError())
 			if e == ERROR_NO_MORE_FILES {
 				break
 			}

--- a/core/os/dir_windows.odin
+++ b/core/os/dir_windows.odin
@@ -58,7 +58,7 @@ read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []F
 
 	dir_fi, _ := file_info_from_get_file_information_by_handle("", h)
 	if !dir_fi.is_dir {
-		return nil, ERROR_FILE_IS_NOT_DIR
+		return nil, .Not_Dir
 	}
 
 	n := n

--- a/core/os/dir_windows.odin
+++ b/core/os/dir_windows.odin
@@ -6,6 +6,7 @@ import "base:runtime"
 
 @(require_results)
 read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []File_Info, err: Error) {
+	@(require_results)
 	find_data_to_file_info :: proc(base_path: string, d: ^win32.WIN32_FIND_DATAW) -> (fi: File_Info) {
 		// Ignore "." and ".."
 		if d.cFileName[0] == '.' && d.cFileName[1] == 0 {

--- a/core/os/dir_windows.odin
+++ b/core/os/dir_windows.odin
@@ -4,6 +4,7 @@ import win32 "core:sys/windows"
 import "core:strings"
 import "base:runtime"
 
+@(require_results)
 read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []File_Info, err: Errno) {
 	find_data_to_file_info :: proc(base_path: string, d: ^win32.WIN32_FIND_DATAW) -> (fi: File_Info) {
 		// Ignore "." and ".."

--- a/core/os/dir_windows.odin
+++ b/core/os/dir_windows.odin
@@ -88,7 +88,7 @@ read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []F
 	find_data := &win32.WIN32_FIND_DATAW{}
 	find_handle := win32.FindFirstFileW(raw_data(wpath_search), find_data)
 	if find_handle == win32.INVALID_HANDLE_VALUE {
-		err = Platform_Error(win32.GetLastError())
+		err = get_last_error()
 		return dfi[:], err
 	}
 	defer win32.FindClose(find_handle)
@@ -101,7 +101,7 @@ read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []F
 		}
 
 		if !win32.FindNextFileW(find_handle, find_data) {
-			e := Platform_Error(win32.GetLastError())
+			e := get_last_error()
 			if e == ERROR_NO_MORE_FILES {
 				break
 			}

--- a/core/os/dir_windows.odin
+++ b/core/os/dir_windows.odin
@@ -5,7 +5,7 @@ import "core:strings"
 import "base:runtime"
 
 @(require_results)
-read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []File_Info, err: Errno) {
+read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []File_Info, err: Error) {
 	find_data_to_file_info :: proc(base_path: string, d: ^win32.WIN32_FIND_DATAW) -> (fi: File_Info) {
 		// Ignore "." and ".."
 		if d.cFileName[0] == '.' && d.cFileName[1] == 0 {

--- a/core/os/dir_windows.odin
+++ b/core/os/dir_windows.odin
@@ -68,15 +68,14 @@ read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []F
 	}
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD(ignore = context.temp_allocator == allocator)
 
-	wpath: []u16
-	wpath, err = cleanpath_from_handle_u16(fd, context.temp_allocator)
-	if len(wpath) == 0 || err != ERROR_NONE {
+	wpath := cleanpath_from_handle_u16(fd, context.temp_allocator) or_return
+	if len(wpath) == 0 {
 		return
 	}
 
-	dfi := make([dynamic]File_Info, 0, size)
+	dfi := make([dynamic]File_Info, 0, size) or_return
 
-	wpath_search := make([]u16, len(wpath)+3, context.temp_allocator)
+	wpath_search := make([]u16, len(wpath)+3, context.temp_allocator) or_return
 	copy(wpath_search, wpath)
 	wpath_search[len(wpath)+0] = '\\'
 	wpath_search[len(wpath)+1] = '*'
@@ -109,5 +108,5 @@ read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []F
 		}
 	}
 
-	return dfi[:], ERROR_NONE
+	return dfi[:], nil
 }

--- a/core/os/env_windows.odin
+++ b/core/os/env_windows.odin
@@ -50,7 +50,7 @@ set_env :: proc(key, value: string) -> Errno {
 	v := win32.utf8_to_wstring(value)
 
 	if !win32.SetEnvironmentVariableW(k, v) {
-		return Errno(win32.GetLastError())
+		return Platform_Error(win32.GetLastError())
 	}
 	return 0
 }
@@ -59,7 +59,7 @@ set_env :: proc(key, value: string) -> Errno {
 unset_env :: proc(key: string) -> Errno {
 	k := win32.utf8_to_wstring(key)
 	if !win32.SetEnvironmentVariableW(k, nil) {
-		return Errno(win32.GetLastError())
+		return Platform_Error(win32.GetLastError())
 	}
 	return 0
 }

--- a/core/os/env_windows.odin
+++ b/core/os/env_windows.odin
@@ -41,7 +41,7 @@ get_env :: proc(key: string, allocator := context.allocator) -> (value: string) 
 }
 
 // set_env sets the value of the environment variable named by the key
-set_env :: proc(key, value: string) -> Errno {
+set_env :: proc(key, value: string) -> Error {
 	k := win32.utf8_to_wstring(key)
 	v := win32.utf8_to_wstring(value)
 
@@ -52,7 +52,7 @@ set_env :: proc(key, value: string) -> Errno {
 }
 
 // unset_env unsets a single environment variable
-unset_env :: proc(key: string) -> Errno {
+unset_env :: proc(key: string) -> Error {
 	k := win32.utf8_to_wstring(key)
 	if !win32.SetEnvironmentVariableW(k, nil) {
 		return get_last_error()

--- a/core/os/env_windows.odin
+++ b/core/os/env_windows.odin
@@ -7,6 +7,7 @@ import "base:runtime"
 // If the variable is found in the environment the value (which can be empty) is returned and the boolean is true
 // Otherwise the returned value will be empty and the boolean will be false
 // NOTE: the value will be allocated with the supplied allocator
+@(require_results)
 lookup_env :: proc(key: string, allocator := context.allocator) -> (value: string, found: bool) {
 	if key == "" {
 		return
@@ -33,6 +34,7 @@ lookup_env :: proc(key: string, allocator := context.allocator) -> (value: strin
 // It returns the value, which will be empty if the variable is not present
 // To distinguish between an empty value and an unset value, use lookup_env
 // NOTE: the value will be allocated with the supplied allocator
+@(require_results)
 get_env :: proc(key: string, allocator := context.allocator) -> (value: string) {
 	value, _ = lookup_env(key, allocator)
 	return
@@ -60,6 +62,7 @@ unset_env :: proc(key: string) -> Errno {
 
 // environ returns a copy of strings representing the environment, in the form "key=value"
 // NOTE: the slice of strings and the strings with be allocated using the supplied allocator
+@(require_results)
 environ :: proc(allocator := context.allocator) -> []string {
 	envs := ([^]win32.WCHAR)(win32.GetEnvironmentStringsW())
 	if envs == nil {

--- a/core/os/errors.odin
+++ b/core/os/errors.odin
@@ -47,6 +47,8 @@ Error :: union #shared_nil {
 
 ERROR_NONE :: Error{}
 
+ERROR_EOF :: io.Error.EOF
+
 @(require_results)
 is_platform_error :: proc "contextless" (ferr: Error) -> (err: i32, ok: bool) {
 	v := ferr.(Platform_Error) or_else {}
@@ -128,32 +130,174 @@ print_error :: proc(f: Handle, ferr: Error, msg: string) -> (n: int, err: Error)
 
 @(require_results, private)
 _error_string :: proc "contextless" (e: Platform_Error) -> string where intrinsics.type_is_enum(Platform_Error) {
-	@(require_results)
-	binary_search :: proc "contextless" (array: $A/[]$T, key: T) -> (index: int, found: bool) #no_bounds_check {
-		n := len(array)
-		left, right := 0, n
-		for left < right {
-			mid := int(uint(left+right) >> 1)
-			if array[mid] < key {
-				left = mid+1
-			} else {
-				// equal or greater
-				right = mid
-			}
-		}
-		return left, left < n && array[left] == key
-	}
-
-
 	if e == nil {
 		return ""
 	}
 
-	err := runtime.Type_Info_Enum_Value(e)
+	when ODIN_OS != .Linux {
+		@(require_results)
+		binary_search :: proc "contextless" (array: $A/[]$T, key: T) -> (index: int, found: bool) #no_bounds_check {
+			n := len(array)
+			left, right := 0, n
+			for left < right {
+				mid := int(uint(left+right) >> 1)
+				if array[mid] < key {
+					left = mid+1
+				} else {
+					// equal or greater
+					right = mid
+				}
+			}
+			return left, left < n && array[left] == key
+		}
 
-	ti := &runtime.type_info_base(type_info_of(Platform_Error)).variant.(runtime.Type_Info_Enum)
-	if idx, ok := binary_search(ti.values, err); ok {
-		return ti.names[idx]
+		err := runtime.Type_Info_Enum_Value(e)
+
+		ti := &runtime.type_info_base(type_info_of(Platform_Error)).variant.(runtime.Type_Info_Enum)
+		if idx, ok := binary_search(ti.values, err); ok {
+			return ti.names[idx]
+		}
+	} else {
+		@(rodata, static)
+		pe_strings := [Platform_Error]string{
+			.NONE            = "",
+			.EPERM           = "Operation not permitted",
+			.ENOENT          = "No such file or directory",
+			.ESRCH           = "No such process",
+			.EINTR           = "Interrupted system call",
+			.EIO             = "Input/output error",
+			.ENXIO           = "No such device or address",
+			.E2BIG           = "Argument list too long",
+			.ENOEXEC         = "Exec format error",
+			.EBADF           = "Bad file descriptor",
+			.ECHILD          = "No child processes",
+			.EAGAIN          = "Resource temporarily unavailable",
+			.ENOMEM          = "Cannot allocate memory",
+			.EACCES          = "Permission denied",
+			.EFAULT          = "Bad address",
+			.ENOTBLK         = "Block device required",
+			.EBUSY           = "Device or resource busy",
+			.EEXIST          = "File exists",
+			.EXDEV           = "Invalid cross-device link",
+			.ENODEV          = "No such device",
+			.ENOTDIR         = "Not a directory",
+			.EISDIR          = "Is a directory",
+			.EINVAL          = "Invalid argument",
+			.ENFILE          = "Too many open files in system",
+			.EMFILE          = "Too many open files",
+			.ENOTTY          = "Inappropriate ioctl for device",
+			.ETXTBSY         = "Text file busy",
+			.EFBIG           = "File too large",
+			.ENOSPC          = "No space left on device",
+			.ESPIPE          = "Illegal seek",
+			.EROFS           = "Read-only file system",
+			.EMLINK          = "Too many links",
+			.EPIPE           = "Broken pipe",
+			.EDOM            = "Numerical argument out of domain",
+			.ERANGE          = "Numerical result out of range",
+			.EDEADLK         = "Resource deadlock avoided",
+			.ENAMETOOLONG    = "File name too long",
+			.ENOLCK          = "No locks available",
+			.ENOSYS          = "Function not implemented",
+			.ENOTEMPTY       = "Directory not empty",
+			.ELOOP           = "Too many levels of symbolic links",
+			.EUNKNOWN_41     = "Unknown Error (41)",
+			.ENOMSG          = "No message of desired type",
+			.EIDRM           = "Identifier removed",
+			.ECHRNG          = "Channel number out of range",
+			.EL2NSYNC        = "Level 2 not synchronized",
+			.EL3HLT          = "Level 3 halted",
+			.EL3RST          = "Level 3 reset",
+			.ELNRNG          = "Link number out of range",
+			.EUNATCH         = "Protocol driver not attached",
+			.ENOCSI          = "No CSI structure available",
+			.EL2HLT          = "Level 2 halted",
+			.EBADE           = "Invalid exchange",
+			.EBADR           = "Invalid request descriptor",
+			.EXFULL          = "Exchange full",
+			.ENOANO          = "No anode",
+			.EBADRQC         = "Invalid request code",
+			.EBADSLT         = "Invalid slot",
+			.EUNKNOWN_58     = "Unknown Error (58)",
+			.EBFONT          = "Bad font file format",
+			.ENOSTR          = "Device not a stream",
+			.ENODATA         = "No data available",
+			.ETIME           = "Timer expired",
+			.ENOSR           = "Out of streams resources",
+			.ENONET          = "Machine is not on the network",
+			.ENOPKG          = "Package not installed",
+			.EREMOTE         = "Object is remote",
+			.ENOLINK         = "Link has been severed",
+			.EADV            = "Advertise error",
+			.ESRMNT          = "Srmount error",
+			.ECOMM           = "Communication error on send",
+			.EPROTO          = "Protocol error",
+			.EMULTIHOP       = "Multihop attempted",
+			.EDOTDOT         = "RFS specific error",
+			.EBADMSG         = "Bad message",
+			.EOVERFLOW       = "Value too large for defined data type",
+			.ENOTUNIQ        = "Name not unique on network",
+			.EBADFD          = "File descriptor in bad state",
+			.EREMCHG         = "Remote address changed",
+			.ELIBACC         = "Can not access a needed shared library",
+			.ELIBBAD         = "Accessing a corrupted shared library",
+			.ELIBSCN         = ".lib section in a.out corrupted",
+			.ELIBMAX         = "Attempting to link in too many shared libraries",
+			.ELIBEXEC        = "Cannot exec a shared library directly",
+			.EILSEQ          = "Invalid or incomplete multibyte or wide character",
+			.ERESTART        = "Interrupted system call should be restarted",
+			.ESTRPIPE        = "Streams pipe error",
+			.EUSERS          = "Too many users",
+			.ENOTSOCK        = "Socket operation on non-socket",
+			.EDESTADDRREQ    = "Destination address required",
+			.EMSGSIZE        = "Message too long",
+			.EPROTOTYPE      = "Protocol wrong type for socket",
+			.ENOPROTOOPT     = "Protocol not available",
+			.EPROTONOSUPPORT = "Protocol not supported",
+			.ESOCKTNOSUPPORT = "Socket type not supported",
+			.EOPNOTSUPP      = "Operation not supported",
+			.EPFNOSUPPORT    = "Protocol family not supported",
+			.EAFNOSUPPORT    = "Address family not supported by protocol",
+			.EADDRINUSE      = "Address already in use",
+			.EADDRNOTAVAIL   = "Cannot assign requested address",
+			.ENETDOWN        = "Network is down",
+			.ENETUNREACH     = "Network is unreachable",
+			.ENETRESET       = "Network dropped connection on reset",
+			.ECONNABORTED    = "Software caused connection abort",
+			.ECONNRESET      = "Connection reset by peer",
+			.ENOBUFS         = "No buffer space available",
+			.EISCONN         = "Transport endpoint is already connected",
+			.ENOTCONN        = "Transport endpoint is not connected",
+			.ESHUTDOWN       = "Cannot send after transport endpoint shutdown",
+			.ETOOMANYREFS    = "Too many references: cannot splice",
+			.ETIMEDOUT       = "Connection timed out",
+			.ECONNREFUSED    = "Connection refused",
+			.EHOSTDOWN       = "Host is down",
+			.EHOSTUNREACH    = "No route to host",
+			.EALREADY        = "Operation already in progress",
+			.EINPROGRESS     = "Operation now in progress",
+			.ESTALE          = "Stale file handle",
+			.EUCLEAN         = "Structure needs cleaning",
+			.ENOTNAM         = "Not a XENIX named type file",
+			.ENAVAIL         = "No XENIX semaphores available",
+			.EISNAM          = "Is a named type file",
+			.EREMOTEIO       = "Remote I/O error",
+			.EDQUOT          = "Disk quota exceeded",
+			.ENOMEDIUM       = "No medium found",
+			.EMEDIUMTYPE     = "Wrong medium type",
+			.ECANCELED       = "Operation canceled",
+			.ENOKEY          = "Required key not available",
+			.EKEYEXPIRED     = "Key has expired",
+			.EKEYREVOKED     = "Key has been revoked",
+			.EKEYREJECTED    = "Key was rejected by service",
+			.EOWNERDEAD      = "Owner died",
+			.ENOTRECOVERABLE = "State not recoverable",
+			.ERFKILL         = "Operation not possible due to RF-kill",
+			.EHWPOISON       = "Memory page has hardware error",
+		}
+		if Platform_Error.NONE <= e && e <= max(Platform_Error) {
+			return pe_strings[e]
+		}
 	}
 	return "<unknown platform error>"
 }

--- a/core/os/errors.odin
+++ b/core/os/errors.odin
@@ -139,6 +139,12 @@ _error_string :: proc "contextless" (e: Platform_Error) -> string where intrinsi
 		return ""
 	}
 
+	when ODIN_OS == .Darwin {
+		if s := string(_darwin_string_error(i32(e))); s != "" {
+			return s
+		}
+	}
+
 	when ODIN_OS != .Linux {
 		@(require_results)
 		binary_search :: proc "contextless" (array: $A/[]$T, key: T) -> (index: int, found: bool) #no_bounds_check {

--- a/core/os/errors.odin
+++ b/core/os/errors.odin
@@ -157,3 +157,11 @@ _error_string :: proc "contextless" (e: Platform_Error) -> string where intrinsi
 	}
 	return "<unknown platform error>"
 }
+
+@(private, require_results)
+error_to_io_error :: proc(ferr: Error) -> io.Error {
+	if ferr == nil {
+		return .None
+	}
+	return ferr.(io.Error) or_else .Unknown
+}

--- a/core/os/errors.odin
+++ b/core/os/errors.odin
@@ -1,0 +1,159 @@
+package os
+
+import "base:intrinsics"
+import "base:runtime"
+import "core:io"
+
+Platform_Error :: _Platform_Error
+#assert(size_of(Platform_Error) <= 4)
+#assert(intrinsics.type_has_nil(Platform_Error))
+
+General_Error :: enum u32 {
+	None,
+
+	Permission_Denied,
+	Exist,
+	Not_Exist,
+	Closed,
+
+	Timeout,
+
+	Broken_Pipe,
+
+	// Indicates that an attempt to retrieve a file's size was made, but the
+	// file doesn't have a size.
+	No_Size,
+
+	Invalid_File,
+	Invalid_Dir,
+	Invalid_Path,
+	Invalid_Callback,
+
+	Pattern_Has_Separator,
+
+	Unsupported,
+}
+
+
+Errno :: Error // alias for legacy use
+
+Error :: union #shared_nil {
+	General_Error,
+	io.Error,
+	runtime.Allocator_Error,
+	Platform_Error,
+}
+#assert(size_of(Error) == 8)
+
+ERROR_NONE :: Error{}
+
+@(require_results)
+is_platform_error :: proc "contextless" (ferr: Error) -> (err: i32, ok: bool) {
+	v := ferr.(Platform_Error) or_else {}
+	return i32(v), i32(v) != 0
+}
+
+@(require_results)
+error_string :: proc "contextless" (ferr: Error) -> string {
+	if ferr == nil {
+		return ""
+	}
+	switch e in ferr {
+	case General_Error:
+		switch e {
+		case .None: return ""
+		case .Permission_Denied: return "permission denied"
+		case .Exist:             return "file already exists"
+		case .Not_Exist:         return "file does not exist"
+		case .Closed:            return "file already closed"
+		case .Timeout:           return "i/o timeout"
+		case .Broken_Pipe:       return "Broken pipe"
+		case .No_Size:           return "file has no definite size"
+		case .Invalid_File:      return "invalid file"
+		case .Invalid_Dir:       return "invalid directory"
+		case .Invalid_Path:      return "invalid path"
+		case .Invalid_Callback:  return "invalid callback"
+		case .Unsupported:       return "unsupported"
+		case .Pattern_Has_Separator: return "pattern has separator"
+		}
+	case io.Error:
+		switch e {
+		case .None: return ""
+		case .EOF:               return "eof"
+		case .Unexpected_EOF:    return "unexpected eof"
+		case .Short_Write:       return "short write"
+		case .Invalid_Write:     return "invalid write result"
+		case .Short_Buffer:      return "short buffer"
+		case .No_Progress:       return "multiple read calls return no data or error"
+		case .Invalid_Whence:    return "invalid whence"
+		case .Invalid_Offset:    return "invalid offset"
+		case .Invalid_Unread:    return "invalid unread"
+		case .Negative_Read:     return "negative read"
+		case .Negative_Write:    return "negative write"
+		case .Negative_Count:    return "negative count"
+		case .Buffer_Full:       return "buffer full"
+		case .Unknown, .Empty: //
+		}
+	case runtime.Allocator_Error:
+		switch e {
+		case .None:                 return ""
+		case .Out_Of_Memory:        return "out of memory"
+		case .Invalid_Pointer:      return "invalid allocator pointer"
+		case .Invalid_Argument:     return "invalid allocator argument"
+		case .Mode_Not_Implemented: return "allocator mode not implemented"
+		}
+	case Platform_Error:
+		return _error_string(e)
+	}
+
+	return "unknown error"
+}
+
+print_error :: proc(f: Handle, ferr: Error, msg: string) -> (n: int, err: Error) {
+	err_str := error_string(ferr)
+
+	// msg + ": " + err_str + '\n'
+	length := len(msg) + 2 + len(err_str) + 1
+	buf_ := intrinsics.alloca(length, 1)
+	buf := buf_[:length]
+
+	copy(buf, msg)
+	buf[len(msg)] = ':'
+	buf[len(msg) + 1] = ' '
+	copy(buf[len(msg) + 2:], err_str)
+	buf[length - 1] = '\n'
+	return write(f, buf)
+}
+
+
+@(require_results, private)
+_error_string :: proc "contextless" (e: Platform_Error) -> string where intrinsics.type_is_enum(Platform_Error) {
+	@(require_results)
+	binary_search :: proc "contextless" (array: $A/[]$T, key: T) -> (index: int, found: bool) #no_bounds_check {
+		n := len(array)
+		left, right := 0, n
+		for left < right {
+			mid := int(uint(left+right) >> 1)
+			if array[mid] < key {
+				left = mid+1
+			} else {
+				// equal or greater
+				right = mid
+			}
+		}
+		return left, left < n && array[left] == key
+	}
+
+
+	if e == nil {
+		return ""
+	}
+
+	err := runtime.Type_Info_Enum_Value(e)
+
+	ti := &runtime.type_info_base(type_info_of(Platform_Error)).variant.(runtime.Type_Info_Enum)
+	if idx, ok := binary_search(ti.values, err); ok {
+		return ti.names[idx]
+	}
+	return "<unknown platform error>"
+}

--- a/core/os/errors.odin
+++ b/core/os/errors.odin
@@ -32,6 +32,9 @@ General_Error :: enum u32 {
 	Pattern_Has_Separator,
 
 	Unsupported,
+
+	File_Is_Pipe,
+	Not_Dir,
 }
 
 
@@ -77,6 +80,8 @@ error_string :: proc "contextless" (ferr: Error) -> string {
 		case .Invalid_Callback:  return "invalid callback"
 		case .Unsupported:       return "unsupported"
 		case .Pattern_Has_Separator: return "pattern has separator"
+		case .File_Is_Pipe:      return "file is pipe"
+		case .Not_Dir:           return "file is not directory"
 		}
 	case io.Error:
 		switch e {

--- a/core/os/file_windows.odin
+++ b/core/os/file_windows.odin
@@ -173,7 +173,7 @@ read :: proc(fd: Handle, data: []byte) -> (total_read: int, err: Error) {
 			// Successful read can mean two things, including EOF, see:
 			// https://learn.microsoft.com/en-us/windows/win32/fileio/testing-for-the-end-of-a-file
 			if bytes_read == 0 {
-				return 0, ERROR_HANDLE_EOF
+				return 0, .EOF
 			} else {
 				return int(bytes_read), nil
 			}

--- a/core/os/file_windows.odin
+++ b/core/os/file_windows.odin
@@ -531,14 +531,9 @@ ftruncate :: proc(fd: Handle, length: i64) -> (err: Errno) {
 }
 
 truncate :: proc(path: string, length: i64) -> (err: Errno) {
-	fd: Handle
-	fd, err = open(path, O_WRONLY|O_CREATE, 0o666)
-	if err != nil {
-		return
-	}
+	fd := open(path, O_WRONLY|O_CREATE, 0o666) or_return
 	defer close(fd)
-	err = ftruncate(fd, length)
-	return
+	return ftruncate(fd, length)
 }
 
 

--- a/core/os/file_windows.odin
+++ b/core/os/file_windows.odin
@@ -11,7 +11,7 @@ is_path_separator :: proc(c: byte) -> bool {
 
 open :: proc(path: string, mode: int = O_RDONLY, perm: int = 0) -> (Handle, Errno) {
 	if len(path) == 0 {
-		return INVALID_HANDLE, ERROR_FILE_NOT_FOUND
+		return INVALID_HANDLE, General_Error.Not_Exist
 	}
 
 	access: u32
@@ -55,8 +55,7 @@ open :: proc(path: string, mode: int = O_RDONLY, perm: int = 0) -> (Handle, Errn
 		return handle, nil
 	}
 
-	err := get_last_error()
-	return INVALID_HANDLE, err
+	return INVALID_HANDLE, get_last_error()
 }
 
 close :: proc(fd: Handle) -> Errno {

--- a/core/os/file_windows.odin
+++ b/core/os/file_windows.odin
@@ -5,10 +5,12 @@ import "base:intrinsics"
 import "base:runtime"
 import "core:unicode/utf16"
 
+@(require_results)
 is_path_separator :: proc(c: byte) -> bool {
 	return c == '/' || c == '\\'
 }
 
+@(require_results)
 open :: proc(path: string, mode: int = O_RDONLY, perm: int = 0) -> (Handle, Error) {
 	if len(path) == 0 {
 		return INVALID_HANDLE, General_Error.Not_Exist
@@ -96,7 +98,7 @@ write :: proc(fd: Handle, data: []byte) -> (int, Error) {
 	return int(total_write), nil
 }
 
-@(private="file")
+@(private="file", require_results)
 read_console :: proc(handle: win32.HANDLE, b: []byte) -> (n: int, err: Error) {
 	if len(b) == 0 {
 		return 0, nil
@@ -206,6 +208,7 @@ seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 	return i64(hi)<<32 + i64(dw_ptr), nil
 }
 
+@(require_results)
 file_size :: proc(fd: Handle) -> (i64, Error) {
 	length: win32.LARGE_INTEGER
 	err: Error
@@ -331,6 +334,7 @@ stdout := get_std_handle(uint(win32.STD_OUTPUT_HANDLE))
 stderr := get_std_handle(uint(win32.STD_ERROR_HANDLE))
 
 
+@(require_results)
 get_std_handle :: proc "contextless" (h: uint) -> Handle {
 	fd := win32.GetStdHandle(win32.DWORD(h))
 	return Handle(fd)
@@ -345,6 +349,7 @@ exists :: proc(path: string) -> bool {
 	return attribs != win32.INVALID_FILE_ATTRIBUTES
 }
 
+@(require_results)
 is_file :: proc(path: string) -> bool {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	wpath := win32.utf8_to_wstring(path, context.temp_allocator)
@@ -356,6 +361,7 @@ is_file :: proc(path: string) -> bool {
 	return false
 }
 
+@(require_results)
 is_dir :: proc(path: string) -> bool {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	wpath := win32.utf8_to_wstring(path, context.temp_allocator)
@@ -370,6 +376,7 @@ is_dir :: proc(path: string) -> bool {
 // NOTE(tetra): GetCurrentDirectory is not thread safe with SetCurrentDirectory and GetFullPathName
 @private cwd_lock := win32.SRWLOCK{} // zero is initialized
 
+@(require_results)
 get_current_directory :: proc(allocator := context.allocator) -> string {
 	win32.AcquireSRWLockExclusive(&cwd_lock)
 
@@ -426,7 +433,7 @@ remove_directory :: proc(path: string) -> (err: Error) {
 
 
 
-@(private)
+@(private, require_results)
 is_abs :: proc(path: string) -> bool {
 	if len(path) > 0 && path[0] == '/' {
 		return true
@@ -442,7 +449,7 @@ is_abs :: proc(path: string) -> bool {
 	return false
 }
 
-@(private)
+@(private, require_results)
 fix_long_path :: proc(path: string) -> string {
 	if len(path) < 248 {
 		return path
@@ -574,6 +581,7 @@ remove :: proc(name: string) -> Error {
 }
 
 
+@(require_results)
 pipe :: proc() -> (r, w: Handle, err: Error) {
 	sa: win32.SECURITY_ATTRIBUTES
 	sa.nLength = size_of(win32.SECURITY_ATTRIBUTES)

--- a/core/os/file_windows.odin
+++ b/core/os/file_windows.odin
@@ -195,7 +195,7 @@ seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 	lo := i32(offset)
 	ft := win32.GetFileType(win32.HANDLE(fd))
 	if ft == win32.FILE_TYPE_PIPE {
-		return 0, ERROR_FILE_IS_PIPE
+		return 0, .File_Is_Pipe
 	}
 
 	dw_ptr := win32.SetFilePointer(win32.HANDLE(fd), lo, &hi, w)
@@ -278,7 +278,7 @@ will read from the location twice on *nix, and from two different locations on W
 */
 read_at :: proc(fd: Handle, data: []byte, offset: i64) -> (n: int, err: Error) {
 	if offset < 0 {
-		return 0, ERROR_NEGATIVE_OFFSET
+		return 0, .Invalid_Offset
 	}
 
 	b, offset := data, offset
@@ -310,7 +310,7 @@ will write to the location twice on *nix, and to two different locations on Wind
 */
 write_at :: proc(fd: Handle, data: []byte, offset: i64) -> (n: int, err: Error) {
 	if offset < 0 {
-		return 0, ERROR_NEGATIVE_OFFSET
+		return 0, .Invalid_Offset
 	}
 
 	b, offset := data, offset

--- a/core/os/os.odin
+++ b/core/os/os.odin
@@ -145,13 +145,13 @@ read_entire_file_from_handle :: proc(fd: Handle, allocator := context.allocator,
 		return nil, true
 	}
 
-	data = make([]byte, int(length), allocator, loc)
-	if data == nil {
+	data, err = make([]byte, int(length), allocator, loc)
+	if data == nil || err != nil {
 		return nil, false
 	}
 
 	bytes_read, read_err := read_full(fd, data)
-	if read_err != ERROR_NONE {
+	if read_err != nil {
 		delete(data)
 		return nil, false
 	}

--- a/core/os/os.odin
+++ b/core/os/os.odin
@@ -64,15 +64,15 @@ is_platform_error :: proc(ferr: Error) -> (err: i32, ok: bool) {
 	return i32(v), i32(v) != 0
 }
 
-write_string :: proc(fd: Handle, str: string) -> (int, Errno) {
+write_string :: proc(fd: Handle, str: string) -> (int, Error) {
 	return write(fd, transmute([]byte)str)
 }
 
-write_byte :: proc(fd: Handle, b: byte) -> (int, Errno) {
+write_byte :: proc(fd: Handle, b: byte) -> (int, Error) {
 	return write(fd, []byte{b})
 }
 
-write_rune :: proc(fd: Handle, r: rune) -> (int, Errno) {
+write_rune :: proc(fd: Handle, r: rune) -> (int, Error) {
 	if r < utf8.RUNE_SELF {
 		return write_byte(fd, byte(r))
 	}
@@ -120,7 +120,7 @@ write_encoded_rune :: proc(f: Handle, r: rune) -> (n: int, err: Error) {
 	return
 }
 
-read_at_least :: proc(fd: Handle, buf: []byte, min: int) -> (n: int, err: Errno) {
+read_at_least :: proc(fd: Handle, buf: []byte, min: int) -> (n: int, err: Error) {
 	if len(buf) < min {
 		return 0, io.Error.Short_Buffer
 	}
@@ -135,7 +135,7 @@ read_at_least :: proc(fd: Handle, buf: []byte, min: int) -> (n: int, err: Errno)
 	return
 }
 
-read_full :: proc(fd: Handle, buf: []byte) -> (n: int, err: Errno) {
+read_full :: proc(fd: Handle, buf: []byte) -> (n: int, err: Error) {
 	return read_at_least(fd, buf, len(buf))
 }
 
@@ -170,7 +170,7 @@ read_entire_file_from_handle :: proc(fd: Handle, allocator := context.allocator,
 	context.allocator = allocator
 
 	length: i64
-	err: Errno
+	err: Error
 	if length, err = file_size(fd); err != nil {
 		return nil, false
 	}
@@ -219,11 +219,11 @@ write_entire_file :: proc(name: string, data: []byte, truncate := true) -> (succ
 	return write_err == nil
 }
 
-write_ptr :: proc(fd: Handle, data: rawptr, len: int) -> (int, Errno) {
+write_ptr :: proc(fd: Handle, data: rawptr, len: int) -> (int, Error) {
 	return write(fd, ([^]byte)(data)[:len])
 }
 
-read_ptr :: proc(fd: Handle, data: rawptr, len: int) -> (int, Errno) {
+read_ptr :: proc(fd: Handle, data: rawptr, len: int) -> (int, Error) {
 	return read(fd, ([^]byte)(data)[:len])
 }
 

--- a/core/os/os.odin
+++ b/core/os/os.odin
@@ -13,6 +13,12 @@ SEEK_SET :: 0
 SEEK_CUR :: 1
 SEEK_END :: 2
 
+Platform_Error :: _Platform_Error
+Error :: Platform_Error
+Errno :: Error // alias
+
+ERROR_NONE :: Errno(0)
+
 write_string :: proc(fd: Handle, str: string) -> (int, Errno) {
 	return write(fd, transmute([]byte)str)
 }

--- a/core/os/os.odin
+++ b/core/os/os.odin
@@ -91,7 +91,7 @@ read_at_least :: proc(fd: Handle, buf: []byte, min: int) -> (n: int, err: Errno)
 		return 0, io.Error.Short_Buffer
 	}
 	nn := max(int)
-	for nn > 0 && n < min && err == 0 {
+	for nn > 0 && n < min && err == nil {
 		nn, err = read(fd, buf[n:])
 		n += nn
 	}
@@ -108,13 +108,13 @@ read_full :: proc(fd: Handle, buf: []byte) -> (n: int, err: Errno) {
 
 file_size_from_path :: proc(path: string) -> i64 {
 	fd, err := open(path, O_RDONLY, 0)
-	if err != 0 {
+	if err != nil {
 		return -1
 	}
 	defer close(fd)
 
 	length: i64
-	if length, err = file_size(fd); err != 0 {
+	if length, err = file_size(fd); err != nil {
 		return -1
 	}
 	return length
@@ -124,7 +124,7 @@ read_entire_file_from_filename :: proc(name: string, allocator := context.alloca
 	context.allocator = allocator
 
 	fd, err := open(name, O_RDONLY, 0)
-	if err != 0 {
+	if err != nil {
 		return nil, false
 	}
 	defer close(fd)
@@ -137,7 +137,7 @@ read_entire_file_from_handle :: proc(fd: Handle, allocator := context.allocator,
 
 	length: i64
 	err: Errno
-	if length, err = file_size(fd); err != 0 {
+	if length, err = file_size(fd); err != nil {
 		return nil, false
 	}
 
@@ -176,13 +176,13 @@ write_entire_file :: proc(name: string, data: []byte, truncate := true) -> (succ
 	}
 
 	fd, err := open(name, flags, mode)
-	if err != 0 {
+	if err != nil {
 		return false
 	}
 	defer close(fd)
 
 	_, write_err := write(fd, data)
-	return write_err == 0
+	return write_err == nil
 }
 
 write_ptr :: proc(fd: Handle, data: rawptr, len: int) -> (int, Errno) {

--- a/core/os/os.odin
+++ b/core/os/os.odin
@@ -19,16 +19,50 @@ Platform_Error :: _Platform_Error
 #assert(size_of(Platform_Error) <= 4)
 #assert(intrinsics.type_has_nil(Platform_Error))
 
+General_Error :: enum u32 {
+	None,
+
+	Permission_Denied,
+	Exist,
+	Not_Exist,
+	Closed,
+
+	Timeout,
+
+	Broken_Pipe,
+
+	// Indicates that an attempt to retrieve a file's size was made, but the
+	// file doesn't have a size.
+	No_Size,
+
+	Invalid_File,
+	Invalid_Dir,
+	Invalid_Path,
+	Invalid_Callback,
+
+	Pattern_Has_Separator,
+
+	Unsupported,
+}
+
+
 Errno :: Error // alias for legacy use
 
 Error :: union #shared_nil {
+	General_Error,
 	io.Error,
 	runtime.Allocator_Error,
 	Platform_Error,
 }
-#assert(size_of(Error) <= 8)
+#assert(size_of(Error) == 8)
 
 ERROR_NONE :: Error{}
+
+@(require_results)
+is_platform_error :: proc(ferr: Error) -> (err: i32, ok: bool) {
+	v := ferr.(Platform_Error) or_else {}
+	return i32(v), i32(v) != 0
+}
 
 write_string :: proc(fd: Handle, str: string) -> (int, Errno) {
 	return write(fd, transmute([]byte)str)

--- a/core/os/os.odin
+++ b/core/os/os.odin
@@ -15,55 +15,6 @@ SEEK_SET :: 0
 SEEK_CUR :: 1
 SEEK_END :: 2
 
-Platform_Error :: _Platform_Error
-#assert(size_of(Platform_Error) <= 4)
-#assert(intrinsics.type_has_nil(Platform_Error))
-
-General_Error :: enum u32 {
-	None,
-
-	Permission_Denied,
-	Exist,
-	Not_Exist,
-	Closed,
-
-	Timeout,
-
-	Broken_Pipe,
-
-	// Indicates that an attempt to retrieve a file's size was made, but the
-	// file doesn't have a size.
-	No_Size,
-
-	Invalid_File,
-	Invalid_Dir,
-	Invalid_Path,
-	Invalid_Callback,
-
-	Pattern_Has_Separator,
-
-	Unsupported,
-}
-
-
-Errno :: Error // alias for legacy use
-
-Error :: union #shared_nil {
-	General_Error,
-	io.Error,
-	runtime.Allocator_Error,
-	Platform_Error,
-}
-#assert(size_of(Error) == 8)
-
-ERROR_NONE :: Error{}
-
-@(require_results)
-is_platform_error :: proc(ferr: Error) -> (err: i32, ok: bool) {
-	v := ferr.(Platform_Error) or_else {}
-	return i32(v), i32(v) != 0
-}
-
 write_string :: proc(fd: Handle, str: string) -> (int, Error) {
 	return write(fd, transmute([]byte)str)
 }

--- a/core/os/os2/errors.odin
+++ b/core/os/os2/errors.odin
@@ -42,13 +42,14 @@ Error :: union #shared_nil {
 ERROR_NONE :: Error{}
 
 
-
+@(require_results)
 is_platform_error :: proc(ferr: Error) -> (err: i32, ok: bool) {
 	v := ferr.(Platform_Error) or_else {}
 	return i32(v), i32(v) != 0
 }
 
 
+@(require_results)
 error_string :: proc(ferr: Error) -> string {
 	if ferr == nil {
 		return ""

--- a/core/os/os2/errors.odin
+++ b/core/os/os2/errors.odin
@@ -3,7 +3,7 @@ package os2
 import "core:io"
 import "base:runtime"
 
-General_Error :: enum u32 {
+General_Platform_Error :: enum u32 {
 	None,
 
 	Permission_Denied,
@@ -29,7 +29,7 @@ General_Error :: enum u32 {
 	Unsupported,
 }
 
-Platform_Error :: enum i32 {None=0}
+Platform_Platform_Error :: enum i32 {None=0}
 
 Error :: union #shared_nil {
 	General_Error,
@@ -43,7 +43,7 @@ ERROR_NONE :: Error{}
 
 
 
-is_platform_error :: proc(ferr: Error) -> (err: i32, ok: bool) {
+is_platform_Platform_Error :: proc(ferr: Error) -> (err: i32, ok: bool) {
 	v := ferr.(Platform_Error) or_else {}
 	return i32(v), i32(v) != 0
 }
@@ -104,7 +104,7 @@ error_string :: proc(ferr: Error) -> string {
 	return "unknown error"
 }
 
-print_error :: proc(f: ^File, ferr: Error, msg: string) {
+print_Platform_Error :: proc(f: ^File, ferr: Error, msg: string) {
 	TEMP_ALLOCATOR_GUARD()
 	err_str := error_string(ferr)
 

--- a/core/os/os2/errors.odin
+++ b/core/os/os2/errors.odin
@@ -3,7 +3,7 @@ package os2
 import "core:io"
 import "base:runtime"
 
-General_Platform_Error :: enum u32 {
+General_Error :: enum u32 {
 	None,
 
 	Permission_Denied,
@@ -29,7 +29,7 @@ General_Platform_Error :: enum u32 {
 	Unsupported,
 }
 
-Platform_Platform_Error :: enum i32 {None=0}
+Platform_Error :: enum i32 {None=0}
 
 Error :: union #shared_nil {
 	General_Error,
@@ -43,7 +43,7 @@ ERROR_NONE :: Error{}
 
 
 
-is_platform_Platform_Error :: proc(ferr: Error) -> (err: i32, ok: bool) {
+is_platform_error :: proc(ferr: Error) -> (err: i32, ok: bool) {
 	v := ferr.(Platform_Error) or_else {}
 	return i32(v), i32(v) != 0
 }
@@ -104,7 +104,7 @@ error_string :: proc(ferr: Error) -> string {
 	return "unknown error"
 }
 
-print_Platform_Error :: proc(f: ^File, ferr: Error, msg: string) {
+print_error :: proc(f: ^File, ferr: Error, msg: string) {
 	TEMP_ALLOCATOR_GUARD()
 	err_str := error_string(ferr)
 

--- a/core/os/os2/errors_linux.odin
+++ b/core/os/os2/errors_linux.odin
@@ -4,7 +4,7 @@ package os2
 import "core:sys/linux"
 
 @(rodata)
-_errno_strings : [linux.Errno]string = {
+_errno_strings : [linux.Error]string = {
 	.NONE            = "Success",
 	.EPERM           = "Operation not permitted",
 	.ENOENT          = "No such file or directory",
@@ -142,7 +142,7 @@ _errno_strings : [linux.Errno]string = {
 }
 
 
-_get_platform_error :: proc(errno: linux.Errno) -> Error {
+_get_platform_error :: proc(errno: linux.Error) -> Error {
 	#partial switch errno {
 	case .NONE:
 		return nil
@@ -158,8 +158,8 @@ _get_platform_error :: proc(errno: linux.Errno) -> Error {
 }
 
 _error_string :: proc(errno: i32) -> string {
-	if errno >= 0 && errno <= i32(max(linux.Errno)) {
-		return _errno_strings[linux.Errno(errno)]
+	if errno >= 0 && errno <= i32(max(linux.Error)) {
+		return _errno_strings[linux.Error(errno)]
 	}
 	return "Unknown Error"
 }

--- a/core/os/os2/errors_linux.odin
+++ b/core/os/os2/errors_linux.odin
@@ -142,7 +142,7 @@ _errno_strings : [linux.Errno]string = {
 }
 
 
-_get_platform_error :: proc(errno: linux.Errno) -> Error {
+_get_platform_Platform_Error :: proc(errno: linux.Errno) -> Error {
 	#partial switch errno {
 	case .NONE:
 		return nil

--- a/core/os/os2/errors_linux.odin
+++ b/core/os/os2/errors_linux.odin
@@ -4,8 +4,8 @@ package os2
 import "core:sys/linux"
 
 @(rodata)
-_errno_strings : [linux.Error]string = {
-	.NONE            = "Success",
+_errno_strings := [linux.Error]string{
+	.NONE            = "",
 	.EPERM           = "Operation not permitted",
 	.ENOENT          = "No such file or directory",
 	.ESRCH           = "No such process",

--- a/core/os/os2/errors_linux.odin
+++ b/core/os/os2/errors_linux.odin
@@ -142,7 +142,7 @@ _errno_strings : [linux.Errno]string = {
 }
 
 
-_get_platform_Platform_Error :: proc(errno: linux.Errno) -> Error {
+_get_platform_error :: proc(errno: linux.Errno) -> Error {
 	#partial switch errno {
 	case .NONE:
 		return nil

--- a/core/os/os2/errors_windows.odin
+++ b/core/os/os2/errors_windows.odin
@@ -20,7 +20,7 @@ _error_string :: proc(errno: i32) -> string {
 	return "<unknown platform error>"
 }
 
-_get_platform_Platform_Error :: proc() -> Error {
+_get_platform_error :: proc() -> Error {
 	err := win32.GetLastError()
 	if err == 0 {
 		return nil

--- a/core/os/os2/errors_windows.odin
+++ b/core/os/os2/errors_windows.odin
@@ -20,7 +20,7 @@ _error_string :: proc(errno: i32) -> string {
 	return "<unknown platform error>"
 }
 
-_get_platform_error :: proc() -> Error {
+_get_platform_Platform_Error :: proc() -> Error {
 	err := win32.GetLastError()
 	if err == 0 {
 		return nil

--- a/core/os/os2/file_stream.odin
+++ b/core/os/os2/file_stream.odin
@@ -15,7 +15,7 @@ to_reader :: to_stream
 
 
 @(private)
-error_to_io_Platform_Error :: proc(ferr: Error) -> io.Error {
+error_to_io_error :: proc(ferr: Error) -> io.Error {
 	if ferr == nil {
 		return .None
 	}

--- a/core/os/os2/file_stream.odin
+++ b/core/os/os2/file_stream.odin
@@ -15,7 +15,7 @@ to_reader :: to_stream
 
 
 @(private)
-error_to_io_error :: proc(ferr: Error) -> io.Error {
+error_to_io_Platform_Error :: proc(ferr: Error) -> io.Error {
 	if ferr == nil {
 		return .None
 	}

--- a/core/os/os2/file_util.odin
+++ b/core/os/os2/file_util.odin
@@ -173,11 +173,8 @@ write_entire_file :: proc(name: string, data: []byte, perm: int, truncate := tru
 	if truncate {
 		flags |= O_TRUNC
 	}
-	f, err := open(name, flags, perm)
-	if err != nil {
-		return err
-	}
-	_, err = write(f, data)
+	f := open(name, flags, perm) or_return
+	_, err := write(f, data)
 	if cerr := close(f); cerr != nil && err == nil {
 		err = cerr
 	}

--- a/core/os/os2/file_util.odin
+++ b/core/os/os2/file_util.odin
@@ -88,6 +88,9 @@ read_at_least :: proc(f: ^File, buf: []byte, min: int) -> (n: int, err: Error) {
 	return
 }
 
+read_full :: proc(f: ^File, buf: []byte) -> (n: int, err: Error) {
+	return read_at_least(f, buf, len(buf))
+}
 
 write_ptr :: proc(f: ^File, data: rawptr, len: int) -> (n: int, err: Error) {
 	return write(f, ([^]byte)(data)[:len])

--- a/core/os/os2/file_util.odin
+++ b/core/os/os2/file_util.odin
@@ -73,6 +73,21 @@ write_encoded_rune :: proc(f: ^File, r: rune) -> (n: int, err: Error) {
 	return
 }
 
+read_at_least :: proc(f: ^File, buf: []byte, min: int) -> (n: int, err: Error) {
+	if len(buf) < min {
+		return 0, .Short_Buffer
+	}
+	nn := max(int)
+	for nn > 0 && n < min && err == nil {
+		nn, err = read(f, buf[n:])
+		n += nn
+	}
+	if n >= min {
+		err = nil
+	}
+	return
+}
+
 
 write_ptr :: proc(f: ^File, data: rawptr, len: int) -> (n: int, err: Error) {
 	return write(f, ([^]byte)(data)[:len])

--- a/core/os/os2/path_linux.odin
+++ b/core/os/os2/path_linux.odin
@@ -59,7 +59,7 @@ _mkdir_all :: proc(path: string, perm: int) -> Error {
 	path_bytes[len(path)] = 0
 
 	dfd: linux.Fd
-	errno: linux.Errno
+	errno: linux.Error
 	if path_bytes[0] == '/' {
 		dfd, errno = linux.open("/", _OPENDIR_FLAGS)
 		path_bytes = path_bytes[1:]

--- a/core/os/os2/process.odin
+++ b/core/os/os2/process.odin
@@ -370,7 +370,7 @@ Process_State :: struct {
 	timeout (if specified) has reached zero. If the timeout is `TIMEOUT_INFINITE`,
 	no timeout restriction is imposed and the procedure can block indefinately.
 
-	If the timeout has expired, the `General_Error.Timeout` is returned as
+	If the timeout has expired, the `GeneralPlatform_Error.Timeout` is returned as
 	the error.
 
 	If an error is returned for any other reason, other than timeout, the

--- a/core/os/os2/process.odin
+++ b/core/os/os2/process.odin
@@ -370,7 +370,7 @@ Process_State :: struct {
 	timeout (if specified) has reached zero. If the timeout is `TIMEOUT_INFINITE`,
 	no timeout restriction is imposed and the procedure can block indefinately.
 
-	If the timeout has expired, the `GeneralPlatform_Error.Timeout` is returned as
+	If the timeout has expired, the `General_Error.Timeout` is returned as
 	the error.
 
 	If an error is returned for any other reason, other than timeout, the

--- a/core/os/os2/process_windows.odin
+++ b/core/os/os2/process_windows.odin
@@ -101,7 +101,7 @@ _process_info_by_pid :: proc(pid: int, selection: Process_Info_Fields, allocator
 	if selection >= {.PPid, .Priority} {
 		entry, entry_err := _process_entry_by_pid(info.pid)
 		if entry_err != nil {
-			err = General_Error.Not_Exist
+			err = GeneralPlatform_Error.Not_Exist
 			return
 		}
 		if .PPid in selection {
@@ -147,7 +147,7 @@ _process_info_by_pid :: proc(pid: int, selection: Process_Info_Fields, allocator
 		}
 		if process_info.PebBaseAddress == nil {
 			// Not sure what the error is
-			err = General_Error.Unsupported
+			err = GeneralPlatform_Error.Unsupported
 			return
 		}
 		process_peb: win32.PEB
@@ -210,7 +210,7 @@ _process_info_by_handle :: proc(process: Process, selection: Process_Info_Fields
 	if selection >= {.PPid, .Priority} { // snap process
 		entry, entry_err := _process_entry_by_pid(info.pid)
 		if entry_err != nil {
-			err = General_Error.Not_Exist
+			err = GeneralPlatform_Error.Not_Exist
 			return
 		}
 		if .PPid in selection {
@@ -239,7 +239,7 @@ _process_info_by_handle :: proc(process: Process, selection: Process_Info_Fields
 		}
 		if process_info.PebBaseAddress == nil {
 			// Not sure what the error is
-			err = General_Error.Unsupported
+			err = GeneralPlatform_Error.Unsupported
 			return
 		}
 
@@ -301,7 +301,7 @@ _current_process_info :: proc(selection: Process_Info_Fields, allocator: runtime
 	if selection >= {.PPid, .Priority} { // snap process
 		entry, entry_err := _process_entry_by_pid(info.pid)
 		if entry_err != nil {
-			err = General_Error.Not_Exist
+			err = GeneralPlatform_Error.Not_Exist
 			return
 		}
 		if .PPid in selection {
@@ -459,7 +459,7 @@ _process_wait :: proc(process: Process, timeout: time.Duration) -> (process_stat
 		}
 		return
 	case win32.WAIT_TIMEOUT:
-		err = General_Error.Timeout
+		err = GeneralPlatform_Error.Timeout
 		return
 	case:
 		err = _get_platform_error()
@@ -508,7 +508,7 @@ _process_entry_by_pid :: proc(pid: int) -> (entry: win32.PROCESSENTRY32W, err: E
 		}
 		status = win32.Process32NextW(snap, &entry)
 	}
-	err = General_Error.Not_Exist
+	err = GeneralPlatform_Error.Not_Exist
 	return
 }
 

--- a/core/os/os2/process_windows.odin
+++ b/core/os/os2/process_windows.odin
@@ -101,7 +101,7 @@ _process_info_by_pid :: proc(pid: int, selection: Process_Info_Fields, allocator
 	if selection >= {.PPid, .Priority} {
 		entry, entry_err := _process_entry_by_pid(info.pid)
 		if entry_err != nil {
-			err = GeneralPlatform_Error.Not_Exist
+			err = General_Error.Not_Exist
 			return
 		}
 		if .PPid in selection {
@@ -147,7 +147,7 @@ _process_info_by_pid :: proc(pid: int, selection: Process_Info_Fields, allocator
 		}
 		if process_info.PebBaseAddress == nil {
 			// Not sure what the error is
-			err = GeneralPlatform_Error.Unsupported
+			err = General_Error.Unsupported
 			return
 		}
 		process_peb: win32.PEB
@@ -210,7 +210,7 @@ _process_info_by_handle :: proc(process: Process, selection: Process_Info_Fields
 	if selection >= {.PPid, .Priority} { // snap process
 		entry, entry_err := _process_entry_by_pid(info.pid)
 		if entry_err != nil {
-			err = GeneralPlatform_Error.Not_Exist
+			err = General_Error.Not_Exist
 			return
 		}
 		if .PPid in selection {
@@ -239,7 +239,7 @@ _process_info_by_handle :: proc(process: Process, selection: Process_Info_Fields
 		}
 		if process_info.PebBaseAddress == nil {
 			// Not sure what the error is
-			err = GeneralPlatform_Error.Unsupported
+			err = General_Error.Unsupported
 			return
 		}
 
@@ -301,7 +301,7 @@ _current_process_info :: proc(selection: Process_Info_Fields, allocator: runtime
 	if selection >= {.PPid, .Priority} { // snap process
 		entry, entry_err := _process_entry_by_pid(info.pid)
 		if entry_err != nil {
-			err = GeneralPlatform_Error.Not_Exist
+			err = General_Error.Not_Exist
 			return
 		}
 		if .PPid in selection {
@@ -459,7 +459,7 @@ _process_wait :: proc(process: Process, timeout: time.Duration) -> (process_stat
 		}
 		return
 	case win32.WAIT_TIMEOUT:
-		err = GeneralPlatform_Error.Timeout
+		err = General_Error.Timeout
 		return
 	case:
 		err = _get_platform_error()
@@ -508,7 +508,7 @@ _process_entry_by_pid :: proc(pid: int) -> (entry: win32.PROCESSENTRY32W, err: E
 		}
 		status = win32.Process32NextW(snap, &entry)
 	}
-	err = GeneralPlatform_Error.Not_Exist
+	err = General_Error.Not_Exist
 	return
 }
 

--- a/core/os/os2/stat_windows.odin
+++ b/core/os/os2/stat_windows.odin
@@ -6,25 +6,22 @@ import "core:time"
 import "core:strings"
 import win32 "core:sys/windows"
 
-_fstat :: proc(f: ^File, allocator: runtime.Allocator) -> (File_Info, Error) {
+_fstat :: proc(f: ^File, allocator: runtime.Allocator) -> (fi: File_Info, err: Error) {
 	if f == nil || (^File_Impl)(f.impl).fd == nil {
-		return {}, nil
+		return
 	}
 
-	path, err := _cleanpath_from_handle(f, allocator)
-	if err != nil {
-		return {}, err
-	}
+	path := _cleanpath_from_handle(f, allocator) or_return
 
 	h := _handle(f)
 	switch win32.GetFileType(h) {
 	case win32.FILE_TYPE_PIPE, win32.FILE_TYPE_CHAR:
-		fi := File_Info {
+		fi = File_Info {
 			fullpath = path,
 			name = basename(path),
 			type = file_type(h),
 		}
-		return fi, nil
+		return
 	}
 
 	return _file_info_from_get_file_information_by_handle(path, h, allocator)

--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -15,252 +15,279 @@ INVALID_HANDLE :: ~Handle(0)
 
 _Platform_Error :: enum i32 {
 	NONE       = 0,
-	EPERM      = 1,       /* Operation not permitted */
-	ENOENT     = 2,       /* No such file or directory */
-	ESRCH      = 3,       /* No such process */
-	EINTR      = 4,       /* Interrupted system call */
-	EIO        = 5,       /* Input/output error */
-	ENXIO      = 6,       /* Device not configured */
-	E2BIG      = 7,       /* Argument list too long */
-	ENOEXEC    = 8,       /* Exec format error */
-	EBADF      = 9,       /* Bad file descriptor */
-	ECHILD     = 10,      /* No child processes */
-	EDEADLK    = 11,      /* Resource deadlock avoided */
-	ENOMEM     = 12,      /* Cannot allocate memory */
-	EACCES     = 13,      /* Permission denied */
-	EFAULT     = 14,      /* Bad address */
-	ENOTBLK    = 15,      /* Block device required */
-	EBUSY      = 16,      /* Device / Resource busy */
-	EEXIST     = 17,      /* File exists */
-	EXDEV      = 18,      /* Cross-device link */
-	ENODEV     = 19,      /* Operation not supported by device */
-	ENOTDIR    = 20,      /* Not a directory */
-	EISDIR     = 21,      /* Is a directory */
-	EINVAL     = 22,      /* Invalid argument */
-	ENFILE     = 23,      /* Too many open files in system */
-	EMFILE     = 24,      /* Too many open files */
-	ENOTTY     = 25,      /* Inappropriate ioctl for device */
-	ETXTBSY    = 26,      /* Text file busy */
-	EFBIG      = 27,      /* File too large */
-	ENOSPC     = 28,      /* No space left on device */
-	ESPIPE     = 29,      /* Illegal seek */
-	EROFS      = 30,      /* Read-only file system */
-	EMLINK     = 31,      /* Too many links */
-	EPIPE      = 32,      /* Broken pipe */
+	EPERM           = 1,      /* Operation not permitted */
+	ENOENT          = 2,      /* No such file or directory */
+	ESRCH           = 3,      /* No such process */
+	EINTR           = 4,      /* Interrupted system call */
+	EIO             = 5,      /* Input/output error */
+	ENXIO           = 6,      /* Device not configured */
+	E2BIG           = 7,      /* Argument list too long */
+	ENOEXEC         = 8,      /* Exec format error */
+	EBADF           = 9,      /* Bad file descriptor */
+	ECHILD          = 10,     /* No child processes */
+	EDEADLK         = 11,     /* Resource deadlock avoided */
+	ENOMEM          = 12,     /* Cannot allocate memory */
+	EACCES          = 13,     /* Permission denied */
+	EFAULT          = 14,     /* Bad address */
+	ENOTBLK         = 15,     /* Block device required */
+	EBUSY           = 16,     /* Device / Resource busy */
+	EEXIST          = 17,     /* File exists */
+	EXDEV           = 18,     /* Cross-device link */
+	ENODEV          = 19,     /* Operation not supported by device */
+	ENOTDIR         = 20,     /* Not a directory */
+	EISDIR          = 21,     /* Is a directory */
+	EINVAL          = 22,     /* Invalid argument */
+	ENFILE          = 23,     /* Too many open files in system */
+	EMFILE          = 24,     /* Too many open files */
+	ENOTTY          = 25,     /* Inappropriate ioctl for device */
+	ETXTBSY         = 26,     /* Text file busy */
+	EFBIG           = 27,     /* File too large */
+	ENOSPC          = 28,     /* No space left on device */
+	ESPIPE          = 29,     /* Illegal seek */
+	EROFS           = 30,     /* Read-only file system */
+	EMLINK          = 31,     /* Too many links */
+	EPIPE           = 32,     /* Broken pipe */
 
 	/* math software */
-	EDOM   = 33,          /* Numerical argument out of domain */
-	ERANGE = 34,          /* Result too large */
+	EDOM            = 33,     /* Numerical argument out of domain */
+	ERANGE          = 34,     /* Result too large */
 
 	/* non-blocking and interrupt i/o */
-	EAGAIN      = 35,         /* Resource temporarily unavailable */
-	EWOULDBLOCK = EAGAIN, /* Operation would block */
-	EINPROGRESS = 36,         /* Operation now in progress */
-	EALREADY    = 37,         /* Operation already in progress */
+	EAGAIN          = 35,     /* Resource temporarily unavailable */
+	EWOULDBLOCK     = EAGAIN, /* Operation would block */
+	EINPROGRESS     = 36,     /* Operation now in progress */
+	EALREADY        = 37,     /* Operation already in progress */
 
 	/* ipc/network software -- argument errors */
-	ENOTSOCK       = 38,    /* Socket operation on non-socket */
-	EDESTADDRREQ   = 39,    /* Destination address required */
-	EMSGSIZE       = 40,    /* Message too long */
-	EPROTOTYPE     = 41,    /* Protocol wrong type for socket */
-	ENOPROTOOPT    = 42,    /* Protocol not available */
-	EPROTONOSUPPOR = 43,    /* Protocol not supported */
-	ESOCKTNOSUPPOR = 44,    /* Socket type not supported */
-	ENOTSUP        = 45,    /* Operation not supported */
-	EOPNOTSUPP     = ENOTSUP,
-	EPFNOSUPPORT   = 46,    /* Protocol family not supported */
-	EAFNOSUPPORT   = 47,    /* Address family not supported by protocol family */
-	EADDRINUSE     = 48,    /* Address already in use */
-	EADDRNOTAVAIL  = 49,    /* Can't assign requested address */
+	ENOTSOCK        = 38,     /* Socket operation on non-socket */
+	EDESTADDRREQ    = 39,     /* Destination address required */
+	EMSGSIZE        = 40,     /* Message too long */
+	EPROTOTYPE      = 41,     /* Protocol wrong type for socket */
+	ENOPROTOOPT     = 42,     /* Protocol not available */
+	EPROTONOSUPPORT = 43,     /* Protocol not supported */
+	ESOCKTNOSUPPORT = 44,     /* Socket type not supported */
+	ENOTSUP         = 45,     /* Operation not supported */
+	EOPNOTSUPP 	= ENOTSUP,
+	EPFNOSUPPORT    = 46,     /* Protocol family not supported */
+	EAFNOSUPPORT    = 47,     /* Address family not supported by protocol family */
+	EADDRINUSE      = 48,     /* Address already in use */
+	EADDRNOTAVAIL   = 49,     /* Can't assign requested address */
 
 	/* ipc/network software -- operational errors */
-	ENETDOWN       = 50,    /* Network is down */
-	ENETUNREAC     = 51,    /* Network is unreachable */
-	ENETRESET      = 52,    /* Network dropped connection on reset */
-	ECONNABORTE    = 53,    /* Software caused connection abort */
-	ECONNRESET     = 54,    /* Connection reset by peer */
-	ENOBUFS        = 55,    /* No buffer space available */
-	EISCONN        = 56,    /* Socket is already connected */
-	ENOTCONN       = 57,    /* Socket is not connected */
-	ESHUTDOWN      = 58,    /* Can't send after socket shutdown */
-	ETOOMANYREF    = 59,    /* Too many references: can't splice */
-	ETIMEDOUT      = 60,    /* Operation timed out */
-	ECONNREFUSE    = 61,    /* Connection refused */
+	ENETDOWN        = 50,     /* Network is down */
+	ENETUNREACH     = 51,     /* Network is unreachable */
+	ENETRESET       = 52,     /* Network dropped connection on reset */
+	ECONNABORTED    = 53,     /* Software caused connection abort */
+	ECONNRESET      = 54,     /* Connection reset by peer */
+	ENOBUFS         = 55,     /* No buffer space available */
+	EISCONN         = 56,     /* Socket is already connected */
+	ENOTCONN        = 57,     /* Socket is not connected */
+	ESHUTDOWN       = 58,     /* Can't send after socket shutdown */
+	ETOOMANYREFS    = 59,     /* Too many references: can't splice */
+	ETIMEDOUT       = 60,     /* Operation timed out */
+	ECONNREFUSED    = 61,     /* Connection refused */
 
-	ELOOP          = 62,    /* Too many levels of symbolic links */
-	ENAMETOOLON    = 63,    /* File name too long */
+	ELOOP           = 62,     /* Too many levels of symbolic links */
+	ENAMETOOLONG    = 63,     /* File name too long */
 
 	/* should be rearranged */
-	EHOSTDOWN      = 64,    /* Host is down */
-	EHOSTUNREAC    = 65,    /* No route to host */
-	ENOTEMPTY      = 66,    /* Directory not empty */
+	EHOSTDOWN       = 64,     /* Host is down */
+	EHOSTUNREACH    = 65,     /* No route to host */
+	ENOTEMPTY       = 66,     /* Directory not empty */
 
 	/* quotas & mush */
-	EPROCLIM       = 67,    /* Too many processes */
-	EUSERS         = 68,    /* Too many users */
-	EDQUOT         = 69,    /* Disc quota exceeded */
+	EPROCLIM        = 67,     /* Too many processes */
+	EUSERS          = 68,     /* Too many users */
+	EDQUOT          = 69,     /* Disc quota exceeded */
 
 	/* Network File System */
-	ESTALE         = 70,    /* Stale NFS file handle */
-	EREMOTE        = 71,    /* Too many levels of remote in path */
-	EBADRPC        = 72,    /* RPC struct is bad */
-	ERPCMISMATC    = 73,    /* RPC version wrong */
-	EPROGUNAVAI    = 74,    /* RPC prog. not avail */
-	EPROGMISMATC   = 75,    /* Program version wrong */
-	EPROCUNAVAI    = 76,    /* Bad procedure for program */
+	ESTALE          = 70,     /* Stale NFS file handle */
+	EREMOTE         = 71,     /* Too many levels of remote in path */
+	EBADRPC         = 72,     /* RPC struct is bad */
+	ERPCMISMATCH    = 73,     /* RPC version wrong */
+	EPROGUNAVAIL    = 74,     /* RPC prog. not avail */
+	EPROGMISMATCH   = 75,     /* Program version wrong */
+	EPROCUNAVAIL    = 76,     /* Bad procedure for program */
 
-	ENOLC          = 77,    /* No locks available */
-	ENOSY          = 78,    /* Function not implemented */
+	ENOLCK          = 77,     /* No locks available */
+	ENOSYS          = 78,     /* Function not implemented */
 
-	EFTYP          = 79,    /* Inappropriate file type or format */
-	EAUT           = 80,    /* Authentication error */
-	ENEEDAUT       = 81,    /* Need authenticator */
+	EFTYPE          = 79,     /* Inappropriate file type or format */
+	EAUTH           = 80,     /* Authentication error */
+	ENEEDAUTH       = 81,     /* Need authenticator */
 
 	/* Intelligent device errors */
-	EPWROF         = 82,    /* Device power is off */
-	EDEVER         = 83,    /* Device error, e.g. paper out */
-	EOVERFLO       = 84,    /* Value too large to be stored in data type */
+	EPWROFF         = 82,     /* Device power is off */
+	EDEVERR         = 83,     /* Device error, e.g. paper out */
+	EOVERFLOW       = 84,     /* Value too large to be stored in data type */
 
 	/* Program loading errors */
-	EBADEXE        = 85,    /* Bad executable */
-	EBADARC        = 86,    /* Bad CPU type in executable */
-	ESHLIBVER      = 87,    /* Shared library version mismatch */
-	EBADMACH       = 88,    /* Malformed Macho file */
+	EBADEXEC        = 85,     /* Bad executable */
+	EBADARCH        = 86,     /* Bad CPU type in executable */
+	ESHLIBVERS      = 87,     /* Shared library version mismatch */
+	EBADMACHO       = 88,     /* Malformed Macho file */
 
-	ECANCELE       = 89,    /* Operation canceled */
+	ECANCELED       = 89,     /* Operation canceled */
 
-	EIDRM          = 90,    /* Identifier removed */
-	ENOMSG         = 91,    /* No message of desired type */
-	EILSEQ         = 92,    /* Illegal byte sequence */
-	ENOATT         = 93,    /* Attribute not found */
+	EIDRM           = 90,     /* Identifier removed */
+	ENOMSG          = 91,     /* No message of desired type */
+	EILSEQ          = 92,     /* Illegal byte sequence */
+	ENOATTR         = 93,     /* Attribute not found */
 
-	EBADMS         = 94,    /* Bad message */
-	EMULTIHO       = 95,    /* Reserved */
-	ENODAT         = 96,    /* No message available on STREAM */
-	ENOLIN         = 97,    /* Reserved */
-	ENOSR          = 98,    /* No STREAM resources */
-	ENOSTR         = 99,    /* Not a STREAM */
-	EPROTO         = 100,  /* Protocol error */
-	ETIME          = 101,  /* STREAM ioctl timeout */
+	EBADMSG         = 94,     /* Bad message */
+	EMULTIHOP       = 95,     /* Reserved */
+	ENODATA         = 96,     /* No message available on STREAM */
+	ENOLINK         = 97,     /* Reserved */
+	ENOSR           = 98,     /* No STREAM resources */
+	ENOSTR          = 99,     /* Not a STREAM */
+	EPROTO          = 100,    /* Protocol error */
+	ETIME           = 101,    /* STREAM ioctl timeout */
 
-	ENOPOLIC       = 103,  /* No such policy registered */
+	ENOPOLICY       = 103,    /* No such policy registered */
 
-	ENOTRECOVERABL = 104,  /* State not recoverable */
-	EOWNERDEAD     = 105,  /* Previous owner died */
+	ENOTRECOVERABLE = 104,    /* State not recoverable */
+	EOWNERDEAD      = 105,    /* Previous owner died */
 
-	EQFUL          = 106,  /* Interface output queue is full */
-	ELAS           = 106,  /* Must be equal largest Error */
+	EQFULL          = 106,    /* Interface output queue is full */
+	ELAST           = 106,    /* Must be equal largest errno */
 }
 
+EPERM           :: _Platform_Error.EPERM
+ENOENT          :: _Platform_Error.ENOENT
+ESRCH           :: _Platform_Error.ESRCH
+EINTR           :: _Platform_Error.EINTR
+EIO             :: _Platform_Error.EIO
+ENXIO           :: _Platform_Error.ENXIO
+E2BIG           :: _Platform_Error.E2BIG
+ENOEXEC         :: _Platform_Error.ENOEXEC
+EBADF           :: _Platform_Error.EBADF
+ECHILD          :: _Platform_Error.ECHILD
+EDEADLK         :: _Platform_Error.EDEADLK
+ENOMEM          :: _Platform_Error.ENOMEM
+EACCES          :: _Platform_Error.EACCES
+EFAULT          :: _Platform_Error.EFAULT
+ENOTBLK         :: _Platform_Error.ENOTBLK
+EBUSY           :: _Platform_Error.EBUSY
+EEXIST          :: _Platform_Error.EEXIST
+EXDEV           :: _Platform_Error.EXDEV
+ENODEV          :: _Platform_Error.ENODEV
+ENOTDIR         :: _Platform_Error.ENOTDIR
+EISDIR          :: _Platform_Error.EISDIR
+EINVAL          :: _Platform_Error.EINVAL
+ENFILE          :: _Platform_Error.ENFILE
+EMFILE          :: _Platform_Error.EMFILE
+ENOTTY          :: _Platform_Error.ENOTTY
+ETXTBSY         :: _Platform_Error.ETXTBSY
+EFBIG           :: _Platform_Error.EFBIG
+ENOSPC          :: _Platform_Error.ENOSPC
+ESPIPE          :: _Platform_Error.ESPIPE
+EROFS           :: _Platform_Error.EROFS
+EMLINK          :: _Platform_Error.EMLINK
+EPIPE           :: _Platform_Error.EPIPE
 
-EPERM          :: Platform_Error.EPERM
-ENOENT         :: Platform_Error.ENOENT
-ESRCH          :: Platform_Error.ESRCH
-EINTR          :: Platform_Error.EINTR
-EIO            :: Platform_Error.EIO
-ENXIO          :: Platform_Error.ENXIO
-E2BIG          :: Platform_Error.E2BIG
-ENOEXEC        :: Platform_Error.ENOEXEC
-EBADF          :: Platform_Error.EBADF
-ECHILD         :: Platform_Error.ECHILD
-EDEADLK        :: Platform_Error.EDEADLK
-ENOMEM         :: Platform_Error.ENOMEM
-EACCES         :: Platform_Error.EACCES
-EFAULT         :: Platform_Error.EFAULT
-ENOTBLK        :: Platform_Error.ENOTBLK
-EBUSY          :: Platform_Error.EBUSY
-EEXIST         :: Platform_Error.EEXIST
-EXDEV          :: Platform_Error.EXDEV
-ENODEV         :: Platform_Error.ENODEV
-ENOTDIR        :: Platform_Error.ENOTDIR
-EISDIR         :: Platform_Error.EISDIR
-EINVAL         :: Platform_Error.EINVAL
-ENFILE         :: Platform_Error.ENFILE
-EMFILE         :: Platform_Error.EMFILE
-ENOTTY         :: Platform_Error.ENOTTY
-ETXTBSY        :: Platform_Error.ETXTBSY
-EFBIG          :: Platform_Error.EFBIG
-ENOSPC         :: Platform_Error.ENOSPC
-ESPIPE         :: Platform_Error.ESPIPE
-EROFS          :: Platform_Error.EROFS
-EMLINK         :: Platform_Error.EMLINK
-EPIPE          :: Platform_Error.EPIPE
-EDOM           :: Platform_Error.EDOM
-ERANGE         :: Platform_Error.ERANGE
-EAGAIN         :: Platform_Error.EAGAIN
-EWOULDBLOCK    :: Platform_Error.EWOULDBLOCK
-EINPROGRESS    :: Platform_Error.EINPROGRESS
-EALREADY       :: Platform_Error.EALREADY
-ENOTSOCK       :: Platform_Error.ENOTSOCK
-EDESTADDRREQ   :: Platform_Error.EDESTADDRREQ
-EMSGSIZE       :: Platform_Error.EMSGSIZE
-EPROTOTYPE     :: Platform_Error.EPROTOTYPE
-ENOPROTOOPT    :: Platform_Error.ENOPROTOOPT
-EPROTONOSUPPOR :: Platform_Error.EPROTONOSUPPOR
-ESOCKTNOSUPPOR :: Platform_Error.ESOCKTNOSUPPOR
-ENOTSUP        :: Platform_Error.ENOTSUP
-EOPNOTSUPP     :: Platform_Error.EOPNOTSUPP
-EPFNOSUPPORT   :: Platform_Error.EPFNOSUPPORT
-EAFNOSUPPORT   :: Platform_Error.EAFNOSUPPORT
-EADDRINUSE     :: Platform_Error.EADDRINUSE
-EADDRNOTAVAIL  :: Platform_Error.EADDRNOTAVAIL
-ENETDOWN       :: Platform_Error.ENETDOWN
-ENETUNREAC     :: Platform_Error.ENETUNREAC
-ENETRESET      :: Platform_Error.ENETRESET
-ECONNABORTE    :: Platform_Error.ECONNABORTE
-ECONNRESET     :: Platform_Error.ECONNRESET
-ENOBUFS        :: Platform_Error.ENOBUFS
-EISCONN        :: Platform_Error.EISCONN
-ENOTCONN       :: Platform_Error.ENOTCONN
-ESHUTDOWN      :: Platform_Error.ESHUTDOWN
-ETOOMANYREF    :: Platform_Error.ETOOMANYREF
-ETIMEDOUT      :: Platform_Error.ETIMEDOUT
-ECONNREFUSE    :: Platform_Error.ECONNREFUSE
-ELOOP          :: Platform_Error.ELOOP
-ENAMETOOLON    :: Platform_Error.ENAMETOOLON
-EHOSTDOWN      :: Platform_Error.EHOSTDOWN
-EHOSTUNREAC    :: Platform_Error.EHOSTUNREAC
-ENOTEMPTY      :: Platform_Error.ENOTEMPTY
-EPROCLIM       :: Platform_Error.EPROCLIM
-EUSERS         :: Platform_Error.EUSERS
-EDQUOT         :: Platform_Error.EDQUOT
-ESTALE         :: Platform_Error.ESTALE
-EREMOTE        :: Platform_Error.EREMOTE
-EBADRPC        :: Platform_Error.EBADRPC
-ERPCMISMATC    :: Platform_Error.ERPCMISMATC
-EPROGUNAVAI    :: Platform_Error.EPROGUNAVAI
-EPROGMISMATC   :: Platform_Error.EPROGMISMATC
-EPROCUNAVAI    :: Platform_Error.EPROCUNAVAI
-ENOLC          :: Platform_Error.ENOLC
-ENOSY          :: Platform_Error.ENOSY
-EFTYP          :: Platform_Error.EFTYP
-EAUT           :: Platform_Error.EAUT
-ENEEDAUT       :: Platform_Error.ENEEDAUT
-EPWROF         :: Platform_Error.EPWROF
-EDEVER         :: Platform_Error.EDEVER
-EOVERFLO       :: Platform_Error.EOVERFLO
-EBADEXE        :: Platform_Error.EBADEXE
-EBADARC        :: Platform_Error.EBADARC
-ESHLIBVER      :: Platform_Error.ESHLIBVER
-EBADMACH       :: Platform_Error.EBADMACH
-ECANCELE       :: Platform_Error.ECANCELE
-EIDRM          :: Platform_Error.EIDRM
-ENOMSG         :: Platform_Error.ENOMSG
-EILSEQ         :: Platform_Error.EILSEQ
-ENOATT         :: Platform_Error.ENOATT
-EBADMS         :: Platform_Error.EBADMS
-EMULTIHO       :: Platform_Error.EMULTIHO
-ENODAT         :: Platform_Error.ENODAT
-ENOLIN         :: Platform_Error.ENOLIN
-ENOSR          :: Platform_Error.ENOSR
-ENOSTR         :: Platform_Error.ENOSTR
-EPROTO         :: Platform_Error.EPROTO
-ETIME          :: Platform_Error.ETIME
-ENOPOLIC       :: Platform_Error.ENOPOLIC
-ENOTRECOVERABL :: Platform_Error.ENOTRECOVERABL
-EOWNERDEAD     :: Platform_Error.EOWNERDEAD
-EQFUL          :: Platform_Error.EQFUL
-ELAS           :: Platform_Error.ELAS
+/* math software */
+EDOM            :: _Platform_Error.EDOM
+ERANGE          :: _Platform_Error.ERANGE
+
+/* non-blocking and interrupt i/o */
+EAGAIN          :: _Platform_Error.EAGAIN
+EWOULDBLOCK     :: _Platform_Error.EWOULDBLOCK
+EINPROGRESS     :: _Platform_Error.EINPROGRESS
+EALREADY        :: _Platform_Error.EALREADY
+
+/* ipc/network software -- argument errors */
+ENOTSOCK        :: _Platform_Error.ENOTSOCK
+EDESTADDRREQ    :: _Platform_Error.EDESTADDRREQ
+EMSGSIZE        :: _Platform_Error.EMSGSIZE
+EPROTOTYPE      :: _Platform_Error.EPROTOTYPE
+ENOPROTOOPT     :: _Platform_Error.ENOPROTOOPT
+EPROTONOSUPPORT :: _Platform_Error.EPROTONOSUPPORT
+ESOCKTNOSUPPORT :: _Platform_Error.ESOCKTNOSUPPORT
+ENOTSUP         :: _Platform_Error.ENOTSUP
+EOPNOTSUPP 	:: _Platform_Error.EOPNOTSUPP
+EPFNOSUPPORT    :: _Platform_Error.EPFNOSUPPORT
+EAFNOSUPPORT    :: _Platform_Error.EAFNOSUPPORT
+EADDRINUSE      :: _Platform_Error.EADDRINUSE
+EADDRNOTAVAIL   :: _Platform_Error.EADDRNOTAVAIL
+
+/* ipc/network software -- operational errors */
+ENETDOWN        :: _Platform_Error.ENETDOWN
+ENETUNREACH     :: _Platform_Error.ENETUNREACH
+ENETRESET       :: _Platform_Error.ENETRESET
+ECONNABORTED    :: _Platform_Error.ECONNABORTED
+ECONNRESET      :: _Platform_Error.ECONNRESET
+ENOBUFS         :: _Platform_Error.ENOBUFS
+EISCONN         :: _Platform_Error.EISCONN
+ENOTCONN        :: _Platform_Error.ENOTCONN
+ESHUTDOWN       :: _Platform_Error.ESHUTDOWN
+ETOOMANYREFS    :: _Platform_Error.ETOOMANYREFS
+ETIMEDOUT       :: _Platform_Error.ETIMEDOUT
+ECONNREFUSED    :: _Platform_Error.ECONNREFUSED
+
+ELOOP           :: _Platform_Error.ELOOP
+ENAMETOOLONG    :: _Platform_Error.ENAMETOOLONG
+
+/* should be rearranged */
+EHOSTDOWN       :: _Platform_Error.EHOSTDOWN
+EHOSTUNREACH    :: _Platform_Error.EHOSTUNREACH
+ENOTEMPTY       :: _Platform_Error.ENOTEMPTY
+
+/* quotas & mush */
+EPROCLIM        :: _Platform_Error.EPROCLIM
+EUSERS          :: _Platform_Error.EUSERS
+EDQUOT          :: _Platform_Error.EDQUOT
+
+/* Network File System */
+ESTALE          :: _Platform_Error.ESTALE
+EREMOTE         :: _Platform_Error.EREMOTE
+EBADRPC         :: _Platform_Error.EBADRPC
+ERPCMISMATCH    :: _Platform_Error.ERPCMISMATCH
+EPROGUNAVAIL    :: _Platform_Error.EPROGUNAVAIL
+EPROGMISMATCH   :: _Platform_Error.EPROGMISMATCH
+EPROCUNAVAIL    :: _Platform_Error.EPROCUNAVAIL
+
+ENOLCK          :: _Platform_Error.ENOLCK
+ENOSYS          :: _Platform_Error.ENOSYS
+
+EFTYPE          :: _Platform_Error.EFTYPE
+EAUTH           :: _Platform_Error.EAUTH
+ENEEDAUTH       :: _Platform_Error.ENEEDAUTH
+
+/* Intelligent device errors */
+EPWROFF         :: _Platform_Error.EPWROFF
+EDEVERR         :: _Platform_Error.EDEVERR
+EOVERFLOW       :: _Platform_Error.EOVERFLOW
+
+/* Program loading errors */
+EBADEXEC        :: _Platform_Error.EBADEXEC
+EBADARCH        :: _Platform_Error.EBADARCH
+ESHLIBVERS      :: _Platform_Error.ESHLIBVERS
+EBADMACHO       :: _Platform_Error.EBADMACHO
+
+ECANCELED       :: _Platform_Error.ECANCELED
+
+EIDRM           :: _Platform_Error.EIDRM
+ENOMSG          :: _Platform_Error.ENOMSG
+EILSEQ          :: _Platform_Error.EILSEQ
+ENOATTR         :: _Platform_Error.ENOATTR
+
+EBADMSG         :: _Platform_Error.EBADMSG
+EMULTIHOP       :: _Platform_Error.EMULTIHOP
+ENODATA         :: _Platform_Error.ENODATA
+ENOLINK         :: _Platform_Error.ENOLINK
+ENOSR           :: _Platform_Error.ENOSR
+ENOSTR          :: _Platform_Error.ENOSTR
+EPROTO          :: _Platform_Error.EPROTO
+ETIME           :: _Platform_Error.ETIME
+
+ENOPOLICY       :: _Platform_Error.ENOPOLICY
+
+ENOTRECOVERABLE :: _Platform_Error.ENOTRECOVERABLE
+EOWNERDEAD      :: _Platform_Error.EOWNERDEAD
+
+EQFULL          :: _Platform_Error.EQFULL
+ELAST           :: _Platform_Error.ELAST
+
 
 O_RDONLY   :: 0x0000
 O_WRONLY   :: 0x0001

--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -10,146 +10,257 @@ import "core:c"
 
 Handle    :: distinct i32
 File_Time :: distinct u64
-Errno     :: distinct int
 
 INVALID_HANDLE :: ~Handle(0)
 
-ERROR_NONE: Errno : 0
-EPERM:		Errno : 1		/* Operation not permitted */
-ENOENT:		Errno : 2		/* No such file or directory */
-ESRCH:		Errno : 3		/* No such process */
-EINTR:		Errno : 4		/* Interrupted system call */
-EIO:		Errno : 5		/* Input/output error */
-ENXIO:		Errno : 6		/* Device not configured */
-E2BIG:		Errno : 7		/* Argument list too long */
-ENOEXEC:	Errno : 8		/* Exec format error */
-EBADF:		Errno : 9		/* Bad file descriptor */
-ECHILD:		Errno : 10		/* No child processes */
-EDEADLK:	Errno : 11		/* Resource deadlock avoided */
-ENOMEM:		Errno : 12		/* Cannot allocate memory */
-EACCES:		Errno : 13		/* Permission denied */
-EFAULT:		Errno : 14		/* Bad address */
-ENOTBLK:	Errno : 15		/* Block device required */
-EBUSY:		Errno : 16		/* Device / Resource busy */
-EEXIST:		Errno : 17		/* File exists */
-EXDEV:		Errno : 18		/* Cross-device link */
-ENODEV:		Errno : 19		/* Operation not supported by device */
-ENOTDIR:	Errno : 20		/* Not a directory */
-EISDIR:		Errno : 21		/* Is a directory */
-EINVAL:		Errno : 22		/* Invalid argument */
-ENFILE:		Errno : 23		/* Too many open files in system */
-EMFILE:		Errno : 24		/* Too many open files */
-ENOTTY:		Errno : 25		/* Inappropriate ioctl for device */
-ETXTBSY:	Errno : 26		/* Text file busy */
-EFBIG:		Errno : 27		/* File too large */
-ENOSPC:		Errno : 28		/* No space left on device */
-ESPIPE:		Errno : 29		/* Illegal seek */
-EROFS:		Errno : 30		/* Read-only file system */
-EMLINK:		Errno : 31		/* Too many links */
-EPIPE:		Errno : 32		/* Broken pipe */
+_Platform_Error :: enum i32  {
+	NONE       = 0,
+	EPERM      = 1,       /* Operation not permitted */
+	ENOENT     = 2,       /* No such file or directory */
+	ESRCH      = 3,       /* No such process */
+	EINTR      = 4,       /* Interrupted system call */
+	EIO        = 5,       /* Input/output error */
+	ENXIO      = 6,       /* Device not configured */
+	E2BIG      = 7,       /* Argument list too long */
+	ENOEXEC    = 8,       /* Exec format error */
+	EBADF      = 9,       /* Bad file descriptor */
+	ECHILD     = 10,      /* No child processes */
+	EDEADLK    = 11,      /* Resource deadlock avoided */
+	ENOMEM     = 12,      /* Cannot allocate memory */
+	EACCES     = 13,      /* Permission denied */
+	EFAULT     = 14,      /* Bad address */
+	ENOTBLK    = 15,      /* Block device required */
+	EBUSY      = 16,      /* Device / Resource busy */
+	EEXIST     = 17,      /* File exists */
+	EXDEV      = 18,      /* Cross-device link */
+	ENODEV     = 19,      /* Operation not supported by device */
+	ENOTDIR    = 20,      /* Not a directory */
+	EISDIR     = 21,      /* Is a directory */
+	EINVAL     = 22,      /* Invalid argument */
+	ENFILE     = 23,      /* Too many open files in system */
+	EMFILE     = 24,      /* Too many open files */
+	ENOTTY     = 25,      /* Inappropriate ioctl for device */
+	ETXTBSY    = 26,      /* Text file busy */
+	EFBIG      = 27,      /* File too large */
+	ENOSPC     = 28,      /* No space left on device */
+	ESPIPE     = 29,      /* Illegal seek */
+	EROFS      = 30,      /* Read-only file system */
+	EMLINK     = 31,      /* Too many links */
+	EPIPE      = 32,      /* Broken pipe */
 
-/* math software */
-EDOM:		Errno : 33		/* Numerical argument out of domain */
-ERANGE:		Errno : 34		/* Result too large */
+	/* math software */
+	EDOM   = 33,          /* Numerical argument out of domain */
+	ERANGE = 34,          /* Result too large */
 
-/* non-blocking and interrupt i/o */
-EAGAIN:			Errno : 35		/* Resource temporarily unavailable */
-EWOULDBLOCK: 	Errno : EAGAIN		/* Operation would block */
-EINPROGRESS: 	Errno : 36		/* Operation now in progress */
-EALREADY:		Errno : 37		/* Operation already in progress */
+	/* non-blocking and interrupt i/o */
+	EAGAIN      = 35,         /* Resource temporarily unavailable */
+	EWOULDBLOCK = EAGAIN, /* Operation would block */
+	EINPROGRESS = 36,         /* Operation now in progress */
+	EALREADY    = 37,         /* Operation already in progress */
 
-/* ipc/network software -- argument errors */
-ENOTSOCK:			Errno : 38		/* Socket operation on non-socket */
-EDESTADDRREQ:		Errno : 39		/* Destination address required */
-EMSGSIZE:			Errno : 40		/* Message too long */
-EPROTOTYPE:			Errno : 41		/* Protocol wrong type for socket */
-ENOPROTOOPT:		Errno : 42		/* Protocol not available */
-EPROTONOSUPPORT:	Errno : 43		/* Protocol not supported */
-ESOCKTNOSUPPORT:	Errno : 44		/* Socket type not supported */
-ENOTSUP:			Errno : 45		/* Operation not supported */
-EOPNOTSUPP::		ENOTSUP
-EPFNOSUPPORT:		Errno : 46		/* Protocol family not supported */
-EAFNOSUPPORT:		Errno : 47		/* Address family not supported by protocol family */
-EADDRINUSE:			Errno : 48		/* Address already in use */
-EADDRNOTAVAIL:		Errno : 49		/* Can't assign requested address */
+	/* ipc/network software -- argument errors */
+	ENOTSOCK       = 38,    /* Socket operation on non-socket */
+	EDESTADDRREQ   = 39,    /* Destination address required */
+	EMSGSIZE       = 40,    /* Message too long */
+	EPROTOTYPE     = 41,    /* Protocol wrong type for socket */
+	ENOPROTOOPT    = 42,    /* Protocol not available */
+	EPROTONOSUPPOR = 43,    /* Protocol not supported */
+	ESOCKTNOSUPPOR = 44,    /* Socket type not supported */
+	ENOTSUP        = 45,    /* Operation not supported */
+	EOPNOTSUPP     = ENOTSUP,
+	EPFNOSUPPORT   = 46,    /* Protocol family not supported */
+	EAFNOSUPPORT   = 47,    /* Address family not supported by protocol family */
+	EADDRINUSE     = 48,    /* Address already in use */
+	EADDRNOTAVAIL  = 49,    /* Can't assign requested address */
 
-/* ipc/network software -- operational errors */
-ENETDOWN:		Errno : 50		/* Network is down */
-ENETUNREACH:	Errno : 51		/* Network is unreachable */
-ENETRESET:		Errno : 52		/* Network dropped connection on reset */
-ECONNABORTED:	Errno : 53		/* Software caused connection abort */
-ECONNRESET:		Errno : 54		/* Connection reset by peer */
-ENOBUFS:		Errno : 55		/* No buffer space available */
-EISCONN:		Errno : 56		/* Socket is already connected */
-ENOTCONN:		Errno : 57		/* Socket is not connected */
-ESHUTDOWN:		Errno : 58		/* Can't send after socket shutdown */
-ETOOMANYREFS:	Errno : 59		/* Too many references: can't splice */
-ETIMEDOUT:		Errno : 60		/* Operation timed out */
-ECONNREFUSED:	Errno : 61		/* Connection refused */
+	/* ipc/network software -- operational errors */
+	ENETDOWN       = 50,    /* Network is down */
+	ENETUNREAC     = 51,    /* Network is unreachable */
+	ENETRESET      = 52,    /* Network dropped connection on reset */
+	ECONNABORTE    = 53,    /* Software caused connection abort */
+	ECONNRESET     = 54,    /* Connection reset by peer */
+	ENOBUFS        = 55,    /* No buffer space available */
+	EISCONN        = 56,    /* Socket is already connected */
+	ENOTCONN       = 57,    /* Socket is not connected */
+	ESHUTDOWN      = 58,    /* Can't send after socket shutdown */
+	ETOOMANYREF    = 59,    /* Too many references: can't splice */
+	ETIMEDOUT      = 60,    /* Operation timed out */
+	ECONNREFUSE    = 61,    /* Connection refused */
 
-ELOOP:			Errno : 62		/* Too many levels of symbolic links */
-ENAMETOOLONG:	Errno : 63		/* File name too long */
+	ELOOP          = 62,    /* Too many levels of symbolic links */
+	ENAMETOOLON    = 63,    /* File name too long */
 
-/* should be rearranged */
-EHOSTDOWN:		Errno : 64		/* Host is down */
-EHOSTUNREACH:	Errno : 65		/* No route to host */
-ENOTEMPTY:		Errno : 66		/* Directory not empty */
+	/* should be rearranged */
+	EHOSTDOWN      = 64,    /* Host is down */
+	EHOSTUNREAC    = 65,    /* No route to host */
+	ENOTEMPTY      = 66,    /* Directory not empty */
 
-/* quotas & mush */
-EPROCLIM:		Errno : 67		/* Too many processes */
-EUSERS:			Errno : 68		/* Too many users */
-EDQUOT:			Errno : 69		/* Disc quota exceeded */
+	/* quotas & mush */
+	EPROCLIM       = 67,    /* Too many processes */
+	EUSERS         = 68,    /* Too many users */
+	EDQUOT         = 69,    /* Disc quota exceeded */
 
-/* Network File System */
-ESTALE:			Errno : 70		/* Stale NFS file handle */
-EREMOTE:		Errno : 71		/* Too many levels of remote in path */
-EBADRPC:		Errno : 72		/* RPC struct is bad */
-ERPCMISMATCH:	Errno : 73		/* RPC version wrong */
-EPROGUNAVAIL:	Errno : 74		/* RPC prog. not avail */
-EPROGMISMATCH:	Errno : 75		/* Program version wrong */
-EPROCUNAVAIL:	Errno : 76		/* Bad procedure for program */
+	/* Network File System */
+	ESTALE         = 70,    /* Stale NFS file handle */
+	EREMOTE        = 71,    /* Too many levels of remote in path */
+	EBADRPC        = 72,    /* RPC struct is bad */
+	ERPCMISMATC    = 73,    /* RPC version wrong */
+	EPROGUNAVAI    = 74,    /* RPC prog. not avail */
+	EPROGMISMATC   = 75,    /* Program version wrong */
+	EPROCUNAVAI    = 76,    /* Bad procedure for program */
 
-ENOLCK:	Errno : 77		/* No locks available */
-ENOSYS:	Errno : 78		/* Function not implemented */
+	ENOLC          = 77,    /* No locks available */
+	ENOSY          = 78,    /* Function not implemented */
 
-EFTYPE:	Errno : 79		/* Inappropriate file type or format */
-EAUTH:	Errno : 80		/* Authentication error */
-ENEEDAUTH:	Errno : 81		/* Need authenticator */
+	EFTYP          = 79,    /* Inappropriate file type or format */
+	EAUT           = 80,    /* Authentication error */
+	ENEEDAUT       = 81,    /* Need authenticator */
 
-/* Intelligent device errors */
-EPWROFF:	Errno : 82	/* Device power is off */
-EDEVERR:	Errno : 83	/* Device error, e.g. paper out */
-EOVERFLOW:	Errno : 84		/* Value too large to be stored in data type */
+	/* Intelligent device errors */
+	EPWROF         = 82,    /* Device power is off */
+	EDEVER         = 83,    /* Device error, e.g. paper out */
+	EOVERFLO       = 84,    /* Value too large to be stored in data type */
 
-/* Program loading errors */
-EBADEXEC:	Errno : 85	/* Bad executable */
-EBADARCH:	Errno : 86	/* Bad CPU type in executable */
-ESHLIBVERS:	Errno : 87	/* Shared library version mismatch */
-EBADMACHO:	Errno : 88	/* Malformed Macho file */
+	/* Program loading errors */
+	EBADEXE        = 85,    /* Bad executable */
+	EBADARC        = 86,    /* Bad CPU type in executable */
+	ESHLIBVER      = 87,    /* Shared library version mismatch */
+	EBADMACH       = 88,    /* Malformed Macho file */
 
-ECANCELED:	Errno : 89		/* Operation canceled */
+	ECANCELE       = 89,    /* Operation canceled */
 
-EIDRM:		Errno : 90		/* Identifier removed */
-ENOMSG:		Errno : 91		/* No message of desired type */
-EILSEQ:		Errno : 92		/* Illegal byte sequence */
-ENOATTR:	Errno : 93		/* Attribute not found */
+	EIDRM          = 90,    /* Identifier removed */
+	ENOMSG         = 91,    /* No message of desired type */
+	EILSEQ         = 92,    /* Illegal byte sequence */
+	ENOATT         = 93,    /* Attribute not found */
 
-EBADMSG:	Errno : 94		/* Bad message */
-EMULTIHOP:	Errno : 95		/* Reserved */
-ENODATA:	Errno : 96		/* No message available on STREAM */
-ENOLINK:	Errno : 97		/* Reserved */
-ENOSR:		Errno : 98		/* No STREAM resources */
-ENOSTR:		Errno : 99		/* Not a STREAM */
-EPROTO:		Errno : 100		/* Protocol error */
-ETIME:		Errno : 101		/* STREAM ioctl timeout */
+	EBADMS         = 94,    /* Bad message */
+	EMULTIHO       = 95,    /* Reserved */
+	ENODAT         = 96,    /* No message available on STREAM */
+	ENOLIN         = 97,    /* Reserved */
+	ENOSR          = 98,    /* No STREAM resources */
+	ENOSTR         = 99,    /* Not a STREAM */
+	EPROTO         = 100,  /* Protocol error */
+	ETIME          = 101,  /* STREAM ioctl timeout */
 
-ENOPOLICY:	Errno : 103		/* No such policy registered */
+	ENOPOLIC       = 103,  /* No such policy registered */
 
-ENOTRECOVERABLE:	Errno : 104		/* State not recoverable */
-EOWNERDEAD:			Errno : 105		/* Previous owner died */
+	ENOTRECOVERABL = 104,  /* State not recoverable */
+	EOWNERDEAD     = 105,  /* Previous owner died */
 
-EQFULL:	Errno : 106		/* Interface output queue is full */
-ELAST:	Errno : 106		/* Must be equal largest errno */
+	EQFUL          = 106,  /* Interface output queue is full */
+	ELAS           = 106,  /* Must be equal largest errno */
+}
+
+
+EPERM          :: Platform_Error.EPERM
+ENOENT         :: Platform_Error.ENOENT
+ESRCH          :: Platform_Error.ESRCH
+EINTR          :: Platform_Error.EINTR
+EIO            :: Platform_Error.EIO
+ENXIO          :: Platform_Error.ENXIO
+E2BIG          :: Platform_Error.E2BIG
+ENOEXEC        :: Platform_Error.ENOEXEC
+EBADF          :: Platform_Error.EBADF
+ECHILD         :: Platform_Error.ECHILD
+EDEADLK        :: Platform_Error.EDEADLK
+ENOMEM         :: Platform_Error.ENOMEM
+EACCES         :: Platform_Error.EACCES
+EFAULT         :: Platform_Error.EFAULT
+ENOTBLK        :: Platform_Error.ENOTBLK
+EBUSY          :: Platform_Error.EBUSY
+EEXIST         :: Platform_Error.EEXIST
+EXDEV          :: Platform_Error.EXDEV
+ENODEV         :: Platform_Error.ENODEV
+ENOTDIR        :: Platform_Error.ENOTDIR
+EISDIR         :: Platform_Error.EISDIR
+EINVAL         :: Platform_Error.EINVAL
+ENFILE         :: Platform_Error.ENFILE
+EMFILE         :: Platform_Error.EMFILE
+ENOTTY         :: Platform_Error.ENOTTY
+ETXTBSY        :: Platform_Error.ETXTBSY
+EFBIG          :: Platform_Error.EFBIG
+ENOSPC         :: Platform_Error.ENOSPC
+ESPIPE         :: Platform_Error.ESPIPE
+EROFS          :: Platform_Error.EROFS
+EMLINK         :: Platform_Error.EMLINK
+EPIPE          :: Platform_Error.EPIPE
+EDOM           :: Platform_Error.EDOM
+ERANGE         :: Platform_Error.ERANGE
+EAGAIN         :: Platform_Error.EAGAIN
+EWOULDBLOCK    :: Platform_Error.EWOULDBLOCK
+EINPROGRESS    :: Platform_Error.EINPROGRESS
+EALREADY       :: Platform_Error.EALREADY
+ENOTSOCK       :: Platform_Error.ENOTSOCK
+EDESTADDRREQ   :: Platform_Error.EDESTADDRREQ
+EMSGSIZE       :: Platform_Error.EMSGSIZE
+EPROTOTYPE     :: Platform_Error.EPROTOTYPE
+ENOPROTOOPT    :: Platform_Error.ENOPROTOOPT
+EPROTONOSUPPOR :: Platform_Error.EPROTONOSUPPOR
+ESOCKTNOSUPPOR :: Platform_Error.ESOCKTNOSUPPOR
+ENOTSUP        :: Platform_Error.ENOTSUP
+EOPNOTSUPP     :: Platform_Error.EOPNOTSUPP
+EPFNOSUPPORT   :: Platform_Error.EPFNOSUPPORT
+EAFNOSUPPORT   :: Platform_Error.EAFNOSUPPORT
+EADDRINUSE     :: Platform_Error.EADDRINUSE
+EADDRNOTAVAIL  :: Platform_Error.EADDRNOTAVAIL
+ENETDOWN       :: Platform_Error.ENETDOWN
+ENETUNREAC     :: Platform_Error.ENETUNREAC
+ENETRESET      :: Platform_Error.ENETRESET
+ECONNABORTE    :: Platform_Error.ECONNABORTE
+ECONNRESET     :: Platform_Error.ECONNRESET
+ENOBUFS        :: Platform_Error.ENOBUFS
+EISCONN        :: Platform_Error.EISCONN
+ENOTCONN       :: Platform_Error.ENOTCONN
+ESHUTDOWN      :: Platform_Error.ESHUTDOWN
+ETOOMANYREF    :: Platform_Error.ETOOMANYREF
+ETIMEDOUT      :: Platform_Error.ETIMEDOUT
+ECONNREFUSE    :: Platform_Error.ECONNREFUSE
+ELOOP          :: Platform_Error.ELOOP
+ENAMETOOLON    :: Platform_Error.ENAMETOOLON
+EHOSTDOWN      :: Platform_Error.EHOSTDOWN
+EHOSTUNREAC    :: Platform_Error.EHOSTUNREAC
+ENOTEMPTY      :: Platform_Error.ENOTEMPTY
+EPROCLIM       :: Platform_Error.EPROCLIM
+EUSERS         :: Platform_Error.EUSERS
+EDQUOT         :: Platform_Error.EDQUOT
+ESTALE         :: Platform_Error.ESTALE
+EREMOTE        :: Platform_Error.EREMOTE
+EBADRPC        :: Platform_Error.EBADRPC
+ERPCMISMATC    :: Platform_Error.ERPCMISMATC
+EPROGUNAVAI    :: Platform_Error.EPROGUNAVAI
+EPROGMISMATC   :: Platform_Error.EPROGMISMATC
+EPROCUNAVAI    :: Platform_Error.EPROCUNAVAI
+ENOLC          :: Platform_Error.ENOLC
+ENOSY          :: Platform_Error.ENOSY
+EFTYP          :: Platform_Error.EFTYP
+EAUT           :: Platform_Error.EAUT
+ENEEDAUT       :: Platform_Error.ENEEDAUT
+EPWROF         :: Platform_Error.EPWROF
+EDEVER         :: Platform_Error.EDEVER
+EOVERFLO       :: Platform_Error.EOVERFLO
+EBADEXE        :: Platform_Error.EBADEXE
+EBADARC        :: Platform_Error.EBADARC
+ESHLIBVER      :: Platform_Error.ESHLIBVER
+EBADMACH       :: Platform_Error.EBADMACH
+ECANCELE       :: Platform_Error.ECANCELE
+EIDRM          :: Platform_Error.EIDRM
+ENOMSG         :: Platform_Error.ENOMSG
+EILSEQ         :: Platform_Error.EILSEQ
+ENOATT         :: Platform_Error.ENOATT
+EBADMS         :: Platform_Error.EBADMS
+EMULTIHO       :: Platform_Error.EMULTIHO
+ENODAT         :: Platform_Error.ENODAT
+ENOLIN         :: Platform_Error.ENOLIN
+ENOSR          :: Platform_Error.ENOSR
+ENOSTR         :: Platform_Error.ENOSTR
+EPROTO         :: Platform_Error.EPROTO
+ETIME          :: Platform_Error.ETIME
+ENOPOLIC       :: Platform_Error.ENOPOLIC
+ENOTRECOVERABL :: Platform_Error.ENOTRECOVERABL
+EOWNERDEAD     :: Platform_Error.EOWNERDEAD
+EQFUL          :: Platform_Error.EQFUL
+ELAS           :: Platform_Error.ELAS
 
 O_RDONLY   :: 0x0000
 O_WRONLY   :: 0x0001
@@ -524,12 +635,12 @@ foreign dl {
 	@(link_name="dlerror") _unix_dlerror :: proc() -> cstring ---
 }
 
-get_last_error :: proc "contextless" () -> int {
-	return int(__error()^)
+get_last_error :: proc "contextless" () -> Error {
+	return Error(__error()^)
 }
 
 get_last_error_string :: proc() -> string {
-	return cast(string)_darwin_string_error(cast(c.int)get_last_error())
+	return string(_darwin_string_error(__error()^))
 }
 
 
@@ -548,7 +659,7 @@ open :: proc(path: string, flags: int = O_RDWR, mode: int = 0) -> (Handle, Errno
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	handle := _unix_open(cstr, i32(flags), u16(mode))
 	if handle == -1 {
-		return INVALID_HANDLE, cast(Errno)get_last_error()
+		return INVALID_HANDLE, get_last_error()
 	}
 
 	/*

--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -635,6 +635,7 @@ foreign dl {
 	@(link_name="dlerror") _unix_dlerror :: proc() -> cstring ---
 }
 
+@(require_results, no_instrumentation)
 get_last_error :: proc "contextless" () -> Error {
 	return Platform_Error(__error()^)
 }

--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -785,7 +785,7 @@ seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 
 	final_offset := i64(_unix_lseek(fd, int(offset), c.int(whence)))
 	if final_offset == -1 {
-		return 0, Platform_Error.EPERM
+		return 0, get_last_error()
 	}
 	return final_offset, nil
 }

--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -636,7 +636,7 @@ foreign dl {
 }
 
 get_last_error :: proc "contextless" () -> Error {
-	return Error(__error()^)
+	return Platform_Error(__error()^)
 }
 
 get_last_error_string :: proc() -> string {
@@ -678,11 +678,11 @@ open :: proc(path: string, flags: int = O_RDWR, mode: int = 0) -> (Handle, Errno
 }
 
 fchmod :: proc(fd: Handle, mode: u16) -> Errno {
-	return cast(Errno)_unix_fchmod(fd, mode)
+	return cast(Platform_Error)_unix_fchmod(fd, mode)
 }
 
 close :: proc(fd: Handle) -> Errno {
-	return cast(Errno)_unix_close(fd)
+	return cast(Platform_Error)_unix_close(fd)
 }
 
 // If you read or write more than `SSIZE_MAX` bytes, most darwin implementations will return `EINVAL`
@@ -756,7 +756,7 @@ seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
 
 	final_offset := i64(_unix_lseek(fd, int(offset), c.int(whence)))
 	if final_offset == -1 {
-		return 0, 1
+		return 0, Platform_Error.EPERM
 	}
 	return final_offset, 0
 }
@@ -1011,7 +1011,7 @@ access :: proc(path: string, mask: int) -> bool {
 }
 
 flush :: proc(fd: Handle) -> Errno {
-	return cast(Errno)_unix_fsync(fd)
+	return cast(Platform_Error)_unix_fsync(fd)
 }
 
 lookup_env :: proc(key: string, allocator := context.allocator) -> (value: string, found: bool) {

--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -668,13 +668,13 @@ open :: proc(path: string, flags: int = O_RDWR, mode: int = 0) -> (Handle, Errno
 	*/
 	if mode != 0 && !isDir {
 		err := fchmod(handle, cast(u16)mode)
-		if err != 0 {
+		if err != nil {
 			_unix_close(handle)
 			return INVALID_HANDLE, err
 		}
 	}
 
-	return handle, 0
+	return handle, nil
 }
 
 fchmod :: proc(fd: Handle, mode: u16) -> Errno {
@@ -758,7 +758,7 @@ seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
 	if final_offset == -1 {
 		return 0, Platform_Error.EPERM
 	}
-	return final_offset, 0
+	return final_offset, nil
 }
 
 file_size :: proc(fd: Handle) -> (i64, Errno) {
@@ -867,7 +867,7 @@ remove :: proc(path: string) -> Errno {
 	if res == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 @private
@@ -921,7 +921,7 @@ _closedir :: proc(dirp: Dir) -> Errno {
 	if rc != 0 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 @private
@@ -1037,7 +1037,7 @@ set_env :: proc(key, value: string) -> Errno {
 	if res < 0 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 unset_env :: proc(key: string) -> Errno {
@@ -1047,7 +1047,7 @@ unset_env :: proc(key: string) -> Errno {
 	if res < 0 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 get_current_directory :: proc() -> string {
@@ -1074,7 +1074,7 @@ set_current_directory :: proc(path: string) -> (err: Errno) {
 	if res == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 make_directory :: proc(path: string, mode: u16 = 0o775) -> Errno {
@@ -1084,7 +1084,7 @@ make_directory :: proc(path: string, mode: u16 = 0o775) -> Errno {
 	if res == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 exit :: proc "contextless" (code: int) -> ! {
@@ -1169,7 +1169,7 @@ connect :: proc(sd: Socket, addr: ^SOCKADDR, len: socklen_t) -> (Errno) {
 	if result < 0 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 bind :: proc(sd: Socket, addr: ^SOCKADDR, len: socklen_t) -> (Errno) {
@@ -1177,7 +1177,7 @@ bind :: proc(sd: Socket, addr: ^SOCKADDR, len: socklen_t) -> (Errno) {
 	if result < 0 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 accept :: proc(sd: Socket, addr: ^SOCKADDR, len: rawptr) -> (Socket, Errno) {
@@ -1193,7 +1193,7 @@ listen :: proc(sd: Socket, backlog: int) -> (Errno) {
 	if result < 0 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 setsockopt :: proc(sd: Socket, level: int, optname: int, optval: rawptr, optlen: socklen_t) -> (Errno) {
@@ -1201,7 +1201,7 @@ setsockopt :: proc(sd: Socket, level: int, optname: int, optval: rawptr, optlen:
 	if result < 0 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 getsockopt :: proc(sd: Socket, level: int, optname: int, optval: rawptr, optlen: socklen_t) -> Errno {
@@ -1209,7 +1209,7 @@ getsockopt :: proc(sd: Socket, level: int, optname: int, optval: rawptr, optlen:
 	if result < 0 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 recvfrom :: proc(sd: Socket, data: []byte, flags: int, addr: ^SOCKADDR, addr_size: ^socklen_t) -> (u32, Errno) {
@@ -1249,7 +1249,7 @@ shutdown :: proc(sd: Socket, how: int) -> (Errno) {
 	if result < 0 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 fcntl :: proc(fd: int, cmd: int, arg: int) -> (int, Errno) {

--- a/core/os/os_essence.odin
+++ b/core/os/os_essence.odin
@@ -5,7 +5,7 @@ import "core:sys/es"
 Handle :: distinct int
 _Platform_Error :: enum i32 {NONE}
 
-// ERROR_NONE :: Errno(es.SUCCESS)
+// ERROR_NONE :: Error(es.SUCCESS)
 
 O_RDONLY :: 0x1
 O_WRONLY :: 0x2
@@ -30,26 +30,26 @@ heap_resize :: proc(ptr: rawptr, new_size: int) -> rawptr {
 	return es.HeapReallocate(ptr, new_size, false)
 }
 
-open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Errno) {
-	return (Handle) (0), (Errno) (1)
+open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Error) {
+	return (Handle) (0), (Error) (1)
 }
 
-close :: proc(fd: Handle) -> Errno {
-	return (Errno) (1)
+close :: proc(fd: Handle) -> Error {
+	return (Error) (1)
 }
 
-file_size :: proc(fd: Handle) -> (i64, Errno) {
-	return (i64) (0), (Errno) (1)
+file_size :: proc(fd: Handle) -> (i64, Error) {
+	return (i64) (0), (Error) (1)
 }
 
-read :: proc(fd: Handle, data: []byte) -> (int, Errno) {
-	return (int) (0), (Errno) (1)
+read :: proc(fd: Handle, data: []byte) -> (int, Error) {
+	return (int) (0), (Error) (1)
 }
 
-write :: proc(fd: Handle, data: []u8) -> (int, Errno) {
-	return (int) (0), (Errno) (1)
+write :: proc(fd: Handle, data: []u8) -> (int, Error) {
+	return (int) (0), (Error) (1)
 }
 
-seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
-	return (i64) (0), (Errno) (1)
+seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
+	return (i64) (0), (Error) (1)
 }

--- a/core/os/os_essence.odin
+++ b/core/os/os_essence.odin
@@ -53,3 +53,8 @@ write :: proc(fd: Handle, data: []u8) -> (int, Error) {
 seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 	return (i64) (0), (Error) (1)
 }
+
+flush :: proc(fd: Handle) -> Error {
+	// do nothing
+	return nil
+}

--- a/core/os/os_essence.odin
+++ b/core/os/os_essence.odin
@@ -5,7 +5,7 @@ import "core:sys/es"
 Handle :: distinct int
 _Platform_Error :: enum i32 {NONE}
 
-ERROR_NONE :: Errno(es.SUCCESS)
+// ERROR_NONE :: Errno(es.SUCCESS)
 
 O_RDONLY :: 0x1
 O_WRONLY :: 0x2

--- a/core/os/os_essence.odin
+++ b/core/os/os_essence.odin
@@ -2,54 +2,54 @@ package os
 
 import "core:sys/es"
 
-Handle :: distinct int;
-Errno :: distinct int;
+Handle :: distinct int
+_Platform_Error :: enum i32 {NONE}
 
-ERROR_NONE :: (Errno) (es.SUCCESS);
+ERROR_NONE :: Errno(es.SUCCESS)
 
-O_RDONLY :: 0x1;
-O_WRONLY :: 0x2;
-O_CREATE :: 0x4;
-O_TRUNC  :: 0x8;
+O_RDONLY :: 0x1
+O_WRONLY :: 0x2
+O_CREATE :: 0x4
+O_TRUNC  :: 0x8
 
-stderr : Handle = 0; 
+stderr : Handle = 0
 
 current_thread_id :: proc "contextless" () -> int {
-	return (int) (es.ThreadGetID(es.CURRENT_THREAD));
+	return (int) (es.ThreadGetID(es.CURRENT_THREAD))
 }
 
 heap_alloc :: proc(size: int, zero_memory := true) -> rawptr {
-	return es.HeapAllocate(size, zero_memory);
+	return es.HeapAllocate(size, zero_memory)
 }
 
 heap_free :: proc(ptr: rawptr) {
-	es.HeapFree(ptr);
+	es.HeapFree(ptr)
 }
 
 heap_resize :: proc(ptr: rawptr, new_size: int) -> rawptr {
-	return es.HeapReallocate(ptr, new_size, false);
+	return es.HeapReallocate(ptr, new_size, false)
 }
 
 open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Errno) {
-	return (Handle) (0), (Errno) (1);
+	return (Handle) (0), (Errno) (1)
 }
 
 close :: proc(fd: Handle) -> Errno {
-	return (Errno) (1);
+	return (Errno) (1)
 }
 
 file_size :: proc(fd: Handle) -> (i64, Errno) {
-	return (i64) (0), (Errno) (1);
+	return (i64) (0), (Errno) (1)
 }
 
 read :: proc(fd: Handle, data: []byte) -> (int, Errno) {
-	return (int) (0), (Errno) (1);
+	return (int) (0), (Errno) (1)
 }
 
 write :: proc(fd: Handle, data: []u8) -> (int, Errno) {
-	return (int) (0), (Errno) (1);
+	return (int) (0), (Errno) (1)
 }
 
 seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
-	return (i64) (0), (Errno) (1);
+	return (i64) (0), (Errno) (1)
 }

--- a/core/os/os_freebsd.odin
+++ b/core/os/os_freebsd.odin
@@ -9,105 +9,200 @@ import "core:c"
 
 Handle :: distinct i32
 File_Time :: distinct u64
-Errno :: distinct i32
 
 INVALID_HANDLE :: ~Handle(0)
 
-ERROR_NONE:      Errno : 0
-EPERM:           Errno : 1
-ENOENT:          Errno : 2
-ESRCH:           Errno : 3
-EINTR:           Errno : 4
-EIO:             Errno : 5
-ENXIO:           Errno : 6
-E2BIG:           Errno : 7
-ENOEXEC:         Errno : 8
-EBADF:           Errno : 9
-ECHILD:          Errno : 10
-EBEADLK:         Errno : 11
-ENOMEM:          Errno : 12
-EACCESS:         Errno : 13
-EFAULT:          Errno : 14
-ENOTBLK:         Errno : 15
-EBUSY:           Errno : 16
-EEXIST:          Errno : 17
-EXDEV:           Errno : 18
-ENODEV:          Errno : 19
-ENOTDIR:         Errno : 20
-EISDIR:          Errno : 21
-EINVAL:          Errno : 22
-ENFILE:          Errno : 23
-EMFILE:          Errno : 24
-ENOTTY:          Errno : 25
-ETXTBSY:         Errno : 26
-EFBIG:           Errno : 27
-ENOSPC:          Errno : 28
-ESPIPE:          Errno : 29
-EROFS:           Errno : 30
-EMLINK:          Errno : 31
-EPIPE:           Errno : 32
-EDOM:            Errno : 33
-ERANGE:          Errno : 34 /* Result too large */
-EAGAIN:          Errno : 35
-EINPROGRESS:     Errno : 36
-EALREADY:        Errno : 37
-ENOTSOCK:        Errno : 38
-EDESTADDRREQ:    Errno : 39
-EMSGSIZE:        Errno : 40
-EPROTOTYPE:      Errno : 41
-ENOPROTOOPT:     Errno : 42
-EPROTONOSUPPORT: Errno : 43
-ESOCKTNOSUPPORT: Errno : 44
-EOPNOTSUPP:      Errno : 45
-EPFNOSUPPORT:    Errno : 46
-EAFNOSUPPORT:    Errno : 47
-EADDRINUSE:      Errno : 48
-EADDRNOTAVAIL:   Errno : 49
-ENETDOWN:        Errno : 50
-ENETUNREACH:     Errno : 51
-ENETRESET:       Errno : 52
-ECONNABORTED:    Errno : 53
-ECONNRESET:      Errno : 54
-ENOBUFS:         Errno : 55
-EISCONN:         Errno : 56
-ENOTCONN:        Errno : 57
-ESHUTDOWN:       Errno : 58
-ETIMEDOUT:       Errno : 60
-ECONNREFUSED:    Errno : 61
-ELOOP:           Errno : 62
-ENAMETOOLING:    Errno : 63
-EHOSTDOWN:       Errno : 64
-EHOSTUNREACH:    Errno : 65
-ENOTEMPTY:       Errno : 66
-EPROCLIM:        Errno : 67
-EUSERS:          Errno : 68
-EDQUOT:          Errno : 69
-ESTALE:          Errno : 70
-EBADRPC:         Errno : 72
-ERPCMISMATCH:    Errno : 73
-EPROGUNAVAIL:    Errno : 74
-EPROGMISMATCH:   Errno : 75
-EPROCUNAVAIL:    Errno : 76
-ENOLCK:          Errno : 77
-ENOSYS:          Errno : 78
-EFTYPE:          Errno : 79
-EAUTH:           Errno : 80
-ENEEDAUTH:       Errno : 81
-EIDRM:           Errno : 82
-ENOMSG:          Errno : 83
-EOVERFLOW:       Errno : 84
-ECANCELED:       Errno : 85
-EILSEQ:          Errno : 86
-ENOATTR:         Errno : 87
-EDOOFUS:         Errno : 88
-EBADMSG:         Errno : 89
-EMULTIHOP:       Errno : 90
-ENOLINK:         Errno : 91
-EPROTO:          Errno : 92
-ENOTCAPABLE:     Errno : 93
-ECAPMODE:        Errno : 94
-ENOTRECOVERABLE: Errno : 95
-EOWNERDEAD:      Errno : 96
+_Platform_Error :: enum i32 {
+	NONE            = 0,
+	EPERM           = 1,
+	ENOENT          = 2,
+	ESRCH           = 3,
+	EINTR           = 4,
+	EIO             = 5,
+	ENXIO           = 6,
+	E2BIG           = 7,
+	ENOEXEC         = 8,
+	EBADF           = 9,
+	ECHILD          = 10,
+	EBEADLK         = 11,
+	ENOMEM          = 12,
+	EACCESS         = 13,
+	EFAULT          = 14,
+	ENOTBLK         = 15,
+	EBUSY           = 16,
+	EEXIST          = 17,
+	EXDEV           = 18,
+	ENODEV          = 19,
+	ENOTDIR         = 20,
+	EISDIR          = 21,
+	EINVAL          = 22,
+	ENFILE          = 23,
+	EMFILE          = 24,
+	ENOTTY          = 25,
+	ETXTBSY         = 26,
+	EFBIG           = 27,
+	ENOSPC          = 28,
+	ESPIPE          = 29,
+	EROFS           = 30,
+	EMLINK          = 31,
+	EPIPE           = 32,
+	EDOM            = 33,
+	ERANGE          = 34, /* Result too large */
+	EAGAIN          = 35,
+	EINPROGRESS     = 36,
+	EALREADY        = 37,
+	ENOTSOCK        = 38,
+	EDESTADDRREQ    = 39,
+	EMSGSIZE        = 40,
+	EPROTOTYPE      = 41,
+	ENOPROTOOPT     = 42,
+	EPROTONOSUPPORT = 43,
+	ESOCKTNOSUPPORT = 44,
+	EOPNOTSUPP      = 45,
+	EPFNOSUPPORT    = 46,
+	EAFNOSUPPORT    = 47,
+	EADDRINUSE      = 48,
+	EADDRNOTAVAIL   = 49,
+	ENETDOWN        = 50,
+	ENETUNREACH     = 51,
+	ENETRESET       = 52,
+	ECONNABORTED    = 53,
+	ECONNRESET      = 54,
+	ENOBUFS         = 55,
+	EISCONN         = 56,
+	ENOTCONN        = 57,
+	ESHUTDOWN       = 58,
+	ETIMEDOUT       = 60,
+	ECONNREFUSED    = 61,
+	ELOOP           = 62,
+	ENAMETOOLING    = 63,
+	EHOSTDOWN       = 64,
+	EHOSTUNREACH    = 65,
+	ENOTEMPTY       = 66,
+	EPROCLIM        = 67,
+	EUSERS          = 68,
+	EDQUOT          = 69,
+	ESTALE          = 70,
+	EBADRPC         = 72,
+	ERPCMISMATCH    = 73,
+	EPROGUNAVAIL    = 74,
+	EPROGMISMATCH   = 75,
+	EPROCUNAVAIL    = 76,
+	ENOLCK          = 77,
+	ENOSYS          = 78,
+	EFTYPE          = 79,
+	EAUTH           = 80,
+	ENEEDAUTH       = 81,
+	EIDRM           = 82,
+	ENOMSG          = 83,
+	EOVERFLOW       = 84,
+	ECANCELED       = 85,
+	EILSEQ          = 86,
+	ENOATTR         = 87,
+	EDOOFUS         = 88,
+	EBADMSG         = 89,
+	EMULTIHOP       = 90,
+	ENOLINK         = 91,
+	EPROTO          = 92,
+	ENOTCAPABLE     = 93,
+	ECAPMODE        = 94,
+	ENOTRECOVERABLE = 95,
+	EOWNERDEAD      = 96,
+}
+EPERM           :: Platform_Error.EPERM
+ENOENT          :: Platform_Error.ENOENT
+ESRCH           :: Platform_Error.ESRCH
+EINTR           :: Platform_Error.EINTR
+EIO             :: Platform_Error.EIO
+ENXIO           :: Platform_Error.ENXIO
+E2BIG           :: Platform_Error.E2BIG
+ENOEXEC         :: Platform_Error.ENOEXEC
+EBADF           :: Platform_Error.EBADF
+ECHILD          :: Platform_Error.ECHILD
+EBEADLK         :: Platform_Error.EBEADLK
+ENOMEM          :: Platform_Error.ENOMEM
+EACCESS         :: Platform_Error.EACCESS
+EFAULT          :: Platform_Error.EFAULT
+ENOTBLK         :: Platform_Error.ENOTBLK
+EBUSY           :: Platform_Error.EBUSY
+EEXIST          :: Platform_Error.EEXIST
+EXDEV           :: Platform_Error.EXDEV
+ENODEV          :: Platform_Error.ENODEV
+ENOTDIR         :: Platform_Error.ENOTDIR
+EISDIR          :: Platform_Error.EISDIR
+EINVAL          :: Platform_Error.EINVAL
+ENFILE          :: Platform_Error.ENFILE
+EMFILE          :: Platform_Error.EMFILE
+ENOTTY          :: Platform_Error.ENOTTY
+ETXTBSY         :: Platform_Error.ETXTBSY
+EFBIG           :: Platform_Error.EFBIG
+ENOSPC          :: Platform_Error.ENOSPC
+ESPIPE          :: Platform_Error.ESPIPE
+EROFS           :: Platform_Error.EROFS
+EMLINK          :: Platform_Error.EMLINK
+EPIPE           :: Platform_Error.EPIPE
+EDOM            :: Platform_Error.EDOM
+ERANGE          :: Platform_Error.ERANGE
+EAGAIN          :: Platform_Error.EAGAIN
+EINPROGRESS     :: Platform_Error.EINPROGRESS
+EALREADY        :: Platform_Error.EALREADY
+ENOTSOCK        :: Platform_Error.ENOTSOCK
+EDESTADDRREQ    :: Platform_Error.EDESTADDRREQ
+EMSGSIZE        :: Platform_Error.EMSGSIZE
+EPROTOTYPE      :: Platform_Error.EPROTOTYPE
+ENOPROTOOPT     :: Platform_Error.ENOPROTOOPT
+EPROTONOSUPPORT :: Platform_Error.EPROTONOSUPPORT
+ESOCKTNOSUPPORT :: Platform_Error.ESOCKTNOSUPPORT
+EOPNOTSUPP      :: Platform_Error.EOPNOTSUPP
+EPFNOSUPPORT    :: Platform_Error.EPFNOSUPPORT
+EAFNOSUPPORT    :: Platform_Error.EAFNOSUPPORT
+EADDRINUSE      :: Platform_Error.EADDRINUSE
+EADDRNOTAVAIL   :: Platform_Error.EADDRNOTAVAIL
+ENETDOWN        :: Platform_Error.ENETDOWN
+ENETUNREACH     :: Platform_Error.ENETUNREACH
+ENETRESET       :: Platform_Error.ENETRESET
+ECONNABORTED    :: Platform_Error.ECONNABORTED
+ECONNRESET      :: Platform_Error.ECONNRESET
+ENOBUFS         :: Platform_Error.ENOBUFS
+EISCONN         :: Platform_Error.EISCONN
+ENOTCONN        :: Platform_Error.ENOTCONN
+ESHUTDOWN       :: Platform_Error.ESHUTDOWN
+ETIMEDOUT       :: Platform_Error.ETIMEDOUT
+ECONNREFUSED    :: Platform_Error.ECONNREFUSED
+ELOOP           :: Platform_Error.ELOOP
+ENAMETOOLING    :: Platform_Error.ENAMETOOLING
+EHOSTDOWN       :: Platform_Error.EHOSTDOWN
+EHOSTUNREACH    :: Platform_Error.EHOSTUNREACH
+ENOTEMPTY       :: Platform_Error.ENOTEMPTY
+EPROCLIM        :: Platform_Error.EPROCLIM
+EUSERS          :: Platform_Error.EUSERS
+EDQUOT          :: Platform_Error.EDQUOT
+ESTALE          :: Platform_Error.ESTALE
+EBADRPC         :: Platform_Error.EBADRPC
+ERPCMISMATCH    :: Platform_Error.ERPCMISMATCH
+EPROGUNAVAIL    :: Platform_Error.EPROGUNAVAIL
+EPROGMISMATCH   :: Platform_Error.EPROGMISMATCH
+EPROCUNAVAIL    :: Platform_Error.EPROCUNAVAIL
+ENOLCK          :: Platform_Error.ENOLCK
+ENOSYS          :: Platform_Error.ENOSYS
+EFTYPE          :: Platform_Error.EFTYPE
+EAUTH           :: Platform_Error.EAUTH
+ENEEDAUTH       :: Platform_Error.ENEEDAUTH
+EIDRM           :: Platform_Error.EIDRM
+ENOMSG          :: Platform_Error.ENOMSG
+EOVERFLOW       :: Platform_Error.EOVERFLOW
+ECANCELED       :: Platform_Error.ECANCELED
+EILSEQ          :: Platform_Error.EILSEQ
+ENOATTR         :: Platform_Error.ENOATTR
+EDOOFUS         :: Platform_Error.EDOOFUS
+EBADMSG         :: Platform_Error.EBADMSG
+EMULTIHOP       :: Platform_Error.EMULTIHOP
+ENOLINK         :: Platform_Error.ENOLINK
+EPROTO          :: Platform_Error.EPROTO
+ENOTCAPABLE     :: Platform_Error.ENOTCAPABLE
+ECAPMODE        :: Platform_Error.ECAPMODE
+ENOTRECOVERABLE :: Platform_Error.ENOTRECOVERABLE
+EOWNERDEAD      :: Platform_Error.EOWNERDEAD
 
 O_RDONLY   :: 0x00000
 O_WRONLY   :: 0x00001
@@ -324,8 +419,8 @@ is_path_separator :: proc(r: rune) -> bool {
 	return r == '/'
 }
 
-get_last_error :: proc "contextless" () -> int {
-	return int(__errno_location()^)
+get_last_error :: proc "contextless" () -> Error {
+	return Error(__errno_location()^)
 }
 
 open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Errno) {

--- a/core/os/os_freebsd.odin
+++ b/core/os/os_freebsd.odin
@@ -420,7 +420,7 @@ is_path_separator :: proc(r: rune) -> bool {
 }
 
 get_last_error :: proc "contextless" () -> Error {
-	return Error(__errno_location()^)
+	return Platform_Error(__errno_location()^)
 }
 
 open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Errno) {

--- a/core/os/os_freebsd.odin
+++ b/core/os/os_freebsd.odin
@@ -442,6 +442,11 @@ close :: proc(fd: Handle) -> Error {
 	return nil
 }
 
+flush :: proc(fd: Handle) -> Error {
+	// do nothing
+	return nil
+}
+
 // If you read or write more than `INT_MAX` bytes, FreeBSD returns `EINVAL`.
 // In practice a read/write call would probably never read/write these big buffers all at once,
 // which is why the number of bytes is returned and why there are procs that will call this in a

--- a/core/os/os_freebsd.odin
+++ b/core/os/os_freebsd.odin
@@ -429,7 +429,7 @@ open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Err
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	handle := _unix_open(cstr, c.int(flags), c.int(mode))
 	if handle == -1 {
-		return INVALID_HANDLE, Error(get_last_error())
+		return INVALID_HANDLE, get_last_error()
 	}
 	return handle, nil
 }
@@ -437,7 +437,7 @@ open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Err
 close :: proc(fd: Handle) -> Error {
 	result := _unix_close(fd)
 	if result == -1 {
-		return Error(get_last_error())
+		return get_last_error()
 	}
 	return nil
 }
@@ -454,7 +454,7 @@ read :: proc(fd: Handle, data: []byte) -> (int, Error) {
 	to_read    := min(c.size_t(len(data)), MAX_RW)
 	bytes_read := _unix_read(fd, &data[0], to_read)
 	if bytes_read == -1 {
-		return -1, Error(get_last_error())
+		return -1, get_last_error()
 	}
 	return int(bytes_read), nil
 }
@@ -467,7 +467,7 @@ write :: proc(fd: Handle, data: []byte) -> (int, Error) {
 	to_write      := min(c.size_t(len(data)), MAX_RW)
 	bytes_written := _unix_write(fd, &data[0], to_write)
 	if bytes_written == -1 {
-		return -1, Error(get_last_error())
+		return -1, get_last_error()
 	}
 	return int(bytes_written), nil
 }
@@ -475,7 +475,7 @@ write :: proc(fd: Handle, data: []byte) -> (int, Error) {
 seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 	res := _unix_seek(fd, offset, c.int(whence))
 	if res == -1 {
-		return -1, Error(get_last_error())
+		return -1, get_last_error()
 	}
 	return res, nil
 }
@@ -493,7 +493,7 @@ rename :: proc(old_path, new_path: string) -> Error {
 	new_path_cstr := strings.clone_to_cstring(new_path, context.temp_allocator)
 	res := _unix_rename(old_path_cstr, new_path_cstr)
 	if res == -1 {
-		return Error(get_last_error())
+		return get_last_error()
 	}
 	return nil
 }
@@ -503,7 +503,7 @@ remove :: proc(path: string) -> Error {
 	path_cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_unlink(path_cstr)
 	if res == -1 {
-		return Error(get_last_error())
+		return get_last_error()
 	}
 	return nil
 }
@@ -513,7 +513,7 @@ make_directory :: proc(path: string, mode: mode_t = 0o775) -> Error {
 	path_cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_mkdir(path_cstr, mode)
 	if res == -1 {
-		return Error(get_last_error())
+		return get_last_error()
 	}
 	return nil
 }
@@ -523,7 +523,7 @@ remove_directory :: proc(path: string) -> Error {
 	path_cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_rmdir(path_cstr)
 	if res == -1 {
-		return Error(get_last_error())
+		return get_last_error()
 	}
 	return nil
 }
@@ -610,7 +610,7 @@ _stat :: proc(path: string) -> (OS_Stat, Error) {
 	s: OS_Stat = ---
 	result := _unix_lstat(cstr, &s)
 	if result == -1 {
-		return s, Error(get_last_error())
+		return s, get_last_error()
 	}
 	return s, nil
 }
@@ -624,7 +624,7 @@ _lstat :: proc(path: string) -> (OS_Stat, Error) {
 	s: OS_Stat = ---
 	res := _unix_lstat(cstr, &s)
 	if res == -1 {
-		return s, Error(get_last_error())
+		return s, get_last_error()
 	}
 	return s, nil
 }
@@ -634,7 +634,7 @@ _fstat :: proc(fd: Handle) -> (OS_Stat, Error) {
 	s: OS_Stat = ---
 	result := _unix_fstat(fd, &s)
 	if result == -1 {
-		return s, Error(get_last_error())
+		return s, get_last_error()
 	}
 	return s, nil
 }
@@ -643,7 +643,7 @@ _fstat :: proc(fd: Handle) -> (OS_Stat, Error) {
 _fdopendir :: proc(fd: Handle) -> (Dir, Error) {
 	dirp := _unix_fdopendir(fd)
 	if dirp == cast(Dir)nil {
-		return nil, Error(get_last_error())
+		return nil, get_last_error()
 	}
 	return dirp, nil
 }
@@ -652,7 +652,7 @@ _fdopendir :: proc(fd: Handle) -> (Dir, Error) {
 _closedir :: proc(dirp: Dir) -> Error {
 	rc := _unix_closedir(dirp)
 	if rc != 0 {
-		return Error(get_last_error())
+		return get_last_error()
 	}
 	return nil
 }
@@ -668,7 +668,7 @@ _readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Error, end_of_stream: bool) 
 	rc := _unix_readdir_r(dirp, &entry, &result)
 
 	if rc != 0 {
-		err = Error(get_last_error())
+		err = get_last_error()
 		return
 	}
 
@@ -692,7 +692,7 @@ _readlink :: proc(path: string) -> (string, Error) {
 		rc := _unix_readlink(path_cstr, &(buf[0]), bufsz)
 		if rc == -1 {
 			delete(buf)
-			return "", Error(get_last_error())
+			return "", get_last_error()
 		} else if rc == int(bufsz) {
 			bufsz += MAX_PATH
 			delete(buf)
@@ -720,7 +720,7 @@ absolute_path_from_handle :: proc(fd: Handle) -> (string, Error) {
 
 	res := _unix_fcntl(fd, F_KINFO, cast(uintptr)&kinfo)
 	if res == -1 {
-		return "", Error(get_last_error())
+		return "", get_last_error()
 	}
 
 	path := strings.clone_from_cstring_bounded(cast(cstring)&kinfo.path[0], len(kinfo.path))
@@ -738,7 +738,7 @@ absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Error) {
 
 	path_ptr := _unix_realpath(rel_cstr, nil)
 	if path_ptr == nil {
-		return "", Error(get_last_error())
+		return "", get_last_error()
 	}
 	defer _unix_free(path_ptr)
 
@@ -754,7 +754,7 @@ access :: proc(path: string, mask: int) -> (bool, Error) {
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	result := _unix_access(cstr, c.int(mask))
 	if result == -1 {
-		return false, Error(get_last_error())
+		return false, get_last_error()
 	}
 	return true, nil
 }
@@ -786,7 +786,7 @@ get_current_directory :: proc() -> string {
 		if cwd != nil {
 			return string(cwd)
 		}
-		if Error(get_last_error()) != ERANGE {
+		if get_last_error() != ERANGE {
 			delete(buf)
 			return ""
 		}
@@ -800,7 +800,7 @@ set_current_directory :: proc(path: string) -> (err: Error) {
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_chdir(cstr)
 	if res == -1 {
-		return Error(get_last_error())
+		return get_last_error()
 	}
 	return nil
 }

--- a/core/os/os_freebsd.odin
+++ b/core/os/os_freebsd.odin
@@ -353,13 +353,13 @@ S_ISGID :: 0o2000 // Set group id on execution
 S_ISVTX :: 0o1000 // Directory restrcted delete
 
 
-S_ISLNK  :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFLNK  }
-S_ISREG  :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFREG  }
-S_ISDIR  :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFDIR  }
-S_ISCHR  :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFCHR  }
-S_ISBLK  :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFBLK  }
-S_ISFIFO :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFIFO  }
-S_ISSOCK :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFSOCK }
+@(require_results) S_ISLNK  :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFLNK  }
+@(require_results) S_ISREG  :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFREG  }
+@(require_results) S_ISDIR  :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFDIR  }
+@(require_results) S_ISCHR  :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFCHR  }
+@(require_results) S_ISBLK  :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFBLK  }
+@(require_results) S_ISFIFO :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFIFO  }
+@(require_results) S_ISSOCK :: #force_inline proc(m: mode_t) -> bool { return (m & S_IFMT) == S_IFSOCK }
 
 F_OK :: 0 // Test for file existance
 X_OK :: 1 // Test for execute permission
@@ -415,6 +415,7 @@ foreign dl {
 	@(link_name="pthread_getthreadid_np") pthread_getthreadid_np :: proc() -> c.int ---
 }
 
+@(require_results)
 is_path_separator :: proc(r: rune) -> bool {
 	return r == '/'
 }
@@ -424,6 +425,7 @@ get_last_error :: proc "contextless" () -> Error {
 	return Platform_Error(__Error_location()^)
 }
 
+@(require_results)
 open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
@@ -505,6 +507,7 @@ seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 	return res, nil
 }
 
+@(require_results)
 file_size :: proc(fd: Handle) -> (size: i64, err: Error) {
 	size = -1
 	s := _fstat(fd) or_return
@@ -553,6 +556,7 @@ remove_directory :: proc(path: string) -> Error {
 	return nil
 }
 
+@(require_results)
 is_file_handle :: proc(fd: Handle) -> bool {
 	s, err := _fstat(fd)
 	if err != nil {
@@ -561,6 +565,7 @@ is_file_handle :: proc(fd: Handle) -> bool {
 	return S_ISREG(s.mode)
 }
 
+@(require_results)
 is_file_path :: proc(path: string, follow_links: bool = true) -> bool {
 	s: OS_Stat
 	err: Error
@@ -575,6 +580,7 @@ is_file_path :: proc(path: string, follow_links: bool = true) -> bool {
 	return S_ISREG(s.mode)
 }
 
+@(require_results)
 is_dir_handle :: proc(fd: Handle) -> bool {
 	s, err := _fstat(fd)
 	if err != nil {
@@ -583,6 +589,7 @@ is_dir_handle :: proc(fd: Handle) -> bool {
 	return S_ISDIR(s.mode)
 }
 
+@(require_results)
 is_dir_path :: proc(path: string, follow_links: bool = true) -> bool {
 	s: OS_Stat
 	err: Error
@@ -610,6 +617,7 @@ stderr: Handle = 2
 last_write_time :: proc(fd: Handle) -> File_Time {}                                                                  
 last_write_time_by_name :: proc(name: string) -> File_Time {}                                                        
 */
+@(require_results)
 last_write_time :: proc(fd: Handle) -> (File_Time, Error) {
 	s, err := _fstat(fd)
 	if err != nil {
@@ -619,6 +627,7 @@ last_write_time :: proc(fd: Handle) -> (File_Time, Error) {
 	return File_Time(modified), nil
 }
 
+@(require_results)
 last_write_time_by_name :: proc(name: string) -> (File_Time, Error) {
 	s, err := _stat(name)
 	if err != nil {
@@ -628,7 +637,7 @@ last_write_time_by_name :: proc(name: string) -> (File_Time, Error) {
 	return File_Time(modified), nil
 }
 
-@private
+@(private, require_results)
 _stat :: proc(path: string) -> (OS_Stat, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
@@ -640,7 +649,7 @@ _stat :: proc(path: string) -> (OS_Stat, Error) {
 	return s, nil
 }
 
-@private
+@(private, require_results)
 _lstat :: proc(path: string) -> (OS_Stat, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
@@ -654,7 +663,7 @@ _lstat :: proc(path: string) -> (OS_Stat, Error) {
 	return s, nil
 }
 
-@private
+@(private, require_results)
 _fstat :: proc(fd: Handle) -> (OS_Stat, Error) {
 	s: OS_Stat = ---
 	result := _unix_fstat(fd, &s)
@@ -664,7 +673,7 @@ _fstat :: proc(fd: Handle) -> (OS_Stat, Error) {
 	return s, nil
 }
 
-@private
+@(private, require_results)
 _fdopendir :: proc(fd: Handle) -> (Dir, Error) {
 	dirp := _unix_fdopendir(fd)
 	if dirp == cast(Dir)nil {
@@ -673,7 +682,7 @@ _fdopendir :: proc(fd: Handle) -> (Dir, Error) {
 	return dirp, nil
 }
 
-@private
+@(private)
 _closedir :: proc(dirp: Dir) -> Error {
 	rc := _unix_closedir(dirp)
 	if rc != 0 {
@@ -682,12 +691,12 @@ _closedir :: proc(dirp: Dir) -> Error {
 	return nil
 }
 
-@private
+@(private)
 _rewinddir :: proc(dirp: Dir) {
 	_unix_rewinddir(dirp)
 }
 
-@private
+@(private, require_results)
 _readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Error, end_of_stream: bool) {
 	result: ^Dirent
 	rc := _unix_readdir_r(dirp, &entry, &result)
@@ -705,7 +714,7 @@ _readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Error, end_of_stream: bool) 
 	return
 }
 
-@private
+@(private, require_results)
 _readlink :: proc(path: string) -> (string, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD(ignore = context.temp_allocator == context.allocator)
 
@@ -730,6 +739,7 @@ _readlink :: proc(path: string) -> (string, Error) {
 	return "", Error{}
 }
 
+@(require_results)
 absolute_path_from_handle :: proc(fd: Handle) -> (string, Error) {
 	// NOTE(Feoramund): The situation isn't ideal, but this was the best way I
 	// could find to implement this. There are a couple outstanding bug reports
@@ -752,6 +762,7 @@ absolute_path_from_handle :: proc(fd: Handle) -> (string, Error) {
 	return path, nil
 }
 
+@(require_results)
 absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Error) {
 	rel := rel
 	if rel == "" {
@@ -784,6 +795,7 @@ access :: proc(path: string, mask: int) -> (bool, Error) {
 	return true, nil
 }
 
+@(require_results)
 lookup_env :: proc(key: string, allocator := context.allocator) -> (value: string, found: bool) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD(ignore = context.temp_allocator == allocator)
 
@@ -795,11 +807,13 @@ lookup_env :: proc(key: string, allocator := context.allocator) -> (value: strin
 	return strings.clone(string(cstr), allocator), true
 }
 
+@(require_results)
 get_env :: proc(key: string, allocator := context.allocator) -> (value: string) {
 	value, _ = lookup_env(key, allocator)
 	return
 }
 
+@(require_results)
 get_current_directory :: proc() -> string {
 	// NOTE(tetra): I would use PATH_MAX here, but I was not able to find
 	// an authoritative value for it across all systems.
@@ -835,16 +849,19 @@ exit :: proc "contextless" (code: int) -> ! {
 	_unix_exit(c.int(code))
 }
 
+@(require_results)
 current_thread_id :: proc "contextless" () -> int {
 	return cast(int) pthread_getthreadid_np()
 }
 
+@(require_results)
 dlopen :: proc(filename: string, flags: int) -> rawptr {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(filename, context.temp_allocator)
 	handle := _unix_dlopen(cstr, c.int(flags))
 	return handle
 }
+@(require_results)
 dlsym :: proc(handle: rawptr, symbol: string) -> rawptr {
 	assert(handle != nil)
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
@@ -860,6 +877,7 @@ dlerror :: proc() -> string {
 	return string(_unix_dlerror())
 }
 
+@(require_results)
 get_page_size :: proc() -> int {
 	// NOTE(tetra): The page size never changes, so why do anything complicated
 	// if we don't have to.
@@ -872,7 +890,7 @@ get_page_size :: proc() -> int {
 	return page_size
 }
 
-@(private)
+@(private, require_results)
 _processor_core_count :: proc() -> int {
 	count : int = 0
 	count_size := size_of(count)
@@ -886,6 +904,7 @@ _processor_core_count :: proc() -> int {
 }
 
 
+@(require_results)
 _alloc_command_line_arguments :: proc() -> []string {
 	res := make([]string, len(runtime.args__))
 	for arg, i in runtime.args__ {

--- a/core/os/os_freebsd.odin
+++ b/core/os/os_freebsd.odin
@@ -438,7 +438,7 @@ close :: proc(fd: Handle) -> Errno {
 	if result == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 // If you read or write more than `INT_MAX` bytes, FreeBSD returns `EINVAL`.
@@ -495,7 +495,7 @@ rename :: proc(old_path, new_path: string) -> Errno {
 	if res == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 remove :: proc(path: string) -> Errno {
@@ -505,7 +505,7 @@ remove :: proc(path: string) -> Errno {
 	if res == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 make_directory :: proc(path: string, mode: mode_t = 0o775) -> Errno {
@@ -515,7 +515,7 @@ make_directory :: proc(path: string, mode: mode_t = 0o775) -> Errno {
 	if res == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 remove_directory :: proc(path: string) -> Errno {
@@ -525,7 +525,7 @@ remove_directory :: proc(path: string) -> Errno {
 	if res == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 is_file_handle :: proc(fd: Handle) -> bool {
@@ -654,7 +654,7 @@ _closedir :: proc(dirp: Dir) -> Errno {
 	if rc != 0 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 @private
@@ -803,7 +803,7 @@ set_current_directory :: proc(path: string) -> (err: Errno) {
 	if res == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 exit :: proc "contextless" (code: int) -> ! {

--- a/core/os/os_freebsd.odin
+++ b/core/os/os_freebsd.odin
@@ -472,6 +472,26 @@ write :: proc(fd: Handle, data: []byte) -> (int, Error) {
 	return int(bytes_written), nil
 }
 
+read_at :: proc(fd: Handle, data: []byte, offset: i64) -> (n: int, err: Error) {
+	curr := seek(fd, offset, SEEK_CUR) or_return
+	n, err = read(fd, data)
+	_, err1 := seek(fd, curr, SEEK_SET)
+	if err1 != nil && err == nil {
+		err = err1
+	}
+	return
+}
+
+write_at :: proc(fd: Handle, data: []byte, offset: i64) -> (n: int, err: Error) {
+	curr := seek(fd, offset, SEEK_CUR) or_return
+	n, err = write(fd, data)
+	_, err1 := seek(fd, curr, SEEK_SET)
+	if err1 != nil && err == nil {
+		err = err1
+	}
+	return
+}
+
 seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 	res := _unix_seek(fd, offset, c.int(whence))
 	if res == -1 {

--- a/core/os/os_freebsd.odin
+++ b/core/os/os_freebsd.odin
@@ -369,7 +369,7 @@ R_OK :: 4 // Test for read permission
 F_KINFO :: 22
 
 foreign libc {
-	@(link_name="__error")		__errno_location :: proc() -> ^c.int ---
+	@(link_name="__error")		__Error_location :: proc() -> ^c.int ---
 
 	@(link_name="open")             _unix_open          :: proc(path: cstring, flags: c.int, mode: c.int) -> Handle ---
 	@(link_name="close")            _unix_close         :: proc(fd: Handle) -> c.int ---
@@ -419,24 +419,25 @@ is_path_separator :: proc(r: rune) -> bool {
 	return r == '/'
 }
 
+@(require_results, no_instrumentation)
 get_last_error :: proc "contextless" () -> Error {
-	return Platform_Error(__errno_location()^)
+	return Platform_Error(__Error_location()^)
 }
 
-open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Errno) {
+open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	handle := _unix_open(cstr, c.int(flags), c.int(mode))
 	if handle == -1 {
-		return INVALID_HANDLE, Errno(get_last_error())
+		return INVALID_HANDLE, Error(get_last_error())
 	}
 	return handle, nil
 }
 
-close :: proc(fd: Handle) -> Errno {
+close :: proc(fd: Handle) -> Error {
 	result := _unix_close(fd)
 	if result == -1 {
-		return Errno(get_last_error())
+		return Error(get_last_error())
 	}
 	return nil
 }
@@ -449,16 +450,16 @@ close :: proc(fd: Handle) -> Errno {
 @(private)
 MAX_RW :: 1 << 30
 
-read :: proc(fd: Handle, data: []byte) -> (int, Errno) {
+read :: proc(fd: Handle, data: []byte) -> (int, Error) {
 	to_read    := min(c.size_t(len(data)), MAX_RW)
 	bytes_read := _unix_read(fd, &data[0], to_read)
 	if bytes_read == -1 {
-		return -1, Errno(get_last_error())
+		return -1, Error(get_last_error())
 	}
 	return int(bytes_read), nil
 }
 
-write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
+write :: proc(fd: Handle, data: []byte) -> (int, Error) {
 	if len(data) == 0 {
 		return 0, nil
 	}
@@ -466,63 +467,63 @@ write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 	to_write      := min(c.size_t(len(data)), MAX_RW)
 	bytes_written := _unix_write(fd, &data[0], to_write)
 	if bytes_written == -1 {
-		return -1, Errno(get_last_error())
+		return -1, Error(get_last_error())
 	}
 	return int(bytes_written), nil
 }
 
-seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
+seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 	res := _unix_seek(fd, offset, c.int(whence))
 	if res == -1 {
-		return -1, Errno(get_last_error())
+		return -1, Error(get_last_error())
 	}
 	return res, nil
 }
 
-file_size :: proc(fd: Handle) -> (size: i64, err: Errno) {
+file_size :: proc(fd: Handle) -> (size: i64, err: Error) {
 	size = -1
 	s := _fstat(fd) or_return
 	size = s.size
 	return
 }
 
-rename :: proc(old_path, new_path: string) -> Errno {
+rename :: proc(old_path, new_path: string) -> Error {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	old_path_cstr := strings.clone_to_cstring(old_path, context.temp_allocator)
 	new_path_cstr := strings.clone_to_cstring(new_path, context.temp_allocator)
 	res := _unix_rename(old_path_cstr, new_path_cstr)
 	if res == -1 {
-		return Errno(get_last_error())
+		return Error(get_last_error())
 	}
 	return nil
 }
 
-remove :: proc(path: string) -> Errno {
+remove :: proc(path: string) -> Error {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	path_cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_unlink(path_cstr)
 	if res == -1 {
-		return Errno(get_last_error())
+		return Error(get_last_error())
 	}
 	return nil
 }
 
-make_directory :: proc(path: string, mode: mode_t = 0o775) -> Errno {
+make_directory :: proc(path: string, mode: mode_t = 0o775) -> Error {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	path_cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_mkdir(path_cstr, mode)
 	if res == -1 {
-		return Errno(get_last_error())
+		return Error(get_last_error())
 	}
 	return nil
 }
 
-remove_directory :: proc(path: string) -> Errno {
+remove_directory :: proc(path: string) -> Error {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	path_cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_rmdir(path_cstr)
 	if res == -1 {
-		return Errno(get_last_error())
+		return Error(get_last_error())
 	}
 	return nil
 }
@@ -537,7 +538,7 @@ is_file_handle :: proc(fd: Handle) -> bool {
 
 is_file_path :: proc(path: string, follow_links: bool = true) -> bool {
 	s: OS_Stat
-	err: Errno
+	err: Error
 	if follow_links {
 		s, err = _stat(path)
 	} else {
@@ -559,7 +560,7 @@ is_dir_handle :: proc(fd: Handle) -> bool {
 
 is_dir_path :: proc(path: string, follow_links: bool = true) -> bool {
 	s: OS_Stat
-	err: Errno
+	err: Error
 	if follow_links {
 		s, err = _stat(path)
 	} else {
@@ -584,7 +585,7 @@ stderr: Handle = 2
 last_write_time :: proc(fd: Handle) -> File_Time {}                                                                  
 last_write_time_by_name :: proc(name: string) -> File_Time {}                                                        
 */
-last_write_time :: proc(fd: Handle) -> (File_Time, Errno) {
+last_write_time :: proc(fd: Handle) -> (File_Time, Error) {
 	s, err := _fstat(fd)
 	if err != nil {
 		return 0, err
@@ -593,7 +594,7 @@ last_write_time :: proc(fd: Handle) -> (File_Time, Errno) {
 	return File_Time(modified), nil
 }
 
-last_write_time_by_name :: proc(name: string) -> (File_Time, Errno) {
+last_write_time_by_name :: proc(name: string) -> (File_Time, Error) {
 	s, err := _stat(name)
 	if err != nil {
 		return 0, err
@@ -603,19 +604,19 @@ last_write_time_by_name :: proc(name: string) -> (File_Time, Errno) {
 }
 
 @private
-_stat :: proc(path: string) -> (OS_Stat, Errno) {
+_stat :: proc(path: string) -> (OS_Stat, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	s: OS_Stat = ---
 	result := _unix_lstat(cstr, &s)
 	if result == -1 {
-		return s, Errno(get_last_error())
+		return s, Error(get_last_error())
 	}
 	return s, nil
 }
 
 @private
-_lstat :: proc(path: string) -> (OS_Stat, Errno) {
+_lstat :: proc(path: string) -> (OS_Stat, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	
@@ -623,35 +624,35 @@ _lstat :: proc(path: string) -> (OS_Stat, Errno) {
 	s: OS_Stat = ---
 	res := _unix_lstat(cstr, &s)
 	if res == -1 {
-		return s, Errno(get_last_error())
+		return s, Error(get_last_error())
 	}
 	return s, nil
 }
 
 @private
-_fstat :: proc(fd: Handle) -> (OS_Stat, Errno) {
+_fstat :: proc(fd: Handle) -> (OS_Stat, Error) {
 	s: OS_Stat = ---
 	result := _unix_fstat(fd, &s)
 	if result == -1 {
-		return s, Errno(get_last_error())
+		return s, Error(get_last_error())
 	}
 	return s, nil
 }
 
 @private
-_fdopendir :: proc(fd: Handle) -> (Dir, Errno) {
+_fdopendir :: proc(fd: Handle) -> (Dir, Error) {
 	dirp := _unix_fdopendir(fd)
 	if dirp == cast(Dir)nil {
-		return nil, Errno(get_last_error())
+		return nil, Error(get_last_error())
 	}
 	return dirp, nil
 }
 
 @private
-_closedir :: proc(dirp: Dir) -> Errno {
+_closedir :: proc(dirp: Dir) -> Error {
 	rc := _unix_closedir(dirp)
 	if rc != 0 {
-		return Errno(get_last_error())
+		return Error(get_last_error())
 	}
 	return nil
 }
@@ -662,12 +663,12 @@ _rewinddir :: proc(dirp: Dir) {
 }
 
 @private
-_readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Errno, end_of_stream: bool) {
+_readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Error, end_of_stream: bool) {
 	result: ^Dirent
 	rc := _unix_readdir_r(dirp, &entry, &result)
 
 	if rc != 0 {
-		err = Errno(get_last_error())
+		err = Error(get_last_error())
 		return
 	}
 
@@ -680,7 +681,7 @@ _readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Errno, end_of_stream: bool) 
 }
 
 @private
-_readlink :: proc(path: string) -> (string, Errno) {
+_readlink :: proc(path: string) -> (string, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD(ignore = context.temp_allocator == context.allocator)
 
 	path_cstr := strings.clone_to_cstring(path, context.temp_allocator)
@@ -691,7 +692,7 @@ _readlink :: proc(path: string) -> (string, Errno) {
 		rc := _unix_readlink(path_cstr, &(buf[0]), bufsz)
 		if rc == -1 {
 			delete(buf)
-			return "", Errno(get_last_error())
+			return "", Error(get_last_error())
 		} else if rc == int(bufsz) {
 			bufsz += MAX_PATH
 			delete(buf)
@@ -701,10 +702,10 @@ _readlink :: proc(path: string) -> (string, Errno) {
 		}	
 	}
 
-	return "", Errno{}
+	return "", Error{}
 }
 
-absolute_path_from_handle :: proc(fd: Handle) -> (string, Errno) {
+absolute_path_from_handle :: proc(fd: Handle) -> (string, Error) {
 	// NOTE(Feoramund): The situation isn't ideal, but this was the best way I
 	// could find to implement this. There are a couple outstanding bug reports
 	// regarding the desire to retrieve an absolute path from a handle, but to
@@ -719,14 +720,14 @@ absolute_path_from_handle :: proc(fd: Handle) -> (string, Errno) {
 
 	res := _unix_fcntl(fd, F_KINFO, cast(uintptr)&kinfo)
 	if res == -1 {
-		return "", Errno(get_last_error())
+		return "", Error(get_last_error())
 	}
 
 	path := strings.clone_from_cstring_bounded(cast(cstring)&kinfo.path[0], len(kinfo.path))
 	return path, nil
 }
 
-absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Errno) {
+absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Error) {
 	rel := rel
 	if rel == "" {
 		rel = "."
@@ -737,7 +738,7 @@ absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Errno) {
 
 	path_ptr := _unix_realpath(rel_cstr, nil)
 	if path_ptr == nil {
-		return "", Errno(get_last_error())
+		return "", Error(get_last_error())
 	}
 	defer _unix_free(path_ptr)
 
@@ -747,13 +748,13 @@ absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Errno) {
 	return path, nil
 }
 
-access :: proc(path: string, mask: int) -> (bool, Errno) {
+access :: proc(path: string, mask: int) -> (bool, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	result := _unix_access(cstr, c.int(mask))
 	if result == -1 {
-		return false, Errno(get_last_error())
+		return false, Error(get_last_error())
 	}
 	return true, nil
 }
@@ -785,7 +786,7 @@ get_current_directory :: proc() -> string {
 		if cwd != nil {
 			return string(cwd)
 		}
-		if Errno(get_last_error()) != ERANGE {
+		if Error(get_last_error()) != ERANGE {
 			delete(buf)
 			return ""
 		}
@@ -794,12 +795,12 @@ get_current_directory :: proc() -> string {
 	unreachable()
 }
 
-set_current_directory :: proc(path: string) -> (err: Errno) {
+set_current_directory :: proc(path: string) -> (err: Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_chdir(cstr)
 	if res == -1 {
-		return Errno(get_last_error())
+		return Error(get_last_error())
 	}
 	return nil
 }

--- a/core/os/os_haiku.odin
+++ b/core/os/os_haiku.odin
@@ -177,6 +177,7 @@ Dirent :: struct {
 
 Dir :: distinct rawptr // DIR*
 
+@(require_results)
 is_path_separator :: proc(r: rune) -> bool {
 	return r == '/'
 }
@@ -186,6 +187,7 @@ get_last_error :: proc "contextless" () -> Error {
 	return Platform_Error(__error()^)
 }
 
+@(require_results)
 fork :: proc() -> (Pid, Error) {
 	pid := _unix_fork()
 	if pid == -1 {
@@ -194,6 +196,7 @@ fork :: proc() -> (Pid, Error) {
 	return Pid(pid), nil
 }
 
+@(require_results)
 open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
@@ -274,6 +277,7 @@ seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 	return res, nil
 }
 
+@(require_results)
 file_size :: proc(fd: Handle) -> (i64, Error) {
 	s, err := _fstat(fd)
 	if err != nil {
@@ -285,6 +289,7 @@ file_size :: proc(fd: Handle) -> (i64, Error) {
 // "Argv" arguments converted to Odin strings
 args := _alloc_command_line_arguments()
 
+@(require_results)
 _alloc_command_line_arguments :: proc() -> []string {
 	res := make([]string, len(runtime.args__))
 	for arg, i in runtime.args__ {
@@ -293,7 +298,7 @@ _alloc_command_line_arguments :: proc() -> []string {
 	return res
 }
 
-@private
+@(private, require_results)
 _stat :: proc(path: string) -> (OS_Stat, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
@@ -307,7 +312,7 @@ _stat :: proc(path: string) -> (OS_Stat, Error) {
 	return s, nil
 }
 
-@private
+@(private, require_results)
 _lstat :: proc(path: string) -> (OS_Stat, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
@@ -321,7 +326,7 @@ _lstat :: proc(path: string) -> (OS_Stat, Error) {
 	return s, nil
 }
 
-@private
+@(private, require_results)
 _fstat :: proc(fd: Handle) -> (OS_Stat, Error) {
 	// deliberately uninitialized
 	s: OS_Stat = ---
@@ -332,7 +337,7 @@ _fstat :: proc(fd: Handle) -> (OS_Stat, Error) {
 	return s, nil
 }
 
-@private
+@(private)
 _fdopendir :: proc(fd: Handle) -> (Dir, Error) {
 	dirp := _unix_fdopendir(fd)
 	if dirp == cast(Dir)nil {
@@ -341,7 +346,7 @@ _fdopendir :: proc(fd: Handle) -> (Dir, Error) {
 	return dirp, nil
 }
 
-@private
+@(private)
 _closedir :: proc(dirp: Dir) -> Error {
 	rc := _unix_closedir(dirp)
 	if rc != 0 {
@@ -350,12 +355,12 @@ _closedir :: proc(dirp: Dir) -> Error {
 	return nil
 }
 
-@private
+@(private)
 _rewinddir :: proc(dirp: Dir) {
 	_unix_rewinddir(dirp)
 }
 
-@private
+@(private, require_results)
 _readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Error, end_of_stream: bool) {
 	result: ^Dirent
 	rc := _unix_readdir_r(dirp, &entry, &result)
@@ -373,7 +378,7 @@ _readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Error, end_of_stream: bool) 
 	return
 }
 
-@private
+@(private, require_results)
 _readlink :: proc(path: string) -> (string, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD(ignore = context.temp_allocator == context.allocator)
 	path_cstr := strings.clone_to_cstring(path, context.temp_allocator)
@@ -395,10 +400,12 @@ _readlink :: proc(path: string) -> (string, Error) {
 	}
 }
 
+@(require_results)
 absolute_path_from_handle :: proc(fd: Handle) -> (string, Error) {
 	return "", Error(ENOSYS)
 }
 
+@(require_results)
 absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Error) {
 	rel := rel
 	if rel == "" {
@@ -430,6 +437,7 @@ access :: proc(path: string, mask: int) -> (bool, Error) {
 	return true, nil
 }
 
+@(require_results)
 lookup_env :: proc(key: string, allocator := context.allocator) -> (value: string, found: bool) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD(ignore = context.temp_allocator == allocator)
 	path_str := strings.clone_to_cstring(key, context.temp_allocator)
@@ -440,12 +448,13 @@ lookup_env :: proc(key: string, allocator := context.allocator) -> (value: strin
 	return strings.clone(string(cstr), allocator), true
 }
 
+@(require_results)
 get_env :: proc(key: string, allocator := context.allocator) -> (value: string) {
 	value, _ = lookup_env(key, allocator)
 	return
 }
 
-@(private)
+@(private, require_results)
 _processor_core_count :: proc() -> int {
 	info: haiku.system_info
 	haiku.get_system_info(&info)

--- a/core/os/os_haiku.odin
+++ b/core/os/os_haiku.odin
@@ -119,7 +119,7 @@ S_ISSOCK :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFSOCK
 
 
 foreign libc {
-	@(link_name="_errnop")	__error		:: proc() -> ^c.int ---
+	@(link_name="_Errorp")	__error		:: proc() -> ^c.int ---
 
 	@(link_name="fork")	_unix_fork	:: proc() -> pid_t ---
 	@(link_name="getthrid")	_unix_getthrid	:: proc() -> int ---
@@ -181,32 +181,33 @@ is_path_separator :: proc(r: rune) -> bool {
 	return r == '/'
 }
 
+@(require_results, no_instrumentation)
 get_last_error :: proc "contextless" () -> Error {
 	return Platform_Error(__error()^)
 }
 
-fork :: proc() -> (Pid, Errno) {
+fork :: proc() -> (Pid, Error) {
 	pid := _unix_fork()
 	if pid == -1 {
-		return Pid(-1), Errno(get_last_error())
+		return Pid(-1), Error(get_last_error())
 	}
 	return Pid(pid), nil
 }
 
-open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Errno) {
+open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	handle := _unix_open(cstr, c.int(flags), c.int(mode))
 	if handle == -1 {
-		return INVALID_HANDLE, Errno(get_last_error())
+		return INVALID_HANDLE, Error(get_last_error())
 	}
 	return handle, nil
 }
 
-close :: proc(fd: Handle) -> Errno {
+close :: proc(fd: Handle) -> Error {
 	result := _unix_close(fd)
 	if result == -1 {
-		return Errno(get_last_error())
+		return Error(get_last_error())
 	}
 	return nil
 }
@@ -218,16 +219,16 @@ close :: proc(fd: Handle) -> Errno {
 @(private)
 MAX_RW :: 1 << 30
 
-read :: proc(fd: Handle, data: []byte) -> (int, Errno) {
+read :: proc(fd: Handle, data: []byte) -> (int, Error) {
 	to_read    := min(c.size_t(len(data)), MAX_RW)
 	bytes_read := _unix_read(fd, &data[0], to_read)
 	if bytes_read == -1 {
-		return -1, Errno(get_last_error())
+		return -1, Error(get_last_error())
 	}
 	return int(bytes_read), nil
 }
 
-write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
+write :: proc(fd: Handle, data: []byte) -> (int, Error) {
 	if len(data) == 0 {
 		return 0, nil
 	}
@@ -235,20 +236,20 @@ write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 	to_write      := min(c.size_t(len(data)), MAX_RW)
 	bytes_written := _unix_write(fd, &data[0], to_write)
 	if bytes_written == -1 {
-		return -1, Errno(get_last_error())
+		return -1, Error(get_last_error())
 	}
 	return int(bytes_written), nil
 }
 
-seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
+seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 	res := _unix_seek(fd, offset, c.int(whence))
 	if res == -1 {
-		return -1, Errno(get_last_error())
+		return -1, Error(get_last_error())
 	}
 	return res, nil
 }
 
-file_size :: proc(fd: Handle) -> (i64, Errno) {
+file_size :: proc(fd: Handle) -> (i64, Error) {
 	s, err := _fstat(fd)
 	if err != nil {
 		return -1, err
@@ -268,7 +269,7 @@ _alloc_command_line_arguments :: proc() -> []string {
 }
 
 @private
-_stat :: proc(path: string) -> (OS_Stat, Errno) {
+_stat :: proc(path: string) -> (OS_Stat, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 
@@ -276,13 +277,13 @@ _stat :: proc(path: string) -> (OS_Stat, Errno) {
 	s: OS_Stat = ---
 	res := _unix_stat(cstr, &s)
 	if res == -1 {
-		return s, Errno(get_last_error())
+		return s, Error(get_last_error())
 	}
 	return s, nil
 }
 
 @private
-_lstat :: proc(path: string) -> (OS_Stat, Errno) {
+_lstat :: proc(path: string) -> (OS_Stat, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 
@@ -290,36 +291,36 @@ _lstat :: proc(path: string) -> (OS_Stat, Errno) {
 	s: OS_Stat = ---
 	res := _unix_lstat(cstr, &s)
 	if res == -1 {
-		return s, Errno(get_last_error())
+		return s, Error(get_last_error())
 	}
 	return s, nil
 }
 
 @private
-_fstat :: proc(fd: Handle) -> (OS_Stat, Errno) {
+_fstat :: proc(fd: Handle) -> (OS_Stat, Error) {
 	// deliberately uninitialized
 	s: OS_Stat = ---
 	res := _unix_fstat(fd, &s)
 	if res == -1 {
-		return s, Errno(get_last_error())
+		return s, Error(get_last_error())
 	}
 	return s, nil
 }
 
 @private
-_fdopendir :: proc(fd: Handle) -> (Dir, Errno) {
+_fdopendir :: proc(fd: Handle) -> (Dir, Error) {
 	dirp := _unix_fdopendir(fd)
 	if dirp == cast(Dir)nil {
-		return nil, Errno(get_last_error())
+		return nil, Error(get_last_error())
 	}
 	return dirp, nil
 }
 
 @private
-_closedir :: proc(dirp: Dir) -> Errno {
+_closedir :: proc(dirp: Dir) -> Error {
 	rc := _unix_closedir(dirp)
 	if rc != 0 {
-		return Errno(get_last_error())
+		return Error(get_last_error())
 	}
 	return nil
 }
@@ -330,12 +331,12 @@ _rewinddir :: proc(dirp: Dir) {
 }
 
 @private
-_readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Errno, end_of_stream: bool) {
+_readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Error, end_of_stream: bool) {
 	result: ^Dirent
 	rc := _unix_readdir_r(dirp, &entry, &result)
 
 	if rc != 0 {
-		err = Errno(get_last_error())
+		err = Error(get_last_error())
 		return
 	}
 
@@ -348,7 +349,7 @@ _readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Errno, end_of_stream: bool) 
 }
 
 @private
-_readlink :: proc(path: string) -> (string, Errno) {
+_readlink :: proc(path: string) -> (string, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD(ignore = context.temp_allocator == context.allocator)
 	path_cstr := strings.clone_to_cstring(path, context.temp_allocator)
 
@@ -358,7 +359,7 @@ _readlink :: proc(path: string) -> (string, Errno) {
 		rc := _unix_readlink(path_cstr, &(buf[0]), bufsz)
 		if rc == -1 {
 			delete(buf)
-			return "", Errno(get_last_error())
+			return "", Error(get_last_error())
 		} else if rc == int(bufsz) {
 			bufsz += MAX_PATH
 			delete(buf)
@@ -369,11 +370,11 @@ _readlink :: proc(path: string) -> (string, Errno) {
 	}
 }
 
-absolute_path_from_handle :: proc(fd: Handle) -> (string, Errno) {
-	return "", Errno(ENOSYS)
+absolute_path_from_handle :: proc(fd: Handle) -> (string, Error) {
+	return "", Error(ENOSYS)
 }
 
-absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Errno) {
+absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Error) {
 	rel := rel
 	if rel == "" {
 		rel = "."
@@ -384,7 +385,7 @@ absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Errno) {
 
 	path_ptr := _unix_realpath(rel_cstr, nil)
 	if path_ptr == nil {
-		return "", Errno(get_last_error())
+		return "", Error(get_last_error())
 	}
 	defer _unix_free(path_ptr)
 
@@ -394,12 +395,12 @@ absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Errno) {
 	return path, nil
 }
 
-access :: proc(path: string, mask: int) -> (bool, Errno) {
+access :: proc(path: string, mask: int) -> (bool, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_access(cstr, c.int(mask))
 	if res == -1 {
-		return false, Errno(get_last_error())
+		return false, Error(get_last_error())
 	}
 	return true, nil
 }

--- a/core/os/os_haiku.odin
+++ b/core/os/os_haiku.odin
@@ -208,7 +208,7 @@ close :: proc(fd: Handle) -> Errno {
 	if result == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 // In practice a read/write call would probably never read/write these big buffers all at once,
@@ -321,7 +321,7 @@ _closedir :: proc(dirp: Dir) -> Errno {
 	if rc != 0 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 @private

--- a/core/os/os_haiku.odin
+++ b/core/os/os_haiku.odin
@@ -189,7 +189,7 @@ get_last_error :: proc "contextless" () -> Error {
 fork :: proc() -> (Pid, Error) {
 	pid := _unix_fork()
 	if pid == -1 {
-		return Pid(-1), Error(get_last_error())
+		return Pid(-1), get_last_error()
 	}
 	return Pid(pid), nil
 }
@@ -199,7 +199,7 @@ open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Err
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	handle := _unix_open(cstr, c.int(flags), c.int(mode))
 	if handle == -1 {
-		return INVALID_HANDLE, Error(get_last_error())
+		return INVALID_HANDLE, get_last_error()
 	}
 	return handle, nil
 }
@@ -207,7 +207,7 @@ open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Err
 close :: proc(fd: Handle) -> Error {
 	result := _unix_close(fd)
 	if result == -1 {
-		return Error(get_last_error())
+		return get_last_error()
 	}
 	return nil
 }
@@ -223,7 +223,7 @@ read :: proc(fd: Handle, data: []byte) -> (int, Error) {
 	to_read    := min(c.size_t(len(data)), MAX_RW)
 	bytes_read := _unix_read(fd, &data[0], to_read)
 	if bytes_read == -1 {
-		return -1, Error(get_last_error())
+		return -1, get_last_error()
 	}
 	return int(bytes_read), nil
 }
@@ -236,7 +236,7 @@ write :: proc(fd: Handle, data: []byte) -> (int, Error) {
 	to_write      := min(c.size_t(len(data)), MAX_RW)
 	bytes_written := _unix_write(fd, &data[0], to_write)
 	if bytes_written == -1 {
-		return -1, Error(get_last_error())
+		return -1, get_last_error()
 	}
 	return int(bytes_written), nil
 }
@@ -244,7 +244,7 @@ write :: proc(fd: Handle, data: []byte) -> (int, Error) {
 seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 	res := _unix_seek(fd, offset, c.int(whence))
 	if res == -1 {
-		return -1, Error(get_last_error())
+		return -1, get_last_error()
 	}
 	return res, nil
 }
@@ -277,7 +277,7 @@ _stat :: proc(path: string) -> (OS_Stat, Error) {
 	s: OS_Stat = ---
 	res := _unix_stat(cstr, &s)
 	if res == -1 {
-		return s, Error(get_last_error())
+		return s, get_last_error()
 	}
 	return s, nil
 }
@@ -291,7 +291,7 @@ _lstat :: proc(path: string) -> (OS_Stat, Error) {
 	s: OS_Stat = ---
 	res := _unix_lstat(cstr, &s)
 	if res == -1 {
-		return s, Error(get_last_error())
+		return s, get_last_error()
 	}
 	return s, nil
 }
@@ -302,7 +302,7 @@ _fstat :: proc(fd: Handle) -> (OS_Stat, Error) {
 	s: OS_Stat = ---
 	res := _unix_fstat(fd, &s)
 	if res == -1 {
-		return s, Error(get_last_error())
+		return s, get_last_error()
 	}
 	return s, nil
 }
@@ -311,7 +311,7 @@ _fstat :: proc(fd: Handle) -> (OS_Stat, Error) {
 _fdopendir :: proc(fd: Handle) -> (Dir, Error) {
 	dirp := _unix_fdopendir(fd)
 	if dirp == cast(Dir)nil {
-		return nil, Error(get_last_error())
+		return nil, get_last_error()
 	}
 	return dirp, nil
 }
@@ -320,7 +320,7 @@ _fdopendir :: proc(fd: Handle) -> (Dir, Error) {
 _closedir :: proc(dirp: Dir) -> Error {
 	rc := _unix_closedir(dirp)
 	if rc != 0 {
-		return Error(get_last_error())
+		return get_last_error()
 	}
 	return nil
 }
@@ -336,7 +336,7 @@ _readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Error, end_of_stream: bool) 
 	rc := _unix_readdir_r(dirp, &entry, &result)
 
 	if rc != 0 {
-		err = Error(get_last_error())
+		err = get_last_error()
 		return
 	}
 
@@ -359,7 +359,7 @@ _readlink :: proc(path: string) -> (string, Error) {
 		rc := _unix_readlink(path_cstr, &(buf[0]), bufsz)
 		if rc == -1 {
 			delete(buf)
-			return "", Error(get_last_error())
+			return "", get_last_error()
 		} else if rc == int(bufsz) {
 			bufsz += MAX_PATH
 			delete(buf)
@@ -385,7 +385,7 @@ absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Error) {
 
 	path_ptr := _unix_realpath(rel_cstr, nil)
 	if path_ptr == nil {
-		return "", Error(get_last_error())
+		return "", get_last_error()
 	}
 	defer _unix_free(path_ptr)
 
@@ -400,7 +400,7 @@ access :: proc(path: string, mask: int) -> (bool, Error) {
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_access(cstr, c.int(mask))
 	if res == -1 {
-		return false, Error(get_last_error())
+		return false, get_last_error()
 	}
 	return true, nil
 }

--- a/core/os/os_haiku.odin
+++ b/core/os/os_haiku.odin
@@ -182,7 +182,7 @@ is_path_separator :: proc(r: rune) -> bool {
 }
 
 get_last_error :: proc "contextless" () -> Error {
-	return Error(__error()^)
+	return Platform_Error(__error()^)
 }
 
 fork :: proc() -> (Pid, Errno) {

--- a/core/os/os_haiku.odin
+++ b/core/os/os_haiku.odin
@@ -119,7 +119,7 @@ S_ISSOCK :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFSOCK
 
 
 foreign libc {
-	@(link_name="_Errorp")	__error		:: proc() -> ^c.int ---
+	@(link_name="_errorp")	__error		:: proc() -> ^c.int ---
 
 	@(link_name="fork")	_unix_fork	:: proc() -> pid_t ---
 	@(link_name="getthrid")	_unix_getthrid	:: proc() -> int ---

--- a/core/os/os_haiku.odin
+++ b/core/os/os_haiku.odin
@@ -212,6 +212,11 @@ close :: proc(fd: Handle) -> Error {
 	return nil
 }
 
+flush :: proc(fd: Handle) -> Error {
+	// do nothing
+	return nil
+}
+
 // In practice a read/write call would probably never read/write these big buffers all at once,
 // which is why the number of bytes is returned and why there are procs that will call this in a
 // loop for you.

--- a/core/os/os_haiku.odin
+++ b/core/os/os_haiku.odin
@@ -241,6 +241,26 @@ write :: proc(fd: Handle, data: []byte) -> (int, Error) {
 	return int(bytes_written), nil
 }
 
+read_at :: proc(fd: Handle, data: []byte, offset: i64) -> (n: int, err: Error) {
+	curr := seek(fd, offset, SEEK_CUR) or_return
+	n, err = read(fd, data)
+	_, err1 := seek(fd, curr, SEEK_SET)
+	if err1 != nil && err == nil {
+		err = err1
+	}
+	return
+}
+
+write_at :: proc(fd: Handle, data: []byte, offset: i64) -> (n: int, err: Error) {
+	curr := seek(fd, offset, SEEK_CUR) or_return
+	n, err = write(fd, data)
+	_, err1 := seek(fd, curr, SEEK_SET)
+	if err1 != nil && err == nil {
+		err = err1
+	}
+	return
+}
+
 seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 	res := _unix_seek(fd, offset, c.int(whence))
 	if res == -1 {

--- a/core/os/os_haiku.odin
+++ b/core/os/os_haiku.odin
@@ -10,15 +10,13 @@ import "core:sys/haiku"
 Handle    :: i32
 Pid       :: i32
 File_Time :: i64
-Errno     :: i32
+_Platform_Error :: haiku.Errno
 
 MAX_PATH :: haiku.PATH_MAX
 
-ENOSYS :: int(haiku.Errno.POSIX_ERROR_BASE) + 9
+ENOSYS :: _Platform_Error(i32(haiku.Errno.POSIX_ERROR_BASE) + 9)
 
 INVALID_HANDLE :: ~Handle(0)
-
-ERROR_NONE: Errno: 0
 
 stdin:  Handle = 0
 stdout: Handle = 1
@@ -183,8 +181,8 @@ is_path_separator :: proc(r: rune) -> bool {
 	return r == '/'
 }
 
-get_last_error :: proc "contextless" () -> int {
-	return int(__error()^)
+get_last_error :: proc "contextless" () -> Error {
+	return Error(__error()^)
 }
 
 fork :: proc() -> (Pid, Errno) {
@@ -391,8 +389,8 @@ absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Errno) {
 	}
 	defer _unix_free(path_ptr)
 
-	path_cstr := transmute(cstring)path_ptr
-	path = strings.clone( string(path_cstr) )
+	path_cstr := cstring(path_ptr)
+	path = strings.clone(string(path_cstr))
 
 	return path, ERROR_NONE
 }

--- a/core/os/os_haiku.odin
+++ b/core/os/os_haiku.odin
@@ -190,7 +190,7 @@ fork :: proc() -> (Pid, Errno) {
 	if pid == -1 {
 		return Pid(-1), Errno(get_last_error())
 	}
-	return Pid(pid), ERROR_NONE
+	return Pid(pid), nil
 }
 
 open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Errno) {
@@ -200,7 +200,7 @@ open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Err
 	if handle == -1 {
 		return INVALID_HANDLE, Errno(get_last_error())
 	}
-	return handle, ERROR_NONE
+	return handle, nil
 }
 
 close :: proc(fd: Handle) -> Errno {
@@ -224,12 +224,12 @@ read :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 	if bytes_read == -1 {
 		return -1, Errno(get_last_error())
 	}
-	return int(bytes_read), ERROR_NONE
+	return int(bytes_read), nil
 }
 
 write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 	if len(data) == 0 {
-		return 0, ERROR_NONE
+		return 0, nil
 	}
 
 	to_write      := min(c.size_t(len(data)), MAX_RW)
@@ -237,7 +237,7 @@ write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 	if bytes_written == -1 {
 		return -1, Errno(get_last_error())
 	}
-	return int(bytes_written), ERROR_NONE
+	return int(bytes_written), nil
 }
 
 seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
@@ -245,15 +245,15 @@ seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
 	if res == -1 {
 		return -1, Errno(get_last_error())
 	}
-	return res, ERROR_NONE
+	return res, nil
 }
 
 file_size :: proc(fd: Handle) -> (i64, Errno) {
 	s, err := _fstat(fd)
-	if err != ERROR_NONE {
+	if err != nil {
 		return -1, err
 	}
-	return s.size, ERROR_NONE
+	return s.size, nil
 }
 
 // "Argv" arguments converted to Odin strings
@@ -278,7 +278,7 @@ _stat :: proc(path: string) -> (OS_Stat, Errno) {
 	if res == -1 {
 		return s, Errno(get_last_error())
 	}
-	return s, ERROR_NONE
+	return s, nil
 }
 
 @private
@@ -292,7 +292,7 @@ _lstat :: proc(path: string) -> (OS_Stat, Errno) {
 	if res == -1 {
 		return s, Errno(get_last_error())
 	}
-	return s, ERROR_NONE
+	return s, nil
 }
 
 @private
@@ -303,7 +303,7 @@ _fstat :: proc(fd: Handle) -> (OS_Stat, Errno) {
 	if res == -1 {
 		return s, Errno(get_last_error())
 	}
-	return s, ERROR_NONE
+	return s, nil
 }
 
 @private
@@ -312,7 +312,7 @@ _fdopendir :: proc(fd: Handle) -> (Dir, Errno) {
 	if dirp == cast(Dir)nil {
 		return nil, Errno(get_last_error())
 	}
-	return dirp, ERROR_NONE
+	return dirp, nil
 }
 
 @private
@@ -338,7 +338,6 @@ _readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Errno, end_of_stream: bool) 
 		err = Errno(get_last_error())
 		return
 	}
-	err = ERROR_NONE
 
 	if result == nil {
 		end_of_stream = true
@@ -365,7 +364,7 @@ _readlink :: proc(path: string) -> (string, Errno) {
 			delete(buf)
 			buf = make([]byte, bufsz)
 		} else {
-			return strings.string_from_ptr(&buf[0], rc), ERROR_NONE
+			return strings.string_from_ptr(&buf[0], rc), nil
 		}	
 	}
 }
@@ -392,7 +391,7 @@ absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Errno) {
 	path_cstr := cstring(path_ptr)
 	path = strings.clone(string(path_cstr))
 
-	return path, ERROR_NONE
+	return path, nil
 }
 
 access :: proc(path: string, mask: int) -> (bool, Errno) {
@@ -402,7 +401,7 @@ access :: proc(path: string, mask: int) -> (bool, Errno) {
 	if res == -1 {
 		return false, Errno(get_last_error())
 	}
-	return true, ERROR_NONE
+	return true, nil
 }
 
 lookup_env :: proc(key: string, allocator := context.allocator) -> (value: string, found: bool) {

--- a/core/os/os_js.odin
+++ b/core/os/os_js.odin
@@ -3,10 +3,12 @@ package os
 
 import "base:runtime"
 
+@(require_results)
 is_path_separator :: proc(c: byte) -> bool {
 	return c == '/' || c == '\\'
 }
 
+@(require_results)
 open :: proc(path: string, mode: int = O_RDONLY, perm: int = 0) -> (Handle, Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
@@ -38,6 +40,7 @@ seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
+@(require_results)
 file_size :: proc(fd: Handle) -> (i64, Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
@@ -65,20 +68,24 @@ write_at :: proc(fd: Handle, data: []byte, offset: i64) -> (n: int, err: Error) 
 stdout: Handle = 1
 stderr: Handle = 2
 
+@(require_results)
 get_std_handle :: proc "contextless" (h: uint) -> Handle {
 	context = runtime.default_context()
 	unimplemented("core:os procedure not supported on JS target")
 }
 
 
+@(require_results)
 exists :: proc(path: string) -> bool {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
+@(require_results)
 is_file :: proc(path: string) -> bool {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
+@(require_results)
 is_dir :: proc(path: string) -> bool {
 	unimplemented("core:os procedure not supported on JS target")
 }
@@ -86,6 +93,7 @@ is_dir :: proc(path: string) -> bool {
 // NOTE(tetra): GetCurrentDirectory is not thread safe with SetCurrentDirectory and GetFullPathName
 //@private cwd_lock := win32.SRWLOCK{} // zero is initialized
 
+@(require_results)
 get_current_directory :: proc(allocator := context.allocator) -> string {
 	unimplemented("core:os procedure not supported on JS target")
 }
@@ -111,12 +119,12 @@ remove_directory :: proc(path: string) -> (err: Error) {
 
 
 
-@(private)
+@(private, require_results)
 is_abs :: proc(path: string) -> bool {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
-@(private)
+@(private, require_results)
 fix_long_path :: proc(path: string) -> string {
 	unimplemented("core:os procedure not supported on JS target")
 }
@@ -151,10 +159,12 @@ remove :: proc(name: string) -> Error {
 }
 
 
+@(require_results)
 pipe :: proc() -> (r, w: Handle, err: Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
+@(require_results)
 read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []File_Info, err: Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
@@ -251,20 +261,23 @@ args := _alloc_command_line_arguments()
 
 
 
+@(require_results)
 last_write_time :: proc(fd: Handle) -> (File_Time, Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
+@(require_results)
 last_write_time_by_name :: proc(name: string) -> (File_Time, Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
 
+@(require_results)
 get_page_size :: proc() -> int {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
-@(private)
+@(private, require_results)
 _processor_core_count :: proc() -> int {
 	unimplemented("core:os procedure not supported on JS target")
 }
@@ -276,6 +289,7 @@ exit :: proc "contextless" (code: int) -> ! {
 
 
 
+@(require_results)
 current_thread_id :: proc "contextless" () -> int {
 	context = runtime.default_context()
 	unimplemented("core:os procedure not supported on JS target")
@@ -283,6 +297,7 @@ current_thread_id :: proc "contextless" () -> int {
 
 
 
+@(require_results)
 _alloc_command_line_arguments :: proc() -> []string {
 	return nil
 }

--- a/core/os/os_js.odin
+++ b/core/os/os_js.odin
@@ -241,10 +241,8 @@ ERROR_PRIVILEGE_NOT_HELD  :: Platform_Error.PRIVILEGE_NOT_HELD
 WSAEACCES                 :: Platform_Error.WSAEACCES
 WSAECONNRESET             :: Platform_Error.WSAECONNRESET
 
-// Windows reserves errors >= 1<<29 for application use
-ERROR_FILE_IS_PIPE        :: Platform_Error.FILE_IS_PIPE
-ERROR_FILE_IS_NOT_DIR     :: Platform_Error.FILE_IS_NOT_DIR
-ERROR_NEGATIVE_OFFSET     :: Platform_Error.NEGATIVE_OFFSET
+ERROR_FILE_IS_PIPE        :: General_Error.File_Is_Pipe
+ERROR_FILE_IS_NOT_DIR     :: General_Error.Not_Dir
 
 // "Argv" arguments converted to Odin strings
 args := _alloc_command_line_arguments()

--- a/core/os/os_js.odin
+++ b/core/os/os_js.odin
@@ -7,38 +7,38 @@ is_path_separator :: proc(c: byte) -> bool {
 	return c == '/' || c == '\\'
 }
 
-open :: proc(path: string, mode: int = O_RDONLY, perm: int = 0) -> (Handle, Errno) {
+open :: proc(path: string, mode: int = O_RDONLY, perm: int = 0) -> (Handle, Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
-close :: proc(fd: Handle) -> Errno {
+close :: proc(fd: Handle) -> Error {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
-flush :: proc(fd: Handle) -> (err: Errno) {
+flush :: proc(fd: Handle) -> (err: Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
 
 
-write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
+write :: proc(fd: Handle, data: []byte) -> (int, Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
 @(private="file")
-read_console :: proc(handle: Handle, b: []byte) -> (n: int, err: Errno) {
+read_console :: proc(handle: Handle, b: []byte) -> (n: int, err: Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
-read :: proc(fd: Handle, data: []byte) -> (int, Errno) {
+read :: proc(fd: Handle, data: []byte) -> (int, Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
-seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
+seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
-file_size :: proc(fd: Handle) -> (i64, Errno) {
+file_size :: proc(fd: Handle) -> (i64, Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
@@ -47,18 +47,18 @@ file_size :: proc(fd: Handle) -> (i64, Errno) {
 MAX_RW :: 1<<30
 
 @(private)
-pread :: proc(fd: Handle, data: []byte, offset: i64) -> (int, Errno) {
+pread :: proc(fd: Handle, data: []byte, offset: i64) -> (int, Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 @(private)
-pwrite :: proc(fd: Handle, data: []byte, offset: i64) -> (int, Errno) {
+pwrite :: proc(fd: Handle, data: []byte, offset: i64) -> (int, Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
-read_at :: proc(fd: Handle, data: []byte, offset: i64) -> (n: int, err: Errno) {
+read_at :: proc(fd: Handle, data: []byte, offset: i64) -> (n: int, err: Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
-write_at :: proc(fd: Handle, data: []byte, offset: i64) -> (n: int, err: Errno) {
+write_at :: proc(fd: Handle, data: []byte, offset: i64) -> (n: int, err: Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
@@ -90,22 +90,22 @@ get_current_directory :: proc(allocator := context.allocator) -> string {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
-set_current_directory :: proc(path: string) -> (err: Errno) {
+set_current_directory :: proc(path: string) -> (err: Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
 
 
-change_directory :: proc(path: string) -> (err: Errno) {
+change_directory :: proc(path: string) -> (err: Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
-make_directory :: proc(path: string, mode: u32 = 0) -> (err: Errno) {
+make_directory :: proc(path: string, mode: u32 = 0) -> (err: Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
 
-remove_directory :: proc(path: string) -> (err: Errno) {
+remove_directory :: proc(path: string) -> (err: Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
@@ -122,40 +122,40 @@ fix_long_path :: proc(path: string) -> string {
 }
 
 
-link :: proc(old_name, new_name: string) -> (err: Errno) {
+link :: proc(old_name, new_name: string) -> (err: Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
-unlink :: proc(path: string) -> (err: Errno) {
-	unimplemented("core:os procedure not supported on JS target")
-}
-
-
-
-rename :: proc(old_path, new_path: string) -> (err: Errno) {
+unlink :: proc(path: string) -> (err: Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
 
-ftruncate :: proc(fd: Handle, length: i64) -> (err: Errno) {
-	unimplemented("core:os procedure not supported on JS target")
-}
 
-truncate :: proc(path: string, length: i64) -> (err: Errno) {
-	unimplemented("core:os procedure not supported on JS target")
-}
-
-
-remove :: proc(name: string) -> Errno {
+rename :: proc(old_path, new_path: string) -> (err: Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
 
-pipe :: proc() -> (r, w: Handle, err: Errno) {
+ftruncate :: proc(fd: Handle, length: i64) -> (err: Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
-read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []File_Info, err: Errno) {
+truncate :: proc(path: string, length: i64) -> (err: Error) {
+	unimplemented("core:os procedure not supported on JS target")
+}
+
+
+remove :: proc(name: string) -> Error {
+	unimplemented("core:os procedure not supported on JS target")
+}
+
+
+pipe :: proc() -> (r, w: Handle, err: Error) {
+	unimplemented("core:os procedure not supported on JS target")
+}
+
+read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []File_Info, err: Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
@@ -253,11 +253,11 @@ args := _alloc_command_line_arguments()
 
 
 
-last_write_time :: proc(fd: Handle) -> (File_Time, Errno) {
+last_write_time :: proc(fd: Handle) -> (File_Time, Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 
-last_write_time_by_name :: proc(name: string) -> (File_Time, Errno) {
+last_write_time_by_name :: proc(name: string) -> (File_Time, Error) {
 	unimplemented("core:os procedure not supported on JS target")
 }
 

--- a/core/os/os_js.odin
+++ b/core/os/os_js.odin
@@ -161,7 +161,40 @@ read_dir :: proc(fd: Handle, n: int, allocator := context.allocator) -> (fi: []F
 
 Handle    :: distinct uintptr
 File_Time :: distinct u64
-Errno     :: distinct int
+
+_Platform_Error :: enum i32 {
+	NONE = 0,
+	FILE_NOT_FOUND      = 2,
+	PATH_NOT_FOUND      = 3,
+	ACCESS_DENIED       = 5,
+	INVALID_HANDLE      = 6,
+	NOT_ENOUGH_MEMORY   = 8,
+	NO_MORE_FILES       = 18,
+	HANDLE_EOF          = 38,
+	NETNAME_DELETED     = 64,
+	FILE_EXISTS         = 80,
+	INVALID_PARAMETER   = 87,
+	BROKEN_PIPE         = 109,
+	BUFFER_OVERFLOW     = 111,
+	INSUFFICIENT_BUFFER = 122,
+	MOD_NOT_FOUND       = 126,
+	PROC_NOT_FOUND      = 127,
+	DIR_NOT_EMPTY       = 145,
+	ALREADY_EXISTS      = 183,
+	ENVVAR_NOT_FOUND    = 203,
+	MORE_DATA           = 234,
+	OPERATION_ABORTED   = 995,
+	IO_PENDING          = 997,
+	NOT_FOUND           = 1168,
+	PRIVILEGE_NOT_HELD  = 1314,
+	WSAEACCES             = 10013,
+	WSAECONNRESET         = 10054,
+
+	// Windows reserves errors >= 1<<29 for application use
+	FILE_IS_PIPE    = 1<<29 + 0,
+	FILE_IS_NOT_DIR = 1<<29 + 1,
+	NEGATIVE_OFFSET = 1<<29 + 2,
+}
 
 
 INVALID_HANDLE :: ~Handle(0)
@@ -182,37 +215,36 @@ O_ASYNC    :: 0x02000
 O_CLOEXEC  :: 0x80000
 
 
-ERROR_NONE:                   Errno : 0
-ERROR_FILE_NOT_FOUND:         Errno : 2
-ERROR_PATH_NOT_FOUND:         Errno : 3
-ERROR_ACCESS_DENIED:          Errno : 5
-ERROR_INVALID_HANDLE:         Errno : 6
-ERROR_NOT_ENOUGH_MEMORY:      Errno : 8
-ERROR_NO_MORE_FILES:          Errno : 18
-ERROR_HANDLE_EOF:             Errno : 38
-ERROR_NETNAME_DELETED:        Errno : 64
-ERROR_FILE_EXISTS:            Errno : 80
-ERROR_INVALID_PARAMETER:      Errno : 87
-ERROR_BROKEN_PIPE:            Errno : 109
-ERROR_BUFFER_OVERFLOW:        Errno : 111
-ERROR_INSUFFICIENT_BUFFER:    Errno : 122
-ERROR_MOD_NOT_FOUND:          Errno : 126
-ERROR_PROC_NOT_FOUND:         Errno : 127
-ERROR_DIR_NOT_EMPTY:          Errno : 145
-ERROR_ALREADY_EXISTS:         Errno : 183
-ERROR_ENVVAR_NOT_FOUND:       Errno : 203
-ERROR_MORE_DATA:              Errno : 234
-ERROR_OPERATION_ABORTED:      Errno : 995
-ERROR_IO_PENDING:             Errno : 997
-ERROR_NOT_FOUND:              Errno : 1168
-ERROR_PRIVILEGE_NOT_HELD:     Errno : 1314
-WSAEACCES:                    Errno : 10013
-WSAECONNRESET:                Errno : 10054
+ERROR_FILE_NOT_FOUND      :: Platform_Error.FILE_NOT_FOUND
+ERROR_PATH_NOT_FOUND      :: Platform_Error.PATH_NOT_FOUND
+ERROR_ACCESS_DENIED       :: Platform_Error.ACCESS_DENIED
+ERROR_INVALID_HANDLE      :: Platform_Error.INVALID_HANDLE
+ERROR_NOT_ENOUGH_MEMORY   :: Platform_Error.NOT_ENOUGH_MEMORY
+ERROR_NO_MORE_FILES       :: Platform_Error.NO_MORE_FILES
+ERROR_HANDLE_EOF          :: Platform_Error.HANDLE_EOF
+ERROR_NETNAME_DELETED     :: Platform_Error.NETNAME_DELETED
+ERROR_FILE_EXISTS         :: Platform_Error.FILE_EXISTS
+ERROR_INVALID_PARAMETER   :: Platform_Error.INVALID_PARAMETER
+ERROR_BROKEN_PIPE         :: Platform_Error.BROKEN_PIPE
+ERROR_BUFFER_OVERFLOW     :: Platform_Error.BUFFER_OVERFLOW
+ERROR_INSUFFICIENT_BUFFER :: Platform_Error.INSUFFICIENT_BUFFER
+ERROR_MOD_NOT_FOUND       :: Platform_Error.MOD_NOT_FOUND
+ERROR_PROC_NOT_FOUND      :: Platform_Error.PROC_NOT_FOUND
+ERROR_DIR_NOT_EMPTY       :: Platform_Error.DIR_NOT_EMPTY
+ERROR_ALREADY_EXISTS      :: Platform_Error.ALREADY_EXISTS
+ERROR_ENVVAR_NOT_FOUND    :: Platform_Error.ENVVAR_NOT_FOUND
+ERROR_MORE_DATA           :: Platform_Error.MORE_DATA
+ERROR_OPERATION_ABORTED   :: Platform_Error.OPERATION_ABORTED
+ERROR_IO_PENDING          :: Platform_Error.IO_PENDING
+ERROR_NOT_FOUND           :: Platform_Error.NOT_FOUND
+ERROR_PRIVILEGE_NOT_HELD  :: Platform_Error.PRIVILEGE_NOT_HELD
+WSAEACCES                 :: Platform_Error.WSAEACCES
+WSAECONNRESET             :: Platform_Error.WSAECONNRESET
 
 // Windows reserves errors >= 1<<29 for application use
-ERROR_FILE_IS_PIPE:           Errno : 1<<29 + 0
-ERROR_FILE_IS_NOT_DIR:        Errno : 1<<29 + 1
-ERROR_NEGATIVE_OFFSET:        Errno : 1<<29 + 2
+ERROR_FILE_IS_PIPE        :: Platform_Error.FILE_IS_PIPE
+ERROR_FILE_IS_NOT_DIR     :: Platform_Error.FILE_IS_NOT_DIR
+ERROR_NEGATIVE_OFFSET     :: Platform_Error.NEGATIVE_OFFSET
 
 // "Argv" arguments converted to Odin strings
 args := _alloc_command_line_arguments()

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -514,14 +514,14 @@ is_path_separator :: proc(r: rune) -> bool {
 @private
 _get_errno :: proc(res: int) -> Errno {
 	if res < 0 && res > -4096 {
-		return Errno(-res)
+		return Platform_Error(-res)
 	}
-	return 0
+	return nil
 }
 
 // get errno from libc
 get_last_error :: proc "contextless" () -> Error {
-	return Error(__errno_location()^)
+	return Platform_Error(__errno_location()^)
 }
 
 personality :: proc(persona: u64) -> (Errno) {

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -581,6 +581,11 @@ close :: proc(fd: Handle) -> Error {
 	return _get_errno(unix.sys_close(int(fd)))
 }
 
+flush :: proc(fd: Handle) -> Error {
+	// do nothing
+	return nil
+}
+
 // If you read or write more than `SSIZE_MAX` bytes, result is implementation defined (probably an error).
 // `SSIZE_MAX` is also implementation defined but usually the max of a `ssize_t` which is `max(int)` in Odin.
 // In practice a read/write call would probably never read/write these big buffers all at once,

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -521,7 +521,18 @@ _get_errno :: proc(res: int) -> Errno {
 
 // get errno from libc
 get_last_error :: proc "contextless" () -> Error {
-	return Platform_Error(__errno_location()^)
+	err := Platform_Error(__errno_location()^)
+	#partial switch err {
+	case .NONE:
+		return nil
+	case .EPERM:
+		return .Permission_Denied
+	case .EEXIST:
+		return .Exist
+	case .ENOENT:
+		return .Not_Exist
+	}
+	return err
 }
 
 personality :: proc(persona: u64) -> (Errno) {

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -529,7 +529,7 @@ personality :: proc(persona: u64) -> (Errno) {
 	if res == -1 {
 		return _get_errno(res)
 	}
-	return ERROR_NONE
+	return nil
 }
 
 fork :: proc() -> (Pid, Errno) {
@@ -814,7 +814,7 @@ _closedir :: proc(dirp: Dir) -> Errno {
 	if rc != 0 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 @private
@@ -930,7 +930,7 @@ set_env :: proc(key, value: string) -> Errno {
 	if res < 0 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 unset_env :: proc(key: string) -> Errno {
@@ -940,7 +940,7 @@ unset_env :: proc(key: string) -> Errno {
 	if res < 0 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 get_current_directory :: proc() -> string {
@@ -971,7 +971,7 @@ set_current_directory :: proc(path: string) -> (err: Errno) {
 	if res < 0 {
 		return _get_errno(res)
 	}
-	return ERROR_NONE
+	return nil
 }
 
 exit :: proc "contextless" (code: int) -> ! {
@@ -1042,7 +1042,7 @@ bind :: proc(sd: Socket, addr: ^SOCKADDR, len: socklen_t) -> (Errno) {
 	if result < 0 {
 		return _get_errno(result)
 	}
-	return ERROR_NONE
+	return nil
 }
 
 
@@ -1051,7 +1051,7 @@ connect :: proc(sd: Socket, addr: ^SOCKADDR, len: socklen_t) -> (Errno) {
 	if result < 0 {
 		return _get_errno(result)
 	}
-	return ERROR_NONE
+	return nil
 }
 
 accept :: proc(sd: Socket, addr: ^SOCKADDR, len: rawptr) -> (Socket, Errno) {
@@ -1067,7 +1067,7 @@ listen :: proc(sd: Socket, backlog: int) -> (Errno) {
 	if result < 0 {
 		return _get_errno(result)
 	}
-	return ERROR_NONE
+	return nil
 }
 
 setsockopt :: proc(sd: Socket, level: int, optname: int, optval: rawptr, optlen: socklen_t) -> (Errno) {
@@ -1075,7 +1075,7 @@ setsockopt :: proc(sd: Socket, level: int, optname: int, optval: rawptr, optlen:
 	if result < 0 {
 		return _get_errno(result)
 	}
-	return ERROR_NONE
+	return nil
 }
 
 
@@ -1117,7 +1117,7 @@ shutdown :: proc(sd: Socket, how: int) -> (Errno) {
 	if result < 0 {
 		return _get_errno(result)
 	}
-	return ERROR_NONE
+	return nil
 }
 
 fcntl :: proc(fd: int, cmd: int, arg: int) -> (int, Errno) {

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -20,148 +20,148 @@ import "base:intrinsics"
 // all that about compatibility. But we don't want to push experimental changes
 // and have people's code break while it's still work in progress.
 import unix "core:sys/unix"
+import linux "core:sys/linux"
 
 Handle    :: distinct i32
 Pid       :: distinct i32
 File_Time :: distinct u64
-Errno     :: distinct i32
 Socket    :: distinct int
 
 INVALID_HANDLE :: ~Handle(0)
 
-ERROR_NONE:     Errno : 0
-EPERM:          Errno : 1
-ENOENT:         Errno : 2
-ESRCH:          Errno : 3
-EINTR:          Errno : 4
-EIO:            Errno : 5
-ENXIO:          Errno : 6
-EBADF:          Errno : 9
-EAGAIN:         Errno : 11
-ENOMEM:         Errno : 12
-EACCES:         Errno : 13
-EFAULT:         Errno : 14
-EEXIST:         Errno : 17
-ENODEV:         Errno : 19
-ENOTDIR:        Errno : 20
-EISDIR:         Errno : 21
-EINVAL:         Errno : 22
-ENFILE:         Errno : 23
-EMFILE:         Errno : 24
-ETXTBSY:        Errno : 26
-EFBIG:          Errno : 27
-ENOSPC:         Errno : 28
-ESPIPE:         Errno : 29
-EROFS:          Errno : 30
-EPIPE:          Errno : 32
+_Platform_Error :: linux.Errno
+EPERM           :: Platform_Error.EPERM
+ENOENT          :: Platform_Error.ENOENT
+ESRCH           :: Platform_Error.ESRCH
+EINTR           :: Platform_Error.EINTR
+EIO             :: Platform_Error.EIO
+ENXIO           :: Platform_Error.ENXIO
+EBADF           :: Platform_Error.EBADF
+EAGAIN          :: Platform_Error.EAGAIN
+ENOMEM          :: Platform_Error.ENOMEM
+EACCES          :: Platform_Error.EACCES
+EFAULT          :: Platform_Error.EFAULT
+EEXIST          :: Platform_Error.EEXIST
+ENODEV          :: Platform_Error.ENODEV
+ENOTDIR         :: Platform_Error.ENOTDIR
+EISDIR          :: Platform_Error.EISDIR
+EINVAL          :: Platform_Error.EINVAL
+ENFILE          :: Platform_Error.ENFILE
+EMFILE          :: Platform_Error.EMFILE
+ETXTBSY         :: Platform_Error.ETXTBSY
+EFBIG           :: Platform_Error.EFBIG
+ENOSPC          :: Platform_Error.ENOSPC
+ESPIPE          :: Platform_Error.ESPIPE
+EROFS           :: Platform_Error.EROFS
+EPIPE           :: Platform_Error.EPIPE
 
-ERANGE:         Errno : 34 /* Result too large */
-EDEADLK:        Errno : 35 /* Resource deadlock would occur */
-ENAMETOOLONG:   Errno : 36 /* File name too long */
-ENOLCK:         Errno : 37 /* No record locks available */
+ERANGE          :: Platform_Error.ERANGE          /* Result too large */
+EDEADLK         :: Platform_Error.EDEADLK         /* Resource deadlock would occur */
+ENAMETOOLONG    :: Platform_Error.ENAMETOOLONG    /* File name too long */
+ENOLCK          :: Platform_Error.ENOLCK          /* No record locks available */
 
-ENOSYS:         Errno : 38	/* Invalid system call number */
+ENOSYS          :: Platform_Error.ENOSYS          /* Invalid system call number */
 
-ENOTEMPTY:      Errno : 39	/* Directory not empty */
-ELOOP:          Errno : 40	/* Too many symbolic links encountered */
-EWOULDBLOCK:    Errno : EAGAIN /* Operation would block */
-ENOMSG:         Errno : 42	/* No message of desired type */
-EIDRM:          Errno : 43	/* Identifier removed */
-ECHRNG:         Errno : 44	/* Channel number out of range */
-EL2NSYNC:       Errno : 45	/* Level 2 not synchronized */
-EL3HLT:         Errno : 46	/* Level 3 halted */
-EL3RST:         Errno : 47	/* Level 3 reset */
-ELNRNG:         Errno : 48	/* Link number out of range */
-EUNATCH:        Errno : 49	/* Protocol driver not attached */
-ENOCSI:         Errno : 50	/* No CSI structure available */
-EL2HLT:         Errno : 51	/* Level 2 halted */
-EBADE:          Errno : 52	/* Invalid exchange */
-EBADR:          Errno : 53	/* Invalid request descriptor */
-EXFULL:         Errno : 54	/* Exchange full */
-ENOANO:         Errno : 55	/* No anode */
-EBADRQC:        Errno : 56	/* Invalid request code */
-EBADSLT:        Errno : 57	/* Invalid slot */
-EDEADLOCK:      Errno : EDEADLK
-EBFONT:         Errno : 59	/* Bad font file format */
-ENOSTR:         Errno : 60	/* Device not a stream */
-ENODATA:        Errno : 61	/* No data available */
-ETIME:          Errno : 62	/* Timer expired */
-ENOSR:          Errno : 63	/* Out of streams resources */
-ENONET:         Errno : 64	/* Machine is not on the network */
-ENOPKG:         Errno : 65	/* Package not installed */
-EREMOTE:        Errno : 66	/* Object is remote */
-ENOLINK:        Errno : 67	/* Link has been severed */
-EADV:           Errno : 68	/* Advertise error */
-ESRMNT:         Errno : 69	/* Srmount error */
-ECOMM:          Errno : 70	/* Communication error on send */
-EPROTO:         Errno : 71	/* Protocol error */
-EMULTIHOP:      Errno : 72	/* Multihop attempted */
-EDOTDOT:        Errno : 73	/* RFS specific error */
-EBADMSG:        Errno : 74	/* Not a data message */
-EOVERFLOW:      Errno : 75	/* Value too large for defined data type */
-ENOTUNIQ:       Errno : 76	/* Name not unique on network */
-EBADFD:         Errno : 77	/* File descriptor in bad state */
-EREMCHG:        Errno : 78	/* Remote address changed */
-ELIBACC:        Errno : 79	/* Can not access a needed shared library */
-ELIBBAD:        Errno : 80	/* Accessing a corrupted shared library */
-ELIBSCN:        Errno : 81	/* .lib section in a.out corrupted */
-ELIBMAX:        Errno : 82	/* Attempting to link in too many shared libraries */
-ELIBEXEC:       Errno : 83	/* Cannot exec a shared library directly */
-EILSEQ:         Errno : 84	/* Illegal byte sequence */
-ERESTART:       Errno : 85	/* Interrupted system call should be restarted */
-ESTRPIPE:       Errno : 86	/* Streams pipe error */
-EUSERS:         Errno : 87	/* Too many users */
-ENOTSOCK:       Errno : 88	/* Socket operation on non-socket */
-EDESTADDRREQ:   Errno : 89	/* Destination address required */
-EMSGSIZE:       Errno : 90	/* Message too long */
-EPROTOTYPE:     Errno : 91	/* Protocol wrong type for socket */
-ENOPROTOOPT:    Errno : 92	/* Protocol not available */
-EPROTONOSUPPORT:Errno : 93	/* Protocol not supported */
-ESOCKTNOSUPPORT:Errno : 94	/* Socket type not supported */
-EOPNOTSUPP: 	Errno : 95	/* Operation not supported on transport endpoint */
-EPFNOSUPPORT: 	Errno : 96	/* Protocol family not supported */
-EAFNOSUPPORT: 	Errno : 97	/* Address family not supported by protocol */
-EADDRINUSE: 	Errno : 98	/* Address already in use */
-EADDRNOTAVAIL: 	Errno : 99	/* Cannot assign requested address */
-ENETDOWN: 		Errno : 100	/* Network is down */
-ENETUNREACH: 	Errno : 101	/* Network is unreachable */
-ENETRESET: 		Errno : 102	/* Network dropped connection because of reset */
-ECONNABORTED: 	Errno : 103	/* Software caused connection abort */
-ECONNRESET: 	Errno : 104	/* Connection reset by peer */
-ENOBUFS: 		Errno : 105	/* No buffer space available */
-EISCONN: 		Errno : 106	/* Transport endpoint is already connected */
-ENOTCONN: 		Errno : 107	/* Transport endpoint is not connected */
-ESHUTDOWN: 		Errno : 108	/* Cannot send after transport endpoint shutdown */
-ETOOMANYREFS: 	Errno : 109	/* Too many references: cannot splice */
-ETIMEDOUT: 		Errno : 110	/* Connection timed out */
-ECONNREFUSED: 	Errno : 111	/* Connection refused */
-EHOSTDOWN: 		Errno : 112	/* Host is down */
-EHOSTUNREACH: 	Errno : 113	/* No route to host */
-EALREADY: 		Errno : 114	/* Operation already in progress */
-EINPROGRESS: 	Errno : 115	/* Operation now in progress */
-ESTALE: 		Errno : 116	/* Stale file handle */
-EUCLEAN: 		Errno : 117	/* Structure needs cleaning */
-ENOTNAM: 		Errno : 118	/* Not a XENIX named type file */
-ENAVAIL: 		Errno : 119	/* No XENIX semaphores available */
-EISNAM: 		Errno : 120	/* Is a named type file */
-EREMOTEIO: 		Errno : 121	/* Remote I/O error */
-EDQUOT: 		Errno : 122	/* Quota exceeded */
+ENOTEMPTY       :: Platform_Error.ENOTEMPTY       /* Directory not empty */
+ELOOP           :: Platform_Error.ELOOP           /* Too many symbolic links encountered */
+EWOULDBLOCK     :: Platform_Error.EWOULDBLOCK     /* Operation would block */
+ENOMSG          :: Platform_Error.ENOMSG          /* No message of desired type */
+EIDRM           :: Platform_Error.EIDRM           /* Identifier removed */
+ECHRNG          :: Platform_Error.ECHRNG          /* Channel number out of range */
+EL2NSYNC        :: Platform_Error.EL2NSYNC        /* Level 2 not synchronized */
+EL3HLT          :: Platform_Error.EL3HLT          /* Level 3 halted */
+EL3RST          :: Platform_Error.EL3RST          /* Level 3 reset */
+ELNRNG          :: Platform_Error.ELNRNG          /* Link number out of range */
+EUNATCH         :: Platform_Error.EUNATCH         /* Protocol driver not attached */
+ENOCSI          :: Platform_Error.ENOCSI          /* No CSI structure available */
+EL2HLT          :: Platform_Error.EL2HLT          /* Level 2 halted */
+EBADE           :: Platform_Error.EBADE           /* Invalid exchange */
+EBADR           :: Platform_Error.EBADR           /* Invalid request descriptor */
+EXFULL          :: Platform_Error.EXFULL          /* Exchange full */
+ENOANO          :: Platform_Error.ENOANO          /* No anode */
+EBADRQC         :: Platform_Error.EBADRQC         /* Invalid request code */
+EBADSLT         :: Platform_Error.EBADSLT         /* Invalid slot */
+EDEADLOCK       :: Platform_Error.EDEADLOCK
+EBFONT          :: Platform_Error.EBFONT          /* Bad font file format */
+ENOSTR          :: Platform_Error.ENOSTR          /* Device not a stream */
+ENODATA         :: Platform_Error.ENODATA         /* No data available */
+ETIME           :: Platform_Error.ETIME           /* Timer expired */
+ENOSR           :: Platform_Error.ENOSR           /* Out of streams resources */
+ENONET          :: Platform_Error.ENONET          /* Machine is not on the network */
+ENOPKG          :: Platform_Error.ENOPKG          /* Package not installed */
+EREMOTE         :: Platform_Error.EREMOTE         /* Object is remote */
+ENOLINK         :: Platform_Error.ENOLINK         /* Link has been severed */
+EADV            :: Platform_Error.EADV            /* Advertise error */
+ESRMNT          :: Platform_Error.ESRMNT          /* Srmount error */
+ECOMM           :: Platform_Error.ECOMM           /* Communication error on send */
+EPROTO          :: Platform_Error.EPROTO          /* Protocol error */
+EMULTIHOP       :: Platform_Error.EMULTIHOP       /* Multihop attempted */
+EDOTDOT         :: Platform_Error.EDOTDOT         /* RFS specific error */
+EBADMSG         :: Platform_Error.EBADMSG         /* Not a data message */
+EOVERFLOW       :: Platform_Error.EOVERFLOW       /* Value too large for defined data type */
+ENOTUNIQ        :: Platform_Error.ENOTUNIQ        /* Name not unique on network */
+EBADFD          :: Platform_Error.EBADFD          /* File descriptor in bad state */
+EREMCHG         :: Platform_Error.EREMCHG         /* Remote address changed */
+ELIBACC         :: Platform_Error.ELIBACC         /* Can not access a needed shared library */
+ELIBBAD         :: Platform_Error.ELIBBAD         /* Accessing a corrupted shared library */
+ELIBSCN         :: Platform_Error.ELIBSCN         /* .lib section in a.out corrupted */
+ELIBMAX         :: Platform_Error.ELIBMAX         /* Attempting to link in too many shared libraries */
+ELIBEXEC        :: Platform_Error.ELIBEXEC        /* Cannot exec a shared library directly */
+EILSEQ          :: Platform_Error.EILSEQ          /* Illegal byte sequence */
+ERESTART        :: Platform_Error.ERESTART        /* Interrupted system call should be restarted */
+ESTRPIPE        :: Platform_Error.ESTRPIPE        /* Streams pipe error */
+EUSERS          :: Platform_Error.EUSERS          /* Too many users */
+ENOTSOCK        :: Platform_Error.ENOTSOCK        /* Socket operation on non-socket */
+EDESTADDRREQ    :: Platform_Error.EDESTADDRREQ    /* Destination address required */
+EMSGSIZE        :: Platform_Error.EMSGSIZE        /* Message too long */
+EPROTOTYPE      :: Platform_Error.EPROTOTYPE      /* Protocol wrong type for socket */
+ENOPROTOOPT     :: Platform_Error.ENOPROTOOPT     /* Protocol not available */
+EPROTONOSUPPOR  :: Platform_Error.EPROTONOSUPPORT /* Protocol not supported */
+ESOCKTNOSUPPOR  :: Platform_Error.ESOCKTNOSUPPORT /* Socket type not supported */
+EOPNOTSUPP      :: Platform_Error.EOPNOTSUPP      /* Operation not supported on transport endpoint */
+EPFNOSUPPORT    :: Platform_Error.EPFNOSUPPORT    /* Protocol family not supported */
+EAFNOSUPPORT    :: Platform_Error.EAFNOSUPPORT    /* Address family not supported by protocol */
+EADDRINUSE      :: Platform_Error.EADDRINUSE      /* Address already in use */
+EADDRNOTAVAIL   :: Platform_Error.EADDRNOTAVAIL   /* Cannot assign requested address */
+ENETDOWN        :: Platform_Error.ENETDOWN        /* Network is down */
+ENETUNREACH     :: Platform_Error.ENETUNREACH     /* Network is unreachable */
+ENETRESET       :: Platform_Error.ENETRESET       /* Network dropped connection because of reset */
+ECONNABORTED    :: Platform_Error.ECONNABORTED    /* Software caused connection abort */
+ECONNRESET      :: Platform_Error.ECONNRESET      /* Connection reset by peer */
+ENOBUFS         :: Platform_Error.ENOBUFS         /* No buffer space available */
+EISCONN         :: Platform_Error.EISCONN         /* Transport endpoint is already connected */
+ENOTCONN        :: Platform_Error.ENOTCONN        /* Transport endpoint is not connected */
+ESHUTDOWN       :: Platform_Error.ESHUTDOWN       /* Cannot send after transport endpoint shutdown */
+ETOOMANYREFS    :: Platform_Error.ETOOMANYREFS    /* Too many references: cannot splice */
+ETIMEDOUT       :: Platform_Error.ETIMEDOUT       /* Connection timed out */
+ECONNREFUSED    :: Platform_Error.ECONNREFUSED    /* Connection refused */
+EHOSTDOWN       :: Platform_Error.EHOSTDOWN       /* Host is down */
+EHOSTUNREACH    :: Platform_Error.EHOSTUNREACH    /* No route to host */
+EALREADY        :: Platform_Error.EALREADY        /* Operation already in progress */
+EINPROGRESS     :: Platform_Error.EINPROGRESS     /* Operation now in progress */
+ESTALE          :: Platform_Error.ESTALE          /* Stale file handle */
+EUCLEAN         :: Platform_Error.EUCLEAN         /* Structure needs cleaning */
+ENOTNAM         :: Platform_Error.ENOTNAM         /* Not a XENIX named type file */
+ENAVAIL         :: Platform_Error.ENAVAIL         /* No XENIX semaphores available */
+EISNAM          :: Platform_Error.EISNAM          /* Is a named type file */
+EREMOTEIO       :: Platform_Error.EREMOTEIO       /* Remote I/O error */
+EDQUOT          :: Platform_Error.EDQUOT          /* Quota exceeded */
 
-ENOMEDIUM: 		Errno : 123	/* No medium found */
-EMEDIUMTYPE: 	Errno : 124	/* Wrong medium type */
-ECANCELED: 		Errno : 125	/* Operation Canceled */
-ENOKEY: 		Errno : 126	/* Required key not available */
-EKEYEXPIRED: 	Errno : 127	/* Key has expired */
-EKEYREVOKED: 	Errno : 128	/* Key has been revoked */
-EKEYREJECTED: 	Errno : 129	/* Key was rejected by service */
+ENOMEDIUM       :: Platform_Error.ENOMEDIUM       /* No medium found */
+EMEDIUMTYPE     :: Platform_Error.EMEDIUMTYPE     /* Wrong medium type */
+ECANCELED       :: Platform_Error.ECANCELED       /* Operation Canceled */
+ENOKEY          :: Platform_Error.ENOKEY          /* Required key not available */
+EKEYEXPIRED     :: Platform_Error.EKEYEXPIRED     /* Key has expired */
+EKEYREVOKED     :: Platform_Error.EKEYREVOKED     /* Key has been revoked */
+EKEYREJECTED    :: Platform_Error.EKEYREJECTED    /* Key was rejected by service */
 
 /* for robust mutexes */
-EOWNERDEAD: 	Errno : 130	/* Owner died */
-ENOTRECOVERABLE: Errno : 131	/* State not recoverable */
+EOWNERDEAD      :: Platform_Error.EOWNERDEAD      /* Owner died */
+ENOTRECOVERABLE :: Platform_Error.ENOTRECOVERABLE /* State not recoverable */
 
-ERFKILL: 		Errno : 132	/* Operation not possible due to RF-kill */
+ERFKILL   :: Platform_Error.ERFKILL               /* Operation not possible due to RF-kill */
 
-EHWPOISON: 		Errno : 133	/* Memory page has hardware error */
+EHWPOISON :: Platform_Error.EHWPOISON             /* Memory page has hardware error */
 
 ADDR_NO_RANDOMIZE :: 0x40000
 
@@ -520,8 +520,8 @@ _get_errno :: proc(res: int) -> Errno {
 }
 
 // get errno from libc
-get_last_error :: proc "contextless" () -> int {
-	return int(__errno_location()^)
+get_last_error :: proc "contextless" () -> Error {
+	return Error(__errno_location()^)
 }
 
 personality :: proc(persona: u64) -> (Errno) {

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -520,6 +520,7 @@ _get_errno :: proc(res: int) -> Error {
 }
 
 // get errno from libc
+@(require_results, no_instrumentation)
 get_last_error :: proc "contextless" () -> Error {
 	err := Platform_Error(__errno_location()^)
 	#partial switch err {

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -563,7 +563,7 @@ execvp :: proc(path: string, args: []string) -> Error {
 	}
 
 	_unix_execvp(path_cstr, raw_data(args_cstrs))
-	return Error(get_last_error())
+	return get_last_error()
 }
 
 
@@ -809,7 +809,7 @@ _fstat :: proc(fd: Handle) -> (OS_Stat, Error) {
 _fdopendir :: proc(fd: Handle) -> (Dir, Error) {
 	dirp := _unix_fdopendir(fd)
 	if dirp == cast(Dir)nil {
-		return nil, Error(get_last_error())
+		return nil, get_last_error()
 	}
 	return dirp, nil
 }
@@ -818,7 +818,7 @@ _fdopendir :: proc(fd: Handle) -> (Dir, Error) {
 _closedir :: proc(dirp: Dir) -> Error {
 	rc := _unix_closedir(dirp)
 	if rc != 0 {
-		return Error(get_last_error())
+		return get_last_error()
 	}
 	return nil
 }
@@ -834,7 +834,7 @@ _readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Error, end_of_stream: bool) 
 	rc := _unix_readdir_r(dirp, &entry, &result)
 
 	if rc != 0 {
-		err = Error(get_last_error())
+		err = get_last_error()
 		return
 	}
 	err = nil
@@ -892,7 +892,7 @@ absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Error) {
 
 	path_ptr := _unix_realpath(rel_cstr, nil)
 	if path_ptr == nil {
-		return "", Error(get_last_error())
+		return "", get_last_error()
 	}
 	defer _unix_free(path_ptr)
 
@@ -934,7 +934,7 @@ set_env :: proc(key, value: string) -> Error {
 	// NOTE(GoNZooo): `setenv` instead of `putenv` because it copies both key and value more commonly
 	res := _unix_setenv(key_cstring, value_cstring, 1)
 	if res < 0 {
-		return Error(get_last_error())
+		return get_last_error()
 	}
 	return nil
 }
@@ -944,7 +944,7 @@ unset_env :: proc(key: string) -> Error {
 	s := strings.clone_to_cstring(key, context.temp_allocator)
 	res := _unix_putenv(s)
 	if res < 0 {
-		return Error(get_last_error())
+		return get_last_error()
 	}
 	return nil
 }

--- a/core/os/os_netbsd.odin
+++ b/core/os/os_netbsd.odin
@@ -421,7 +421,7 @@ W_OK :: 2 // Test for write permission
 R_OK :: 4 // Test for read permission
 
 foreign libc {
-	@(link_name="__Error")          __Error_location    :: proc() -> ^c.int ---
+	@(link_name="__error")          __error_location    :: proc() -> ^c.int ---
 
 	@(link_name="open")             _unix_open          :: proc(path: cstring, flags: c.int, mode: c.int) -> Handle ---
 	@(link_name="close")            _unix_close         :: proc(fd: Handle) -> c.int ---
@@ -480,7 +480,7 @@ is_path_separator :: proc(r: rune) -> bool {
 
 @(require_results, no_instrumentation)
 get_last_error :: proc "contextless" () -> Error {
-	return Platform_Error(__Error_location()^)
+	return Platform_Error(__error_location()^)
 }
 
 @(require_results)

--- a/core/os/os_netbsd.odin
+++ b/core/os/os_netbsd.odin
@@ -407,13 +407,13 @@ S_ISUID :: 0o4000 // Set user id on execution
 S_ISGID :: 0o2000 // Set group id on execution
 S_ISVTX :: 0o1000 // Directory restrcted delete
 
-S_ISLNK  :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFLNK  }
-S_ISREG  :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFREG  }
-S_ISDIR  :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFDIR  }
-S_ISCHR  :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFCHR  }
-S_ISBLK  :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFBLK  }
-S_ISFIFO :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFIFO  }
-S_ISSOCK :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFSOCK }
+@(require_results) S_ISLNK  :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFLNK  }
+@(require_results) S_ISREG  :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFREG  }
+@(require_results) S_ISDIR  :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFDIR  }
+@(require_results) S_ISCHR  :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFCHR  }
+@(require_results) S_ISBLK  :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFBLK  }
+@(require_results) S_ISFIFO :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFIFO  }
+@(require_results) S_ISSOCK :: #force_inline proc "contextless" (m: mode_t) -> bool { return (m & S_IFMT) == S_IFSOCK }
 
 F_OK :: 0 // Test for file existance
 X_OK :: 1 // Test for execute permission
@@ -561,6 +561,7 @@ seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 	return res, nil
 }
 
+@(require_results)
 file_size :: proc(fd: Handle) -> (size: i64, err: Error) {
 	size = -1
 	s := _fstat(fd) or_return
@@ -609,6 +610,7 @@ remove_directory :: proc(path: string) -> Error {
 	return nil
 }
 
+@(require_results)
 is_file_handle :: proc(fd: Handle) -> bool {
 	s, err := _fstat(fd)
 	if err != nil {
@@ -617,6 +619,7 @@ is_file_handle :: proc(fd: Handle) -> bool {
 	return S_ISREG(s.mode)
 }
 
+@(require_results)
 is_file_path :: proc(path: string, follow_links: bool = true) -> bool {
 	s: OS_Stat
 	err: Error
@@ -631,6 +634,7 @@ is_file_path :: proc(path: string, follow_links: bool = true) -> bool {
 	return S_ISREG(s.mode)
 }
 
+@(require_results)
 is_dir_handle :: proc(fd: Handle) -> bool {
 	s, err := _fstat(fd)
 	if err != nil {
@@ -639,6 +643,7 @@ is_dir_handle :: proc(fd: Handle) -> bool {
 	return S_ISDIR(s.mode)
 }
 
+@(require_results)
 is_dir_path :: proc(path: string, follow_links: bool = true) -> bool {
 	s: OS_Stat
 	err: Error
@@ -656,6 +661,7 @@ is_dir_path :: proc(path: string, follow_links: bool = true) -> bool {
 is_file :: proc {is_file_path, is_file_handle}
 is_dir :: proc {is_dir_path, is_dir_handle}
 
+@(require_results)
 exists :: proc(path: string) -> bool {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cpath := strings.clone_to_cstring(path, context.temp_allocator)
@@ -663,6 +669,7 @@ exists :: proc(path: string) -> bool {
 	return res == 0
 }
 
+@(require_results)
 fcntl :: proc(fd: int, cmd: int, arg: int) -> (int, Error) {
 	result := _unix_fcntl(Handle(fd), c.int(cmd), uintptr(arg))
 	if result < 0 {
@@ -677,19 +684,21 @@ stdin: Handle  = 0
 stdout: Handle = 1
 stderr: Handle = 2
 
+@(require_results)
 last_write_time :: proc(fd: Handle) -> (time: File_Time, err: Error) {
 	s := _fstat(fd) or_return
 	modified := s.modified.seconds * 1_000_000_000 + s.modified.nanoseconds
 	return File_Time(modified), nil
 }
 
+@(require_results)
 last_write_time_by_name :: proc(name: string) -> (time: File_Time, err: Error) {
 	s := _stat(name) or_return
 	modified := s.modified.seconds * 1_000_000_000 + s.modified.nanoseconds
 	return File_Time(modified), nil
 }
 
-@private
+@(private, require_results)
 _stat :: proc(path: string) -> (OS_Stat, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
@@ -701,7 +710,7 @@ _stat :: proc(path: string) -> (OS_Stat, Error) {
 	return s, nil
 }
 
-@private
+@(private, require_results)
 _lstat :: proc(path: string) -> (OS_Stat, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
@@ -715,7 +724,7 @@ _lstat :: proc(path: string) -> (OS_Stat, Error) {
 	return s, nil
 }
 
-@private
+@(private, require_results)
 _fstat :: proc(fd: Handle) -> (OS_Stat, Error) {
 	s: OS_Stat = ---
 	result := _unix_fstat(fd, &s)
@@ -725,7 +734,7 @@ _fstat :: proc(fd: Handle) -> (OS_Stat, Error) {
 	return s, nil
 }
 
-@private
+@(private, require_results)
 _fdopendir :: proc(fd: Handle) -> (Dir, Error) {
 	dirp := _unix_fdopendir(fd)
 	if dirp == cast(Dir)nil {
@@ -734,7 +743,7 @@ _fdopendir :: proc(fd: Handle) -> (Dir, Error) {
 	return dirp, nil
 }
 
-@private
+@(private)
 _closedir :: proc(dirp: Dir) -> Error {
 	rc := _unix_closedir(dirp)
 	if rc != 0 {
@@ -743,12 +752,12 @@ _closedir :: proc(dirp: Dir) -> Error {
 	return nil
 }
 
-@private
+@(private)
 _rewinddir :: proc(dirp: Dir) {
 	_unix_rewinddir(dirp)
 }
 
-@private
+@(private, require_results)
 _readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Error, end_of_stream: bool) {
 	result: ^Dirent
 	rc := _unix_readdir_r(dirp, &entry, &result)
@@ -767,7 +776,7 @@ _readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Error, end_of_stream: bool) 
 	return
 }
 
-@private
+@(private, require_results)
 _readlink :: proc(path: string) -> (string, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD(ignore = context.temp_allocator == context.allocator)
 
@@ -792,12 +801,14 @@ _readlink :: proc(path: string) -> (string, Error) {
 	return "", Error{}
 }
 
+@(require_results)
 absolute_path_from_handle :: proc(fd: Handle) -> (path: string, err: Error) {
 	buf: [MAX_PATH]byte
 	_ = fcntl(int(fd), F_GETPATH, int(uintptr(&buf[0]))) or_return
 	return strings.clone_from_cstring(cstring(&buf[0]))
 }
 
+@(require_results)
 absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Error) {
 	rel := rel
 	if rel == "" {
@@ -829,6 +840,7 @@ access :: proc(path: string, mask: int) -> (bool, Error) {
 	return true, nil
 }
 
+@(require_results)
 lookup_env :: proc(key: string, allocator := context.allocator) -> (value: string, found: bool) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD(ignore = context.temp_allocator == allocator)
 
@@ -840,11 +852,13 @@ lookup_env :: proc(key: string, allocator := context.allocator) -> (value: strin
 	return strings.clone(string(cstr), allocator), true
 }
 
+@(require_results)
 get_env :: proc(key: string, allocator := context.allocator) -> (value: string) {
 	value, _ = lookup_env(key, allocator)
 	return
 }
 
+@(require_results)
 get_current_directory :: proc() -> string {
 	// NOTE(tetra): I would use PATH_MAX here, but I was not able to find
 	// an authoritative value for it across all systems.
@@ -880,10 +894,12 @@ exit :: proc "contextless" (code: int) -> ! {
 	_unix_exit(c.int(code))
 }
 
+@(require_results)
 current_thread_id :: proc "contextless" () -> int {
 	return int(_lwp_self())
 }
 
+@(require_results)
 dlopen :: proc(filename: string, flags: int) -> rawptr {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(filename, context.temp_allocator)
@@ -891,6 +907,7 @@ dlopen :: proc(filename: string, flags: int) -> rawptr {
 	return handle
 }
 
+@(require_results)
 dlsym :: proc(handle: rawptr, symbol: string) -> rawptr {
 	assert(handle != nil)
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
@@ -904,10 +921,12 @@ dlclose :: proc(handle: rawptr) -> bool {
 	return _unix_dlclose(handle) == 0
 }
 
+@(require_results)
 dlerror :: proc() -> string {
 	return string(_unix_dlerror())
 }
 
+@(require_results)
 get_page_size :: proc() -> int {
 	// NOTE(tetra): The page size never changes, so why do anything complicated
 	// if we don't have to.
@@ -920,7 +939,7 @@ get_page_size :: proc() -> int {
 	return page_size
 }
 
-@(private)
+@(private, require_results)
 _processor_core_count :: proc() -> int {
 	count : int = 0
 	count_size := size_of(count)
@@ -933,6 +952,7 @@ _processor_core_count :: proc() -> int {
 	return 1
 }
 
+@(require_results)
 _alloc_command_line_arguments :: proc() -> []string {
 	res := make([]string, len(runtime.args__))
 	for arg, i in runtime.args__ {

--- a/core/os/os_netbsd.odin
+++ b/core/os/os_netbsd.odin
@@ -528,6 +528,26 @@ write :: proc(fd: Handle, data: []byte) -> (int, Error) {
 	return int(bytes_written), nil
 }
 
+read_at :: proc(fd: Handle, data: []byte, offset: i64) -> (n: int, err: Error) {
+	curr := seek(fd, offset, SEEK_CUR) or_return
+	n, err = read(fd, data)
+	_, err1 := seek(fd, curr, SEEK_SET)
+	if err1 != nil && err == nil {
+		err = err1
+	}
+	return
+}
+
+write_at :: proc(fd: Handle, data: []byte, offset: i64) -> (n: int, err: Error) {
+	curr := seek(fd, offset, SEEK_CUR) or_return
+	n, err = write(fd, data)
+	_, err1 := seek(fd, curr, SEEK_SET)
+	if err1 != nil && err == nil {
+		err = err1
+	}
+	return
+}
+
 seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 	res := _unix_seek(fd, offset, c.int(whence))
 	if res == -1 {

--- a/core/os/os_netbsd.odin
+++ b/core/os/os_netbsd.odin
@@ -9,148 +9,287 @@ import "core:c"
 
 Handle :: distinct i32
 File_Time :: distinct u64
-Errno :: distinct i32
 
 INVALID_HANDLE :: ~Handle(0)
 
-ERROR_NONE:     Errno : 0 		/* No error */
-EPERM:          Errno : 1		/* Operation not permitted */
-ENOENT:         Errno : 2		/* No such file or directory */
-EINTR:          Errno : 4		/* Interrupted system call */
-ESRCH:          Errno : 3		/* No such process */
-EIO:            Errno : 5		/* Input/output error */
-ENXIO:          Errno : 6		/* Device not configured */
-E2BIG:          Errno : 7		/* Argument list too long */
-ENOEXEC:        Errno : 8		/* Exec format error */
-EBADF:          Errno : 9		/* Bad file descriptor */
-ECHILD:         Errno : 10		/* No child processes */
-EDEADLK:        Errno : 11		/* Resource deadlock avoided. 11 was EAGAIN */
-ENOMEM:         Errno : 12		/* Cannot allocate memory */
-EACCES:         Errno : 13		/* Permission denied */
-EFAULT:         Errno : 14		/* Bad address */
-ENOTBLK:        Errno : 15		/* Block device required */
-EBUSY:          Errno : 16		/* Device busy */
-EEXIST:         Errno : 17		/* File exists */
-EXDEV:          Errno : 18		/* Cross-device link */
-ENODEV:         Errno : 19		/* Operation not supported by device */
-ENOTDIR:        Errno : 20		/* Not a directory */
-EISDIR:         Errno : 21		/* Is a directory */
-EINVAL:         Errno : 22		/* Invalid argument */
-ENFILE:         Errno : 23		/* Too many open files in system */
-EMFILE:         Errno : 24		/* Too many open files */
-ENOTTY:         Errno : 25		/* Inappropriate ioctl for device */
-ETXTBSY:        Errno : 26		/* Text file busy */
-EFBIG:          Errno : 27		/* File too large */
-ENOSPC:         Errno : 28		/* No space left on device */
-ESPIPE:         Errno : 29		/* Illegal seek */
-EROFS:          Errno : 30		/* Read-only file system */
-EMLINK:         Errno : 31		/* Too many links */
-EPIPE:          Errno : 32		/* Broken pipe */
+_Platform_Error :: enum i32 {
+	NONE            = 0,
+	EPERM           = 1,          /* Operation not permitted */
+	ENOENT          = 2,          /* No such file or directory */
+	EINTR           = 4,          /* Interrupted system call */
+	ESRCH           = 3,          /* No such process */
+	EIO             = 5,          /* Input/output error */
+	ENXIO           = 6,          /* Device not configured */
+	E2BIG           = 7,          /* Argument list too long */
+	ENOEXEC         = 8,          /* Exec format error */
+	EBADF           = 9,          /* Bad file descriptor */
+	ECHILD          = 10,         /* No child processes */
+	EDEADLK         = 11,         /* Resource deadlock avoided. 11 was EAGAIN */
+	ENOMEM          = 12,         /* Cannot allocate memory */
+	EACCES          = 13,         /* Permission denied */
+	EFAULT          = 14,         /* Bad address */
+	ENOTBLK         = 15,         /* Block device required */
+	EBUSY           = 16,         /* Device busy */
+	EEXIST          = 17,         /* File exists */
+	EXDEV           = 18,         /* Cross-device link */
+	ENODEV          = 19,         /* Operation not supported by device */
+	ENOTDIR         = 20,         /* Not a directory */
+	EISDIR          = 21,         /* Is a directory */
+	EINVAL          = 22,         /* Invalid argument */
+	ENFILE          = 23,         /* Too many open files in system */
+	EMFILE          = 24,         /* Too many open files */
+	ENOTTY          = 25,         /* Inappropriate ioctl for device */
+	ETXTBSY         = 26,         /* Text file busy */
+	EFBIG           = 27,         /* File too large */
+	ENOSPC          = 28,         /* No space left on device */
+	ESPIPE          = 29,         /* Illegal seek */
+	EROFS           = 30,         /* Read-only file system */
+	EMLINK          = 31,         /* Too many links */
+	EPIPE           = 32,         /* Broken pipe */
+
+	/* math software */
+	EDOM            = 33,         /* Numerical argument out of domain */
+	ERANGE          = 34,         /* Result too large or too small */
+
+	/* non-blocking and interrupt i/o */
+	EAGAIN          = 35,         /* Resource temporarily unavailable */
+	EWOULDBLOCK     = EAGAIN,     /*  Operation would block */
+	EINPROGRESS     = 36,         /* Operation now in progress */
+	EALREADY        = 37,         /* Operation already in progress */
+
+	/* ipc/network software -- argument errors */
+	ENOTSOCK        = 38,         /* Socket operation on non-socket */
+	EDESTADDRREQ    = 39,         /* Destination address required */
+	EMSGSIZE        = 40,         /* Message too long */
+	EPROTOTYPE      = 41,         /* Protocol wrong type for socket */
+	ENOPROTOOPT     = 42,         /* Protocol option not available */
+	EPROTONOSUPPORT = 43,         /* Protocol not supported */
+	ESOCKTNOSUPPORT = 44,         /* Socket type not supported */
+	EOPNOTSUPP      = 45,         /* Operation not supported */
+	EPFNOSUPPORT    = 46,         /* Protocol family not supported */
+	EAFNOSUPPORT    = 47,         /* Address family not supported by protocol family */
+	EADDRINUSE      = 48,         /* Address already in use */
+	EADDRNOTAVAIL   = 49,         /* Can't assign requested address */
+
+	/* ipc/network software -- operational errors */
+	ENETDOWN        = 50,         /* Network is down */
+	ENETUNREACH     = 51,         /* Network is unreachable */
+	ENETRESET       = 52,         /* Network dropped connection on reset */
+	ECONNABORTED    = 53,         /* Software caused connection abort */
+	ECONNRESET      = 54,         /* Connection reset by peer */
+	ENOBUFS         = 55,         /* No buffer space available */
+	EISCONN         = 56,         /* Socket is already connected */
+	ENOTCONN        = 57,         /* Socket is not connected */
+	ESHUTDOWN       = 58,         /* Can't send after socket shutdown */
+	ETOOMANYREFS    = 59,         /* Too many references: can't splice */
+	ETIMEDOUT       = 60,         /* Operation timed out */
+	ECONNREFUSED    = 61,         /* Connection refused */
+
+	ELOOP           = 62,         /* Too many levels of symbolic links */
+	ENAMETOOLONG    = 63,         /* File name too long */
+
+	/* should be rearranged */
+	EHOSTDOWN       = 64,         /* Host is down */
+	EHOSTUNREACH    = 65,         /* No route to host */
+	ENOTEMPTY       = 66,         /* Directory not empty */
+
+	/* quotas & mush */
+	EPROCLIM        = 67,         /* Too many processes */
+	EUSERS          = 68,         /* Too many users */
+	EDQUOT          = 69,         /* Disc quota exceeded */
+
+	/* Network File System */
+	ESTALE          = 70,         /* Stale NFS file handle */
+	EREMOTE         = 71,         /* Too many levels of remote in path */
+	EBADRPC         = 72,         /* RPC struct is bad */
+	ERPCMISMATCH    = 73,         /* RPC version wrong */
+	EPROGUNAVAIL    = 74,         /* RPC prog. not avail */
+	EPROGMISMATCH   = 75,         /* Program version wrong */
+	EPROCUNAVAIL    = 76,         /* Bad procedure for program */
+
+	ENOLCK          = 77,         /* No locks available */
+	ENOSYS          = 78,         /* Function not implemented */
+
+	EFTYPE          = 79,         /* Inappropriate file type or format */
+	EAUTH           = 80,         /* Authentication error */
+	ENEEDAUTH       = 81,         /* Need authenticator */
+
+	/* SystemV IPC */
+	EIDRM           = 82,         /* Identifier removed */
+	ENOMSG          = 83,         /* No message of desired type */
+	EOVERFLOW       = 84,         /* Value too large to be stored in data type */
+
+	/* Wide/multibyte-character handling, ISO/IEC 9899/AMD1:1995 */
+	EILSEQ          = 85,         /* Illegal byte sequence */
+
+	/* From IEEE Std 1003.1-2001 */
+	/* Base, Realtime, Threads or Thread Priority Scheduling option errors */
+	ENOTSUP         = 86,         /* Not supported */
+
+	/* Realtime option errors */
+	ECANCELED       = 87,         /* Operation canceled */
+
+	/* Realtime, XSI STREAMS option errors */
+	EBADMSG         = 88,         /* Bad or Corrupt message */
+
+	/* XSI STREAMS option errors  */
+	ENODATA         = 89,         /* No message available */
+	ENOSR           = 90,         /* No STREAM resources */
+	ENOSTR          = 91,         /* Not a STREAM */
+	ETIME           = 92,         /* STREAM ioctl timeout */
+
+	/* File system extended attribute errors */
+	ENOATTR         = 93,         /* Attribute not found */
+
+	/* Realtime, XSI STREAMS option errors */
+	EMULTIHOP       = 94,         /* Multihop attempted */
+	ENOLINK         = 95,         /* Link has been severed */
+	EPROTO          = 96,         /* Protocol error */
+
+	/* Robust mutexes */
+	EOWNERDEAD      = 97,         /* Previous owner died */
+	ENOTRECOVERABLE = 98,         /* State not recoverable */
+
+	ELAST           = 98,         /* Must equal largest errno */
+}
+
+EPERM           :: Platform_Error.EPERM           /* Operation not permitted */
+ENOENT          :: Platform_Error.ENOENT          /* No such file or directory */
+EINTR           :: Platform_Error.EINTR           /* Interrupted system call */
+ESRCH           :: Platform_Error.ESRCH           /* No such process */
+EIO             :: Platform_Error.EIO             /* Input/output error */
+ENXIO           :: Platform_Error.ENXIO           /* Device not configured */
+E2BIG           :: Platform_Error.E2BIG           /* Argument list too long */
+ENOEXEC         :: Platform_Error.ENOEXEC         /* Exec format error */
+EBADF           :: Platform_Error.EBADF           /* Bad file descriptor */
+ECHILD          :: Platform_Error.ECHILD          /* No child processes */
+EDEADLK         :: Platform_Error.EDEADLK         /* Resource deadlock avoided. 11 was EAGAIN */
+ENOMEM          :: Platform_Error.ENOMEM          /* Cannot allocate memory */
+EACCES          :: Platform_Error.EACCES          /* Permission denied */
+EFAULT          :: Platform_Error.EFAULT          /* Bad address */
+ENOTBLK         :: Platform_Error.ENOTBLK         /* Block device required */
+EBUSY           :: Platform_Error.EBUSY           /* Device busy */
+EEXIST          :: Platform_Error.EEXIST          /* File exists */
+EXDEV           :: Platform_Error.EXDEV           /* Cross-device link */
+ENODEV          :: Platform_Error.ENODEV          /* Operation not supported by device */
+ENOTDIR         :: Platform_Error.ENOTDIR         /* Not a directory */
+EISDIR          :: Platform_Error.EISDIR          /* Is a directory */
+EINVAL          :: Platform_Error.EINVAL          /* Invalid argument */
+ENFILE          :: Platform_Error.ENFILE          /* Too many open files in system */
+EMFILE          :: Platform_Error.EMFILE          /* Too many open files */
+ENOTTY          :: Platform_Error.ENOTTY          /* Inappropriate ioctl for device */
+ETXTBSY         :: Platform_Error.ETXTBSY         /* Text file busy */
+EFBIG           :: Platform_Error.EFBIG           /* File too large */
+ENOSPC          :: Platform_Error.ENOSPC          /* No space left on device */
+ESPIPE          :: Platform_Error.ESPIPE          /* Illegal seek */
+EROFS           :: Platform_Error.EROFS           /* Read-only file system */
+EMLINK          :: Platform_Error.EMLINK          /* Too many links */
+EPIPE           :: Platform_Error.EPIPE           /* Broken pipe */
 
 /* math software */
-EDOM:           Errno : 33		/* Numerical argument out of domain */
-ERANGE:         Errno : 34		/* Result too large or too small */
+EDOM            :: Platform_Error.EDOM            /* Numerical argument out of domain */
+ERANGE          :: Platform_Error.ERANGE          /* Result too large or too small */
 
 /* non-blocking and interrupt i/o */
-EAGAIN:         Errno : 35		/* Resource temporarily unavailable */
-EWOULDBLOCK:    Errno : EAGAIN	/* Operation would block */
-EINPROGRESS:    Errno : 36		/* Operation now in progress */
-EALREADY:       Errno : 37		/* Operation already in progress */
+EAGAIN          :: Platform_Error.EAGAIN          /* Resource temporarily unavailable */
+EWOULDBLOCK     :: EAGAIN        /*  Operation would block */
+EINPROGRESS     :: Platform_Error.EINPROGRESS     /* Operation now in progress */
+EALREADY        :: Platform_Error.EALREADY        /* Operation already in progress */
 
 /* ipc/network software -- argument errors */
-ENOTSOCK:       Errno : 38		/* Socket operation on non-socket */
-EDESTADDRREQ:   Errno : 39		/* Destination address required */
-EMSGSIZE:       Errno : 40		/* Message too long */
-EPROTOTYPE:     Errno : 41		/* Protocol wrong type for socket */
-ENOPROTOOPT:    Errno : 42		/* Protocol option not available */
-EPROTONOSUPPORT:    Errno : 43		/* Protocol not supported */
-ESOCKTNOSUPPORT:    Errno : 44		/* Socket type not supported */
-EOPNOTSUPP:     Errno : 45		/* Operation not supported */
-EPFNOSUPPORT:   Errno : 46		/* Protocol family not supported */
-EAFNOSUPPORT:   Errno : 47		/* Address family not supported by protocol family */
-EADDRINUSE:     Errno : 48		/* Address already in use */
-EADDRNOTAVAIL:  Errno : 49		/* Can't assign requested address */
+ENOTSOCK        :: Platform_Error.ENOTSOCK        /* Socket operation on non-socket */
+EDESTADDRREQ    :: Platform_Error.EDESTADDRREQ    /* Destination address required */
+EMSGSIZE        :: Platform_Error.EMSGSIZE        /* Message too long */
+EPROTOTYPE      :: Platform_Error.EPROTOTYPE      /* Protocol wrong type for socket */
+ENOPROTOOPT     :: Platform_Error.ENOPROTOOPT     /* Protocol option not available */
+EPROTONOSUPPORT :: Platform_Error.EPROTONOSUPPORT /* Protocol not supported */
+ESOCKTNOSUPPORT :: Platform_Error.ESOCKTNOSUPPORT /* Socket type not supported */
+EOPNOTSUPP      :: Platform_Error.EOPNOTSUPP      /* Operation not supported */
+EPFNOSUPPORT    :: Platform_Error.EPFNOSUPPORT    /* Protocol family not supported */
+EAFNOSUPPORT    :: Platform_Error.EAFNOSUPPORT    /* Address family not supported by protocol family */
+EADDRINUSE      :: Platform_Error.EADDRINUSE      /* Address already in use */
+EADDRNOTAVAIL   :: Platform_Error.EADDRNOTAVAIL   /* Can't assign requested address */
 
 /* ipc/network software -- operational errors */
-ENETDOWN:       Errno : 50		/* Network is down */
-ENETUNREACH:    Errno : 51		/* Network is unreachable */
-ENETRESET:      Errno : 52		/* Network dropped connection on reset */
-ECONNABORTED:   Errno : 53		/* Software caused connection abort */
-ECONNRESET:     Errno : 54		/* Connection reset by peer */
-ENOBUFS:        Errno : 55		/* No buffer space available */
-EISCONN:        Errno : 56		/* Socket is already connected */
-ENOTCONN:       Errno : 57		/* Socket is not connected */
-ESHUTDOWN:      Errno : 58		/* Can't send after socket shutdown */
-ETOOMANYREFS:   Errno : 59		/* Too many references: can't splice */
-ETIMEDOUT:      Errno : 60		/* Operation timed out */
-ECONNREFUSED:   Errno : 61		/* Connection refused */
+ENETDOWN        :: Platform_Error.ENETDOWN        /* Network is down */
+ENETUNREACH     :: Platform_Error.ENETUNREACH     /* Network is unreachable */
+ENETRESET       :: Platform_Error.ENETRESET       /* Network dropped connection on reset */
+ECONNABORTED    :: Platform_Error.ECONNABORTED    /* Software caused connection abort */
+ECONNRESET      :: Platform_Error.ECONNRESET      /* Connection reset by peer */
+ENOBUFS         :: Platform_Error.ENOBUFS         /* No buffer space available */
+EISCONN         :: Platform_Error.EISCONN         /* Socket is already connected */
+ENOTCONN        :: Platform_Error.ENOTCONN        /* Socket is not connected */
+ESHUTDOWN       :: Platform_Error.ESHUTDOWN       /* Can't send after socket shutdown */
+ETOOMANYREFS    :: Platform_Error.ETOOMANYREFS    /* Too many references: can't splice */
+ETIMEDOUT       :: Platform_Error.ETIMEDOUT       /* Operation timed out */
+ECONNREFUSED    :: Platform_Error.ECONNREFUSED    /* Connection refused */
 
-ELOOP:          Errno : 62		/* Too many levels of symbolic links */
-ENAMETOOLONG:   Errno : 63		/* File name too long */
+ELOOP           :: Platform_Error.ELOOP           /* Too many levels of symbolic links */
+ENAMETOOLONG    :: Platform_Error.ENAMETOOLONG    /* File name too long */
 
 /* should be rearranged */
-EHOSTDOWN:      Errno : 64		/* Host is down */
-EHOSTUNREACH:   Errno : 65		/* No route to host */
-ENOTEMPTY:      Errno : 66		/* Directory not empty */
+EHOSTDOWN       :: Platform_Error.EHOSTDOWN       /* Host is down */
+EHOSTUNREACH    :: Platform_Error.EHOSTUNREACH    /* No route to host */
+ENOTEMPTY       :: Platform_Error.ENOTEMPTY       /* Directory not empty */
 
 /* quotas & mush */
-EPROCLIM:       Errno : 67		/* Too many processes */
-EUSERS:         Errno : 68		/* Too many users */
-EDQUOT:         Errno : 69		/* Disc quota exceeded */
+EPROCLIM        :: Platform_Error.EPROCLIM        /* Too many processes */
+EUSERS          :: Platform_Error.EUSERS          /* Too many users */
+EDQUOT          :: Platform_Error.EDQUOT          /* Disc quota exceeded */
 
 /* Network File System */
-ESTALE:         Errno : 70		/* Stale NFS file handle */
-EREMOTE:        Errno : 71		/* Too many levels of remote in path */
-EBADRPC:        Errno : 72		/* RPC struct is bad */
-ERPCMISMATCH:   Errno : 73		/* RPC version wrong */
-EPROGUNAVAIL:   Errno : 74		/* RPC prog. not avail */
-EPROGMISMATCH:  Errno : 75		/* Program version wrong */
-EPROCUNAVAIL:   Errno : 76		/* Bad procedure for program */
+ESTALE          :: Platform_Error.ESTALE          /* Stale NFS file handle */
+EREMOTE         :: Platform_Error.EREMOTE         /* Too many levels of remote in path */
+EBADRPC         :: Platform_Error.EBADRPC         /* RPC struct is bad */
+ERPCMISMATCH    :: Platform_Error.ERPCMISMATCH    /* RPC version wrong */
+EPROGUNAVAIL    :: Platform_Error.EPROGUNAVAIL    /* RPC prog. not avail */
+EPROGMISMATCH   :: Platform_Error.EPROGMISMATCH   /* Program version wrong */
+EPROCUNAVAIL    :: Platform_Error.EPROCUNAVAIL    /* Bad procedure for program */
 
-ENOLCK:         Errno : 77		/* No locks available */
-ENOSYS:         Errno : 78		/* Function not implemented */
+ENOLCK          :: Platform_Error.ENOLCK          /* No locks available */
+ENOSYS          :: Platform_Error.ENOSYS          /* Function not implemented */
 
-EFTYPE:         Errno : 79		/* Inappropriate file type or format */
-EAUTH:          Errno : 80		/* Authentication error */
-ENEEDAUTH:      Errno : 81		/* Need authenticator */
+EFTYPE          :: Platform_Error.EFTYPE          /* Inappropriate file type or format */
+EAUTH           :: Platform_Error.EAUTH           /* Authentication error */
+ENEEDAUTH       :: Platform_Error.ENEEDAUTH       /* Need authenticator */
 
 /* SystemV IPC */
-EIDRM:          Errno : 82		/* Identifier removed */
-ENOMSG:         Errno : 83		/* No message of desired type */
-EOVERFLOW:      Errno : 84		/* Value too large to be stored in data type */
+EIDRM           :: Platform_Error.EIDRM           /* Identifier removed */
+ENOMSG          :: Platform_Error.ENOMSG          /* No message of desired type */
+EOVERFLOW       :: Platform_Error.EOVERFLOW       /* Value too large to be stored in data type */
 
 /* Wide/multibyte-character handling, ISO/IEC 9899/AMD1:1995 */
-EILSEQ:         Errno : 85		/* Illegal byte sequence */
+EILSEQ          :: Platform_Error.EILSEQ          /* Illegal byte sequence */
 
 /* From IEEE Std 1003.1-2001 */
 /* Base, Realtime, Threads or Thread Priority Scheduling option errors */
-ENOTSUP:        Errno : 86		/* Not supported */
+ENOTSUP         :: Platform_Error.ENOTSUP         /* Not supported */
 
 /* Realtime option errors */
-ECANCELED:      Errno : 87		/* Operation canceled */
+ECANCELED       :: Platform_Error.ECANCELED       /* Operation canceled */
 
 /* Realtime, XSI STREAMS option errors */
-EBADMSG:        Errno : 88		/* Bad or Corrupt message */
+EBADMSG         :: Platform_Error.EBADMSG         /* Bad or Corrupt message */
 
 /* XSI STREAMS option errors  */
-ENODATA:        Errno : 89		/* No message available */
-ENOSR:          Errno : 90		/* No STREAM resources */
-ENOSTR:         Errno : 91		/* Not a STREAM */
-ETIME:          Errno : 92		/* STREAM ioctl timeout */
+ENODATA         :: Platform_Error.ENODATA         /* No message available */
+ENOSR           :: Platform_Error.ENOSR           /* No STREAM resources */
+ENOSTR          :: Platform_Error.ENOSTR          /* Not a STREAM */
+ETIME           :: Platform_Error.ETIME           /* STREAM ioctl timeout */
 
 /* File system extended attribute errors */
-ENOATTR:        Errno : 93		/* Attribute not found */
+ENOATTR         :: Platform_Error.ENOATTR         /* Attribute not found */
 
 /* Realtime, XSI STREAMS option errors */
-EMULTIHOP:      Errno : 94		/* Multihop attempted */
-ENOLINK:        Errno : 95		/* Link has been severed */
-EPROTO:         Errno : 96		/* Protocol error */
+EMULTIHOP       :: Platform_Error.EMULTIHOP       /* Multihop attempted */
+ENOLINK         :: Platform_Error.ENOLINK         /* Link has been severed */
+EPROTO          :: Platform_Error.EPROTO          /* Protocol error */
 
 /* Robust mutexes */
-EOWNERDEAD:     Errno : 97		/* Previous owner died */
-ENOTRECOVERABLE:    Errno : 98		/* State not recoverable */
+EOWNERDEAD      :: Platform_Error.EOWNERDEAD      /* Previous owner died */
+ENOTRECOVERABLE :: Platform_Error.ENOTRECOVERABLE /* State not recoverable */
 
-ELAST:          Errno : 98		/* Must equal largest errno */
+ELAST           :: Platform_Error.ELAST           /* Must equal largest errno */
 
 /* end of errno */
 
@@ -338,8 +477,8 @@ is_path_separator :: proc(r: rune) -> bool {
 	return r == '/'
 }
 
-get_last_error :: proc "contextless" () -> int {
-	return int(__errno_location()^)
+get_last_error :: proc "contextless" () -> Error {
+	return Error(__errno_location()^)
 }
 
 open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Errno) {

--- a/core/os/os_netbsd.odin
+++ b/core/os/os_netbsd.odin
@@ -478,7 +478,7 @@ is_path_separator :: proc(r: rune) -> bool {
 }
 
 get_last_error :: proc "contextless" () -> Error {
-	return Error(__errno_location()^)
+	return Platform_Error(__errno_location()^)
 }
 
 open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Errno) {

--- a/core/os/os_netbsd.odin
+++ b/core/os/os_netbsd.odin
@@ -496,7 +496,7 @@ close :: proc(fd: Handle) -> Errno {
 	if result == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 // We set a max of 1GB to keep alignment and to be safe.
@@ -549,7 +549,7 @@ rename :: proc(old_path, new_path: string) -> Errno {
 	if res == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 remove :: proc(path: string) -> Errno {
@@ -559,7 +559,7 @@ remove :: proc(path: string) -> Errno {
 	if res == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 make_directory :: proc(path: string, mode: mode_t = 0o775) -> Errno {
@@ -569,7 +569,7 @@ make_directory :: proc(path: string, mode: mode_t = 0o775) -> Errno {
 	if res == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 remove_directory :: proc(path: string) -> Errno {
@@ -579,7 +579,7 @@ remove_directory :: proc(path: string) -> Errno {
 	if res == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 is_file_handle :: proc(fd: Handle) -> bool {
@@ -719,7 +719,7 @@ _closedir :: proc(dirp: Dir) -> Errno {
 	if rc != 0 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 @private
@@ -856,7 +856,7 @@ set_current_directory :: proc(path: string) -> (err: Errno) {
 	if res == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 exit :: proc "contextless" (code: int) -> ! {

--- a/core/os/os_netbsd.odin
+++ b/core/os/os_netbsd.odin
@@ -502,6 +502,11 @@ close :: proc(fd: Handle) -> Error {
 	return nil
 }
 
+flush :: proc(fd: Handle) -> Error {
+	// do nothing
+	return nil
+}
+
 // We set a max of 1GB to keep alignment and to be safe.
 @(private)
 MAX_RW :: 1 << 30

--- a/core/os/os_openbsd.odin
+++ b/core/os/os_openbsd.odin
@@ -388,36 +388,40 @@ foreign libc {
 	@(link_name="dlerror")	_unix_dlerror	:: proc() -> cstring ---
 }
 
+@(require_results)
 is_path_separator :: proc(r: rune) -> bool {
 	return r == '/'
 }
 
+@(require_results, no_instrumentation)
 get_last_error :: proc "contextless" () -> Error {
 	return Platform_Error(__error()^)
 }
 
-fork :: proc() -> (Pid, Errno) {
+@(require_results)
+fork :: proc() -> (Pid, Error) {
 	pid := _unix_fork()
 	if pid == -1 {
-		return Pid(-1), Errno(get_last_error())
+		return Pid(-1), Error(get_last_error())
 	}
 	return Pid(pid), nil
 }
 
-open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Errno) {
+@(require_results)
+open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	handle := _unix_open(cstr, c.int(flags), c.int(mode))
 	if handle == -1 {
-		return INVALID_HANDLE, Errno(get_last_error())
+		return INVALID_HANDLE, Error(get_last_error())
 	}
 	return handle, nil
 }
 
-close :: proc(fd: Handle) -> Errno {
+close :: proc(fd: Handle) -> Error {
 	result := _unix_close(fd)
 	if result == -1 {
-		return Errno(get_last_error())
+		return Error(get_last_error())
 	}
 	return nil
 }
@@ -430,16 +434,16 @@ close :: proc(fd: Handle) -> Errno {
 @(private)
 MAX_RW :: 1 << 30
 
-read :: proc(fd: Handle, data: []byte) -> (int, Errno) {
+read :: proc(fd: Handle, data: []byte) -> (int, Error) {
 	to_read    := min(c.size_t(len(data)), MAX_RW)
 	bytes_read := _unix_read(fd, &data[0], to_read)
 	if bytes_read == -1 {
-		return -1, Errno(get_last_error())
+		return -1, Error(get_last_error())
 	}
 	return int(bytes_read), nil
 }
 
-write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
+write :: proc(fd: Handle, data: []byte) -> (int, Error) {
 	if len(data) == 0 {
 		return 0, nil
 	}
@@ -447,63 +451,63 @@ write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 	to_write      := min(c.size_t(len(data)), MAX_RW)
 	bytes_written := _unix_write(fd, &data[0], to_write)
 	if bytes_written == -1 {
-		return -1, Errno(get_last_error())
+		return -1, Error(get_last_error())
 	}
 	return int(bytes_written), nil
 }
 
-seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
+seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 	res := _unix_seek(fd, offset, c.int(whence))
 	if res == -1 {
-		return -1, Errno(get_last_error())
+		return -1, Error(get_last_error())
 	}
 	return res, nil
 }
 
-file_size :: proc(fd: Handle) -> (size: i64, err: Errno) {
+file_size :: proc(fd: Handle) -> (size: i64, err: Error) {
 	size = -1
 	s :=  _fstat(fd) or_return
 	size = s.size
 	return
 }
 
-rename :: proc(old_path, new_path: string) -> Errno {
+rename :: proc(old_path, new_path: string) -> Error {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	old_path_cstr := strings.clone_to_cstring(old_path, context.temp_allocator)
 	new_path_cstr := strings.clone_to_cstring(new_path, context.temp_allocator)
 	res := _unix_rename(old_path_cstr, new_path_cstr)
 	if res == -1 {
-		return Errno(get_last_error())
+		return Error(get_last_error())
 	}
 	return nil
 }
 
-remove :: proc(path: string) -> Errno {
+remove :: proc(path: string) -> Error {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	path_cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_unlink(path_cstr)
 	if res == -1 {
-		return Errno(get_last_error())
+		return Error(get_last_error())
 	}
 	return nil
 }
 
-make_directory :: proc(path: string, mode: mode_t = 0o775) -> Errno {
+make_directory :: proc(path: string, mode: mode_t = 0o775) -> Error {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	path_cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_mkdir(path_cstr, mode)
 	if res == -1 {
-		return Errno(get_last_error())
+		return Error(get_last_error())
 	}
 	return nil
 }
 
-remove_directory :: proc(path: string) -> Errno {
+remove_directory :: proc(path: string) -> Error {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	path_cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_rmdir(path_cstr)
 	if res == -1 {
-		return Errno(get_last_error())
+		return Error(get_last_error())
 	}
 	return nil
 }
@@ -518,7 +522,7 @@ is_file_handle :: proc(fd: Handle) -> bool {
 
 is_file_path :: proc(path: string, follow_links: bool = true) -> bool {
 	s: OS_Stat
-	err: Errno
+	err: Error
 	if follow_links {
 		s, err = _stat(path)
 	} else {
@@ -540,7 +544,7 @@ is_dir_handle :: proc(fd: Handle) -> bool {
 
 is_dir_path :: proc(path: string, follow_links: bool = true) -> bool {
 	s: OS_Stat
-	err: Errno
+	err: Error
 	if follow_links {
 		s, err = _stat(path)
 	} else {
@@ -565,20 +569,20 @@ stderr: Handle = 2
 last_write_time :: proc(fd: Handle) -> File_Time {}                                                               
 last_write_time_by_name :: proc(name: string) -> File_Time {}                                                     
 */
-last_write_time :: proc(fd: Handle) -> (time: File_Time, err: Errno) {
+last_write_time :: proc(fd: Handle) -> (time: File_Time, err: Error) {
 	s := _fstat(fd) or_return
 	modified := s.modified.seconds * 1_000_000_000 + s.modified.nanoseconds
 	return File_Time(modified), nil
 }
 
-last_write_time_by_name :: proc(name: string) -> (time: File_Time, err: Errno) {
+last_write_time_by_name :: proc(name: string) -> (time: File_Time, err: Error) {
 	s := _stat(name) or_return
 	modified := s.modified.seconds * 1_000_000_000 + s.modified.nanoseconds
 	return File_Time(modified), nil
 }
 
 @private
-_stat :: proc(path: string) -> (OS_Stat, Errno) {
+_stat :: proc(path: string) -> (OS_Stat, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 
@@ -586,13 +590,13 @@ _stat :: proc(path: string) -> (OS_Stat, Errno) {
 	s: OS_Stat = ---
 	res := _unix_stat(cstr, &s)
 	if res == -1 {
-		return s, Errno(get_last_error())
+		return s, Error(get_last_error())
 	}
 	return s, nil
 }
 
 @private
-_lstat :: proc(path: string) -> (OS_Stat, Errno) {
+_lstat :: proc(path: string) -> (OS_Stat, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 
@@ -600,36 +604,36 @@ _lstat :: proc(path: string) -> (OS_Stat, Errno) {
 	s: OS_Stat = ---
 	res := _unix_lstat(cstr, &s)
 	if res == -1 {
-		return s, Errno(get_last_error())
+		return s, Error(get_last_error())
 	}
 	return s, nil
 }
 
 @private
-_fstat :: proc(fd: Handle) -> (OS_Stat, Errno) {
+_fstat :: proc(fd: Handle) -> (OS_Stat, Error) {
 	// deliberately uninitialized
 	s: OS_Stat = ---
 	res := _unix_fstat(fd, &s)
 	if res == -1 {
-		return s, Errno(get_last_error())
+		return s, Error(get_last_error())
 	}
 	return s, nil
 }
 
 @private
-_fdopendir :: proc(fd: Handle) -> (Dir, Errno) {
+_fdopendir :: proc(fd: Handle) -> (Dir, Error) {
 	dirp := _unix_fdopendir(fd)
 	if dirp == cast(Dir)nil {
-		return nil, Errno(get_last_error())
+		return nil, Error(get_last_error())
 	}
 	return dirp, nil
 }
 
 @private
-_closedir :: proc(dirp: Dir) -> Errno {
+_closedir :: proc(dirp: Dir) -> Error {
 	rc := _unix_closedir(dirp)
 	if rc != 0 {
-		return Errno(get_last_error())
+		return Error(get_last_error())
 	}
 	return nil
 }
@@ -640,12 +644,12 @@ _rewinddir :: proc(dirp: Dir) {
 }
 
 @private
-_readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Errno, end_of_stream: bool) {
+_readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Error, end_of_stream: bool) {
 	result: ^Dirent
 	rc := _unix_readdir_r(dirp, &entry, &result)
 
 	if rc != 0 {
-		err = Errno(get_last_error())
+		err = Error(get_last_error())
 		return
 	}
 	err = nil
@@ -659,7 +663,7 @@ _readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Errno, end_of_stream: bool) 
 }
 
 @private
-_readlink :: proc(path: string) -> (string, Errno) {
+_readlink :: proc(path: string) -> (string, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD(ignore = context.temp_allocator == context.allocator)
 	path_cstr := strings.clone_to_cstring(path, context.temp_allocator)
 
@@ -669,7 +673,7 @@ _readlink :: proc(path: string) -> (string, Errno) {
 		rc := _unix_readlink(path_cstr, &(buf[0]), bufsz)
 		if rc == -1 {
 			delete(buf)
-			return "", Errno(get_last_error())
+			return "", Error(get_last_error())
 		} else if rc == int(bufsz) {
 			bufsz += MAX_PATH
 			delete(buf)
@@ -681,11 +685,11 @@ _readlink :: proc(path: string) -> (string, Errno) {
 }
 
 // XXX OpenBSD
-absolute_path_from_handle :: proc(fd: Handle) -> (string, Errno) {
-	return "", Errno(ENOSYS)
+absolute_path_from_handle :: proc(fd: Handle) -> (string, Error) {
+	return "", Error(ENOSYS)
 }
 
-absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Errno) {
+absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Error) {
 	rel := rel
 	if rel == "" {
 		rel = "."
@@ -696,7 +700,7 @@ absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Errno) {
 
 	path_ptr := _unix_realpath(rel_cstr, nil)
 	if path_ptr == nil {
-		return "", Errno(get_last_error())
+		return "", Error(get_last_error())
 	}
 	defer _unix_free(path_ptr)
 
@@ -705,12 +709,12 @@ absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Errno) {
 	return path, nil
 }
 
-access :: proc(path: string, mask: int) -> (bool, Errno) {
+access :: proc(path: string, mask: int) -> (bool, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_access(cstr, c.int(mask))
 	if res == -1 {
-		return false, Errno(get_last_error())
+		return false, Error(get_last_error())
 	}
 	return true, nil
 }
@@ -737,7 +741,7 @@ get_current_directory :: proc() -> string {
 		if cwd != nil {
 			return string(cwd)
 		}
-		if Errno(get_last_error()) != ERANGE {
+		if Error(get_last_error()) != ERANGE {
 			delete(buf)
 			return ""
 		}
@@ -746,12 +750,12 @@ get_current_directory :: proc() -> string {
 	unreachable()
 }
 
-set_current_directory :: proc(path: string) -> (err: Errno) {
+set_current_directory :: proc(path: string) -> (err: Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_chdir(cstr)
 	if res == -1 {
-		return Errno(get_last_error())
+		return Error(get_last_error())
 	}
 	return nil
 }

--- a/core/os/os_openbsd.odin
+++ b/core/os/os_openbsd.odin
@@ -426,6 +426,11 @@ close :: proc(fd: Handle) -> Error {
 	return nil
 }
 
+flush :: proc(fd: Handle) -> Error {
+	// do nothing
+	return nil
+}
+
 // If you read or write more than `SSIZE_MAX` bytes, OpenBSD returns `EINVAL`.
 // In practice a read/write call would probably never read/write these big buffers all at once,
 // which is why the number of bytes is returned and why there are procs that will call this in a

--- a/core/os/os_openbsd.odin
+++ b/core/os/os_openbsd.odin
@@ -322,13 +322,13 @@ S_ISUID :: 0o4000 // Set user id on execution
 S_ISGID :: 0o2000 // Set group id on execution
 S_ISTXT :: 0o1000 // Sticky bit
 
-S_ISLNK  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFLNK  }
-S_ISREG  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFREG  }
-S_ISDIR  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFDIR  }
-S_ISCHR  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFCHR  }
-S_ISBLK  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFBLK  }
-S_ISFIFO :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFIFO  }
-S_ISSOCK :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFSOCK }
+@(require_results) S_ISLNK  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFLNK  }
+@(require_results) S_ISREG  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFREG  }
+@(require_results) S_ISDIR  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFDIR  }
+@(require_results) S_ISCHR  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFCHR  }
+@(require_results) S_ISBLK  :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFBLK  }
+@(require_results) S_ISFIFO :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFIFO  }
+@(require_results) S_ISSOCK :: #force_inline proc(m: u32) -> bool { return (m & S_IFMT) == S_IFSOCK }
 
 F_OK :: 0x00 // Test for file existance
 X_OK :: 0x01 // Test for execute permission
@@ -489,6 +489,7 @@ seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 	return res, nil
 }
 
+@(require_results)
 file_size :: proc(fd: Handle) -> (size: i64, err: Error) {
 	size = -1
 	s :=  _fstat(fd) or_return
@@ -537,6 +538,7 @@ remove_directory :: proc(path: string) -> Error {
 	return nil
 }
 
+@(require_results)
 is_file_handle :: proc(fd: Handle) -> bool {
 	s, err := _fstat(fd)
 	if err != nil {
@@ -545,6 +547,7 @@ is_file_handle :: proc(fd: Handle) -> bool {
 	return S_ISREG(s.mode)
 }
 
+@(require_results)
 is_file_path :: proc(path: string, follow_links: bool = true) -> bool {
 	s: OS_Stat
 	err: Error
@@ -559,6 +562,7 @@ is_file_path :: proc(path: string, follow_links: bool = true) -> bool {
 	return S_ISREG(s.mode)
 }
 
+@(require_results)
 is_dir_handle :: proc(fd: Handle) -> bool {
 	s, err := _fstat(fd)
 	if err != nil {
@@ -567,6 +571,7 @@ is_dir_handle :: proc(fd: Handle) -> bool {
 	return S_ISDIR(s.mode)
 }
 
+@(require_results)
 is_dir_path :: proc(path: string, follow_links: bool = true) -> bool {
 	s: OS_Stat
 	err: Error
@@ -594,19 +599,21 @@ stderr: Handle = 2
 last_write_time :: proc(fd: Handle) -> File_Time {}                                                               
 last_write_time_by_name :: proc(name: string) -> File_Time {}                                                     
 */
+@(require_results)
 last_write_time :: proc(fd: Handle) -> (time: File_Time, err: Error) {
 	s := _fstat(fd) or_return
 	modified := s.modified.seconds * 1_000_000_000 + s.modified.nanoseconds
 	return File_Time(modified), nil
 }
 
+@(require_results)
 last_write_time_by_name :: proc(name: string) -> (time: File_Time, err: Error) {
 	s := _stat(name) or_return
 	modified := s.modified.seconds * 1_000_000_000 + s.modified.nanoseconds
 	return File_Time(modified), nil
 }
 
-@private
+@(private, require_results)
 _stat :: proc(path: string) -> (OS_Stat, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
@@ -620,7 +627,7 @@ _stat :: proc(path: string) -> (OS_Stat, Error) {
 	return s, nil
 }
 
-@private
+@(private, require_results)
 _lstat :: proc(path: string) -> (OS_Stat, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
@@ -634,7 +641,7 @@ _lstat :: proc(path: string) -> (OS_Stat, Error) {
 	return s, nil
 }
 
-@private
+@(private, require_results)
 _fstat :: proc(fd: Handle) -> (OS_Stat, Error) {
 	// deliberately uninitialized
 	s: OS_Stat = ---
@@ -645,7 +652,7 @@ _fstat :: proc(fd: Handle) -> (OS_Stat, Error) {
 	return s, nil
 }
 
-@private
+@(private, require_results)
 _fdopendir :: proc(fd: Handle) -> (Dir, Error) {
 	dirp := _unix_fdopendir(fd)
 	if dirp == cast(Dir)nil {
@@ -654,7 +661,7 @@ _fdopendir :: proc(fd: Handle) -> (Dir, Error) {
 	return dirp, nil
 }
 
-@private
+@(private)
 _closedir :: proc(dirp: Dir) -> Error {
 	rc := _unix_closedir(dirp)
 	if rc != 0 {
@@ -663,12 +670,12 @@ _closedir :: proc(dirp: Dir) -> Error {
 	return nil
 }
 
-@private
+@(private)
 _rewinddir :: proc(dirp: Dir) {
 	_unix_rewinddir(dirp)
 }
 
-@private
+@(private, require_results)
 _readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Error, end_of_stream: bool) {
 	result: ^Dirent
 	rc := _unix_readdir_r(dirp, &entry, &result)
@@ -687,7 +694,7 @@ _readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Error, end_of_stream: bool) 
 	return
 }
 
-@private
+@(private, require_results)
 _readlink :: proc(path: string) -> (string, Error) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD(ignore = context.temp_allocator == context.allocator)
 	path_cstr := strings.clone_to_cstring(path, context.temp_allocator)
@@ -710,10 +717,12 @@ _readlink :: proc(path: string) -> (string, Error) {
 }
 
 // XXX OpenBSD
+@(require_results)
 absolute_path_from_handle :: proc(fd: Handle) -> (string, Error) {
 	return "", Error(ENOSYS)
 }
 
+@(require_results)
 absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Error) {
 	rel := rel
 	if rel == "" {
@@ -744,6 +753,7 @@ access :: proc(path: string, mask: int) -> (bool, Error) {
 	return true, nil
 }
 
+@(require_results)
 lookup_env :: proc(key: string, allocator := context.allocator) -> (value: string, found: bool) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD(ignore = context.temp_allocator == allocator)
 	path_str := strings.clone_to_cstring(key, context.temp_allocator)
@@ -754,11 +764,13 @@ lookup_env :: proc(key: string, allocator := context.allocator) -> (value: strin
 	return strings.clone(string(cstr), allocator), true
 }
 
+@(require_results)
 get_env :: proc(key: string, allocator := context.allocator) -> (value: string) {
 	value, _ = lookup_env(key, allocator)
 	return
 }
 
+@(require_results)
 get_current_directory :: proc() -> string {
 	buf := make([dynamic]u8, MAX_PATH)
 	for {
@@ -790,16 +802,19 @@ exit :: proc "contextless" (code: int) -> ! {
 	_unix_exit(c.int(code))
 }
 
+@(require_results)
 current_thread_id :: proc "contextless" () -> int {
 	return _unix_getthrid()
 }
 
+@(require_results)
 dlopen :: proc(filename: string, flags: int) -> rawptr {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
 	cstr := strings.clone_to_cstring(filename, context.temp_allocator)
 	handle := _unix_dlopen(cstr, c.int(flags))
 	return handle
 }
+@(require_results)
 dlsym :: proc(handle: rawptr, symbol: string) -> rawptr {
 	assert(handle != nil)
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
@@ -811,10 +826,12 @@ dlclose :: proc(handle: rawptr) -> bool {
 	assert(handle != nil)
 	return _unix_dlclose(handle) == 0
 }
+@(require_results)
 dlerror :: proc() -> string {
 	return string(_unix_dlerror())
 }
 
+@(require_results)
 get_page_size :: proc() -> int {
 	// NOTE(tetra): The page size never changes, so why do anything complicated
 	// if we don't have to.
@@ -829,11 +846,12 @@ get_page_size :: proc() -> int {
 
 _SC_NPROCESSORS_ONLN :: 503
 
-@(private)
+@(private, require_results)
 _processor_core_count :: proc() -> int {
 	return int(_sysconf(_SC_NPROCESSORS_ONLN))
 }
 
+@(require_results)
 _alloc_command_line_arguments :: proc() -> []string {
 	res := make([]string, len(runtime.args__))
 	for arg, i in runtime.args__ {

--- a/core/os/os_openbsd.odin
+++ b/core/os/os_openbsd.odin
@@ -419,7 +419,7 @@ close :: proc(fd: Handle) -> Errno {
 	if result == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 // If you read or write more than `SSIZE_MAX` bytes, OpenBSD returns `EINVAL`.
@@ -476,7 +476,7 @@ rename :: proc(old_path, new_path: string) -> Errno {
 	if res == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 remove :: proc(path: string) -> Errno {
@@ -486,7 +486,7 @@ remove :: proc(path: string) -> Errno {
 	if res == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 make_directory :: proc(path: string, mode: mode_t = 0o775) -> Errno {
@@ -496,7 +496,7 @@ make_directory :: proc(path: string, mode: mode_t = 0o775) -> Errno {
 	if res == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 remove_directory :: proc(path: string) -> Errno {
@@ -506,7 +506,7 @@ remove_directory :: proc(path: string) -> Errno {
 	if res == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 is_file_handle :: proc(fd: Handle) -> bool {
@@ -638,7 +638,7 @@ _closedir :: proc(dirp: Dir) -> Errno {
 	if rc != 0 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 @private
@@ -760,7 +760,7 @@ set_current_directory :: proc(path: string) -> (err: Errno) {
 	if res == -1 {
 		return Errno(get_last_error())
 	}
-	return ERROR_NONE
+	return nil
 }
 
 exit :: proc "contextless" (code: int) -> ! {

--- a/core/os/os_openbsd.odin
+++ b/core/os/os_openbsd.odin
@@ -393,7 +393,7 @@ is_path_separator :: proc(r: rune) -> bool {
 }
 
 get_last_error :: proc "contextless" () -> Error {
-	return Error(__error()^)
+	return Platform_Error(__error()^)
 }
 
 fork :: proc() -> (Pid, Errno) {

--- a/core/os/os_openbsd.odin
+++ b/core/os/os_openbsd.odin
@@ -456,6 +456,26 @@ write :: proc(fd: Handle, data: []byte) -> (int, Error) {
 	return int(bytes_written), nil
 }
 
+read_at :: proc(fd: Handle, data: []byte, offset: i64) -> (n: int, err: Error) {
+	curr := seek(fd, offset, SEEK_CUR) or_return
+	n, err = read(fd, data)
+	_, err1 := seek(fd, curr, SEEK_SET)
+	if err1 != nil && err == nil {
+		err = err1
+	}
+	return
+}
+
+write_at :: proc(fd: Handle, data: []byte, offset: i64) -> (n: int, err: Error) {
+	curr := seek(fd, offset, SEEK_CUR) or_return
+	n, err = write(fd, data)
+	_, err1 := seek(fd, curr, SEEK_SET)
+	if err1 != nil && err == nil {
+		err = err1
+	}
+	return
+}
+
 seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 	res := _unix_seek(fd, offset, c.int(whence))
 	if res == -1 {

--- a/core/os/os_openbsd.odin
+++ b/core/os/os_openbsd.odin
@@ -402,7 +402,7 @@ get_last_error :: proc "contextless" () -> Error {
 fork :: proc() -> (Pid, Error) {
 	pid := _unix_fork()
 	if pid == -1 {
-		return Pid(-1), Error(get_last_error())
+		return Pid(-1), get_last_error()
 	}
 	return Pid(pid), nil
 }
@@ -413,7 +413,7 @@ open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Err
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	handle := _unix_open(cstr, c.int(flags), c.int(mode))
 	if handle == -1 {
-		return INVALID_HANDLE, Error(get_last_error())
+		return INVALID_HANDLE, get_last_error()
 	}
 	return handle, nil
 }
@@ -421,7 +421,7 @@ open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Err
 close :: proc(fd: Handle) -> Error {
 	result := _unix_close(fd)
 	if result == -1 {
-		return Error(get_last_error())
+		return get_last_error()
 	}
 	return nil
 }
@@ -438,7 +438,7 @@ read :: proc(fd: Handle, data: []byte) -> (int, Error) {
 	to_read    := min(c.size_t(len(data)), MAX_RW)
 	bytes_read := _unix_read(fd, &data[0], to_read)
 	if bytes_read == -1 {
-		return -1, Error(get_last_error())
+		return -1, get_last_error()
 	}
 	return int(bytes_read), nil
 }
@@ -451,7 +451,7 @@ write :: proc(fd: Handle, data: []byte) -> (int, Error) {
 	to_write      := min(c.size_t(len(data)), MAX_RW)
 	bytes_written := _unix_write(fd, &data[0], to_write)
 	if bytes_written == -1 {
-		return -1, Error(get_last_error())
+		return -1, get_last_error()
 	}
 	return int(bytes_written), nil
 }
@@ -459,7 +459,7 @@ write :: proc(fd: Handle, data: []byte) -> (int, Error) {
 seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Error) {
 	res := _unix_seek(fd, offset, c.int(whence))
 	if res == -1 {
-		return -1, Error(get_last_error())
+		return -1, get_last_error()
 	}
 	return res, nil
 }
@@ -477,7 +477,7 @@ rename :: proc(old_path, new_path: string) -> Error {
 	new_path_cstr := strings.clone_to_cstring(new_path, context.temp_allocator)
 	res := _unix_rename(old_path_cstr, new_path_cstr)
 	if res == -1 {
-		return Error(get_last_error())
+		return get_last_error()
 	}
 	return nil
 }
@@ -487,7 +487,7 @@ remove :: proc(path: string) -> Error {
 	path_cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_unlink(path_cstr)
 	if res == -1 {
-		return Error(get_last_error())
+		return get_last_error()
 	}
 	return nil
 }
@@ -497,7 +497,7 @@ make_directory :: proc(path: string, mode: mode_t = 0o775) -> Error {
 	path_cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_mkdir(path_cstr, mode)
 	if res == -1 {
-		return Error(get_last_error())
+		return get_last_error()
 	}
 	return nil
 }
@@ -507,7 +507,7 @@ remove_directory :: proc(path: string) -> Error {
 	path_cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_rmdir(path_cstr)
 	if res == -1 {
-		return Error(get_last_error())
+		return get_last_error()
 	}
 	return nil
 }
@@ -590,7 +590,7 @@ _stat :: proc(path: string) -> (OS_Stat, Error) {
 	s: OS_Stat = ---
 	res := _unix_stat(cstr, &s)
 	if res == -1 {
-		return s, Error(get_last_error())
+		return s, get_last_error()
 	}
 	return s, nil
 }
@@ -604,7 +604,7 @@ _lstat :: proc(path: string) -> (OS_Stat, Error) {
 	s: OS_Stat = ---
 	res := _unix_lstat(cstr, &s)
 	if res == -1 {
-		return s, Error(get_last_error())
+		return s, get_last_error()
 	}
 	return s, nil
 }
@@ -615,7 +615,7 @@ _fstat :: proc(fd: Handle) -> (OS_Stat, Error) {
 	s: OS_Stat = ---
 	res := _unix_fstat(fd, &s)
 	if res == -1 {
-		return s, Error(get_last_error())
+		return s, get_last_error()
 	}
 	return s, nil
 }
@@ -624,7 +624,7 @@ _fstat :: proc(fd: Handle) -> (OS_Stat, Error) {
 _fdopendir :: proc(fd: Handle) -> (Dir, Error) {
 	dirp := _unix_fdopendir(fd)
 	if dirp == cast(Dir)nil {
-		return nil, Error(get_last_error())
+		return nil, get_last_error()
 	}
 	return dirp, nil
 }
@@ -633,7 +633,7 @@ _fdopendir :: proc(fd: Handle) -> (Dir, Error) {
 _closedir :: proc(dirp: Dir) -> Error {
 	rc := _unix_closedir(dirp)
 	if rc != 0 {
-		return Error(get_last_error())
+		return get_last_error()
 	}
 	return nil
 }
@@ -649,7 +649,7 @@ _readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Error, end_of_stream: bool) 
 	rc := _unix_readdir_r(dirp, &entry, &result)
 
 	if rc != 0 {
-		err = Error(get_last_error())
+		err = get_last_error()
 		return
 	}
 	err = nil
@@ -673,7 +673,7 @@ _readlink :: proc(path: string) -> (string, Error) {
 		rc := _unix_readlink(path_cstr, &(buf[0]), bufsz)
 		if rc == -1 {
 			delete(buf)
-			return "", Error(get_last_error())
+			return "", get_last_error()
 		} else if rc == int(bufsz) {
 			bufsz += MAX_PATH
 			delete(buf)
@@ -700,7 +700,7 @@ absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Error) {
 
 	path_ptr := _unix_realpath(rel_cstr, nil)
 	if path_ptr == nil {
-		return "", Error(get_last_error())
+		return "", get_last_error()
 	}
 	defer _unix_free(path_ptr)
 
@@ -714,7 +714,7 @@ access :: proc(path: string, mask: int) -> (bool, Error) {
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_access(cstr, c.int(mask))
 	if res == -1 {
-		return false, Error(get_last_error())
+		return false, get_last_error()
 	}
 	return true, nil
 }
@@ -741,7 +741,7 @@ get_current_directory :: proc() -> string {
 		if cwd != nil {
 			return string(cwd)
 		}
-		if Error(get_last_error()) != ERANGE {
+		if get_last_error() != ERANGE {
 			delete(buf)
 			return ""
 		}
@@ -755,7 +755,7 @@ set_current_directory :: proc(path: string) -> (err: Error) {
 	cstr := strings.clone_to_cstring(path, context.temp_allocator)
 	res := _unix_chdir(cstr)
 	if res == -1 {
-		return Error(get_last_error())
+		return get_last_error()
 	}
 	return nil
 }

--- a/core/os/os_openbsd.odin
+++ b/core/os/os_openbsd.odin
@@ -401,7 +401,7 @@ fork :: proc() -> (Pid, Errno) {
 	if pid == -1 {
 		return Pid(-1), Errno(get_last_error())
 	}
-	return Pid(pid), ERROR_NONE
+	return Pid(pid), nil
 }
 
 open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Errno) {
@@ -411,7 +411,7 @@ open :: proc(path: string, flags: int = O_RDONLY, mode: int = 0) -> (Handle, Err
 	if handle == -1 {
 		return INVALID_HANDLE, Errno(get_last_error())
 	}
-	return handle, ERROR_NONE
+	return handle, nil
 }
 
 close :: proc(fd: Handle) -> Errno {
@@ -436,12 +436,12 @@ read :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 	if bytes_read == -1 {
 		return -1, Errno(get_last_error())
 	}
-	return int(bytes_read), ERROR_NONE
+	return int(bytes_read), nil
 }
 
 write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 	if len(data) == 0 {
-		return 0, ERROR_NONE
+		return 0, nil
 	}
 
 	to_write      := min(c.size_t(len(data)), MAX_RW)
@@ -449,7 +449,7 @@ write :: proc(fd: Handle, data: []byte) -> (int, Errno) {
 	if bytes_written == -1 {
 		return -1, Errno(get_last_error())
 	}
-	return int(bytes_written), ERROR_NONE
+	return int(bytes_written), nil
 }
 
 seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
@@ -457,15 +457,14 @@ seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
 	if res == -1 {
 		return -1, Errno(get_last_error())
 	}
-	return res, ERROR_NONE
+	return res, nil
 }
 
-file_size :: proc(fd: Handle) -> (i64, Errno) {
-	s, err := _fstat(fd)
-	if err != ERROR_NONE {
-		return -1, err
-	}
-	return s.size, ERROR_NONE
+file_size :: proc(fd: Handle) -> (size: i64, err: Errno) {
+	size = -1
+	s :=  _fstat(fd) or_return
+	size = s.size
+	return
 }
 
 rename :: proc(old_path, new_path: string) -> Errno {
@@ -511,7 +510,7 @@ remove_directory :: proc(path: string) -> Errno {
 
 is_file_handle :: proc(fd: Handle) -> bool {
 	s, err := _fstat(fd)
-	if err != ERROR_NONE {
+	if err != nil {
 		return false
 	}
 	return S_ISREG(s.mode)
@@ -525,7 +524,7 @@ is_file_path :: proc(path: string, follow_links: bool = true) -> bool {
 	} else {
 		s, err = _lstat(path)
 	}
-	if err != ERROR_NONE {
+	if err != nil {
 		return false
 	}
 	return S_ISREG(s.mode)
@@ -533,7 +532,7 @@ is_file_path :: proc(path: string, follow_links: bool = true) -> bool {
 
 is_dir_handle :: proc(fd: Handle) -> bool {
 	s, err := _fstat(fd)
-	if err != ERROR_NONE {
+	if err != nil {
 		return false
 	}
 	return S_ISDIR(s.mode)
@@ -547,7 +546,7 @@ is_dir_path :: proc(path: string, follow_links: bool = true) -> bool {
 	} else {
 		s, err = _lstat(path)
 	}
-	if err != ERROR_NONE {
+	if err != nil {
 		return false
 	}
 	return S_ISDIR(s.mode)
@@ -566,22 +565,16 @@ stderr: Handle = 2
 last_write_time :: proc(fd: Handle) -> File_Time {}                                                               
 last_write_time_by_name :: proc(name: string) -> File_Time {}                                                     
 */
-last_write_time :: proc(fd: Handle) -> (File_Time, Errno) {
-	s, err := _fstat(fd)
-	if err != ERROR_NONE {
-		return 0, err
-	}
+last_write_time :: proc(fd: Handle) -> (time: File_Time, err: Errno) {
+	s := _fstat(fd) or_return
 	modified := s.modified.seconds * 1_000_000_000 + s.modified.nanoseconds
-	return File_Time(modified), ERROR_NONE
+	return File_Time(modified), nil
 }
 
-last_write_time_by_name :: proc(name: string) -> (File_Time, Errno) {
-	s, err := _stat(name)
-	if err != ERROR_NONE {
-		return 0, err
-	}
+last_write_time_by_name :: proc(name: string) -> (time: File_Time, err: Errno) {
+	s := _stat(name) or_return
 	modified := s.modified.seconds * 1_000_000_000 + s.modified.nanoseconds
-	return File_Time(modified), ERROR_NONE
+	return File_Time(modified), nil
 }
 
 @private
@@ -595,7 +588,7 @@ _stat :: proc(path: string) -> (OS_Stat, Errno) {
 	if res == -1 {
 		return s, Errno(get_last_error())
 	}
-	return s, ERROR_NONE
+	return s, nil
 }
 
 @private
@@ -609,7 +602,7 @@ _lstat :: proc(path: string) -> (OS_Stat, Errno) {
 	if res == -1 {
 		return s, Errno(get_last_error())
 	}
-	return s, ERROR_NONE
+	return s, nil
 }
 
 @private
@@ -620,7 +613,7 @@ _fstat :: proc(fd: Handle) -> (OS_Stat, Errno) {
 	if res == -1 {
 		return s, Errno(get_last_error())
 	}
-	return s, ERROR_NONE
+	return s, nil
 }
 
 @private
@@ -629,7 +622,7 @@ _fdopendir :: proc(fd: Handle) -> (Dir, Errno) {
 	if dirp == cast(Dir)nil {
 		return nil, Errno(get_last_error())
 	}
-	return dirp, ERROR_NONE
+	return dirp, nil
 }
 
 @private
@@ -655,7 +648,7 @@ _readdir :: proc(dirp: Dir) -> (entry: Dirent, err: Errno, end_of_stream: bool) 
 		err = Errno(get_last_error())
 		return
 	}
-	err = ERROR_NONE
+	err = nil
 
 	if result == nil {
 		end_of_stream = true
@@ -682,7 +675,7 @@ _readlink :: proc(path: string) -> (string, Errno) {
 			delete(buf)
 			buf = make([]byte, bufsz)
 		} else {
-			return strings.string_from_ptr(&buf[0], rc), ERROR_NONE
+			return strings.string_from_ptr(&buf[0], rc), nil
 		}	
 	}
 }
@@ -709,7 +702,7 @@ absolute_path_from_relative :: proc(rel: string) -> (path: string, err: Errno) {
 
 	path = strings.clone(string(cstring(path_ptr)))
 
-	return path, ERROR_NONE
+	return path, nil
 }
 
 access :: proc(path: string, mask: int) -> (bool, Errno) {
@@ -719,7 +712,7 @@ access :: proc(path: string, mask: int) -> (bool, Errno) {
 	if res == -1 {
 		return false, Errno(get_last_error())
 	}
-	return true, ERROR_NONE
+	return true, nil
 }
 
 lookup_env :: proc(key: string, allocator := context.allocator) -> (value: string, found: bool) {

--- a/core/os/os_openbsd.odin
+++ b/core/os/os_openbsd.odin
@@ -9,108 +9,205 @@ import "base:runtime"
 Handle    :: distinct i32
 Pid       :: distinct i32
 File_Time :: distinct u64
-Errno     :: distinct i32
 
 INVALID_HANDLE :: ~Handle(0)
 
-ERROR_NONE:	Errno: 0
+_Platform_Error :: enum i32 {
+	NONE = 0,
+	EPERM           = 1,
+	ENOENT          = 2,
+	ESRCH           = 3,
+	EINTR           = 4,
+	EIO             = 5,
+	ENXIO           = 6,
+	E2BIG           = 7,
+	ENOEXEC         = 8,
+	EBADF           = 9,
+	ECHILD          = 10,
+	EDEADLK         = 11,
+	ENOMEM          = 12,
+	EACCES          = 13,
+	EFAULT          = 14,
+	ENOTBLK         = 15,
+	EBUSY           = 16,
+	EEXIST          = 17,
+	EXDEV           = 18,
+	ENODEV          = 19,
+	ENOTDIR         = 20,
+	EISDIR          = 21,
+	EINVAL          = 22,
+	ENFILE          = 23,
+	EMFILE          = 24,
+	ENOTTY          = 25,
+	ETXTBSY         = 26,
+	EFBIG           = 27,
+	ENOSPC          = 28,
+	ESPIPE          = 29,
+	EROFS           = 30,
+	EMLINK          = 31,
+	EPIPE           = 32,
+	EDOM            = 33,
+	ERANGE          = 34,
+	EAGAIN          = 35,
+	EWOULDBLOCK     = EAGAIN,
+	EINPROGRESS     = 36,
+	EALREADY        = 37,
+	ENOTSOCK        = 38,
+	EDESTADDRREQ    = 39,
+	EMSGSIZE        = 40,
+	EPROTOTYPE      = 41,
+	ENOPROTOOPT     = 42,
+	EPROTONOSUPPORT = 43,
+	ESOCKTNOSUPPORT = 44,
+	EOPNOTSUPP      = 45,
+	EPFNOSUPPORT    = 46,
+	EAFNOSUPPORT    = 47,
+	EADDRINUSE      = 48,
+	EADDRNOTAVAIL   = 49,
+	ENETDOWN        = 50,
+	ENETUNREACH     = 51,
+	ENETRESET       = 52,
+	ECONNABORTED    = 53,
+	ECONNRESET      = 54,
+	ENOBUFS         = 55,
+	EISCONN         = 56,
+	ENOTCONN        = 57,
+	ESHUTDOWN       = 58,
+	ETOOMANYREFS    = 59,
+	ETIMEDOUT       = 60,
+	ECONNREFUSED    = 61,
+	ELOOP           = 62,
+	ENAMETOOLONG    = 63,
+	EHOSTDOWN       = 64,
+	EHOSTUNREACH    = 65,
+	ENOTEMPTY       = 66,
+	EPROCLIM        = 67,
+	EUSERS          = 68,
+	EDQUOT          = 69,
+	ESTALE          = 70,
+	EREMOTE         = 71,
+	EBADRPC         = 72,
+	ERPCMISMATCH    = 73,
+	EPROGUNAVAIL    = 74,
+	EPROGMISMATCH   = 75,
+	EPROCUNAVAIL    = 76,
+	ENOLCK          = 77,
+	ENOSYS          = 78,
+	EFTYPE          = 79,
+	EAUTH           = 80,
+	ENEEDAUTH       = 81,
+	EIPSEC          = 82,
+	ENOATTR         = 83,
+	EILSEQ          = 84,
+	ENOMEDIUM       = 85,
+	EMEDIUMTYPE     = 86,
+	EOVERFLOW       = 87,
+	ECANCELED       = 88,
+	EIDRM           = 89,
+	ENOMSG          = 90,
+	ENOTSUP         = 91,
+	EBADMSG         = 92,
+	ENOTRECOVERABLE = 93,
+	EOWNERDEAD      = 94,
+	EPROTO          = 95,
+}
 
-EPERM:		Errno: 1
-ENOENT:		Errno: 2
-ESRCH:		Errno: 3
-EINTR:		Errno: 4
-EIO:		Errno: 5
-ENXIO:		Errno: 6
-E2BIG:		Errno: 7
-ENOEXEC:	Errno: 8
-EBADF:		Errno: 9
-ECHILD:		Errno: 10
-EDEADLK:	Errno: 11
-ENOMEM:		Errno: 12
-EACCES:		Errno: 13
-EFAULT:		Errno: 14
-ENOTBLK:	Errno: 15
-EBUSY:		Errno: 16
-EEXIST:		Errno: 17
-EXDEV:		Errno: 18
-ENODEV:		Errno: 19
-ENOTDIR:	Errno: 20
-EISDIR:		Errno: 21
-EINVAL:		Errno: 22
-ENFILE:		Errno: 23
-EMFILE:		Errno: 24
-ENOTTY:		Errno: 25
-ETXTBSY:	Errno: 26
-EFBIG:		Errno: 27
-ENOSPC:		Errno: 28
-ESPIPE:		Errno: 29
-EROFS:		Errno: 30
-EMLINK:		Errno: 31
-EPIPE:		Errno: 32
-EDOM:		Errno: 33
-ERANGE:		Errno: 34
-EAGAIN:		Errno: 35
-EWOULDBLOCK:	Errno: EAGAIN
-EINPROGRESS:	Errno: 36
-EALREADY:	Errno: 37
-ENOTSOCK:	Errno: 38
-EDESTADDRREQ:	Errno: 39
-EMSGSIZE:	Errno: 40
-EPROTOTYPE:	Errno: 41
-ENOPROTOOPT:	Errno: 42
-EPROTONOSUPPORT: Errno: 43
-ESOCKTNOSUPPORT: Errno: 44
-EOPNOTSUPP:	Errno: 45
-EPFNOSUPPORT:	Errno: 46
-EAFNOSUPPORT:	Errno: 47
-EADDRINUSE:	Errno: 48
-EADDRNOTAVAIL:	Errno: 49
-ENETDOWN:	Errno: 50
-ENETUNREACH:	Errno: 51
-ENETRESET:	Errno: 52
-ECONNABORTED:	Errno: 53
-ECONNRESET:	Errno: 54
-ENOBUFS:	Errno: 55
-EISCONN:	Errno: 56
-ENOTCONN:	Errno: 57
-ESHUTDOWN:	Errno: 58
-ETOOMANYREFS:	Errno: 59
-ETIMEDOUT:	Errno: 60
-ECONNREFUSED:	Errno: 61
-ELOOP:		Errno: 62
-ENAMETOOLONG:	Errno: 63
-EHOSTDOWN:	Errno: 64
-EHOSTUNREACH:	Errno: 65
-ENOTEMPTY:	Errno: 66
-EPROCLIM:	Errno: 67
-EUSERS:		Errno: 68
-EDQUOT:		Errno: 69
-ESTALE:		Errno: 70
-EREMOTE:	Errno: 71
-EBADRPC:	Errno: 72
-ERPCMISMATCH:	Errno: 73
-EPROGUNAVAIL:	Errno: 74
-EPROGMISMATCH:	Errno: 75
-EPROCUNAVAIL:	Errno: 76
-ENOLCK:		Errno: 77
-ENOSYS:		Errno: 78
-EFTYPE:		Errno: 79
-EAUTH:		Errno: 80
-ENEEDAUTH:	Errno: 81
-EIPSEC:		Errno: 82
-ENOATTR:	Errno: 83
-EILSEQ:		Errno: 84
-ENOMEDIUM:	Errno: 85
-EMEDIUMTYPE:	Errno: 86
-EOVERFLOW:	Errno: 87
-ECANCELED:	Errno: 88
-EIDRM:		Errno: 89
-ENOMSG:		Errno: 90
-ENOTSUP:	Errno: 91
-EBADMSG:	Errno: 92
-ENOTRECOVERABLE: Errno: 93
-EOWNERDEAD:	Errno: 94
-EPROTO:		Errno: 95
+EPERM           :: Platform_Error.EPERM
+ENOENT          :: Platform_Error.ENOENT
+ESRCH           :: Platform_Error.ESRCH
+EINTR           :: Platform_Error.EINTR
+EIO             :: Platform_Error.EIO
+ENXIO           :: Platform_Error.ENXIO
+E2BIG           :: Platform_Error.E2BIG
+ENOEXEC         :: Platform_Error.ENOEXEC
+EBADF           :: Platform_Error.EBADF
+ECHILD          :: Platform_Error.ECHILD
+EDEADLK         :: Platform_Error.EDEADLK
+ENOMEM          :: Platform_Error.ENOMEM
+EACCES          :: Platform_Error.EACCES
+EFAULT          :: Platform_Error.EFAULT
+ENOTBLK         :: Platform_Error.ENOTBLK
+EBUSY           :: Platform_Error.EBUSY
+EEXIST          :: Platform_Error.EEXIST
+EXDEV           :: Platform_Error.EXDEV
+ENODEV          :: Platform_Error.ENODEV
+ENOTDIR         :: Platform_Error.ENOTDIR
+EISDIR          :: Platform_Error.EISDIR
+EINVAL          :: Platform_Error.EINVAL
+ENFILE          :: Platform_Error.ENFILE
+EMFILE          :: Platform_Error.EMFILE
+ENOTTY          :: Platform_Error.ENOTTY
+ETXTBSY         :: Platform_Error.ETXTBSY
+EFBIG           :: Platform_Error.EFBIG
+ENOSPC          :: Platform_Error.ENOSPC
+ESPIPE          :: Platform_Error.ESPIPE
+EROFS           :: Platform_Error.EROFS
+EMLINK          :: Platform_Error.EMLINK
+EPIPE           :: Platform_Error.EPIPE
+EDOM            :: Platform_Error.EDOM
+ERANGE          :: Platform_Error.ERANGE
+EAGAIN          :: Platform_Error.EAGAIN
+EWOULDBLOCK     :: Platform_Error.EWOULDBLOCK
+EINPROGRESS     :: Platform_Error.EINPROGRESS
+EALREADY        :: Platform_Error.EALREADY
+ENOTSOCK        :: Platform_Error.ENOTSOCK
+EDESTADDRREQ    :: Platform_Error.EDESTADDRREQ
+EMSGSIZE        :: Platform_Error.EMSGSIZE
+EPROTOTYPE      :: Platform_Error.EPROTOTYPE
+ENOPROTOOPT     :: Platform_Error.ENOPROTOOPT
+EPROTONOSUPPORT :: Platform_Error.EPROTONOSUPPORT
+ESOCKTNOSUPPORT :: Platform_Error.ESOCKTNOSUPPORT
+EOPNOTSUPP      :: Platform_Error.EOPNOTSUPP
+EPFNOSUPPORT    :: Platform_Error.EPFNOSUPPORT
+EAFNOSUPPORT    :: Platform_Error.EAFNOSUPPORT
+EADDRINUSE      :: Platform_Error.EADDRINUSE
+EADDRNOTAVAIL   :: Platform_Error.EADDRNOTAVAIL
+ENETDOWN        :: Platform_Error.ENETDOWN
+ENETUNREACH     :: Platform_Error.ENETUNREACH
+ENETRESET       :: Platform_Error.ENETRESET
+ECONNABORTED    :: Platform_Error.ECONNABORTED
+ECONNRESET      :: Platform_Error.ECONNRESET
+ENOBUFS         :: Platform_Error.ENOBUFS
+EISCONN         :: Platform_Error.EISCONN
+ENOTCONN        :: Platform_Error.ENOTCONN
+ESHUTDOWN       :: Platform_Error.ESHUTDOWN
+ETOOMANYREFS    :: Platform_Error.ETOOMANYREFS
+ETIMEDOUT       :: Platform_Error.ETIMEDOUT
+ECONNREFUSED    :: Platform_Error.ECONNREFUSED
+ELOOP           :: Platform_Error.ELOOP
+ENAMETOOLONG    :: Platform_Error.ENAMETOOLONG
+EHOSTDOWN       :: Platform_Error.EHOSTDOWN
+EHOSTUNREACH    :: Platform_Error.EHOSTUNREACH
+ENOTEMPTY       :: Platform_Error.ENOTEMPTY
+EPROCLIM        :: Platform_Error.EPROCLIM
+EUSERS          :: Platform_Error.EUSERS
+EDQUOT          :: Platform_Error.EDQUOT
+ESTALE          :: Platform_Error.ESTALE
+EREMOTE         :: Platform_Error.EREMOTE
+EBADRPC         :: Platform_Error.EBADRPC
+ERPCMISMATCH    :: Platform_Error.ERPCMISMATCH
+EPROGUNAVAIL    :: Platform_Error.EPROGUNAVAIL
+EPROGMISMATCH   :: Platform_Error.EPROGMISMATCH
+EPROCUNAVAIL    :: Platform_Error.EPROCUNAVAIL
+ENOLCK          :: Platform_Error.ENOLCK
+ENOSYS          :: Platform_Error.ENOSYS
+EFTYPE          :: Platform_Error.EFTYPE
+EAUTH           :: Platform_Error.EAUTH
+ENEEDAUTH       :: Platform_Error.ENEEDAUTH
+EIPSEC          :: Platform_Error.EIPSEC
+ENOATTR         :: Platform_Error.ENOATTR
+EILSEQ          :: Platform_Error.EILSEQ
+ENOMEDIUM       :: Platform_Error.ENOMEDIUM
+EMEDIUMTYPE     :: Platform_Error.EMEDIUMTYPE
+EOVERFLOW       :: Platform_Error.EOVERFLOW
+ECANCELED       :: Platform_Error.ECANCELED
+EIDRM           :: Platform_Error.EIDRM
+ENOMSG          :: Platform_Error.ENOMSG
+ENOTSUP         :: Platform_Error.ENOTSUP
+EBADMSG         :: Platform_Error.EBADMSG
+ENOTRECOVERABLE :: Platform_Error.ENOTRECOVERABLE
+EOWNERDEAD      :: Platform_Error.EOWNERDEAD
+EPROTO          :: Platform_Error.EPROTO
 
 O_RDONLY   :: 0x00000
 O_WRONLY   :: 0x00001
@@ -295,8 +392,8 @@ is_path_separator :: proc(r: rune) -> bool {
 	return r == '/'
 }
 
-get_last_error :: proc "contextless" () -> int {
-	return int(__error()^)
+get_last_error :: proc "contextless" () -> Error {
+	return Error(__error()^)
 }
 
 fork :: proc() -> (Pid, Errno) {

--- a/core/os/os_wasi.odin
+++ b/core/os/os_wasi.odin
@@ -205,6 +205,12 @@ close :: proc(fd: Handle) -> Errno {
 	err := wasi.fd_close(wasi.fd_t(fd))
 	return Platform_Error(err)
 }
+
+flush :: proc(fd: Handle) -> Error {
+	// do nothing
+	return nil
+}
+
 seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
 	n, err := wasi.fd_seek(wasi.fd_t(fd), wasi.filedelta_t(offset), wasi.whence_t(whence))
 	return i64(n), Platform_Error(err)

--- a/core/os/os_wasi.odin
+++ b/core/os/os_wasi.odin
@@ -224,7 +224,7 @@ file_size :: proc(fd: Handle) -> (i64, Errno) {
 	if err != nil {
 		return 0, Platform_Error(err)
 	}
-	return i64(stat.size), 0
+	return i64(stat.size), nil
 }
 
 

--- a/core/os/os_wasi.odin
+++ b/core/os/os_wasi.odin
@@ -4,11 +4,13 @@ import "core:sys/wasm/wasi"
 import "base:runtime"
 
 Handle :: distinct i32
-Errno :: distinct i32
+_Platform_Error :: enum i32 {
+	NONE = 0,
+}
 
 INVALID_HANDLE :: -1
 
-ERROR_NONE :: Errno(wasi.errno_t.SUCCESS)
+// ERROR_NONE :: Errno(wasi.errno_t.SUCCESS) // that is a weird error code. Probably better to remap it
 
 O_RDONLY   :: 0x00000
 O_WRONLY   :: 0x00001

--- a/core/os/os_wasi.odin
+++ b/core/os/os_wasi.odin
@@ -219,12 +219,10 @@ _processor_core_count :: proc() -> int {
 	return 1
 }
 
-file_size :: proc(fd: Handle) -> (i64, Errno) {
-	stat, err := wasi.fd_filestat_get(wasi.fd_t(fd))
-	if err != nil {
-		return 0, Platform_Error(err)
-	}
-	return i64(stat.size), nil
+file_size :: proc(fd: Handle) -> (size: i64, err: Errno) {
+	stat := wasi.fd_filestat_get(wasi.fd_t(fd)) or_return
+	size = i64(stat.size)
+	return
 }
 
 

--- a/core/os/os_wasi.odin
+++ b/core/os/os_wasi.odin
@@ -27,6 +27,7 @@ stderr: Handle = 2
 
 args := _alloc_command_line_arguments()
 
+@(require_results)
 _alloc_command_line_arguments :: proc() -> (args: []string) {
 	args = make([]string, len(runtime.args__))
 	for &arg, i in args {
@@ -91,8 +92,9 @@ init_preopens :: proc() {
 	preopens = dyn_preopens[:]
 }
 
+@(require_results)
 wasi_match_preopen :: proc(path: string) -> (wasi.fd_t, string, bool) {
-
+	@(require_results)
 	prefix_matches :: proc(prefix, path: string) -> bool {
 		// Empty is valid for any relative path.
 		if len(prefix) == 0 && len(path) > 0 && path[0] != '/' {
@@ -163,6 +165,7 @@ read_at :: proc(fd: Handle, data: []byte, offset: i64) -> (int, Errno) {
 	n, err := wasi.fd_pread(wasi.fd_t(fd), {iovs}, wasi.filesize_t(offset))
 	return int(n), Platform_Error(err)
 }
+@(require_results)
 open :: proc(path: string, mode: int = O_RDONLY, perm: int = 0) -> (Handle, Errno) {
 	oflags: wasi.oflags_t
 	if mode & O_CREATE == O_CREATE {
@@ -215,14 +218,16 @@ seek :: proc(fd: Handle, offset: i64, whence: int) -> (i64, Errno) {
 	n, err := wasi.fd_seek(wasi.fd_t(fd), wasi.filedelta_t(offset), wasi.whence_t(whence))
 	return i64(n), Platform_Error(err)
 }
+@(require_results)
 current_thread_id :: proc "contextless" () -> int {
 	return 0
 }
-@(private)
+@(private, require_results)
 _processor_core_count :: proc() -> int {
 	return 1
 }
 
+@(require_results)
 file_size :: proc(fd: Handle) -> (size: i64, err: Errno) {
 	stat := wasi.fd_filestat_get(wasi.fd_t(fd)) or_return
 	size = i64(stat.size)

--- a/core/os/os_wasi.odin
+++ b/core/os/os_wasi.odin
@@ -8,8 +8,6 @@ _Platform_Error :: wasi.errno_t
 
 INVALID_HANDLE :: -1
 
-// ERROR_NONE :: Errno(wasi.errno_t.SUCCESS) // that is a weird error code. Probably better to remap it
-
 O_RDONLY   :: 0x00000
 O_WRONLY   :: 0x00001
 O_RDWR     :: 0x00002

--- a/core/os/os_windows.odin
+++ b/core/os/os_windows.odin
@@ -54,10 +54,8 @@ ERROR_PRIVILEGE_NOT_HELD  :: _Platform_Error(1314)
 WSAEACCES                 :: _Platform_Error(10013)
 WSAECONNRESET             :: _Platform_Error(10054)
 
-// Windows reserves errors >= 1<<29 for application use
-ERROR_FILE_IS_PIPE        :: _Platform_Error(1<<29 + 0)
-ERROR_FILE_IS_NOT_DIR     :: _Platform_Error(1<<29 + 1)
-ERROR_NEGATIVE_OFFSET     :: _Platform_Error(1<<29 + 2)
+ERROR_FILE_IS_PIPE        :: General_Error.File_Is_Pipe
+ERROR_FILE_IS_NOT_DIR     :: General_Error.Not_Dir
 
 // "Argv" arguments converted to Odin strings
 args := _alloc_command_line_arguments()

--- a/core/os/os_windows.odin
+++ b/core/os/os_windows.odin
@@ -35,7 +35,7 @@ ERROR_INVALID_HANDLE      :: _Platform_Error(6)
 ERROR_NOT_ENOUGH_MEMORY   :: _Platform_Error(8)
 ERROR_NO_MORE_FILES       :: _Platform_Error(18)
 ERROR_HANDLE_EOF          :: _Platform_Error(38)
-ERROR_EOF                 :: ERROR_HANDLE_EOF
+ERROR_EOF                 :: General_Error.EOF
 ERROR_NETNAME_DELETED     :: _Platform_Error(64)
 ERROR_FILE_EXISTS         :: _Platform_Error(80)
 ERROR_INVALID_PARAMETER   :: _Platform_Error(87)

--- a/core/os/os_windows.odin
+++ b/core/os/os_windows.odin
@@ -64,7 +64,53 @@ ERROR_NEGATIVE_OFFSET     :: _Platform_Error(1<<29 + 2)
 args := _alloc_command_line_arguments()
 
 get_last_error :: proc "contextless" () -> Error {
-	return Platform_Error(win32.GetLastError())
+	err := win32.GetLastError()
+	if err == 0 {
+		return nil
+	}
+	switch err {
+	case win32.ERROR_ACCESS_DENIED, win32.ERROR_SHARING_VIOLATION:
+		return .Permission_Denied
+
+	case win32.ERROR_FILE_EXISTS, win32.ERROR_ALREADY_EXISTS:
+		return .Exist
+
+	case win32.ERROR_FILE_NOT_FOUND, win32.ERROR_PATH_NOT_FOUND:
+		return .Not_Exist
+
+	case win32.ERROR_NO_DATA:
+		return .Closed
+
+	case win32.ERROR_TIMEOUT, win32.WAIT_TIMEOUT:
+		return .Timeout
+
+	case win32.ERROR_NOT_SUPPORTED:
+		return .Unsupported
+
+	case win32.ERROR_HANDLE_EOF:
+		return .EOF
+
+	case win32.ERROR_INVALID_HANDLE:
+		return .Invalid_File
+
+	case
+		win32.ERROR_BAD_ARGUMENTS,
+		win32.ERROR_INVALID_PARAMETER,
+		win32.ERROR_NOT_ENOUGH_MEMORY,
+		win32.ERROR_NO_MORE_FILES,
+		win32.ERROR_LOCK_VIOLATION,
+		win32.ERROR_BROKEN_PIPE,
+		win32.ERROR_CALL_NOT_IMPLEMENTED,
+		win32.ERROR_INSUFFICIENT_BUFFER,
+		win32.ERROR_INVALID_NAME,
+		win32.ERROR_LOCK_FAILED,
+		win32.ERROR_ENVVAR_NOT_FOUND,
+		win32.ERROR_OPERATION_ABORTED,
+		win32.ERROR_IO_PENDING,
+		win32.ERROR_NO_UNICODE_TRANSLATION:
+		// fallthrough
+	}
+	return Platform_Error(err)
 }
 
 

--- a/core/os/os_windows.odin
+++ b/core/os/os_windows.odin
@@ -114,7 +114,7 @@ get_last_error :: proc "contextless" () -> Error {
 }
 
 
-last_write_time :: proc(fd: Handle) -> (File_Time, Errno) {
+last_write_time :: proc(fd: Handle) -> (File_Time, Error) {
 	file_info: win32.BY_HANDLE_FILE_INFORMATION
 	if !win32.GetFileInformationByHandle(win32.HANDLE(fd), &file_info) {
 		return 0, get_last_error()
@@ -124,7 +124,7 @@ last_write_time :: proc(fd: Handle) -> (File_Time, Errno) {
 	return lo | hi << 32, nil
 }
 
-last_write_time_by_name :: proc(name: string) -> (File_Time, Errno) {
+last_write_time_by_name :: proc(name: string) -> (File_Time, Error) {
 	data: win32.WIN32_FILE_ATTRIBUTE_DATA
 
 	wide_path := win32.utf8_to_wstring(name)

--- a/core/os/os_windows.odin
+++ b/core/os/os_windows.odin
@@ -71,11 +71,11 @@ get_last_error :: proc "contextless" () -> Error {
 last_write_time :: proc(fd: Handle) -> (File_Time, Errno) {
 	file_info: win32.BY_HANDLE_FILE_INFORMATION
 	if !win32.GetFileInformationByHandle(win32.HANDLE(fd), &file_info) {
-		return 0, Platform_Error(win32.GetLastError())
+		return 0, get_last_error()
 	}
 	lo := File_Time(file_info.ftLastWriteTime.dwLowDateTime)
 	hi := File_Time(file_info.ftLastWriteTime.dwHighDateTime)
-	return lo | hi << 32, ERROR_NONE
+	return lo | hi << 32, nil
 }
 
 last_write_time_by_name :: proc(name: string) -> (File_Time, Errno) {
@@ -83,12 +83,12 @@ last_write_time_by_name :: proc(name: string) -> (File_Time, Errno) {
 
 	wide_path := win32.utf8_to_wstring(name)
 	if !win32.GetFileAttributesExW(wide_path, win32.GetFileExInfoStandard, &data) {
-		return 0, Platform_Error(win32.GetLastError())
+		return 0, get_last_error()
 	}
 
 	l := File_Time(data.ftLastWriteTime.dwLowDateTime)
 	h := File_Time(data.ftLastWriteTime.dwHighDateTime)
-	return l | h << 32, ERROR_NONE
+	return l | h << 32, nil
 }
 
 

--- a/core/os/os_windows.odin
+++ b/core/os/os_windows.odin
@@ -63,6 +63,7 @@ ERROR_NEGATIVE_OFFSET     :: _Platform_Error(1<<29 + 2)
 // "Argv" arguments converted to Odin strings
 args := _alloc_command_line_arguments()
 
+@(require_results, no_instrumentation)
 get_last_error :: proc "contextless" () -> Error {
 	err := win32.GetLastError()
 	if err == 0 {
@@ -114,6 +115,7 @@ get_last_error :: proc "contextless" () -> Error {
 }
 
 
+@(require_results)
 last_write_time :: proc(fd: Handle) -> (File_Time, Error) {
 	file_info: win32.BY_HANDLE_FILE_INFORMATION
 	if !win32.GetFileInformationByHandle(win32.HANDLE(fd), &file_info) {
@@ -124,6 +126,7 @@ last_write_time :: proc(fd: Handle) -> (File_Time, Error) {
 	return lo | hi << 32, nil
 }
 
+@(require_results)
 last_write_time_by_name :: proc(name: string) -> (File_Time, Error) {
 	data: win32.WIN32_FILE_ATTRIBUTE_DATA
 
@@ -138,6 +141,7 @@ last_write_time_by_name :: proc(name: string) -> (File_Time, Error) {
 }
 
 
+@(require_results)
 get_page_size :: proc() -> int {
 	// NOTE(tetra): The page size never changes, so why do anything complicated
 	// if we don't have to.

--- a/core/os/os_windows.odin
+++ b/core/os/os_windows.odin
@@ -35,7 +35,6 @@ ERROR_INVALID_HANDLE      :: _Platform_Error(6)
 ERROR_NOT_ENOUGH_MEMORY   :: _Platform_Error(8)
 ERROR_NO_MORE_FILES       :: _Platform_Error(18)
 ERROR_HANDLE_EOF          :: _Platform_Error(38)
-ERROR_EOF                 :: General_Error.EOF
 ERROR_NETNAME_DELETED     :: _Platform_Error(64)
 ERROR_FILE_EXISTS         :: _Platform_Error(80)
 ERROR_INVALID_PARAMETER   :: _Platform_Error(87)

--- a/core/os/os_windows.odin
+++ b/core/os/os_windows.odin
@@ -7,7 +7,6 @@ import "base:intrinsics"
 
 Handle    :: distinct uintptr
 File_Time :: distinct u64
-Errno     :: distinct int
 
 
 INVALID_HANDLE :: ~Handle(0)
@@ -27,38 +26,38 @@ O_SYNC     :: 0x01000
 O_ASYNC    :: 0x02000
 O_CLOEXEC  :: 0x80000
 
+_Platform_Error :: win32.System_Error
 
-ERROR_NONE:                   Errno : 0
-ERROR_FILE_NOT_FOUND:         Errno : 2
-ERROR_PATH_NOT_FOUND:         Errno : 3
-ERROR_ACCESS_DENIED:          Errno : 5
-ERROR_INVALID_HANDLE:         Errno : 6
-ERROR_NOT_ENOUGH_MEMORY:      Errno : 8
-ERROR_NO_MORE_FILES:          Errno : 18
-ERROR_HANDLE_EOF:             Errno : 38
-ERROR_NETNAME_DELETED:        Errno : 64
-ERROR_FILE_EXISTS:            Errno : 80
-ERROR_INVALID_PARAMETER:      Errno : 87
-ERROR_BROKEN_PIPE:            Errno : 109
-ERROR_BUFFER_OVERFLOW:        Errno : 111
-ERROR_INSUFFICIENT_BUFFER:    Errno : 122
-ERROR_MOD_NOT_FOUND:          Errno : 126
-ERROR_PROC_NOT_FOUND:         Errno : 127
-ERROR_DIR_NOT_EMPTY:          Errno : 145
-ERROR_ALREADY_EXISTS:         Errno : 183
-ERROR_ENVVAR_NOT_FOUND:       Errno : 203
-ERROR_MORE_DATA:              Errno : 234
-ERROR_OPERATION_ABORTED:      Errno : 995
-ERROR_IO_PENDING:             Errno : 997
-ERROR_NOT_FOUND:              Errno : 1168
-ERROR_PRIVILEGE_NOT_HELD:     Errno : 1314
-WSAEACCES:                    Errno : 10013
-WSAECONNRESET:                Errno : 10054
+ERROR_FILE_NOT_FOUND      :: _Platform_Error(2)
+ERROR_PATH_NOT_FOUND      :: _Platform_Error(3)
+ERROR_ACCESS_DENIED       :: _Platform_Error(5)
+ERROR_INVALID_HANDLE      :: _Platform_Error(6)
+ERROR_NOT_ENOUGH_MEMORY   :: _Platform_Error(8)
+ERROR_NO_MORE_FILES       :: _Platform_Error(18)
+ERROR_HANDLE_EOF          :: _Platform_Error(38)
+ERROR_NETNAME_DELETED     :: _Platform_Error(64)
+ERROR_FILE_EXISTS         :: _Platform_Error(80)
+ERROR_INVALID_PARAMETER   :: _Platform_Error(87)
+ERROR_BROKEN_PIPE         :: _Platform_Error(109)
+ERROR_BUFFER_OVERFLOW     :: _Platform_Error(111)
+ERROR_INSUFFICIENT_BUFFER :: _Platform_Error(122)
+ERROR_MOD_NOT_FOUND       :: _Platform_Error(126)
+ERROR_PROC_NOT_FOUND      :: _Platform_Error(127)
+ERROR_DIR_NOT_EMPTY       :: _Platform_Error(145)
+ERROR_ALREADY_EXISTS      :: _Platform_Error(183)
+ERROR_ENVVAR_NOT_FOUND    :: _Platform_Error(203)
+ERROR_MORE_DATA           :: _Platform_Error(234)
+ERROR_OPERATION_ABORTED   :: _Platform_Error(995)
+ERROR_IO_PENDING          :: _Platform_Error(997)
+ERROR_NOT_FOUND           :: _Platform_Error(1168)
+ERROR_PRIVILEGE_NOT_HELD  :: _Platform_Error(1314)
+WSAEACCES                 :: _Platform_Error(10013)
+WSAECONNRESET             :: _Platform_Error(10054)
 
 // Windows reserves errors >= 1<<29 for application use
-ERROR_FILE_IS_PIPE:           Errno : 1<<29 + 0
-ERROR_FILE_IS_NOT_DIR:        Errno : 1<<29 + 1
-ERROR_NEGATIVE_OFFSET:        Errno : 1<<29 + 2
+ERROR_FILE_IS_PIPE        :: _Platform_Error(1<<29 + 0)
+ERROR_FILE_IS_NOT_DIR     :: _Platform_Error(1<<29 + 1)
+ERROR_NEGATIVE_OFFSET     :: _Platform_Error(1<<29 + 2)
 
 // "Argv" arguments converted to Odin strings
 args := _alloc_command_line_arguments()

--- a/core/os/os_windows.odin
+++ b/core/os/os_windows.odin
@@ -35,6 +35,7 @@ ERROR_INVALID_HANDLE      :: _Platform_Error(6)
 ERROR_NOT_ENOUGH_MEMORY   :: _Platform_Error(8)
 ERROR_NO_MORE_FILES       :: _Platform_Error(18)
 ERROR_HANDLE_EOF          :: _Platform_Error(38)
+ERROR_EOF                 :: ERROR_HANDLE_EOF
 ERROR_NETNAME_DELETED     :: _Platform_Error(64)
 ERROR_FILE_EXISTS         :: _Platform_Error(80)
 ERROR_INVALID_PARAMETER   :: _Platform_Error(87)
@@ -62,14 +63,15 @@ ERROR_NEGATIVE_OFFSET     :: _Platform_Error(1<<29 + 2)
 // "Argv" arguments converted to Odin strings
 args := _alloc_command_line_arguments()
 
-
-
+get_last_error :: proc "contextless" () -> Error {
+	return Platform_Error(win32.GetLastError())
+}
 
 
 last_write_time :: proc(fd: Handle) -> (File_Time, Errno) {
 	file_info: win32.BY_HANDLE_FILE_INFORMATION
 	if !win32.GetFileInformationByHandle(win32.HANDLE(fd), &file_info) {
-		return 0, Errno(win32.GetLastError())
+		return 0, Platform_Error(win32.GetLastError())
 	}
 	lo := File_Time(file_info.ftLastWriteTime.dwLowDateTime)
 	hi := File_Time(file_info.ftLastWriteTime.dwHighDateTime)
@@ -81,7 +83,7 @@ last_write_time_by_name :: proc(name: string) -> (File_Time, Errno) {
 
 	wide_path := win32.utf8_to_wstring(name)
 	if !win32.GetFileAttributesExW(wide_path, win32.GetFileExInfoStandard, &data) {
-		return 0, Errno(win32.GetLastError())
+		return 0, Platform_Error(win32.GetLastError())
 	}
 
 	l := File_Time(data.ftLastWriteTime.dwLowDateTime)

--- a/core/os/os_windows.odin
+++ b/core/os/os_windows.odin
@@ -153,7 +153,7 @@ get_page_size :: proc() -> int {
 	return page_size
 }
 
-@(private)
+@(private, require_results)
 _processor_core_count :: proc() -> int {
 	length : win32.DWORD = 0
 	result := win32.GetLogicalProcessorInformation(nil, &length)
@@ -184,12 +184,14 @@ exit :: proc "contextless" (code: int) -> ! {
 
 
 
+@(require_results)
 current_thread_id :: proc "contextless" () -> int {
 	return int(win32.GetCurrentThreadId())
 }
 
 
 
+@(require_results)
 _alloc_command_line_arguments :: proc() -> []string {
 	arg_count: i32
 	arg_list_ptr := win32.CommandLineToArgvW(win32.GetCommandLineW(), &arg_count)
@@ -223,44 +225,52 @@ _alloc_command_line_arguments :: proc() -> []string {
 */
 WINDOWS_11_BUILD_CUTOFF :: 22_000
 
-get_windows_version_w :: proc() -> win32.OSVERSIONINFOEXW {
+@(require_results)
+get_windows_version_w :: proc "contextless" () -> win32.OSVERSIONINFOEXW {
 	osvi : win32.OSVERSIONINFOEXW
 	osvi.dwOSVersionInfoSize = size_of(win32.OSVERSIONINFOEXW)
 	win32.RtlGetVersion(&osvi)
 	return osvi
 }
 
-is_windows_xp :: proc() -> bool {
+@(require_results)
+is_windows_xp :: proc "contextless" () -> bool {
 	osvi := get_windows_version_w()
 	return (osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 1)
 }
 
-is_windows_vista :: proc() -> bool {
+@(require_results)
+is_windows_vista :: proc "contextless" () -> bool {
 	osvi := get_windows_version_w()
 	return (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 0)
 }
 
-is_windows_7 :: proc() -> bool {
+@(require_results)
+is_windows_7 :: proc "contextless" () -> bool {
 	osvi := get_windows_version_w()
 	return (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 1)
 }
 
-is_windows_8 :: proc() -> bool {
+@(require_results)
+is_windows_8 :: proc "contextless" () -> bool {
 	osvi := get_windows_version_w()
 	return (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 2)
 }
 
-is_windows_8_1 :: proc() -> bool {
+@(require_results)
+is_windows_8_1 :: proc "contextless" () -> bool {
 	osvi := get_windows_version_w()
 	return (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 3)
 }
 
-is_windows_10 :: proc() -> bool {
+@(require_results)
+is_windows_10 :: proc "contextless" () -> bool {
 	osvi := get_windows_version_w()
 	return (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber <  WINDOWS_11_BUILD_CUTOFF)
 }
 
-is_windows_11 :: proc() -> bool {
+@(require_results)
+is_windows_11 :: proc "contextless" () -> bool {
 	osvi := get_windows_version_w()
 	return (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber >= WINDOWS_11_BUILD_CUTOFF)
 }

--- a/core/os/stat_unix.odin
+++ b/core/os/stat_unix.odin
@@ -101,54 +101,31 @@ path_base :: proc(path: string) -> string {
 
 
 lstat :: proc(name: string, allocator := context.allocator) -> (fi: File_Info, err: Errno) {
-
 	context.allocator = allocator
 
-	s: OS_Stat
-	s, err = _lstat(name)
-	if err != ERROR_NONE {
-		return fi, err
-	}
+	s := _lstat(name) or_return
 	_fill_file_info_from_stat(&fi, s)
-	fi.fullpath, err = absolute_path_from_relative(name)
-	if err != ERROR_NONE {
-		return
-	}
+	fi.fullpath = absolute_path_from_relative(name) or_return
 	fi.name = path_base(fi.fullpath)
-	return fi, ERROR_NONE
+	return
 }
 
 stat :: proc(name: string, allocator := context.allocator) -> (fi: File_Info, err: Errno) {
 	context.allocator = allocator
 
-	s: OS_Stat
-	s, err = _stat(name)
-	if err != ERROR_NONE {
-		return fi, err
-	}
+	s := _stat(name) or_return
 	_fill_file_info_from_stat(&fi, s)
-	fi.fullpath, err = absolute_path_from_relative(name)
-	if err != ERROR_NONE {
-		return
-	}
+	fi.fullpath = absolute_path_from_relative(name) or_return
 	fi.name = path_base(fi.fullpath)
-	return fi, ERROR_NONE
+	return
 }
 
 fstat :: proc(fd: Handle, allocator := context.allocator) -> (fi: File_Info, err: Errno) {
-
 	context.allocator = allocator
 
-	s: OS_Stat
-	s, err = _fstat(fd)
-	if err != ERROR_NONE {
-		return fi, err
-	}
+	s := _fstat(fd) or_return
 	_fill_file_info_from_stat(&fi, s)
-	fi.fullpath, err = absolute_path_from_handle(fd)
-	if err != ERROR_NONE {
-		return
-	}
+	fi.fullpath = absolute_path_from_handle(fd) or_return
 	fi.name = path_base(fi.fullpath)
-	return fi, ERROR_NONE
+	return
 }

--- a/core/os/stat_unix.odin
+++ b/core/os/stat_unix.odin
@@ -50,14 +50,14 @@ File_Info :: struct {
 }
 */
 
-@private
+@(private, require_results)
 _make_time_from_unix_file_time :: proc(uft: Unix_File_Time) -> time.Time {
 	return time.Time{
 		_nsec = uft.nanoseconds + uft.seconds * 1_000_000_000,
 	}
 }
 
-@private
+@(private)
 _fill_file_info_from_stat :: proc(fi: ^File_Info, s: OS_Stat) {
 	fi.size = s.size
 	fi.mode = cast(File_Mode)s.mode
@@ -71,7 +71,7 @@ _fill_file_info_from_stat :: proc(fi: ^File_Info, s: OS_Stat) {
 }
 
 
-@private
+@(private, require_results)
 path_base :: proc(path: string) -> string {
 	is_separator :: proc(c: byte) -> bool {
 		return c == '/'
@@ -100,6 +100,7 @@ path_base :: proc(path: string) -> string {
 }
 
 
+@(require_results)
 lstat :: proc(name: string, allocator := context.allocator) -> (fi: File_Info, err: Error) {
 	context.allocator = allocator
 
@@ -110,6 +111,7 @@ lstat :: proc(name: string, allocator := context.allocator) -> (fi: File_Info, e
 	return
 }
 
+@(require_results)
 stat :: proc(name: string, allocator := context.allocator) -> (fi: File_Info, err: Error) {
 	context.allocator = allocator
 
@@ -120,6 +122,7 @@ stat :: proc(name: string, allocator := context.allocator) -> (fi: File_Info, er
 	return
 }
 
+@(require_results)
 fstat :: proc(fd: Handle, allocator := context.allocator) -> (fi: File_Info, err: Error) {
 	context.allocator = allocator
 

--- a/core/os/stat_unix.odin
+++ b/core/os/stat_unix.odin
@@ -100,7 +100,7 @@ path_base :: proc(path: string) -> string {
 }
 
 
-lstat :: proc(name: string, allocator := context.allocator) -> (fi: File_Info, err: Errno) {
+lstat :: proc(name: string, allocator := context.allocator) -> (fi: File_Info, err: Error) {
 	context.allocator = allocator
 
 	s := _lstat(name) or_return
@@ -110,7 +110,7 @@ lstat :: proc(name: string, allocator := context.allocator) -> (fi: File_Info, e
 	return
 }
 
-stat :: proc(name: string, allocator := context.allocator) -> (fi: File_Info, err: Errno) {
+stat :: proc(name: string, allocator := context.allocator) -> (fi: File_Info, err: Error) {
 	context.allocator = allocator
 
 	s := _stat(name) or_return
@@ -120,7 +120,7 @@ stat :: proc(name: string, allocator := context.allocator) -> (fi: File_Info, er
 	return
 }
 
-fstat :: proc(fd: Handle, allocator := context.allocator) -> (fi: File_Info, err: Errno) {
+fstat :: proc(fd: Handle, allocator := context.allocator) -> (fi: File_Info, err: Error) {
 	context.allocator = allocator
 
 	s := _fstat(fd) or_return

--- a/core/os/stat_windows.odin
+++ b/core/os/stat_windows.odin
@@ -4,7 +4,7 @@ import "core:time"
 import "base:runtime"
 import win32 "core:sys/windows"
 
-@(private)
+@(private, require_results)
 full_path_from_name :: proc(name: string, allocator := context.allocator) -> (path: string, err: Errno) {
 	context.allocator = allocator
 	
@@ -30,7 +30,7 @@ full_path_from_name :: proc(name: string, allocator := context.allocator) -> (pa
 	return
 }
 
-@(private)
+@(private, require_results)
 _stat :: proc(name: string, create_file_attributes: u32, allocator := context.allocator) -> (fi: File_Info, e: Errno) {
 	if len(name) == 0 {
 		return {}, ERROR_PATH_NOT_FOUND
@@ -72,17 +72,20 @@ _stat :: proc(name: string, create_file_attributes: u32, allocator := context.al
 }
 
 
+@(require_results)
 lstat :: proc(name: string, allocator := context.allocator) -> (File_Info, Errno) {
 	attrs := win32.FILE_FLAG_BACKUP_SEMANTICS
 	attrs |= win32.FILE_FLAG_OPEN_REPARSE_POINT
 	return _stat(name, attrs, allocator)
 }
 
+@(require_results)
 stat :: proc(name: string, allocator := context.allocator) -> (File_Info, Errno) {
 	attrs := win32.FILE_FLAG_BACKUP_SEMANTICS
 	return _stat(name, attrs, allocator)
 }
 
+@(require_results)
 fstat :: proc(fd: Handle, allocator := context.allocator) -> (fi: File_Info, err: Errno) {
 	if fd == 0 {
 		err = ERROR_INVALID_HANDLE
@@ -108,7 +111,7 @@ fstat :: proc(fd: Handle, allocator := context.allocator) -> (fi: File_Info, err
 }
 
 
-@(private)
+@(private, require_results)
 cleanpath_strip_prefix :: proc(buf: []u16) -> []u16 {
 	buf := buf
 	N := 0
@@ -133,13 +136,13 @@ cleanpath_strip_prefix :: proc(buf: []u16) -> []u16 {
 	return buf
 }
 
-@(private)
+@(private, require_results)
 cleanpath_from_handle :: proc(fd: Handle) -> (s: string, err: Errno) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD(ignore = context.temp_allocator == context.allocator)
 	buf := cleanpath_from_handle_u16(fd, context.temp_allocator) or_return
 	return win32.utf16_to_utf8(buf, context.allocator)
 }
-@(private)
+@(private, require_results)
 cleanpath_from_handle_u16 :: proc(fd: Handle, allocator: runtime.Allocator) -> ([]u16, Errno) {
 	if fd == 0 {
 		return nil, ERROR_INVALID_HANDLE
@@ -154,14 +157,14 @@ cleanpath_from_handle_u16 :: proc(fd: Handle, allocator: runtime.Allocator) -> (
 	buf_len := win32.GetFinalPathNameByHandleW(h, raw_data(buf), n, 0)
 	return buf[:buf_len], nil
 }
-@(private)
+@(private, require_results)
 cleanpath_from_buf :: proc(buf: []u16) -> string {
 	buf := buf
 	buf = cleanpath_strip_prefix(buf)
 	return win32.utf16_to_utf8(buf, context.allocator) or_else ""
 }
 
-@(private)
+@(private, require_results)
 basename :: proc(name: string) -> (base: string) {
 	name := name
 	if len(name) > 3 && name[:3] == `\\?` {
@@ -187,7 +190,7 @@ basename :: proc(name: string) -> (base: string) {
 	return name
 }
 
-@(private)
+@(private, require_results)
 file_type_mode :: proc(h: win32.HANDLE) -> File_Mode {
 	switch win32.GetFileType(h) {
 	case win32.FILE_TYPE_PIPE:
@@ -199,7 +202,7 @@ file_type_mode :: proc(h: win32.HANDLE) -> File_Mode {
 }
 
 
-@(private)
+@(private, require_results)
 file_mode_from_file_attributes :: proc(FileAttributes: win32.DWORD, h: win32.HANDLE, ReparseTag: win32.DWORD) -> (mode: File_Mode) {
 	if FileAttributes & win32.FILE_ATTRIBUTE_READONLY != 0 {
 		mode |= 0o444
@@ -236,7 +239,7 @@ windows_set_file_info_times :: proc(fi: ^File_Info, d: ^$T) {
 	fi.access_time       = time.unix(0, win32.FILETIME_as_unix_nanoseconds(d.ftLastAccessTime))
 }
 
-@(private)
+@(private, require_results)
 file_info_from_win32_file_attribute_data :: proc(d: ^win32.WIN32_FILE_ATTRIBUTE_DATA, name: string) -> (fi: File_Info, e: Errno) {
 	fi.size = i64(d.nFileSizeHigh)<<32 + i64(d.nFileSizeLow)
 
@@ -251,7 +254,7 @@ file_info_from_win32_file_attribute_data :: proc(d: ^win32.WIN32_FILE_ATTRIBUTE_
 	return
 }
 
-@(private)
+@(private, require_results)
 file_info_from_win32_find_data :: proc(d: ^win32.WIN32_FIND_DATAW, name: string) -> (fi: File_Info, e: Errno) {
 	fi.size = i64(d.nFileSizeHigh)<<32 + i64(d.nFileSizeLow)
 
@@ -266,7 +269,7 @@ file_info_from_win32_find_data :: proc(d: ^win32.WIN32_FIND_DATAW, name: string)
 	return
 }
 
-@(private)
+@(private, require_results)
 file_info_from_get_file_information_by_handle :: proc(path: string, h: win32.HANDLE) -> (File_Info, Errno) {
 	d: win32.BY_HANDLE_FILE_INFORMATION
 	if !win32.GetFileInformationByHandle(h, &d) {

--- a/core/os/stat_windows.odin
+++ b/core/os/stat_windows.odin
@@ -19,7 +19,7 @@ full_path_from_name :: proc(name: string, allocator := context.allocator) -> (pa
 	for {
 		n := win32.GetFullPathNameW(raw_data(p), u32(len(buf)), raw_data(buf), nil)
 		if n == 0 {
-			return "", Platform_Error(win32.GetLastError())
+			return "", get_last_error()
 		}
 		if n <= u32(len(buf)) {
 			return win32.utf16_to_utf8(buf[:n], allocator) or_else "", ERROR_NONE
@@ -54,7 +54,7 @@ _stat :: proc(name: string, create_file_attributes: u32, allocator := context.al
 		fd: win32.WIN32_FIND_DATAW
 		sh := win32.FindFirstFileW(wname, &fd)
 		if sh == win32.INVALID_HANDLE_VALUE {
-			e = Platform_Error(win32.GetLastError())
+			e = get_last_error()
 			return
 		}
 		win32.FindClose(sh)
@@ -64,7 +64,7 @@ _stat :: proc(name: string, create_file_attributes: u32, allocator := context.al
 
 	h := win32.CreateFileW(wname, 0, 0, nil, win32.OPEN_EXISTING, create_file_attributes, nil)
 	if h == win32.INVALID_HANDLE_VALUE {
-		e = Platform_Error(win32.GetLastError())
+		e = get_last_error()
 		return
 	}
 	defer win32.CloseHandle(h)
@@ -134,13 +134,10 @@ cleanpath_strip_prefix :: proc(buf: []u16) -> []u16 {
 }
 
 @(private)
-cleanpath_from_handle :: proc(fd: Handle) -> (string, Errno) {
+cleanpath_from_handle :: proc(fd: Handle) -> (s: string, err: Errno) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD(ignore = context.temp_allocator == context.allocator)
-	buf, err := cleanpath_from_handle_u16(fd, context.temp_allocator)
-	if err != 0 {
-		return "", err
-	}
-	return win32.utf16_to_utf8(buf, context.allocator) or_else "", err
+	buf := cleanpath_from_handle_u16(fd, context.temp_allocator) or_return
+	return win32.utf16_to_utf8(buf, context.allocator)
 }
 @(private)
 cleanpath_from_handle_u16 :: proc(fd: Handle, allocator: runtime.Allocator) -> ([]u16, Errno) {
@@ -151,7 +148,7 @@ cleanpath_from_handle_u16 :: proc(fd: Handle, allocator: runtime.Allocator) -> (
 
 	n := win32.GetFinalPathNameByHandleW(h, nil, 0, 0)
 	if n == 0 {
-		return nil, Platform_Error(win32.GetLastError())
+		return nil, get_last_error()
 	}
 	buf := make([]u16, max(n, win32.DWORD(260))+1, allocator)
 	buf_len := win32.GetFinalPathNameByHandleW(h, raw_data(buf), n, 0)
@@ -273,14 +270,14 @@ file_info_from_win32_find_data :: proc(d: ^win32.WIN32_FIND_DATAW, name: string)
 file_info_from_get_file_information_by_handle :: proc(path: string, h: win32.HANDLE) -> (File_Info, Errno) {
 	d: win32.BY_HANDLE_FILE_INFORMATION
 	if !win32.GetFileInformationByHandle(h, &d) {
-		err := Platform_Error(win32.GetLastError())
+		err := get_last_error()
 		return {}, err
 
 	}
 
 	ti: win32.FILE_ATTRIBUTE_TAG_INFO
 	if !win32.GetFileInformationByHandleEx(h, .FileAttributeTagInfo, &ti, size_of(ti)) {
-		err := Platform_Error(win32.GetLastError())
+		err := get_last_error()
 		if err != ERROR_INVALID_PARAMETER {
 			return {}, err
 		}

--- a/core/os/stream.odin
+++ b/core/os/stream.odin
@@ -32,12 +32,10 @@ _file_stream_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, 
 		}
 
 	case .Read_At:
-		when !(ODIN_OS == .FreeBSD || ODIN_OS == .OpenBSD || ODIN_OS == .NetBSD || ODIN_OS == .Haiku) {
-			n_int, os_err = read_at(fd, p, offset)
-			n = i64(n_int)
-			if n == 0 && os_err == nil {
-				err = .EOF
-			}
+		n_int, os_err = read_at(fd, p, offset)
+		n = i64(n_int)
+		if n == 0 && os_err == nil {
+			err = .EOF
 		}
 	case .Write:
 		n_int, os_err = write(fd, p)
@@ -46,12 +44,10 @@ _file_stream_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, 
 			err = .EOF
 		}
 	case .Write_At:
-		when !(ODIN_OS == .FreeBSD || ODIN_OS == .OpenBSD || ODIN_OS == .NetBSD || ODIN_OS == .Haiku) {
-			n_int, os_err = write_at(fd, p, offset)
-			n = i64(n_int)
-			if n == 0 && os_err == nil {
-				err = .EOF
-			}
+		n_int, os_err = write_at(fd, p, offset)
+		n = i64(n_int)
+		if n == 0 && os_err == nil {
+			err = .EOF
 		}
 	case .Seek:
 		n, os_err = seek(fd, offset, int(whence))
@@ -60,11 +56,7 @@ _file_stream_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, 
 	case .Destroy:
 		err = .Empty
 	case .Query:
-		when ODIN_OS == .FreeBSD || ODIN_OS == .OpenBSD || ODIN_OS == .NetBSD || ODIN_OS == .Haiku {
-			return io.query_utility({.Close, .Flush, .Read, .Write, .Seek, .Size, .Query})
-		} else {
-			return io.query_utility({.Close, .Flush, .Read, .Read_At, .Write, .Write_At, .Seek, .Size, .Query})
-		}
+		return io.query_utility({.Close, .Flush, .Read, .Read_At, .Write, .Write_At, .Seek, .Size, .Query})
 	}
 
 	if err == nil && os_err != nil {
@@ -73,7 +65,7 @@ _file_stream_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, 
 				return n, .EOF
 			}
 		}
-		err = .Unknown
+		err = error_to_io_error(os_err)
 	}
 	return
 }

--- a/core/os/stream.odin
+++ b/core/os/stream.odin
@@ -14,7 +14,7 @@ stream_from_handle :: proc(fd: Handle) -> io.Stream {
 _file_stream_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, offset: i64, whence: io.Seek_From) -> (n: i64, err: io.Error) {
 	fd := Handle(uintptr(stream_data))
 	n_int: int
-	os_err: Errno
+	os_err: Error
 	switch mode {
 	case .Close:
 		close(fd)

--- a/core/os/stream.odin
+++ b/core/os/stream.odin
@@ -60,11 +60,6 @@ _file_stream_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, 
 	}
 
 	if err == nil && os_err != nil {
-		when ODIN_OS == .Windows {
-			if os_err == ERROR_HANDLE_EOF {
-				return n, .EOF
-			}
-		}
 		err = error_to_io_error(os_err)
 	}
 	return

--- a/core/os/stream.odin
+++ b/core/os/stream.odin
@@ -19,7 +19,7 @@ _file_stream_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, 
 	case .Close:
 		close(fd)
 	case .Flush:
-		when ODIN_OS == .Windows {
+		when ODIN_OS == .Windows || ODIN_OS == .Darwin || ODIN_OS == .JS {
 			flush(fd)
 		} else {
 			// TOOD(bill): other operating systems

--- a/core/os/stream.odin
+++ b/core/os/stream.odin
@@ -17,13 +17,9 @@ _file_stream_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, 
 	os_err: Error
 	switch mode {
 	case .Close:
-		close(fd)
+		os_err = close(fd)
 	case .Flush:
-		when ODIN_OS == .Windows || ODIN_OS == .Darwin || ODIN_OS == .JS {
-			flush(fd)
-		} else {
-			// TOOD(bill): other operating systems
-		}
+		os_err = flush(fd)
 	case .Read:
 		n_int, os_err = read(fd, p)
 		n = i64(n_int)

--- a/core/os/stream.odin
+++ b/core/os/stream.odin
@@ -27,7 +27,7 @@ _file_stream_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, 
 	case .Read:
 		n_int, os_err = read(fd, p)
 		n = i64(n_int)
-		if n == 0 && os_err == 0 {
+		if n == 0 && os_err == nil {
 			err = .EOF
 		}
 
@@ -35,21 +35,21 @@ _file_stream_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, 
 		when !(ODIN_OS == .FreeBSD || ODIN_OS == .OpenBSD || ODIN_OS == .NetBSD || ODIN_OS == .Haiku) {
 			n_int, os_err = read_at(fd, p, offset)
 			n = i64(n_int)
-			if n == 0 && os_err == 0 {
+			if n == 0 && os_err == nil {
 				err = .EOF
 			}
 		}
 	case .Write:
 		n_int, os_err = write(fd, p)
 		n = i64(n_int)
-		if n == 0 && os_err == 0 {
+		if n == 0 && os_err == nil {
 			err = .EOF
 		}
 	case .Write_At:
 		when !(ODIN_OS == .FreeBSD || ODIN_OS == .OpenBSD || ODIN_OS == .NetBSD || ODIN_OS == .Haiku) {
 			n_int, os_err = write_at(fd, p, offset)
 			n = i64(n_int)
-			if n == 0 && os_err == 0 {
+			if n == 0 && os_err == nil {
 				err = .EOF
 			}
 		}
@@ -67,7 +67,7 @@ _file_stream_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, 
 		}
 	}
 
-	if err == nil && os_err != 0 {
+	if err == nil && os_err != nil {
 		when ODIN_OS == .Windows {
 			if os_err == ERROR_HANDLE_EOF {
 				return n, .EOF

--- a/core/path/filepath/match.odin
+++ b/core/path/filepath/match.odin
@@ -271,7 +271,7 @@ _glob :: proc(dir, pattern: string, matches: ^[dynamic]string, allocator := cont
 
 
 	d, derr := os.open(dir, os.O_RDONLY)
-	if derr != 0 {
+	if derr != nil {
 		return
 	}
 	defer os.close(d)
@@ -280,7 +280,7 @@ _glob :: proc(dir, pattern: string, matches: ^[dynamic]string, allocator := cont
 		file_info, ferr := os.fstat(d)
 		defer os.file_info_delete(file_info)
 
-		if ferr != 0 {
+		if ferr != nil {
 			return
 		}
 		if !file_info.is_dir {

--- a/core/path/filepath/path_windows.odin
+++ b/core/path/filepath/path_windows.odin
@@ -63,17 +63,17 @@ temp_full_path :: proc(name: string) -> (path: string, err: os.Error) {
 	p := win32.utf8_to_utf16(name, ta)
 	n := win32.GetFullPathNameW(raw_data(p), 0, nil, nil)
 	if n == 0 {
-		return "", os.Platform_Error(win32.GetLastError())
+		return "", os.get_last_error()
 	}
 
 	buf := make([]u16, n, ta)
 	n = win32.GetFullPathNameW(raw_data(p), u32(len(buf)), raw_data(buf), nil)
 	if n == 0 {
 		delete(buf)
-		return "", os.Platform_Error(win32.GetLastError())
+		return "", os.get_last_error()
 	}
 
-	return win32.utf16_to_utf8(buf[:n], ta) or_else "", os.ERROR_NONE
+	return win32.utf16_to_utf8(buf[:n], ta)
 }
 
 

--- a/core/path/filepath/path_windows.odin
+++ b/core/path/filepath/path_windows.odin
@@ -81,7 +81,7 @@ temp_full_path :: proc(name: string) -> (path: string, err: os.Error) {
 abs :: proc(path: string, allocator := context.allocator) -> (string, bool) {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD(ignore = allocator == context.temp_allocator)
 	full_path, err := temp_full_path(path)
-	if err != 0 {
+	if err != nil {
 		return "", false
 	}
 	p := clean(full_path, allocator)

--- a/core/path/filepath/path_windows.odin
+++ b/core/path/filepath/path_windows.odin
@@ -63,14 +63,14 @@ temp_full_path :: proc(name: string) -> (path: string, err: os.Errno) {
 	p := win32.utf8_to_utf16(name, ta)
 	n := win32.GetFullPathNameW(raw_data(p), 0, nil, nil)
 	if n == 0 {
-		return "", os.Errno(win32.GetLastError())
+		return "", os.Platform_Error(win32.GetLastError())
 	}
 
 	buf := make([]u16, n, ta)
 	n = win32.GetFullPathNameW(raw_data(p), u32(len(buf)), raw_data(buf), nil)
 	if n == 0 {
 		delete(buf)
-		return "", os.Errno(win32.GetLastError())
+		return "", os.Platform_Error(win32.GetLastError())
 	}
 
 	return win32.utf16_to_utf8(buf[:n], ta) or_else "", os.ERROR_NONE

--- a/core/path/filepath/path_windows.odin
+++ b/core/path/filepath/path_windows.odin
@@ -52,7 +52,7 @@ is_abs :: proc(path: string) -> bool {
 
 
 @(private)
-temp_full_path :: proc(name: string) -> (path: string, err: os.Errno) {
+temp_full_path :: proc(name: string) -> (path: string, err: os.Error) {
 	ta := context.temp_allocator
 
 	name := name

--- a/core/prof/spall/spall.odin
+++ b/core/prof/spall/spall.odin
@@ -227,7 +227,7 @@ _buffer_end :: proc "contextless" (ctx: ^Context, buffer: ^Buffer) #no_bounds_ch
 }
 
 @(no_instrumentation)
-write :: proc "contextless" (fd: os.Handle, buf: []byte) -> (n: int, err: os.Errno) {
+write :: proc "contextless" (fd: os.Handle, buf: []byte) -> (n: int, err: os.Error) {
 	return _write(fd, buf)
 }
 

--- a/core/prof/spall/spall.odin
+++ b/core/prof/spall/spall.odin
@@ -68,7 +68,7 @@ BUFFER_DEFAULT_SIZE :: 0x10_0000
 
 context_create_with_scale :: proc(filename: string, precise_time: bool, timestamp_scale: f64) -> (ctx: Context, ok: bool) #optional_ok {
 	fd, err := os.open(filename, os.O_WRONLY | os.O_APPEND | os.O_CREATE | os.O_TRUNC, 0o600)
-	if err != os.ERROR_NONE {
+	if err != nil {
 		return
 	}
 

--- a/core/prof/spall/spall_linux.odin
+++ b/core/prof/spall/spall_linux.odin
@@ -11,20 +11,11 @@ MAX_RW :: 0x7fffffff
 
 @(no_instrumentation)
 _write :: proc "contextless" (fd: os.Handle, data: []byte) -> (n: int, err: os.Error) #no_bounds_check /* bounds check would segfault instrumentation */ {
-	if len(data) == 0 {
-		return 0, nil
-	}
-	
 	for n < len(data) {
 		chunk := data[:min(len(data), MAX_RW)]
-		written, errno := linux.write(linux.Fd(fd), chunk)
-		if errno != nil {
-			return n, os.Platform_Error(errno)
-		}
-		n += written
+		n += linux.write(linux.Fd(fd), chunk) or_return
 	}
-
-	return n, nil
+	return
 }
 
 CLOCK_MONOTONIC_RAW :: 4 // NOTE(tetra): "RAW" means: Not adjusted by NTP.

--- a/core/prof/spall/spall_linux.odin
+++ b/core/prof/spall/spall_linux.odin
@@ -10,7 +10,7 @@ import "core:sys/linux"
 MAX_RW :: 0x7fffffff
 
 @(no_instrumentation)
-_write :: proc "contextless" (fd: os.Handle, data: []byte) -> (n: int, err: os.Errno) #no_bounds_check /* bounds check would segfault instrumentation */ {
+_write :: proc "contextless" (fd: os.Handle, data: []byte) -> (n: int, err: os.Error) #no_bounds_check /* bounds check would segfault instrumentation */ {
 	if len(data) == 0 {
 		return 0, os.ERROR_NONE
 	}
@@ -19,7 +19,7 @@ _write :: proc "contextless" (fd: os.Handle, data: []byte) -> (n: int, err: os.E
 		chunk := data[:min(len(data), MAX_RW)]
 		written, errno := linux.write(linux.Fd(fd), chunk)
 		if errno != .NONE {
-			return n, os.Errno(errno)
+			return n, os.Error(errno)
 		}
 		n += written
 	}

--- a/core/prof/spall/spall_linux.odin
+++ b/core/prof/spall/spall_linux.odin
@@ -12,19 +12,19 @@ MAX_RW :: 0x7fffffff
 @(no_instrumentation)
 _write :: proc "contextless" (fd: os.Handle, data: []byte) -> (n: int, err: os.Error) #no_bounds_check /* bounds check would segfault instrumentation */ {
 	if len(data) == 0 {
-		return 0, os.ERROR_NONE
+		return 0, nil
 	}
 	
 	for n < len(data) {
 		chunk := data[:min(len(data), MAX_RW)]
 		written, errno := linux.write(linux.Fd(fd), chunk)
-		if errno != .NONE {
-			return n, os.Error(errno)
+		if errno != nil {
+			return n, os.Platform_Error(errno)
 		}
 		n += written
 	}
 
-	return n, os.ERROR_NONE
+	return n, nil
 }
 
 CLOCK_MONOTONIC_RAW :: 4 // NOTE(tetra): "RAW" means: Not adjusted by NTP.

--- a/core/prof/spall/spall_unix.odin
+++ b/core/prof/spall/spall_unix.odin
@@ -22,29 +22,24 @@ foreign libc {
 	@(link_name="clock_gettime") _unix_clock_gettime :: proc(clock_id: u64, timespec: ^timespec) -> i32 ---
 }
 
-@(no_instrumentation)
-get_last_error :: proc "contextless" () -> os.Platform_Error {
-	return os.Platform_Error(__error()^)
-}
-
 MAX_RW :: 0x7fffffff
 
 @(no_instrumentation)
 _write :: proc "contextless" (fd: os.Handle, data: []byte) -> (n: int, err: os.Error) #no_bounds_check /* bounds check would segfault instrumentation */ {
 	if len(data) == 0 {
-		return 0, os.ERROR_NONE
+		return 0, nil
 	}
 
 	for n < len(data) {
 		chunk := data[:min(len(data), MAX_RW)]
 		written := _unix_write(fd, raw_data(chunk), len(chunk))
 		if written < 0 {
-			return n, os.Error(get_last_error())
+			return n, os.get_last_error()
 		}
 		n += written
 	}
 
-	return n, os.ERROR_NONE
+	return n, nil
 }
 
 CLOCK_MONOTONIC_RAW :: 4 // NOTE(tetra): "RAW" means: Not adjusted by NTP.

--- a/core/prof/spall/spall_unix.odin
+++ b/core/prof/spall/spall_unix.odin
@@ -30,7 +30,7 @@ get_last_error :: proc "contextless" () -> os.Platform_Error {
 MAX_RW :: 0x7fffffff
 
 @(no_instrumentation)
-_write :: proc "contextless" (fd: os.Handle, data: []byte) -> (n: int, err: os.Errno) #no_bounds_check /* bounds check would segfault instrumentation */ {
+_write :: proc "contextless" (fd: os.Handle, data: []byte) -> (n: int, err: os.Error) #no_bounds_check /* bounds check would segfault instrumentation */ {
 	if len(data) == 0 {
 		return 0, os.ERROR_NONE
 	}
@@ -39,7 +39,7 @@ _write :: proc "contextless" (fd: os.Handle, data: []byte) -> (n: int, err: os.E
 		chunk := data[:min(len(data), MAX_RW)]
 		written := _unix_write(fd, raw_data(chunk), len(chunk))
 		if written < 0 {
-			return n, os.Errno(get_last_error())
+			return n, os.Error(get_last_error())
 		}
 		n += written
 	}

--- a/core/prof/spall/spall_unix.odin
+++ b/core/prof/spall/spall_unix.odin
@@ -23,8 +23,8 @@ foreign libc {
 }
 
 @(no_instrumentation)
-get_last_error :: proc "contextless" () -> int {
-	return int(__error()^)
+get_last_error :: proc "contextless" () -> os.Platform_Error {
+	return os.Platform_Error(__error()^)
 }
 
 MAX_RW :: 0x7fffffff

--- a/core/prof/spall/spall_windows.odin
+++ b/core/prof/spall/spall_windows.odin
@@ -10,7 +10,7 @@ import win32 "core:sys/windows"
 MAX_RW :: 1<<30
 
 @(no_instrumentation)
-_write :: proc "contextless" (fd: os.Handle, data: []byte) -> (int, os.Errno) #no_bounds_check /* bounds check would segfault instrumentation */ {
+_write :: proc "contextless" (fd: os.Handle, data: []byte) -> (int, os.Error) #no_bounds_check /* bounds check would segfault instrumentation */ {
 	if len(data) == 0 {
 		return 0, os.ERROR_NONE
 	}

--- a/core/prof/spall/spall_windows.odin
+++ b/core/prof/spall/spall_windows.odin
@@ -25,7 +25,7 @@ _write :: proc "contextless" (fd: os.Handle, data: []byte) -> (int, os.Errno) #n
 
 		e := win32.WriteFile(win32.HANDLE(fd), &data[total_write], to_write, &single_write_length, nil)
 		if single_write_length <= 0 || !e {
-			err := os.Errno(win32.GetLastError())
+			err := os.Platform_Error(win32.GetLastError())
 			return int(total_write), err
 		}
 		total_write += i64(single_write_length)

--- a/core/prof/spall/spall_windows.odin
+++ b/core/prof/spall/spall_windows.odin
@@ -12,7 +12,7 @@ MAX_RW :: 1<<30
 @(no_instrumentation)
 _write :: proc "contextless" (fd: os.Handle, data: []byte) -> (int, os.Error) #no_bounds_check /* bounds check would segfault instrumentation */ {
 	if len(data) == 0 {
-		return 0, os.ERROR_NONE
+		return 0, nil
 	}
 
 	single_write_length: win32.DWORD
@@ -25,12 +25,11 @@ _write :: proc "contextless" (fd: os.Handle, data: []byte) -> (int, os.Error) #n
 
 		e := win32.WriteFile(win32.HANDLE(fd), &data[total_write], to_write, &single_write_length, nil)
 		if single_write_length <= 0 || !e {
-			err := os.Platform_Error(win32.GetLastError())
-			return int(total_write), err
+			return int(total_write), os.get_last_error()
 		}
 		total_write += i64(single_write_length)
 	}
-	return int(total_write), os.ERROR_NONE
+	return int(total_write), nil
 }
 
 @(no_instrumentation)

--- a/core/sync/futex_haiku.odin
+++ b/core/sync/futex_haiku.odin
@@ -2,7 +2,6 @@
 package sync
 
 import "core:c"
-import "base:runtime"
 import "core:sys/haiku"
 import "core:sys/unix"
 import "core:time"
@@ -86,10 +85,10 @@ _futex_wait :: proc "contextless" (f: ^Futex, expect: u32) -> (ok: bool) {
 	waiter.prev.next = waiter.next
 	waiter.next.prev = waiter.prev
 
- 	unix.pthread_sigmask(haiku.SIG_SETMASK, &old_mask, nil)
+	_ = unix.pthread_sigmask(haiku.SIG_SETMASK, &old_mask, nil)
 
  	// FIXME: Add error handling!
- 	return
+	return
 }
 
 _futex_wait_with_timeout :: proc "contextless" (f: ^Futex, expect: u32, duration: time.Duration) -> (ok: bool) {
@@ -133,10 +132,10 @@ _futex_wait_with_timeout :: proc "contextless" (f: ^Futex, expect: u32, duration
 	waiter.prev.next = waiter.next
 	waiter.next.prev = waiter.prev
 
- 	unix.pthread_sigmask(haiku.SIG_SETMASK, &old_mask, nil)
+	unix.pthread_sigmask(haiku.SIG_SETMASK, &old_mask, nil)
 
- 	// FIXME: Add error handling!
- 	return 
+	// FIXME: Add error handling!
+	return
 }
 
 _futex_signal :: proc "contextless" (f: ^Futex) {

--- a/core/sys/haiku/os.odin
+++ b/core/sys/haiku/os.odin
@@ -399,7 +399,7 @@ cpu_topology_node_info :: struct {
 		},
 		_package: struct {
 			vendor:          cpu_vendor,
-			cache_line_size: u32
+			cache_line_size: u32,
 		},
 		_core: struct {
 			model:             u32,

--- a/core/sys/wasm/wasi/wasi_api.odin
+++ b/core/sys/wasm/wasi/wasi_api.odin
@@ -16,6 +16,7 @@ CLOCK_REALTIME           :: clockid_t(2)
 CLOCK_THREAD_CPUTIME_ID  :: clockid_t(3)
 
 errno_t :: enum u16 {
+	NONE = 0,
 	// No error occurred. System call completed successfully.
 	SUCCESS = 0,
 	// Argument list too long.

--- a/core/testing/runner.odin
+++ b/core/testing/runner.odin
@@ -868,8 +868,8 @@ To partly mitigate this, redirect STDERR to a file or use the -define:ODIN_TEST_
 		when ODIN_OS != .Windows {
 			mode = os.S_IRUSR|os.S_IWUSR|os.S_IRGRP|os.S_IROTH
 		}
-		json_fd, errno := os.open(JSON_REPORT, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
-		fmt.assertf(errno == os.ERROR_NONE, "unable to open file %q for writing of JSON report, error: %v", JSON_REPORT, errno)
+		json_fd, err := os.open(JSON_REPORT, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+		fmt.assertf(err == nil, "unable to open file %q for writing of JSON report, error: %v", JSON_REPORT, err)
 		defer os.close(json_fd)
 
 		for test, i in report.all_tests {

--- a/examples/demo/demo.odin
+++ b/examples/demo/demo.odin
@@ -359,7 +359,7 @@ control_flow :: proc() {
 
 		if false {
 			f, err := os.open("my_file.txt")
-			if err != os.ERROR_NONE {
+			if err != nil {
 				// handle error
 			}
 			defer os.close(f)

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -4463,6 +4463,7 @@ gb_internal void convert_to_typed(CheckerContext *c, Operand *operand, Type *tar
 		// as a kind of transition period
 		if (operand->mode == Addressing_Constant &&
 		    target_type->kind == Type_Named &&
+		    (c->pkg == nullptr || c->pkg->name != "os") &&
 		    target_type->Named.name == "Error") {
 			Entity *e = target_type->Named.type_name;
 			if (e->pkg && e->pkg->name == "os") {

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -127,6 +127,8 @@ gb_internal bool complete_soa_type(Checker *checker, Type *t, bool wait_to_finis
 
 gb_internal bool check_is_castable_to(CheckerContext *c, Operand *operand, Type *y);
 
+gb_internal bool is_exact_value_zero(ExactValue const &v);
+
 enum LoadDirectiveResult {
 	LoadDirective_Success  = 0,
 	LoadDirective_Error    = 1,
@@ -4364,6 +4366,25 @@ gb_internal void convert_to_typed(CheckerContext *c, Operand *operand, Type *tar
 	}
 
 	switch (t->kind) {
+	// IMPORTANT NOTE HACK(bill): This is just to allow for comparisons against `0` with the `os.Error` type
+	// as a kind of transition period
+	case Type_Enum:
+		if (operand->mode == Addressing_Constant &&
+		    target_type->kind == Type_Named &&
+		    target_type->Named.name == "Error") {
+			Entity *e = target_type->Named.type_name;
+			if (e->pkg && e->pkg->name == "os") {
+				if (is_exact_value_zero(operand->value)) {
+					check_is_expressible(c, operand, t);
+					if (operand->mode == Addressing_Invalid) {
+						return;
+					}
+					update_untyped_expr_value(c, operand->expr, operand->value);
+				}
+			}
+		}
+		break;
+
 	case Type_Basic:
 		if (operand->mode == Addressing_Constant) {
 			check_is_expressible(c, operand, t);

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -4461,7 +4461,8 @@ gb_internal void convert_to_typed(CheckerContext *c, Operand *operand, Type *tar
 	case Type_Union:
 		// IMPORTANT NOTE HACK(bill): This is just to allow for comparisons against `0` with the `os.Error` type
 		// as a kind of transition period
-		if (operand->mode == Addressing_Constant &&
+		if (!build_context.strict_style &&
+		    operand->mode == Addressing_Constant &&
 		    target_type->kind == Type_Named &&
 		    (c->pkg == nullptr || c->pkg->name != "os") &&
 		    target_type->Named.name == "Error") {

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -4470,7 +4470,10 @@ gb_internal void convert_to_typed(CheckerContext *c, Operand *operand, Type *tar
 				if (is_exact_value_zero(operand->value) &&
 				    (operand->value.kind == ExactValue_Integer ||
 				     operand->value.kind == ExactValue_Float)) {
-					update_untyped_expr_value(c, operand->expr, empty_exact_value);
+					operand->mode = Addressing_Value;
+					target_type = t_untyped_nil;
+				     	operand->value = empty_exact_value;
+					update_untyped_expr_value(c, operand->expr, operand->value);
 					break;
 				}
 			}

--- a/tests/core/flags/test_core_flags.odin
+++ b/tests/core/flags/test_core_flags.odin
@@ -1117,7 +1117,7 @@ test_os_handle :: proc(t: ^testing.T) {
 		// Delete the file now that we're done.
 		//
 		// This is not done all the time, just in case the file is useful to debugging.
-		testing.expect_value(t, os.remove(TEMPORARY_FILENAME), os.ERROR_NONE)
+		testing.expect_value(t, os.remove(TEMPORARY_FILENAME), nil)
 	}
 
 	TEMPORARY_FILENAME :: "test_core_flags_write_test_output_data"

--- a/tests/core/os/os.odin
+++ b/tests/core/os/os.odin
@@ -7,12 +7,12 @@ import "core:testing"
 
 @(test)
 read_dir :: proc(t: ^testing.T) {
-	fd, errno := os.open(#directory + "/dir")
-	testing.expect_value(t, errno, os.ERROR_NONE)
+	fd, err := os.open(#directory + "/dir")
+	testing.expect_value(t, err, nil)
 	defer os.close(fd)
 
-	dir, errno2 := os.read_dir(fd, -1)
-	testing.expect_value(t, errno2, os.ERROR_NONE)
+	dir, err2 := os.read_dir(fd, -1)
+	testing.expect_value(t, err2, nil)
 	defer os.file_info_slice_delete(dir)
 
 	slice.sort_by_key(dir, proc(fi: os.File_Info) -> string { return fi.name })

--- a/tests/documentation/documentation_tester.odin
+++ b/tests/documentation/documentation_tester.odin
@@ -439,7 +439,7 @@ main :: proc() {
 		}
 		save_path := fmt.tprintf("verify/test_%v_%v.odin", test.package_name, code_test_name)
 
-		test_file_handle, err := os.open(save_path, os.O_WRONLY | os.O_CREATE); if err != 0 {
+		test_file_handle, err := os.open(save_path, os.O_WRONLY | os.O_CREATE); if err != nil {
 			fmt.eprintf("We could not open the file to the path %q for writing\n", save_path)
 			g_bad_doc = true
 			continue


### PR DESCRIPTION
When `core:os/os2` is ready and stable, that will eventually replace `core:os`, however in the meantime, we should start to convert the error type in the current `core:os`.

`os.Errno` was extremely inconsistent across platforms and not necessarily even that useful. And since it was just an integer, it could not take advantage of constructs like `or_return` or `or_else`.

What this PR change does:

* `Errno :: Error` alias
* `Error` is a `union #shared_nil` of multiple different enums
* Errors split into `General_Error`, `runtime.Allocator_Error`, `io.Error`, and `Platform_Error`
* `Platform_Error` usually maps to the `core:sys/*` equivalent `enum` if it exists
* Convert a lot of uses of `os.ERROR_NONE` to just `nil`
* Convert `if err != nil` to `or_return` where possible an appropriate