### PR TITLE
Fix `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,6 @@ bld/
 [Oo]bj/
 [Ll]og/
 ![Cc]ore/[Ll]og/
-tests/documentation/verify/
-tests/documentation/all.odin-doc
 # Visual Studio 2015 cache/options directory
 .vs/
 # Visual Studio Code options directory

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 [Rr]eleases/
 x64/
 x86/
+!/core/simd/x86
 bld/
 [Bb]in/
 [Oo]bj/
@@ -31,7 +32,6 @@ tests/documentation/all.odin-doc
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 demo
-benchmark
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,19 @@
+# Ignore all files.
+*
+
+# Un-ignore all directories.
+!*/
+
+# Un-ignore files with an extension.
+#
+# In conjunction with the first two rules, this should catch extensionless
+# binaries on the UNIX-like platforms.
+!*.*
+
+# But remember to ignore executables with an extension.
+*.exe
+*.bin
+
+# Ignore documentation-related files.
+/documentation/verify/
+/documentation/all.odin-doc


### PR DESCRIPTION
I'm not familiar enough with non-UNIX build systems to suggest what to do about the lines around the all-encompassing `x86/` (or if they're even relevant anymore), but this change at least lets me make modifications to `core:simd/x86` and `tests/benchmark` without complaints from `git`.