### PR TITLE
find_visual_studio_and_windows_sdk() now returns the newest available version of Visual Studio instead of the first found

### DIFF
--- a/src/microsoft_craziness.h
+++ b/src/microsoft_craziness.h
@@ -38,8 +38,8 @@
 //
 // I don't claim that this is the absolute best way to solve this problem,
 // and so far we punt on things (if you have multiple versions of Visual Studio
-// installed, we return the first one, rather than the newest). But it
-// will solve the basic problem for you as simply as I know how to do it,
+// installed, we return the newest one, which may not be compatible with Odin's codebase).
+// But it will solve the basic problem for you as simply as I know how to do it,
 // and because there isn't too much code here, it's easy to modify and expand.
 //
 //
@@ -388,7 +388,7 @@ gb_internal bool find_visual_studio_by_fighting_through_microsoft_craziness(Find
 		defer (instances->Release());
 
 		// First, find the newest Visual Studio version by looping through all existing instances.
-		int iNewestVersion = 0;
+		int vs_newest_version = 0;
 		for (;;) {
 			ULONG found = 0;
 			ISetupInstance *instance = NULL;
@@ -407,11 +407,12 @@ gb_internal bool find_visual_studio_by_fighting_through_microsoft_craziness(Find
 			if (success < 4) continue;
 
 			// We only interested in major version number.
-			if (i0 > iNewestVersion) {
-				iNewestVersion = i0;
+			if (i0 > vs_newest_version) {
+				vs_newest_version = i0;
 			}
 		}
 
+		// Reset the enumerator to start from the beginning.
 		instances->Reset();
 
 		// Now loop through all instances again to find the chosen version and read its properties.
@@ -432,7 +433,7 @@ gb_internal bool find_visual_studio_by_fighting_through_microsoft_craziness(Find
 			auto success = swscanf_s(inst_version_wide, L"%d.%d.%d.%d", &i0, &i1, &i2, &i3);
 			if (success < 4) continue;
 
-			if (i0 != iNewestVersion) {
+			if (i0 != vs_newest_version) {
 				// Skip until we find the newest version.
 				continue;
 			}


### PR DESCRIPTION
I have three versions of Visual Studio on my machine 2017, 2019 and 2022. The latest version of Odin dev-2024-08-nightly:8359995 was failing to build the simplest "hello world" program giving an error: 

libucrt.lib(checkcfg.obj) : error LNK2001: unresolved external symbol guard_check_icall$fo$
C:/Dev/Odin/dev/odin1.exe : fatal error LNK1120: 1 unresolved externals

 -print-linker-flags was showing following:
/LIBPATH:"C:/Program Files (x86)/Windows Kits/10/Lib/10.0.26100.0/um/x64" /LIBPATH:"C:/Program Files (x86)/Windows Kits/10/Lib/10.0.26100.0/ucrt/x64" /LIBPATH:"C:/Program Files (x86)/Microsoft Visual Studio/2017/Professional/VC/Tools/MSVC/14.16.27023/lib/x64" /ENTRY:mainCRTStartup /defaultlib:libcmt /NOIMPLIB /NOEXP /incremental:no /opt:ref /nologo /subsystem:CONSOLE /machine:x64    "kernel32.lib" 

Which is obviously picking the oldest version of Visual Studio. 
Inspecting the code I found that it returns the first Visual Studio that comes out of version enumeration. This fix is finding the newest version of Visual Studio instead and it fixed my linking problem.

I'm not sure if this is the right fix for linking problem I mentioned, maybe it should work with VS2017 in the first place.