### PR TITLE
Fix SIMD intrinsics wording

### DIFF
--- a/base/intrinsics/intrinsics.odin
+++ b/base/intrinsics/intrinsics.odin
@@ -303,11 +303,11 @@ simd_nearest :: proc(a: #simd[N]any_float) -> #simd[N]any_float ---
 
 simd_to_bits :: proc(v: #simd[N]T) -> #simd[N]Integer where size_of(T) == size_of(Integer), type_is_unsigned(Integer) ---
 
-// equivalent a swizzle with descending indices, e.g. reserve(a, 3, 2, 1, 0)
-simd_reverse :: proc(a: #simd[N]T) -> #simd[N]T ---
+// equivalent to a swizzle with descending indices, e.g. reserve(a, 3, 2, 1, 0)
+simd_lanes_reverse :: proc(a: #simd[N]T) -> #simd[N]T ---
 
-simd_rotate_left  :: proc(a: #simd[N]T, $offset: int) -> #simd[N]T ---
-simd_rotate_right :: proc(a: #simd[N]T, $offset: int) -> #simd[N]T ---
+simd_lanes_rotate_left  :: proc(a: #simd[N]T, $offset: int) -> #simd[N]T ---
+simd_lanes_rotate_right :: proc(a: #simd[N]T, $offset: int) -> #simd[N]T ---
 
 // Checks if the current target supports the given target features.
 //

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -1532,8 +1532,8 @@ gb_internal lbValue lb_build_builtin_simd_proc(lbProcedure *p, Ast *expr, TypeAn
 		{
 			char const *name = nullptr;
 			switch (builtin_id) {
-			case BuiltinProc_simd_reduce_any: name = "llvm.vector.reduce.and"; break;
-			case BuiltinProc_simd_reduce_all: name = "llvm.vector.reduce.or";  break;
+			case BuiltinProc_simd_reduce_any: name = "llvm.vector.reduce.or";  break;
+			case BuiltinProc_simd_reduce_all: name = "llvm.vector.reduce.and"; break;
 			}
 
 			LLVMTypeRef types[1] = { lb_type(p->module, arg0.type) };


### PR DESCRIPTION
I found 3 SIMD intrinsics were missing `_lanes` in their names by referencing the backend.

Additionally, `reduce_any` was using `and` instead of `or`. I swapped the two. Here's the new behavior, which made more sense to me:

```odin
package main

import "base:intrinsics"
import "core:fmt"

main :: proc() {
	{
		fmt.println("--- reduce any ---")
		val1: #simd[4]b32 = {false, false, false, false}
		val2: #simd[4]b32 = {true, false, false, false}
		val3: #simd[4]b32 = {true, true, true, true}

		fmt.printfln("%v\t%v", val1, intrinsics.simd_reduce_any(val1))
		fmt.printfln("%v\t%v", val2, intrinsics.simd_reduce_any(val2))
		fmt.printfln("%v\t%v", val3, intrinsics.simd_reduce_any(val3))
	}

	{
		fmt.println("--- reduce all ---")
		val1: #simd[4]b32 = {false, false, false, false}
		val2: #simd[4]b32 = {true, false, false, false}
		val3: #simd[4]b32 = {true, true, true, true}

		fmt.printfln("%v\t%v", val1, intrinsics.simd_reduce_all(val1))
		fmt.printfln("%v\t%v", val2, intrinsics.simd_reduce_all(val2))
		fmt.printfln("%v\t%v", val3, intrinsics.simd_reduce_all(val3))
	}
}
```

```
--- reduce any ---
<false, false, false, false>	false
<true, false, false, false>	true
<true, true, true, true>	true

--- reduce all ---
<false, false, false, false>	false
<true, false, false, false>	false
<true, true, true, true>	true
```