### PR TITLE
Fix 'odin [run|test] --' giving a compiler out of bounds

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2973,13 +2973,19 @@ int main(int arg_count, char const **arg_ptr) {
 				break;
 			}
 		}
-		if(run_args_start_idx != -1) {
+		if (run_args_start_idx != -1) {
 			last_non_run_arg = run_args_start_idx;
+
+			if (run_args_start_idx == 2) {
+				// missing src path on argv[2], invocation: odin [run|test] --
+				usage(args[0]);
+				return 1;
+			}
+
 			for(isize i = run_args_start_idx+1; i < args.count; ++i) {
 				array_add(&run_args, args[i]);
 			}
 		}
-
 		args = array_slice(args, 0, last_non_run_arg);
 		run_args_string = string_join_and_quote(heap_allocator(), run_args);
 


### PR DESCRIPTION
`src/array.cpp(13): Assertion Failure: ``cast(usize)index < cast(usize)count`` Index 2 is out of bounds ranges 0..<2`

Fixes the following invocations (missing source path):
- `odin [run|test] --`
- `odin [run|test] -- [..ARGS]`

Replaces them both with a usage message