### PR TITLE
Implement lshrti3 on wasm

### DIFF
--- a/base/runtime/procs_wasm.odin
+++ b/base/runtime/procs_wasm.odin
@@ -52,3 +52,24 @@ udivti3 :: proc "c" (la, ha, lb, hb: u64) -> u128 {
 	b.lo, b.hi = lb, hb
 	return udivmodti4(a.all, b.all, nil)
 }
+
+@(link_name="__lshrti3", linkage="strong")
+__lshrti3 :: proc "c" (la, ha: u64, b: u32) -> i128 {
+	bits :: size_of(u32)*8
+
+	input, result: ti_int
+	input.lo = la
+	input.hi = ha
+
+	if b & bits != 0 {
+		result.hi = 0
+		result.lo = input.hi >> (b - bits)
+	} else if b == 0 {
+		return input.all
+	} else {
+		result.hi = input.hi >> b
+		result.lo = (input.hi << (bits - b)) | (input.lo >> b)
+	}
+
+	return result.all
+}

--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -2723,6 +2723,7 @@ gb_internal void generate_minimum_dependency_set(Checker *c, Entity *start) {
 		// WASM Specific
 		str_lit("__ashlti3"),
 		str_lit("__multi3"),
+		str_lit("__lshrti3"),
 	);
 
 	FORCE_ADD_RUNTIME_ENTITIES(!build_context.no_rtti,


### PR DESCRIPTION
Allows `u128(10) >> u128(1)` on wasm.

I also moved up the dependency adder because it wasn't actually running on shift operations, line 3992 short-circuits on them so it never got to it.