### PR TITLE
(raygui) Restores vertical text alignment broken after 4.0 migration

### DIFF
--- a/vendor/raylib/raygui.odin
+++ b/vendor/raylib/raygui.odin
@@ -111,7 +111,7 @@ GuiDefaultProperty :: enum c.int {
 	BACKGROUND_COLOR,           // Background color
 	TEXT_LINE_SPACING,          // Text spacing between lines
 	TEXT_ALIGNMENT_VERTICAL,    // Text vertical alignment inside text bounds (after border and padding)
-	TEXT_WRAP_MODE              // Text wrap-mode inside text bounds
+	TEXT_WRAP_MODE,             // Text wrap-mode inside text bounds
 }
 
 // Label

--- a/vendor/raylib/raygui.odin
+++ b/vendor/raylib/raygui.odin
@@ -110,6 +110,8 @@ GuiDefaultProperty :: enum c.int {
 	LINE_COLOR,                 // Line control color
 	BACKGROUND_COLOR,           // Background color
 	TEXT_LINE_SPACING,          // Text spacing between lines
+	TEXT_ALIGNMENT_VERTICAL,    // Text vertical alignment inside text bounds (after border and padding)
+	TEXT_WRAP_MODE              // Text wrap-mode inside text bounds
 }
 
 // Label
