### PR TITLE
Allow testing for intentional leaks in test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,10 @@ jobs:
           gmake -C vendor/miniaudio/src
           ./odin check examples/all -vet -strict-style -disallow-do -target:netbsd_amd64
           ./odin check examples/all -vet -strict-style -disallow-do -target:netbsd_arm64
-          ./odin test tests/core/normal.odin -file -all-packages -define:ODIN_TEST_FANCY=false
-          ./odin test tests/core/speed.odin -file -all-packages -o:speed -define:ODIN_TEST_FANCY=false
-          ./odin test tests/vendor -all-packages -define:ODIN_TEST_FANCY=false
-          ./odin test tests/benchmark -all-packages -define:ODIN_TEST_FANCY=false
+          ./odin test tests/core/normal.odin -file -all-packages -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_LOG_LEVEL_MEMORY=fatal
+          ./odin test tests/core/speed.odin -file -all-packages -o:speed -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_LOG_LEVEL_MEMORY=fatal
+          ./odin test tests/vendor -all-packages -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_LOG_LEVEL_MEMORY=fatal
+          ./odin test tests/benchmark -all-packages -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_LOG_LEVEL_MEMORY=fatal
           (cd tests/issues; ./run.sh)
   build_freebsd:
     name: FreeBSD Build, Check, and Test
@@ -61,10 +61,10 @@ jobs:
           gmake -C vendor/cgltf/src
           gmake -C vendor/miniaudio/src
           ./odin check examples/all -vet -strict-style -disallow-do -target:freebsd_amd64
-          ./odin test tests/core/normal.odin -file -all-packages -define:ODIN_TEST_FANCY=false
-          ./odin test tests/core/speed.odin -file -all-packages -o:speed -define:ODIN_TEST_FANCY=false
-          ./odin test tests/vendor -all-packages -define:ODIN_TEST_FANCY=false
-          ./odin test tests/benchmark -all-packages -define:ODIN_TEST_FANCY=false
+          ./odin test tests/core/normal.odin -file -all-packages -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_LOG_LEVEL_MEMORY=fatal
+          ./odin test tests/core/speed.odin -file -all-packages -o:speed -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_LOG_LEVEL_MEMORY=fatal
+          ./odin test tests/vendor -all-packages -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_LOG_LEVEL_MEMORY=fatal
+          ./odin test tests/benchmark -all-packages -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_LOG_LEVEL_MEMORY=fatal
           (cd tests/issues; ./run.sh)
   ci:
     strategy:
@@ -118,15 +118,15 @@ jobs:
       - name: Odin check examples/all
         run: ./odin check examples/all -strict-style
       - name: Normal Core library tests
-        run: ./odin test tests/core/normal.odin -file -all-packages -define:ODIN_TEST_FANCY=false
+        run: ./odin test tests/core/normal.odin -file -all-packages -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_LOG_LEVEL_MEMORY=fatal
       - name: Optimized Core library tests
-        run: ./odin test tests/core/speed.odin -o:speed -file -all-packages -define:ODIN_TEST_FANCY=false
+        run: ./odin test tests/core/speed.odin -o:speed -file -all-packages -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_LOG_LEVEL_MEMORY=fatal
       - name: Vendor library tests
-        run: ./odin test tests/vendor -all-packages -define:ODIN_TEST_FANCY=false
+        run: ./odin test tests/vendor -all-packages -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_LOG_LEVEL_MEMORY=fatal
       - name: Internals tests
-        run: ./odin test tests/internal -all-packages -define:ODIN_TEST_FANCY=false
+        run: ./odin test tests/internal -all-packages -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_LOG_LEVEL_MEMORY=fatal
       - name: Core library benchmarks
-        run: ./odin test tests/benchmark -all-packages -define:ODIN_TEST_FANCY=false
+        run: ./odin test tests/benchmark -all-packages -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_LOG_LEVEL_MEMORY=fatal
       - name: GitHub Issue tests
         run: |
           cd tests/issues
@@ -190,28 +190,28 @@ jobs:
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
-          odin test tests/core/normal.odin -file -all-packages -define:ODIN_TEST_FANCY=false
+          odin test tests/core/normal.odin -file -all-packages -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_LOG_LEVEL_MEMORY=fatal
       - name: Optimized core library tests
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
-          odin test tests/core/speed.odin -o:speed -file -all-packages -define:ODIN_TEST_FANCY=false
+          odin test tests/core/speed.odin -o:speed -file -all-packages -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_LOG_LEVEL_MEMORY=fatal
       - name: Core library benchmarks
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
-          odin test tests/benchmark -all-packages -define:ODIN_TEST_FANCY=false
+          odin test tests/benchmark -all-packages -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_LOG_LEVEL_MEMORY=fatal
       - name: Vendor library tests
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
           copy vendor\lua\5.4\windows\*.dll .
