### PR TITLE
core:sys/linux - implement clock_settime, clock_getres and clock_nanosleep

### DIFF
--- a/core/sys/linux/sys.odin
+++ b/core/sys/linux/sys.odin
@@ -2428,9 +2428,10 @@ clock_gettime :: proc "contextless" (clock: Clock_Id) -> (ts: Time_Spec, err: Er
 	Finds the resolution of the specified clock.
 	Available since Linux 2.6.
 */
-clock_getres :: proc "contextless" (clock: Clock_Id, res: ^Time_Spec) -> (Errno) {
-	ret := syscall(SYS_clock_getres, clock, res)
-	return Errno(-ret)
+clock_getres :: proc "contextless" (clock: Clock_Id) -> (res: Time_Spec, err: Errno) {
+	ret := syscall(SYS_clock_getres, clock, &res)
+	err = Errno(-ret)
+	return
 }
 
 /*

--- a/core/sys/linux/sys.odin
+++ b/core/sys/linux/sys.odin
@@ -2404,17 +2404,43 @@ timer_delete :: proc "contextless" (timer: Timer) -> (Errno) {
 	return Errno(-ret)
 }
 
-// TODO(flysand): clock_settime
+/*
+	Set the time of the specified clock.
+	Available since Linux 2.6.
+*/
+clock_settime :: proc "contextless" (clock: Clock_Id, ts: ^Time_Spec) -> (Errno) {
+	ret := syscall(SYS_clock_settime, clock, ts)
+	return Errno(-ret)
+}
 
+/*
+	Retrieve the time of the specified clock.
+	Available since Linux 2.6.
+*/
 clock_gettime :: proc "contextless" (clock: Clock_Id) -> (ts: Time_Spec, err: Errno) {
 	ret := syscall(SYS_clock_gettime, clock, &ts)
 	err = Errno(-ret)
 	return
 }
 
-// TODO(flysand): clock_getres
 
-// TODO(flysand): clock_nanosleep
+/*
+	Finds the resolution of the specified clock.
+	Available since Linux 2.6.
+*/
+clock_getres :: proc "contextless" (clock: Clock_Id, res: ^Time_Spec) -> (Errno) {
+	ret := syscall(SYS_clock_getres, clock, res)
+	return Errno(-ret)
+}
+
+/*
+	Sleep for an interval specified with nanosecond precision.
+	Available since Linux 2.6.
+*/
+clock_nanosleep :: proc "contextless" (clock: Clock_Id, flags: ITimer_Flags, request: ^Time_Spec, remain: ^Time_Spec) -> (Errno) {
+	ret := syscall(SYS_clock_nanosleep, clock, transmute(u32) flags, request, remain)
+	return Errno(-ret)
+}
 
 /*
 	Exit the thread group.


### PR DESCRIPTION
Hi, I implemented clock_settime, clock_getres and clock_nanosleep.
Below codeblock is my test for the procedures and seem to work.
cc. @flysand7 

```odin
package main

import "core:fmt"
import "core:sys/linux"

main :: proc() {
    realtime := linux.Clock_Id.REALTIME
    r1, e1 := linux.clock_gettime(realtime)
    fmt.println("clock_gettime result:", r1)
    fmt.println("e1:", e1)

    r2 := &r1
    e2 := linux.clock_settime(realtime, r2)
    fmt.println("clock_settime result:", r2)
    fmt.println("e2:", e2)

    fmt.println("clock_nanosleep - Sleeping for 1s 5ns")
    req := linux.Time_Spec{ uint(1), uint(5)}
    rem := linux.Time_Spec{}
    e3 := linux.clock_nanosleep(realtime, { linux.ITimer_Flags_Bits.ABSTIME } , &req, &rem)
    fmt.println("e3:", e3)
    
    r4, e4 := linux.clock_getres(realtime)
    fmt.println("clock_getres result:", r4)
    fmt.println("e4:", e4)
}
```