@@ -163,11 +165,7 @@ GuiDropdownBoxProperty :: enum c.int {
 
 // TextBox/TextBoxMulti/ValueBox/Spinner
 GuiTextBoxProperty :: enum c.int {
-	TEXT_INNER_PADDING = 16,    // TextBox/TextBoxMulti/ValueBox/Spinner inner text padding
-	TEXT_LINES_SPACING,         // TextBoxMulti lines separation
-	TEXT_ALIGNMENT_VERTICAL,    // TextBoxMulti vertical alignment: 0-CENTERED, 1-UP, 2-DOWN
-	TEXT_MULTILINE,             // TextBox supports multiple lines
-	TEXT_WRAP_MODE,             // TextBox wrap mode for multiline: 0-NO_WRAP, 1-CHAR_WRAP, 2-WORD_WRAP
+	TEXT_READONLY = 16,         // TextBox in read-only mode: 0-text editable, 1-text no-editable
 }
 
 // Spinner
@@ -229,8 +227,8 @@ foreign lib {
 	
 	// Style set/get functions
 	
-	GuiSetStyle         :: proc(control: GuiControl, property: GuiControlProperty, value: c.int) ---          // Set one style property
-	GuiGetStyle         :: proc(control: GuiControl, property: GuiControlProperty) -> c.int ---               // Get one style property
+	GuiSetStyle         :: proc(control: GuiControl, property: c.int, value: c.int) ---          // Set one style property
+	GuiGetStyle         :: proc(control: GuiControl, property: c.int) -> c.int ---               // Get one style property
 	
 	// Styles loading functions
 	


### PR DESCRIPTION
## Changes

A series of changes between raygui 3.6 and 4.0 were that various text box properties were moved from the text box specific properties up into the extended default control properties. This change corrects the various property enums to match the raygui 4.0 API (https://github.com/raysan5/raygui/blob/4.0/src/raygui.h).

One additional aspect of this change was rolling back a previous commit made to this vendor file that changed the signature of GuiSetStyle and GuiGetStyle from using a c.int as property value to a more strongly-defined GuiControlProperty enum (https://github.com/odin-lang/Odin/commit/1f2ab84e828d058019d760f8a2549ca6158e4555). Unfortunately, this breaks the raygui API by disallowing the use of various control-specific extended properties due to how the enums are built (for example: https://github.com/raysan5/raygui/blob/4.0/examples/controls_test_suite/controls_test_suite.c)

## Validation

- Reviewed the other control properties in the tagged 4.0 header of the raygui project to ensure the other control properties were correct (https://github.com/raysan5/raygui/blob/4.0/src/raygui.h)
- Created and ran below example raygui program to verify text alignment options now work as expected:

```odin
import rl "vendor:raylib"

LOREM_IPSUM :: `
	Lorem ipsum dolor sit amet,
	consectetur adipiscing elit.
	Donec efficitur ac urna eu vulputate.
	Nullam et bibendum mauris.
	Nulla condimentum ultrices nunc,
	et hendrerit urna eleifend in.
`
WINDOW_WIDTH  :: 1280
WINDOW_HEIGHT :: 760
PADDING 	  :: 24

main :: proc() {
	text_align := rl.GuiTextAlignment.TEXT_ALIGN_LEFT
	vertical_text_align := rl.GuiTextAlignmentVertical.TEXT_ALIGN_MIDDLE

	rl.InitWindow(WINDOW_WIDTH, WINDOW_HEIGHT, "Text Alignment")
	for !rl.WindowShouldClose() {
	  rl.BeginDrawing()
	  rl.ClearBackground(rl.WHITE)
  
	  rl.GuiSetStyle(.DEFAULT, i32(rl.GuiControlProperty.TEXT_ALIGNMENT), i32(rl.GuiTextAlignment.TEXT_ALIGN_CENTER))
	  rl.GuiSetStyle(.DEFAULT, i32(rl.GuiDefaultProperty.TEXT_ALIGNMENT_VERTICAL), i32(rl.GuiTextAlignmentVertical.TEXT_ALIGN_MIDDLE))
	  if (rl.GuiButton(rl.Rectangle{ PADDING, PADDING / 2, 24, 24 }, rl.GuiIconText(rl.GuiIconName.ICON_BOX_TOP, ""))) {
		vertical_text_align = rl.GuiTextAlignmentVertical.TEXT_ALIGN_TOP
	  }
	  if (rl.GuiButton(rl.Rectangle{ PADDING + (PADDING + 10), PADDING / 2, 24, 24 }, rl.GuiIconText(rl.GuiIconName.ICON_BOX_CENTER, ""))) {
		vertical_text_align = rl.GuiTextAlignmentVertical.TEXT_ALIGN_MIDDLE
	  }
	  if (rl.GuiButton(rl.Rectangle{ PADDING + ((PADDING + 10) * 2), PADDING / 2, 24, 24 }, rl.GuiIconText(rl.GuiIconName.ICON_BOX_BOTTOM, ""))) {
		vertical_text_align = rl.GuiTextAlignmentVertical.TEXT_ALIGN_BOTTOM
	  }
	  if (rl.GuiButton(rl.Rectangle{ PADDING + ((PADDING + 10) * 4), PADDING / 2, 24, 24 }, rl.GuiIconText(rl.GuiIconName.ICON_BOX_LEFT, ""))) {
		text_align = rl.GuiTextAlignment.TEXT_ALIGN_LEFT
	  }
	  if (rl.GuiButton(rl.Rectangle{ PADDING + ((PADDING + 10) * 5), PADDING / 2, 24, 24 }, rl.GuiIconText(rl.GuiIconName.ICON_BOX_CENTER, ""))) {
		text_align = rl.GuiTextAlignment.TEXT_ALIGN_CENTER
	  }
	  if (rl.GuiButton(rl.Rectangle{ PADDING + ((PADDING + 10) * 6), PADDING / 2, 24, 24 }, rl.GuiIconText(rl.GuiIconName.ICON_BOX_RIGHT, ""))) {
		text_align = rl.GuiTextAlignment.TEXT_ALIGN_RIGHT
	  }

	  rl.GuiSetStyle(.DEFAULT, i32(rl.GuiControlProperty.TEXT_ALIGNMENT), i32(text_align))
	  rl.GuiSetStyle(.DEFAULT, i32(rl.GuiDefaultProperty.TEXT_ALIGNMENT_VERTICAL), i32(vertical_text_align))
	  rl.GuiTextBox(rl.Rectangle{ PADDING, PADDING * 2, WINDOW_WIDTH - PADDING * 2, WINDOW_HEIGHT - PADDING * 4 }, LOREM_IPSUM, 32, false)
  
	  rl.EndDrawing()
	}
}
```