### PR TITLE
fix vararg default values

### DIFF
--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -3725,10 +3725,7 @@ gb_internal lbValue lb_build_call_expr_internal(lbProcedure *p, Ast *expr) {
 		GB_ASSERT(args.count >= min_count);
 		for_array(arg_index, pt->params->Tuple.variables) {
 			Entity *e = pt->params->Tuple.variables[arg_index];
-			if (pt->variadic && arg_index == pt->variadic_index) {
-				if (!is_c_vararg && args[arg_index].value == 0) {
-					args[arg_index] = lb_const_nil(p->module, e->type);
-				}
+			if (pt->variadic && arg_index == pt->variadic_index && is_c_vararg) {
 				continue;
 			}
 

--- a/tests/internal/test_vararg.odin
+++ b/tests/internal/test_vararg.odin
@@ -1,0 +1,45 @@
+package test_internal
+
+import "core:testing"
+
+@(test)
+test_default_vararg :: proc(t: ^testing.T) {
+
+	no_default :: proc(t: ^testing.T, args: ..int) {
+		testing.expect_value(t, len(args), 0)
+	}
+	no_default(t)
+
+	no_default_overwritten :: proc(t: ^testing.T, args: ..int) {
+		testing.expect_value(t, len(args), 1)
+		testing.expect_value(t, args[0], 1)
+	}
+	no_default_overwritten(t, 1)
+
+	one_default :: proc(t: ^testing.T, args: ..int = {1}) {
+		testing.expect_value(t, len(args), 1)
+		testing.expect_value(t, args[0], 1)
+	}
+	one_default(t)
+
+	one_default_overwritten :: proc(t: ^testing.T, args: ..int = {1}) {
+		testing.expect_value(t, len(args), 0)
+	}
+	one_default_overwritten(t, ..[]int{})
+
+	more_defaults :: proc(t: ^testing.T, args: ..int = {1, 2, 3}) {
+		testing.expect_value(t, len(args), 3)
+		testing.expect_value(t, args[0], 1)
+		testing.expect_value(t, args[1], 2)
+		testing.expect_value(t, args[2], 3)
+	}
+	more_defaults(t)
+
+	more_defaults_overwritten :: proc(t: ^testing.T, args: ..int = {1, 2, 3}) {
+		testing.expect_value(t, len(args), 3)
+		testing.expect_value(t, args[0], 3)
+		testing.expect_value(t, args[1], 2)
+		testing.expect_value(t, args[2], 1)
+	}
+	more_defaults_overwritten(t, 3, 2, 1)
+}


### PR DESCRIPTION
Default values for varargs didn't work, no error but also no default value (always got `nil`). This simple change makes them work properly.
I could also see not allowing it at all, in which case #2977 would be a good merge.