### PR TITLE
Core sys windows rawinput code

### DIFF
--- a/core/sys/windows/gdi32.odin
+++ b/core/sys/windows/gdi32.odin
@@ -28,7 +28,7 @@ foreign gdi32 {
 
 	SetPixelFormat :: proc(hdc: HDC, format: INT, ppfd: ^PIXELFORMATDESCRIPTOR) -> BOOL ---
 	ChoosePixelFormat :: proc(hdc: HDC, ppfd: ^PIXELFORMATDESCRIPTOR) -> INT ---
-	DescribePixelFormat :: proc(hdc: HDC, iPixelFormat: INT, nBytes: UINT, ppfd: ^PIXELFORMATDESCRIPTOR) -> INT ---	
+	DescribePixelFormat :: proc(hdc: HDC, iPixelFormat: INT, nBytes: UINT, ppfd: ^PIXELFORMATDESCRIPTOR) -> INT ---
 	SwapBuffers :: proc(hdc: HDC) -> BOOL ---
 
 	SetDCBrushColor :: proc(hdc: HDC, color: COLORREF) -> COLORREF ---

--- a/core/sys/windows/types.odin
+++ b/core/sys/windows/types.odin
@@ -2781,7 +2781,7 @@ CONTEXT :: struct {
 PCONTEXT :: ^CONTEXT
 LPCONTEXT :: ^CONTEXT
 
-when size_of(uintptr) == 32 { 
+when size_of(uintptr) == 32 {
 	XSAVE_FORMAT :: struct #align(16) {
 		ControlWord: WORD,
 		StatusWord: WORD,

--- a/core/sys/windows/user32.odin
+++ b/core/sys/windows/user32.odin
@@ -373,8 +373,9 @@ GET_XBUTTON_WPARAM :: #force_inline proc "contextless" (wParam: WPARAM) -> WORD 
 	return HIWORD(cast(DWORD)wParam)
 }
 
-GET_RAWINPUT_CODE_WPARAM :: #force_inline proc "contextless" (wParam: WPARAM) -> BYTE {
-	return BYTE(wParam) & 0xFF
+// Retrieves the input code from wParam in WM_INPUT message.
+GET_RAWINPUT_CODE_WPARAM :: #force_inline proc "contextless" (wParam: WPARAM) -> RAWINPUT_CODE {
+	return RAWINPUT_CODE(wParam & 0xFF)
 }
 
 MAKEINTRESOURCEW :: #force_inline proc "contextless" (#any_int i: int) -> LPWSTR {
@@ -397,6 +398,16 @@ DPI_AWARENESS_CONTEXT_SYSTEM_AWARE         :: DPI_AWARENESS_CONTEXT(~uintptr(1))
 DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE    :: DPI_AWARENESS_CONTEXT(~uintptr(2)) // -3
 DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 :: DPI_AWARENESS_CONTEXT(~uintptr(3)) // -4
 DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED    :: DPI_AWARENESS_CONTEXT(~uintptr(4)) // -5
+
+RAWINPUT_CODE :: enum {
+	// The input is in the regular message flow,
+	// the app is required to call DefWindowProc
+	// so that the system can perform clean ups.
+	RIM_INPUT       = 0,
+	// The input is sink only. The app is expected
+	// to behave nicely.
+	RIM_INPUTSINK   = 1,
+}
 
 RAWINPUTHEADER :: struct {
 	dwType: DWORD,

--- a/tests/core/sys/windows/test_user32.odin
+++ b/tests/core/sys/windows/test_user32.odin
@@ -1,0 +1,13 @@
+//+build windows
+package test_core_sys_windows
+
+import "core:testing"
+import win32 "core:sys/windows"
+
+@(test)
+verify_rawinput_code :: proc(t: ^testing.T) {
+	testing.expect_value(t, win32.GET_RAWINPUT_CODE_WPARAM(0), win32.RAWINPUT_CODE.RIM_INPUT)
+	testing.expect_value(t, win32.GET_RAWINPUT_CODE_WPARAM(1), win32.RAWINPUT_CODE.RIM_INPUTSINK)
+	testing.expect_value(t, win32.GET_RAWINPUT_CODE_WPARAM(0x100), win32.RAWINPUT_CODE.RIM_INPUT)
+	testing.expect_value(t, win32.GET_RAWINPUT_CODE_WPARAM(0x101), win32.RAWINPUT_CODE.RIM_INPUTSINK)
+}


### PR DESCRIPTION
Small fix for the GET_RAWINPUT_CODE_WPARAM "macro"