### PR TITLE
Remove deprecated `log` procs from `core:testing`

### DIFF
--- a/core/testing/logging.odin
+++ b/core/testing/logging.odin
@@ -12,7 +12,7 @@ package testing
 
 import "base:runtime"
 import "core:fmt"
-import pkg_log "core:log"
+import "core:log"
 import "core:strings"
 import "core:sync/chan"
 import "core:time"
@@ -81,9 +81,9 @@ format_log_text :: proc(level: runtime.Logger_Level, text: string, options: runt
 	backing: [1024]byte
 	buf := strings.builder_from_bytes(backing[:])
 
-	pkg_log.do_level_header(options, &buf, level)
-	pkg_log.do_time_header(options, &buf, at_time)
-	pkg_log.do_location_header(options, &buf, location)
+	log.do_level_header(options, &buf, level)
+	log.do_time_header(options, &buf, at_time)
+	log.do_location_header(options, &buf, location)
 
 	return fmt.aprintf("%s%s", strings.to_string(buf), text, allocator = allocator)
 }

--- a/core/testing/runner.odin
+++ b/core/testing/runner.odin
@@ -18,7 +18,7 @@ import "core:encoding/ansi"
 @require import "core:encoding/json"
 import "core:fmt"
 import "core:io"
-@require import pkg_log "core:log"
+@require import "core:log"
 import "core:math/rand"
 import "core:mem"
 import "core:os"
