### PR TITLE
fix os2.read_entire_file_from_file for files with known size

### DIFF
--- a/core/os/os2/file_util.odin
+++ b/core/os/os2/file_util.odin
@@ -133,22 +133,14 @@ read_entire_file_from_file :: proc(f: ^File, allocator: runtime.Allocator) -> (d
 		err = serr
 		return
 	}
-	size += 1 // for EOF
 
-	// TODO(bill): Is this correct logic?
 	if has_size {
-		total: int
 		data = make([]byte, size, allocator) or_return
-		for {
-			n: int
-			n, err = read(f, data[total:])
-			total += n
-			if err != nil {
-				if err == .EOF {
-					err = nil
-				}
-				data = data[:total]
-				return
+		n: int = ---
+		n, err = read(f, data[:])
+		if err != nil {
+			if err == .EOF {
+				err = nil
 			}
 		}
 	} else {
@@ -165,10 +157,11 @@ read_entire_file_from_file :: proc(f: ^File, allocator: runtime.Allocator) -> (d
 					err = nil
 				}
 				data = out_buffer[:total]
-				return
+				break
 			}
 		}
 	}
+	return
 }
 
 @(require_results)

--- a/core/os/os2/file_util.odin
+++ b/core/os/os2/file_util.odin
@@ -136,8 +136,7 @@ read_entire_file_from_file :: proc(f: ^File, allocator: runtime.Allocator) -> (d
 
 	if has_size {
 		data = make([]byte, size, allocator) or_return
-		n: int = ---
-		n, err = read(f, data[:])
+		_, err = read(f, data[:])
 		if err != nil {
 			if err == .EOF {
 				err = nil

--- a/core/os/os2/file_util.odin
+++ b/core/os/os2/file_util.odin
@@ -121,12 +121,16 @@ read_entire_file_from_file :: proc(f: ^File, allocator: runtime.Allocator) -> (d
 	size: int
 	has_size := true
 	if size64, serr := file_size(f); serr == nil {
-		if i64(int(size64)) != size64 {
+		if i64(int(size64)) == size64 {
 			size = int(size64)
+		} else {
+			err = .Unknown
+			return
 		}
 	} else if serr == .No_Size {
 		has_size = false
 	} else {
+		err = serr
 		return
 	}
 	size += 1 // for EOF


### PR DESCRIPTION
`os2.read_entire_file_from_file` has a couple of bugs when using a `os2.File` with a known size.
The size that is determined gets reset to 0, in case there is a problem with the OS's int type being too small then inconsistent is passed that leads to more problems.

In the next step, the code in the "known size" branch of the logic creates a loop that throws away useful data until an error occurs, so the "known size" branch can never succeed.

I haven't tested the "unknown size" branch yet, but so far, that one looks good to me, so there's probably still a bug.