### PR TITLE
add debug build message and align more with build.bat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: debug
+all: default
 
 demo:
 	./odin run examples/demo/demo.odin -file
@@ -6,11 +6,17 @@ demo:
 report:
 	./odin report
 
+default:
+	PROGRAM=make ./build_odin.sh # debug
+
 debug:
 	./build_odin.sh debug
 
 release:
 	./build_odin.sh release
+
+release-native:
+	./build_odin.sh release-native
 
 release_native:
 	./build_odin.sh release-native

--- a/build_odin.sh
+++ b/build_odin.sh
@@ -144,12 +144,17 @@ build_odin() {
 }
 
 run_demo() {
-	./odin run examples/demo -vet -strict-style -- Hellope World
+	if [ $# -eq 0 ] || [ "$1" = "debug" ]; then
+		./odin run examples/demo -vet -strict-style -- Hellope World
+	fi
 }
 
 if [ $# -eq 0 ]; then
 	build_odin debug
 	run_demo
+
+	: ${PROGRAM:=$0}
+	echo "\nDebug compiler built. Note: run \"$PROGRAM release\" or \"$PROGRAM release-native\" if you want a faster, release mode compiler."
 elif [ $# -eq 1 ]; then
 	case $1 in
 	report)


### PR DESCRIPTION
1. if ran without choosing a build type (just `make` or `build_odin.sh`), print out a message about it being a debug build
2. Add `make release-native` alongside `make release_native` to align with `build_odin.sh release-native`
3. Only run the demo if it is a debug build (just like `build.bat`)