@@ -167,7 +167,7 @@ run_test_task :: proc(task: thread.Task) {
 		data.t.error_count += memory_leaks + bad_frees
 
 		if memory_is_in_bad_state {
-			pkg_log.errorf("Memory failure in `%s.%s` with %i leak%s and %i bad free%s.",
+			log.errorf("Memory failure in `%s.%s` with %i leak%s and %i bad free%s.",
 				data.it.pkg, data.it.name,
 				memory_leaks, "" if memory_leaks == 1 else "s",
 				bad_frees, "" if bad_frees == 1 else "s")
@@ -486,34 +486,34 @@ runner :: proc(internal_tests: []Internal_Test) -> bool {
 	}
 
 	when TEST_THREADS == 0 {
-		pkg_log.infof("Starting test runner with %i thread%s. Set with -define:ODIN_TEST_THREADS=n.",
+		log.infof("Starting test runner with %i thread%s. Set with -define:ODIN_TEST_THREADS=n.",
 			thread_count,
 			"" if thread_count == 1 else "s")
 	} else {
-		pkg_log.infof("Starting test runner with %i thread%s.",
+		log.infof("Starting test runner with %i thread%s.",
 			thread_count,
 			"" if thread_count == 1 else "s")
 	}
 
 	when SHARED_RANDOM_SEED == 0 {
-		pkg_log.infof("The random seed sent to every test is: %v. Set with -define:ODIN_TEST_RANDOM_SEED=n.", shared_random_seed)
+		log.infof("The random seed sent to every test is: %v. Set with -define:ODIN_TEST_RANDOM_SEED=n.", shared_random_seed)
 	} else {
-		pkg_log.infof("The random seed sent to every test is: %v.", shared_random_seed)
+		log.infof("The random seed sent to every test is: %v.", shared_random_seed)
 	}
 
 	when TRACKING_MEMORY {
 		when ALWAYS_REPORT_MEMORY {
-			pkg_log.info("Memory tracking is enabled. Tests will log their memory usage when complete.")
+			log.info("Memory tracking is enabled. Tests will log their memory usage when complete.")
 		} else {
-			pkg_log.info("Memory tracking is enabled. Tests will log their memory usage if there's an issue.")
+			log.info("Memory tracking is enabled. Tests will log their memory usage if there's an issue.")
 		}
-		pkg_log.info("< Final Mem/ Total Mem> <  Peak Mem> (#Free/Alloc) :: [package.test_name]")
+		log.info("< Final Mem/ Total Mem> <  Peak Mem> (#Free/Alloc) :: [package.test_name]")
 	} else {
 		when ALWAYS_REPORT_MEMORY {
-			pkg_log.warn("ODIN_TEST_ALWAYS_REPORT_MEMORY is true, but ODIN_TEST_TRACK_MEMORY is false.")
+			log.warn("ODIN_TEST_ALWAYS_REPORT_MEMORY is true, but ODIN_TEST_TRACK_MEMORY is false.")
 		}
 		when FAIL_ON_BAD_MEMORY {
-			pkg_log.warn("ODIN_TEST_FAIL_ON_BAD_MEMORY is true, but ODIN_TEST_TRACK_MEMORY is false.")
+			log.warn("ODIN_TEST_FAIL_ON_BAD_MEMORY is true, but ODIN_TEST_TRACK_MEMORY is false.")
 		}
 	}
 
@@ -557,9 +557,9 @@ runner :: proc(internal_tests: []Internal_Test) -> bool {
 					write_memory_report(batch_writer, tracker, data.it.pkg, data.it.name)
 
 					when FAIL_ON_BAD_MEMORY {
-						pkg_log.log(.Error if memory_is_in_bad_state else .Info, bytes.buffer_to_string(&batch_buffer))
+						log.log(.Error if memory_is_in_bad_state else .Info, bytes.buffer_to_string(&batch_buffer))
 					} else {
-						pkg_log.log(.Warning if memory_is_in_bad_state else .Info, bytes.buffer_to_string(&batch_buffer))
+						log.log(.Warning if memory_is_in_bad_state else .Info, bytes.buffer_to_string(&batch_buffer))
 					}
 					bytes.buffer_reset(&batch_buffer)
 				}
@@ -607,7 +607,7 @@ runner :: proc(internal_tests: []Internal_Test) -> bool {
 					}
 
 					when ODIN_DEBUG {
-						pkg_log.debugf("Test #%i %s.%s changed state to %v.", task_channel.test_index, it.pkg, it.name, event.new_state)
+						log.debugf("Test #%i %s.%s changed state to %v.", task_channel.test_index, it.pkg, it.name, event.new_state)
 					}
 
 					pkg.last_change_state = event.new_state
@@ -744,7 +744,7 @@ runner :: proc(internal_tests: []Internal_Test) -> bool {
 					// the signal won't be very useful, whereas asserts and panics
 					// will provide a user-written error message.
 					failed_test_reason_map[test_index] = fmt.aprintf("Signal caught: %v", reason, allocator = shared_log_allocator)
-					pkg_log.fatalf("Caught signal to stop test #%i %s.%s for: %v.", test_index, it.pkg, it.name, reason)
+					log.fatalf("Caught signal to stop test #%i %s.%s for: %v.", test_index, it.pkg, it.name, reason)
 				}
 
 				when FANCY_OUTPUT {

--- a/core/testing/signal_handler.odin
+++ b/core/testing/signal_handler.odin
@@ -10,7 +10,7 @@ package testing
 */
 
 import "base:runtime"
-import pkg_log "core:log"
+import "core:log"
 
 Stop_Reason :: enum {
 	Unknown,
@@ -21,7 +21,7 @@ Stop_Reason :: enum {
 }
 
 test_assertion_failure_proc :: proc(prefix, message: string, loc: runtime.Source_Code_Location) -> ! {
-	pkg_log.fatalf("%s: %s", prefix, message, location = loc)
+	log.fatalf("%s: %s", prefix, message, location = loc)
 	runtime.trap()
 }
 

--- a/core/testing/testing.odin
+++ b/core/testing/testing.odin
@@ -11,7 +11,7 @@ package testing
 
 import "base:intrinsics"
 import "base:runtime"
-import pkg_log "core:log"
+import "core:log"
 import "core:reflect"
 import "core:sync"
 import "core:sync/chan"
@@ -64,18 +64,8 @@ T :: struct {
 }
 
 
-@(deprecated="prefer `log.error`")
-error :: proc(t: ^T, args: ..any, loc := #caller_location) {
-	pkg_log.error(..args, location = loc)
-}
-
-@(deprecated="prefer `log.errorf`")
-errorf :: proc(t: ^T, format: string, args: ..any, loc := #caller_location) {
-	pkg_log.errorf(format, ..args, location = loc)
-}
-
 fail :: proc(t: ^T, loc := #caller_location) {
-	pkg_log.error("FAIL", location=loc)
+	log.error("FAIL", location=loc)
 }
 
 // fail_now will cause a test to immediately fail and abort, much in the same
@@ -87,9 +77,9 @@ fail :: proc(t: ^T, loc := #caller_location) {
 fail_now :: proc(t: ^T, msg := "", loc := #caller_location) -> ! {
 	t._fail_now_called = true
 	if msg != "" {
-		pkg_log.error("FAIL:", msg, location=loc)
+		log.error("FAIL:", msg, location=loc)
 	} else {
-		pkg_log.error("FAIL", location=loc)
+		log.error("FAIL", location=loc)
 	}
 	runtime.trap()
 }
@@ -97,17 +87,6 @@ fail_now :: proc(t: ^T, msg := "", loc := #caller_location) -> ! {
 failed :: proc(t: ^T) -> bool {
 	return t.error_count != 0
 }
-
-@(deprecated="prefer `log.info`")
-log :: proc(t: ^T, args: ..any, loc := #caller_location) {
-	pkg_log.info(..args, location = loc)
-}
-
-@(deprecated="prefer `log.infof`")
-logf :: proc(t: ^T, format: string, args: ..any, loc := #caller_location) {
-	pkg_log.infof(format, ..args, location = loc)
-}
-
 
 // cleanup registers a procedure and user_data, which will be called when the test, and all its subtests, complete.
 // Cleanup procedures will be called in LIFO (last added, first called) order.
@@ -128,14 +107,14 @@ cleanup :: proc(t: ^T, procedure: proc(rawptr), user_data: rawptr) {
 
 expect :: proc(t: ^T, ok: bool, msg: string = "", loc := #caller_location) -> bool {
 	if !ok {
-		pkg_log.error(msg, location=loc)
+		log.error(msg, location=loc)
 	}
 	return ok
 }
 
 expectf :: proc(t: ^T, ok: bool, format: string, args: ..any, loc := #caller_location) -> bool {
 	if !ok {
-		pkg_log.errorf(format, ..args, location=loc)
+		log.errorf(format, ..args, location=loc)
 	}
 	return ok
 }
@@ -143,7 +122,7 @@ expectf :: proc(t: ^T, ok: bool, format: string, args: ..any, loc := #caller_loc
 expect_value :: proc(t: ^T, value, expected: $T, loc := #caller_location) -> bool where intrinsics.type_is_comparable(T) {
 	ok := value == expected || reflect.is_nil(value) && reflect.is_nil(expected)
 	if !ok {
-		pkg_log.errorf("expected %v, got %v", expected, value, location=loc)
+		log.errorf("expected %v, got %v", expected, value, location=loc)
 	}
 	return ok
 }


### PR DESCRIPTION
It's been a few months now.