### PR TITLE
re-enable some wasm things in runtime

### DIFF
--- a/base/runtime/internal.odin
+++ b/base/runtime/internal.odin
@@ -8,10 +8,9 @@ IS_WASM :: ODIN_ARCH == .wasm32 || ODIN_ARCH == .wasm64p32
 
 @(private)
 RUNTIME_LINKAGE :: "strong" when (
-	(ODIN_USE_SEPARATE_MODULES || 
+	ODIN_USE_SEPARATE_MODULES || 
 	ODIN_BUILD_MODE == .Dynamic ||
-	!ODIN_NO_CRT) &&
-	!IS_WASM) else "internal"
+	!ODIN_NO_CRT) else "internal"
 RUNTIME_REQUIRE :: false // !ODIN_TILDE
 
 @(private)
@@ -879,9 +878,6 @@ extendhfsf2 :: proc "c" (value: __float16) -> f32 {
 
 @(link_name="__floattidf", linkage=RUNTIME_LINKAGE, require=RUNTIME_REQUIRE)
 floattidf :: proc "c" (a: i128) -> f64 {
-when IS_WASM {
-	return 0
-} else {
 	DBL_MANT_DIG :: 53
 	if a == 0 {
 		return 0.0
@@ -921,14 +917,10 @@ when IS_WASM {
 	fb[0] = u32(a)                           // mantissa-low
 	return transmute(f64)fb
 }
-}
 
 
 @(link_name="__floattidf_unsigned", linkage=RUNTIME_LINKAGE, require=RUNTIME_REQUIRE)
 floattidf_unsigned :: proc "c" (a: u128) -> f64 {
-when IS_WASM {
-	return 0
-} else {
 	DBL_MANT_DIG :: 53
 	if a == 0 {
 		return 0.0
@@ -965,7 +957,6 @@ when IS_WASM {
 	        u32((u64(a) >> 32) & 0x000FFFFF) // mantissa-high
 	fb[0] = u32(a)                           // mantissa-low
 	return transmute(f64)fb
-}
 }
 
 


### PR DESCRIPTION
No idea why the floattidf procs are bodged to return 0, does somebody know? I have just enabled the original codepath, if nobody knows I suggest just enabling it and see if we get complaints, it works on all wasm stuff I tried.

The linkage being set to "internal" instead of "strong" is actually causing problems in my projects which is what prompted looking at this in the first place, some of these functions were actually needed but not added/used because they had internal linkage. This only happens on bigger projects (or just when using f16?).

Unfortunately `git blame` gave me this generic commit: https://github.com/odin-lang/Odin/commit/94bad4d7861c78b9e7191ec0c3114861a1536d5c of @gingerBill 