### PR TITLE
fix error handling in os2.read_entire_file_from_file()

### DIFF
--- a/core/os/os2/file_util.odin
+++ b/core/os/os2/file_util.odin
@@ -126,6 +126,7 @@ read_entire_file_from_file :: proc(f: ^File, allocator: runtime.Allocator) -> (d
 			size = int(size64)
 		}
 	} else if serr != .No_Size {
+		err = serr
 		return
 	}
 


### PR DESCRIPTION
@laytan A small fix, since even when an error in file_size() happened, os2.ERROR_NONE was returned