-          odin test tests/vendor -all-packages -define:ODIN_TEST_FANCY=false
+          odin test tests/vendor -all-packages -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_LOG_LEVEL_MEMORY=fatal
       - name: Odin internals tests
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
-          odin test tests/internal -all-packages -define:ODIN_TEST_FANCY=false
+          odin test tests/internal -all-packages -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_LOG_LEVEL_MEMORY=fatal
       - name: Odin documentation tests
         shell: cmd
         run: |

--- a/core/testing/testing.odin
+++ b/core/testing/testing.odin
@@ -10,6 +10,7 @@ import "core:time"
 import "core:mem"
 
 _ :: reflect // alias reflect to nothing to force visibility for -vet
+_ :: mem     // in case TRACKING_MEMORY is not enabled
 
 // IMPORTANT NOTE: Compiler requires this layout
 Test_Signature :: proc(^T)

--- a/tests/core/compress/test_core_compress.odin
+++ b/tests/core/compress/test_core_compress.odin
@@ -87,12 +87,10 @@ shoco_test :: proc(t: ^testing.T) {
 	}
 
 	for v in Shoco_Tests {
-		when ODIN_OS == .Windows {
-			v := v
-			// Compressed source files are not encoded with carriage returns but git replaces raw files lf with crlf on commit (on windows only)
-			// So replace crlf with lf on windows
-			v.raw, _ = bytes.replace_all(v.raw, { 0xD, 0xA }, { 0xA })
-		}
+		v := v
+		// Compressed source files are not encoded with carriage returns but git replaces raw files lf with crlf on commit (on windows only)
+		// So replace crlf with lf on windows
+		v.raw, _ = bytes.replace_all(v.raw, { 0xD, 0xA }, { 0xA }, context.temp_allocator)
 
 		expected_raw        := len(v.raw)
 		expected_compressed := len(v.compressed)

--- a/tests/core/mem/test_mem_dynamic_pool.odin
+++ b/tests/core/mem/test_mem_dynamic_pool.odin
@@ -5,76 +5,91 @@ import "core:mem"
 
 
 expect_pool_allocation :: proc(t: ^testing.T, expected_used_bytes, num_bytes, alignment: int) {
-    pool: mem.Dynamic_Pool
-    mem.dynamic_pool_init(pool = &pool, alignment = alignment)
-    pool_allocator := mem.dynamic_pool_allocator(&pool)
+	pool: mem.Dynamic_Pool
+	mem.dynamic_pool_init(pool = &pool, alignment = alignment)
+	pool_allocator := mem.dynamic_pool_allocator(&pool)
 
-    element, err := mem.alloc(num_bytes, alignment, pool_allocator)
-    testing.expect(t, err == .None)
-    testing.expect(t, element != nil)
+	element, err := mem.alloc(num_bytes, alignment, pool_allocator)
+	testing.expect(t, err == .None)
+	testing.expect(t, element != nil)
 
-    expected_bytes_left := pool.block_size - expected_used_bytes
-    testing.expectf(t, pool.bytes_left == expected_bytes_left,
-        `
-        Allocated data with size %v bytes, expected %v bytes left, got %v bytes left, off by %v bytes.
-        Pool:
-        block_size = %v
-        out_band_size = %v
-        alignment = %v
-        unused_blocks = %v
-        used_blocks = %v
-        out_band_allocations = %v
-        current_block = %v
-        current_pos = %v
-        bytes_left = %v
-        `,
-        num_bytes, expected_bytes_left, pool.bytes_left, expected_bytes_left - pool.bytes_left,
-        pool.block_size,
-        pool.out_band_size,
-        pool.alignment,
-        pool.unused_blocks,
-        pool.used_blocks,
-        pool.out_band_allocations,
-        pool.current_block,
-        pool.current_pos,
-        pool.bytes_left,
-    )
+	expected_bytes_left := pool.block_size - expected_used_bytes
+	testing.expectf(t, pool.bytes_left == expected_bytes_left,
+		`
+		Allocated data with size %v bytes, expected %v bytes left, got %v bytes left, off by %v bytes.
+		Pool:
+		block_size = %v
+		out_band_size = %v
+		alignment = %v
+		unused_blocks = %v
+		used_blocks = %v
+		out_band_allocations = %v
+		current_block = %v
+		current_pos = %v
+		bytes_left = %v
+		`,
+		num_bytes, expected_bytes_left, pool.bytes_left, expected_bytes_left - pool.bytes_left,
+		pool.block_size,
+		pool.out_band_size,
+		pool.alignment,
+		pool.unused_blocks,
+		pool.used_blocks,
+		pool.out_band_allocations,
+		pool.current_block,
+		pool.current_pos,
+		pool.bytes_left,
+	)
 
-    mem.dynamic_pool_destroy(&pool)
-    testing.expect(t, pool.used_blocks == nil)
+	mem.dynamic_pool_destroy(&pool)
+	testing.expect(t, pool.used_blocks == nil)
 }
 
 expect_pool_allocation_out_of_band :: proc(t: ^testing.T, num_bytes, out_band_size: int) {
-    testing.expect(t, num_bytes >= out_band_size, "Sanity check failed, your test call is flawed! Make sure that num_bytes >= out_band_size!")
+	testing.expect(t, num_bytes >= out_band_size, "Sanity check failed, your test call is flawed! Make sure that num_bytes >= out_band_size!")
 
-    pool: mem.Dynamic_Pool
-    mem.dynamic_pool_init(pool = &pool, out_band_size = out_band_size)
-    pool_allocator := mem.dynamic_pool_allocator(&pool)
+	pool: mem.Dynamic_Pool
+	mem.dynamic_pool_init(pool = &pool, out_band_size = out_band_size)
+	pool_allocator := mem.dynamic_pool_allocator(&pool)
 
-    element, err := mem.alloc(num_bytes, allocator = pool_allocator)
-    testing.expect(t, err == .None)
-    testing.expect(t, element != nil)
-    testing.expectf(t, pool.out_band_allocations != nil,
-        "Allocated data with size %v bytes, which is >= out_of_band_size and it should be in pool.out_band_allocations, but isn't!",
-    )
+	element, err := mem.alloc(num_bytes, allocator = pool_allocator)
+	testing.expect(t, err == .None)
+	testing.expect(t, element != nil)
+	testing.expectf(t, pool.out_band_allocations != nil,
+		"Allocated data with size %v bytes, which is >= out_of_band_size and it should be in pool.out_band_allocations, but isn't!",
+	)
 
-    mem.dynamic_pool_destroy(&pool)
-    testing.expect(t, pool.out_band_allocations == nil)
+	mem.dynamic_pool_destroy(&pool)
+	testing.expect(t, pool.out_band_allocations == nil)
 }
 
 @(test)
 test_dynamic_pool_alloc_aligned :: proc(t: ^testing.T) {
-    expect_pool_allocation(t, expected_used_bytes = 16, num_bytes = 16, alignment=8)
+	expect_pool_allocation(t, expected_used_bytes = 16, num_bytes = 16, alignment=8)
 }
 
 @(test)
 test_dynamic_pool_alloc_unaligned :: proc(t: ^testing.T) {
-    expect_pool_allocation(t, expected_used_bytes =   8,   num_bytes=1, alignment=8)
-    expect_pool_allocation(t, expected_used_bytes =   16,  num_bytes=9, alignment=8)
+	expect_pool_allocation(t, expected_used_bytes =   8,   num_bytes=1, alignment=8)
+	expect_pool_allocation(t, expected_used_bytes =   16,  num_bytes=9, alignment=8)
 }
 
 @(test)
 test_dynamic_pool_alloc_out_of_band :: proc(t: ^testing.T) {
-    expect_pool_allocation_out_of_band(t, num_bytes = 128, out_band_size = 128)
-    expect_pool_allocation_out_of_band(t, num_bytes = 129, out_band_size = 128)
+	expect_pool_allocation_out_of_band(t, num_bytes = 128, out_band_size = 128)
+	expect_pool_allocation_out_of_band(t, num_bytes = 129, out_band_size = 128)
+}
+
+@(test)
+test_intentional_leaks :: proc(t: ^testing.T) {
+	testing.expect_leaks(t, intentionally_leaky_test, leak_verifier)
+}
+
+// Not tagged with @(test) because it's run through `test_intentional_leaks`
+intentionally_leaky_test :: proc(t: ^testing.T) {
+	a: [dynamic]int
+	append(&a, 42)
+}
+
+leak_verifier :: proc(t: ^testing.T, ta: ^mem.Tracking_Allocator) {
+	testing.expect_value(t, len(ta.allocation_map), 1)
 }

--- a/tests/core/mem/test_mem_dynamic_pool.odin
+++ b/tests/core/mem/test_mem_dynamic_pool.odin
@@ -87,9 +87,15 @@ test_intentional_leaks :: proc(t: ^testing.T) {
 // Not tagged with @(test) because it's run through `test_intentional_leaks`
 intentionally_leaky_test :: proc(t: ^testing.T) {
 	a: [dynamic]int
+	// Intentional leak
 	append(&a, 42)
+
+	// Intentional bad free
+	b := uintptr(&a[0]) + 42
+	free(rawptr(b))
 }
 
 leak_verifier :: proc(t: ^testing.T, ta: ^mem.Tracking_Allocator) {
 	testing.expect_value(t, len(ta.allocation_map), 1)
+	testing.expect_value(t, len(ta.bad_free_array), 1)
 }


### PR DESCRIPTION
Adds `expect_leak_or_bad_free :: proc(t: ^T, client_test: proc(t: ^T), verifier: Memory_Verifier_Proc)`.

It sets up its own `Tracking_Allocator`, runs the `client_test`, and then calls the `verifier` procedure.
The verifier can then inspect the contents of the tracking allocator and call `testing.expect*` as sensible for the test in question.

Any allocations are then cleared so that the test runner doesn't itself complain about leaks.

Additionally, `ODIN_TEST_LOG_LEVEL_MEMORY` has been added as a define to set the severity of the test runner's memory tracker. You can use `-define:ODIN_TEST_LOG_LEVEL_MEMORY=error` to make tests fail rather than warn if leaks or bad frees have been found.