### PR TITLE
Vectorize `base:runtime.memory_*`

### DIFF
--- a/base/runtime/internal.odin
+++ b/base/runtime/internal.odin
@@ -238,65 +238,6 @@ memory_equal :: proc "contextless" (x, y: rawptr, n: int) -> bool {
 		}
 	}
 	return true
-	
-/*
-
-	when size_of(uint) == 8 {
-		if word_length := length >> 3; word_length != 0 {
-			for _ in 0..<word_length {
-				if intrinsics.unaligned_load((^u64)(a)) != intrinsics.unaligned_load((^u64)(b)) {
-					return false
-				}
-				a = a[size_of(u64):]
-				b = b[size_of(u64):]
-			}
-		}
-		
-		if length & 4 != 0 {
-			if intrinsics.unaligned_load((^u32)(a)) != intrinsics.unaligned_load((^u32)(b)) {
-				return false
-			}
-			a = a[size_of(u32):]
-			b = b[size_of(u32):]
-		}
-		
-		if length & 2 != 0 {
-			if intrinsics.unaligned_load((^u16)(a)) != intrinsics.unaligned_load((^u16)(b)) {
-				return false
-			}
-			a = a[size_of(u16):]
-			b = b[size_of(u16):]
-		}
-		
-		if length & 1 != 0 && a[0] != b[0] {
-			return false	
-		}
-		return true
-	} else {
-		if word_length := length >> 2; word_length != 0 {
-			for _ in 0..<word_length {
-				if intrinsics.unaligned_load((^u32)(a)) != intrinsics.unaligned_load((^u32)(b)) {
-					return false
-				}
-				a = a[size_of(u32):]
-				b = b[size_of(u32):]
-			}
-		}
-		
-		length &= 3
-		
-		if length != 0 {
-			for i in 0..<length {
-				if a[i] != b[i] {
-					return false
-				}
-			}
-		}
-
-		return true
-	}
-*/
-
 }
 memory_compare :: proc "contextless" (a, b: rawptr, n: int) -> int #no_bounds_check {
 	switch {

--- a/base/runtime/internal.odin
+++ b/base/runtime/internal.odin
@@ -16,6 +16,11 @@ RUNTIME_REQUIRE :: false // !ODIN_TILDE
 @(private)
 __float16 :: f16 when __ODIN_LLVM_F16_SUPPORTED else u16
 
+SIMD_IS_EMULATED :: true when (ODIN_ARCH == .amd64 || ODIN_ARCH == .i386) && !intrinsics.has_target_feature("sse2") else
+	true when (ODIN_ARCH == .arm64 || ODIN_ARCH == .arm32) && !intrinsics.has_target_feature("neon") else
+	true when (ODIN_ARCH == .wasm64p32 || ODIN_ARCH == .wasm32) && !intrinsics.has_target_feature("simd128") else
+	true when (ODIN_ARCH == .riscv64) && !intrinsics.has_target_feature("v") else
+	false
 
 @(private)
 byte_slice :: #force_inline proc "contextless" (data: rawptr, len: int) -> []byte #no_bounds_check {

--- a/core/bytes/bytes.odin
+++ b/core/bytes/bytes.odin
@@ -350,7 +350,7 @@ index_byte :: proc "contextless" (s: []byte, c: byte) -> (index: int) #no_bounds
 	}
 
 	c_vec: simd.u8x16 = c
