### PR TITLE
Corrects ColorToInt signature to return int instead of uint

### DIFF
--- a/vendor/raylib/raylib.odin
+++ b/vendor/raylib/raylib.odin
@@ -1366,7 +1366,7 @@ foreign lib {
 	// Color/pixel related functions
 
 	Fade                :: proc(color: Color, alpha: f32) -> Color ---                  // Get color with alpha applied, alpha goes from 0.0f to 1.0f
-	ColorToInt          :: proc(color: Color) -> c.uint ---                             // Get hexadecimal value for a Color
+	ColorToInt          :: proc(color: Color) -> c.int ---                              // Get hexadecimal value for a Color
 	ColorNormalize      :: proc(color: Color) -> Vector4 ---                            // Get Color normalized as float [0..1]
 	ColorFromNormalized :: proc(normalized: Vector4) -> Color ---                       // Get Color from normalized values [0..1]
 	ColorToHSV          :: proc(color: Color) -> Vector3 ---                            // Get HSV values for a Color, hue [0..360], saturation/value [0..1]


### PR DESCRIPTION
I think this could definitely use a review from somebody with more experience than me. I was working through raygui examples when I discovered that I couldn't port one. The issue came down to being unable to use `GuiSetStyle` in raygui with a raylib color. This is because GuiSetStyle's value param is a `c.int` where as `ColorToInt` in raylib is a `c.uint.`

At first glance, it would make sense for Color to be an unsigned integer since it's basically 4 8-bit integers (R/G/B/A). But as shown below, the actual raylib ABI is an `int`, not an `unsigned int`. The implementation also explicitly casts to (int).

I couldn't find a way for the compiler to let me to force the color white (`0xffffffff`) into the `c.int` parameter in `GuiSetStyle` of raygui as it always reports it as (validly) not being able to fit into the max value of a i32. For example, to be able to set the color of the lines drawn by `GuiGrid()`, you have to set the default LINE_COLOR property:

```
    // Not possible before this change
    rl.GuiSetStyle(.DEFAULT, i32(rl.GuiDefaultProperty.LINE_COLOR), rl.ColorToInt(rl.WHITE))
```

If folks feel strongly about this having the "correct" type in Odin, even though it appears to conflict with raylib ABI, and there's a workaround, I could use that instead.

# Description

The current C definition of ColorToInt in the raylib.h header itself is: `RLAPI int ColorToInt(Color color);`

Though it feels improper (and perhaps relies on undefined behavior?), the raylib implementation does indeed cast an unsigned integer to a signed one:

https://github.com/raysan5/raylib/blob/7fab03c0b4f079a6450f03d82ca17f2e18be3477/src/rtextures.c#L4893
```
int ColorToInt(Color color)
{
    int result = 0;

    result = (int)(((unsigned int)color.r << 24) |
                   ((unsigned int)color.g << 16) |
                   ((unsigned int)color.b << 8) |
                    (unsigned int)color.a);

    return result;
}
```

This is unfortunately a breaking change for users of this package. I'm unsure of whether a different approach would be better. This incorrect signature made it impossible, from what I could tell, to be able to set default control colors in raygui.

```
    rl.GuiSetStyle(.DEFAULT, i32(rl.GuiDefaultProperty.LINE_COLOR), rl.ColorToInt(rl.WHITE))
```

With the previously incorrect signature, I couldn't find a way to cast a raylib color to i32 in a forced way. Perhaps my own Odin knowledge shortcoming.