### PR TITLE
[fmt] Add bit fields to the pointer printing logic

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -2728,7 +2728,8 @@ fmt_value :: proc(fi: ^Info, v: any, verb: rune) {
 						}
 
 					case runtime.Type_Info_Struct,
-					     runtime.Type_Info_Union:
+					     runtime.Type_Info_Union,
+					     runtime.Type_Info_Bit_Field:
 						if ptr == nil {
 							io.write_string(fi.writer, "<nil>", &fi.n)
 							return


### PR DESCRIPTION
core:fmt prints pointers to structs as `&StructName{ ... }` but `bit_field`s are currently printed the same as rawptrs (`0xAABBCCDDEEFF` only).

This commit changes that so they behave the same as structs and unions.