-	when !simd.IS_EMULATED {
+	when simd.HAS_HARDWARE_SIMD {
 		// Note: While this is something that could also logically take
 		// advantage of AVX512, the various downclocking and power
 		// consumption related woes make premature to have a dedicated
@@ -485,7 +485,7 @@ last_index_byte :: proc "contextless" (s: []byte, c: byte) -> int #no_bounds_che
 	}
 
 	c_vec: simd.u8x16 = c
-	when !simd.IS_EMULATED {
+	when simd.HAS_HARDWARE_SIMD {
 		// Note: While this is something that could also logically take
 		// advantage of AVX512, the various downclocking and power
 		// consumption related woes make premature to have a dedicated

--- a/core/crypto/_chacha20/simd128/chacha20_simd128.odin
+++ b/core/crypto/_chacha20/simd128/chacha20_simd128.odin
@@ -39,7 +39,7 @@ when ODIN_ARCH == .arm64 || ODIN_ARCH == .arm32 {
 
 // Some targets lack runtime feature detection, and will flat out refuse
 // to load binaries that have unknown instructions.  This is distinct from
-// `simd.IS_EMULATED` as actually good designs support runtime feature
+// `simd.HAS_HARDWARE_SIMD` as actually good designs support runtime feature
 // detection and that constant establishes a baseline.
 //
 // See:

--- a/core/simd/simd.odin
+++ b/core/simd/simd.odin
@@ -26,12 +26,12 @@ import "base:runtime"
 /*
 Check if SIMD is software-emulated on a target platform.
 
-This value is `false`, when the compile-time target has the hardware support for
-at 128-bit (or wider) SIMD. If the compile-time target lacks the hardware support
-for 128-bit SIMD, this value is `true`, and all SIMD operations will likely be
+This value is `true`, when the compile-time target has the hardware support for
+at least 128-bit (or wider) SIMD. If the compile-time target lacks the hardware support
+for 128-bit SIMD, this value is `false`, and all SIMD operations will likely be
 emulated.
 */
-IS_EMULATED :: runtime.SIMD_IS_EMULATED
+HAS_HARDWARE_SIMD :: runtime.HAS_HARDWARE_SIMD
 
 /*
 Vector of 16 `u8` lanes (128 bits).

--- a/core/simd/simd.odin
+++ b/core/simd/simd.odin
@@ -21,6 +21,7 @@ package simd
 
 import "base:builtin"
 import "base:intrinsics"
+import "base:runtime"
 
 /*
 Check if SIMD is software-emulated on a target platform.
@@ -30,11 +31,7 @@ at 128-bit (or wider) SIMD. If the compile-time target lacks the hardware suppor
 for 128-bit SIMD, this value is `true`, and all SIMD operations will likely be
 emulated.
 */
-IS_EMULATED :: true when (ODIN_ARCH == .amd64 || ODIN_ARCH == .i386) && !intrinsics.has_target_feature("sse2") else
-	true when (ODIN_ARCH == .arm64 || ODIN_ARCH == .arm32) && !intrinsics.has_target_feature("neon") else
-	true when (ODIN_ARCH == .wasm64p32 || ODIN_ARCH == .wasm32) && !intrinsics.has_target_feature("simd128") else
-	true when (ODIN_ARCH == .riscv64) && !intrinsics.has_target_feature("v") else
-	false
+IS_EMULATED :: runtime.SIMD_IS_EMULATED
 
 /*
 Vector of 16 `u8` lanes (128 bits).

--- a/tests/benchmark/bytes/benchmark_bytes.odin
+++ b/tests/benchmark/bytes/benchmark_bytes.odin
@@ -54,14 +54,15 @@ run_trial_size :: proc(p: proc "contextless" ([]u8, byte) -> int, size: int, idx
 
 	accumulator: int
 
-	for _ in 0..<runs {
-		start := time.now()
-		accumulator += p(data, 'z')
-		done := time.since(start)
-		timing += done
-	}
+	watch: time.Stopwatch
 
-	timing /= time.Duration(runs)
+	time.stopwatch_start(&watch)
+	for _ in 0..<runs {
+		accumulator += p(data, 'z')
+	}
+	time.stopwatch_stop(&watch)
+
+	timing = time.stopwatch_duration(watch)
 
 	log.debug(accumulator)
 	return

--- a/tests/benchmark/runtime/benchmark_runtime.odin
+++ b/tests/benchmark/runtime/benchmark_runtime.odin
@@ -1,0 +1,227 @@
+package benchmark_runtime
+
+import "base:runtime"
+import "core:fmt"
+import "core:log"
+import "core:testing"
+import "core:strings"
+import "core:text/table"
+import "core:time"
+
+RUNS_PER_SIZE :: 2500
+
+sizes := [?]int {
+	7, 8, 9,
+	15, 16, 17,
+	31, 32, 33,
+	63, 64, 65,
+	95, 96, 97,
+	128,
+	256,
+	512,
+	1024,
+	4096,
+	1024 * 1024,
+}
+
+// These are the normal, unoptimized algorithms.
+
+plain_memory_equal :: proc "contextless" (x, y: rawptr, n: int) -> bool {
+	switch {
+	case n == 0: return true
+	case x == y: return true
+	}
+	a, b := ([^]byte)(x), ([^]byte)(y)
+	length := uint(n)
+
+	for i := uint(0); i < length; i += 1 {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+plain_memory_compare :: proc "contextless" (a, b: rawptr, n: int) -> int #no_bounds_check {
+	switch {
+	case a == b:   return 0
+	case a == nil: return -1
+	case b == nil: return +1
+	}
+
+	x := uintptr(a)
+	y := uintptr(b)
+	n := uintptr(n)
+
+	SU :: size_of(uintptr)
+	fast := n/SU + 1
+	offset := (fast-1)*SU
+	curr_block := uintptr(0)
+	if n < SU {
+		fast = 0
+	}
+
+	for /**/; curr_block < fast; curr_block += 1 {
+		va := (^uintptr)(x + curr_block * size_of(uintptr))^
+		vb := (^uintptr)(y + curr_block * size_of(uintptr))^
+		if va ~ vb != 0 {
+			for pos := curr_block*SU; pos < n; pos += 1 {
+				a := (^byte)(x+pos)^
+				b := (^byte)(y+pos)^
+				if a ~ b != 0 {
+					return -1 if (int(a) - int(b)) < 0 else +1
+				}
+			}
+		}
+	}
+
+	for /**/; offset < n; offset += 1 {
+		a := (^byte)(x+offset)^
+		b := (^byte)(y+offset)^
+		if a ~ b != 0 {
+			return -1 if (int(a) - int(b)) < 0 else +1
+		}
+	}
+
+	return 0
+}
+
+plain_memory_compare_zero :: proc "contextless" (a: rawptr, n: int) -> int #no_bounds_check {
+	x := uintptr(a)
+	n := uintptr(n)
+
+	SU :: size_of(uintptr)
+	fast := n/SU + 1
+	offset := (fast-1)*SU
+	curr_block := uintptr(0)
+	if n < SU {
+		fast = 0
+	}
+
+	for /**/; curr_block < fast; curr_block += 1 {
+		va := (^uintptr)(x + curr_block * size_of(uintptr))^
+		if va ~ 0 != 0 {
+			for pos := curr_block*SU; pos < n; pos += 1 {
+				a := (^byte)(x+pos)^
+				if a ~ 0 != 0 {
+					return -1 if int(a) < 0 else +1
+				}
+			}
+		}
+	}
+
+	for /**/; offset < n; offset += 1 {
+		a := (^byte)(x+offset)^
+		if a ~ 0 != 0 {
+			return -1 if int(a) < 0 else +1
+		}
+	}
+
+	return 0
+}
+
+run_trial_size_cmp :: proc(p: proc "contextless" (rawptr, rawptr, int) -> $R, size: int, idx: int, runs: int, loc := #caller_location) -> (timing: time.Duration) {
+	left  := make([]u8, size)
+	right := make([]u8, size)
+	defer {
+		delete(left)
+		delete(right)
+	}
+
+	right[idx] = 0x01
+
+	accumulator: int
+
+	watch: time.Stopwatch
+
+	time.stopwatch_start(&watch)
+	for _ in 0..<runs {
+		result := p(&left[0], &right[0], size)
+		when R == bool {
+			assert(result == false, loc = loc)
+			accumulator += 1
+		} else when R == int {
+			assert(result == -1, loc = loc)
+			accumulator += result
+		}
+	}
+	time.stopwatch_stop(&watch)
+	timing = time.stopwatch_duration(watch)
+
+	log.debug(accumulator)
+	return
+}
+
+run_trial_size_zero :: proc(p: proc "contextless" (rawptr, int) -> int, size: int, idx: int, runs: int, loc := #caller_location) -> (timing: time.Duration) {
+	data := make([]u8, size)
+	defer delete(data)
+
+	data[idx] = 0x01
+
+	accumulator: int
+
+	watch: time.Stopwatch
+
+	time.stopwatch_start(&watch)
+	for _ in 0..<runs {
+		result := p(&data[0], size)
+		assert(result == 1, loc = loc)
+		accumulator += result
+	}
+	time.stopwatch_stop(&watch)
+	timing = time.stopwatch_duration(watch)
+
+	log.debug(accumulator)
+	return
+}
+
+run_trial_size :: proc {
+	run_trial_size_cmp,
+	run_trial_size_zero,
+}
+
+
+bench_table :: proc(algo_name: string, plain, simd: $P) {
+	string_buffer := strings.builder_make()
+	defer strings.builder_destroy(&string_buffer)
+
+	tbl: table.Table
+	table.init(&tbl)
+	defer table.destroy(&tbl)
+
+	table.aligned_header_of_values(&tbl, .Right, "Algorithm", "Size", "Iterations", "Scalar", "SIMD", "SIMD Relative (%)", "SIMD Relative (x)")
+
+	for size in sizes {
+		// Place the non-zero byte somewhere in the middle.
+		needle_index := size / 2
+
+		plain_timing := run_trial_size(plain, size, needle_index, RUNS_PER_SIZE)
+		simd_timing  := run_trial_size(simd,  size, needle_index, RUNS_PER_SIZE)
+
+		_plain := fmt.tprintf("%8M",  plain_timing)
+		_simd  := fmt.tprintf("%8M",  simd_timing)
+		_relp  := fmt.tprintf("%.3f %%", f64(simd_timing) / f64(plain_timing) * 100.0)
+		_relx  := fmt.tprintf("%.3f x",  1 / (f64(simd_timing) / f64(plain_timing)))
+
+		table.aligned_row_of_values(
+			&tbl,
+			.Right,
+			algo_name,
+			size, RUNS_PER_SIZE, _plain, _simd, _relp, _relx)
+	}
+
+	builder_writer := strings.to_writer(&string_buffer)
+
+	fmt.sbprintln(&string_buffer)
+	table.write_plain_table(builder_writer, &tbl)
+
+	my_table_string := strings.to_string(string_buffer)
+	log.info(my_table_string)
+}
+
+@test
+benchmark_memory_procs :: proc(t: ^testing.T) {
+	bench_table("memory_equal", plain_memory_equal, runtime.memory_equal)
+	bench_table("memory_compare", plain_memory_compare, runtime.memory_compare)
+	bench_table("memory_compare_zero", plain_memory_compare_zero, runtime.memory_compare_zero)
+}


### PR DESCRIPTION
The speedups here aren't as profound as with `index_byte`, but there are some noticeable improvements with larger data sizes.

I'm going to leave this as a draft to await feedback. I'm mostly interested to hear if this has any impact in real-world programs.

I want to note that the original `memory_compare*` procs had no notion of unaligned loads. Were we just getting by without checking for alignment somehow?

`odin test . -o:aggressive -disable-assert -no-bounds-check -define:ODIN_TEST_THREADS=1 -microarch:alderlake`
<details>
<summary>Plain results</summary>
<pre>
[INFO ] --- [2024-08-11 23:38:19] [runtime.odin:259:benchmark_plain_memory_compare_cold()]
        +++      15B | 101ns
        +++      16B | 127ns
        +++      17B | 45ns
        +++      31B | 56ns
        +++      32B | 49ns
        +++      33B | 45ns
        +++      63B | 69ns
        +++      64B | 62ns
        +++      65B | 36ns
        +++     256B | 64ns
        +++     512B | 78ns
        +++  1.00KiB | 99ns
        +++  1.00MiB | 90.804µs
        +++  1.00GiB | 73.176684ms
[INFO ] --- [2024-08-11 23:38:20] [runtime.odin:269:benchmark_plain_memory_compare_hot()]
        +++      15B | 26ns
        +++      16B | 19ns
        +++      17B | 21ns
        +++      31B | 20ns
        +++      32B | 16ns
        +++      33B | 17ns
        +++      63B | 25ns
        +++      64B | 19ns
        +++      65B | 18ns
        +++     256B | 23ns
        +++     512B | 36ns
        +++  1.00KiB | 47ns
        +++  1.00MiB | 38.926µs
        +++  1.00GiB | 73.154996ms
[INFO ] --- [2024-08-11 23:38:20] [runtime.odin:301:benchmark_plain_memory_compare_zero_cold()]
        +++      15B | 126ns
        +++      16B | 33ns
        +++      17B | 30ns
        +++      31B | 40ns
        +++      32B | 21ns
        +++      33B | 25ns
        +++      63B | 39ns
        +++      64B | 21ns
        +++      65B | 34ns
        +++     256B | 61ns
        +++     512B | 45ns
        +++  1.00KiB | 53ns
        +++  1.00MiB | 40.53µs
        +++  1.00GiB | 54.984574ms
[INFO ] --- [2024-08-11 23:38:21] [runtime.odin:311:benchmark_plain_memory_compare_zero_hot()]
        +++      15B | 15ns
        +++      16B | 17ns
        +++      17B | 21ns
        +++      31B | 21ns
        +++      32B | 16ns
        +++      33B | 23ns
        +++      63B | 22ns
        +++      64B | 18ns
        +++      65B | 18ns
        +++     256B | 26ns
        +++     512B | 39ns
        +++  1.00KiB | 52ns
        +++  1.00MiB | 36.948µs
        +++  1.00GiB | 54.865693ms
[INFO ] --- [2024-08-11 23:38:21] [runtime.odin:217:benchmark_plain_memory_equal_cold()]
        +++      15B | 192ns
        +++      16B | 40ns
        +++      17B | 59ns
        +++      31B | 36ns
        +++      32B | 40ns
        +++      33B | 21ns
        +++      63B | 38ns
        +++      64B | 36ns
        +++      65B | 32ns
        +++     256B | 75ns
        +++     512B | 126ns
        +++  1.00KiB | 224ns
        +++  1.00MiB | 226.184µs
        +++  1.00GiB | 240.402243ms
[INFO ] --- [2024-08-11 23:38:23] [runtime.odin:227:benchmark_plain_memory_equal_hot()]
        +++      15B | 21ns
        +++      16B | 22ns
        +++      17B | 22ns
        +++      31B | 31ns
        +++      32B | 28ns
        +++      33B | 24ns
        +++      63B | 35ns
        +++      64B | 32ns
        +++      65B | 30ns
        +++     256B | 69ns
        +++     512B | 122ns
        +++  1.00KiB | 228ns
        +++  1.00MiB | 214.525µs
        +++  1.00GiB | 237.592753ms
</pre>
</details>
<details>
<summary>SIMD results</summary>
<pre>
[INFO ] --- [2024-08-11 23:38:23] [runtime.odin:279:benchmark_simd_memory_compare_cold()]
        +++      15B | 90ns
        +++      16B | 31ns
        +++      17B | 46ns
        +++      31B | 47ns
        +++      32B | 47ns
        +++      33B | 50ns
        +++      63B | 47ns
        +++      64B | 36ns
        +++      65B | 38ns
        +++     256B | 62ns
        +++     512B | 46ns
        +++  1.00KiB | 43ns
        +++  1.00MiB | 50.884µs
        +++  1.00GiB | 62.515442ms
[INFO ] --- [2024-08-11 23:38:24] [runtime.odin:289:benchmark_simd_memory_compare_hot()]
        +++      15B | 34ns
        +++      16B | 24ns
        +++      17B | 23ns
        +++      31B | 33ns
        +++      32B | 24ns
        +++      33B | 33ns
        +++      63B | 37ns
        +++      64B | 20ns
        +++      65B | 19ns
        +++     256B | 25ns
        +++     512B | 25ns
        +++  1.00KiB | 35ns
        +++  1.00MiB | 29.662µs
        +++  1.00GiB | 62.706172ms
[INFO ] --- [2024-08-11 23:38:24] [runtime.odin:321:benchmark_simd_memory_compare_zero_cold()]
        +++      15B | 158ns
        +++      16B | 46ns
        +++      17B | 30ns
        +++      31B | 49ns
        +++      32B | 32ns
        +++      33B | 25ns
        +++      63B | 39ns
        +++      64B | 103ns
        +++      65B | 60ns
        +++     256B | 56ns
        +++     512B | 48ns
        +++  1.00KiB | 59ns
        +++  1.00MiB | 9.361µs
        +++  1.00GiB | 35.172623ms
[INFO ] --- [2024-08-11 23:38:24] [runtime.odin:331:benchmark_simd_memory_compare_zero_hot()]
        +++      15B | 32ns
        +++      16B | 25ns
        +++      17B | 23ns
        +++      31B | 31ns
        +++      32B | 24ns
        +++      33B | 24ns
        +++      63B | 34ns
        +++      64B | 34ns
        +++      65B | 32ns
        +++     256B | 33ns
        +++     512B | 33ns
        +++  1.00KiB | 37ns
        +++  1.00MiB | 8.932µs
        +++  1.00GiB | 34.838497ms
[INFO ] --- [2024-08-11 23:38:24] [runtime.odin:237:benchmark_simd_memory_equal_cold()]
        +++      15B | 181ns
        +++      16B | 50ns
        +++      17B | 51ns
        +++      31B | 35ns
        +++      32B | 32ns
        +++      33B | 25ns
        +++      63B | 37ns
        +++      64B | 42ns
        +++      65B | 33ns
        +++     256B | 52ns
        +++     512B | 23ns
        +++  1.00KiB | 40ns
        +++  1.00MiB | 45.397µs
        +++  1.00GiB | 62.699833ms
[INFO ] --- [2024-08-11 23:38:25] [runtime.odin:247:benchmark_simd_memory_equal_hot()]
        +++      15B | 30ns
        +++      16B | 27ns
        +++      17B | 24ns
        +++      31B | 29ns
        +++      32B | 31ns
        +++      33B | 34ns
        +++      63B | 36ns
        +++      64B | 12ns
        +++      65B | 16ns
        +++     256B | 23ns
        +++     512B | 23ns
        +++  1.00KiB | 30ns
        +++  1.00MiB | 47.923µs
        +++  1.00GiB | 62.565219ms
</pre>
</details>

---

Fixes #4405
Supercedes #4411