### PR TITLE
orca: implement core:time and core:log

### DIFF
--- a/core/log/file_console_logger.odin
+++ b/core/log/file_console_logger.odin
@@ -1,4 +1,5 @@
 //+build !freestanding
+//+build !orca
 package log
 
 import "core:encoding/ansi"

--- a/core/sys/orca/macros.odin
+++ b/core/sys/orca/macros.odin
@@ -2,8 +2,6 @@
 
 package orca
 
-import "core:fmt"
-
 ////////////////////////////////////////////////////////////////////////////////
 // Helpers for logging, asserting and aborting.
 ////////////////////////////////////////////////////////////////////////////////
@@ -18,16 +16,6 @@ log_error :: proc "contextless" (msg: cstring, loc := #caller_location) {
 	)
 }
 
-log_errorf :: proc(format: string, args: ..any, loc := #caller_location) {
-	log_ext(
-		.ERROR,
-		cstring(raw_data(loc.procedure)),
-		cstring(raw_data(loc.file_path)),
-		loc.line,
-		fmt.ctprintf(format, ..args),
-	)
-}
-
 log_warning :: proc "contextless" (msg: cstring, loc := #caller_location) {
 	log_ext(
 		.WARNING,
@@ -35,16 +23,6 @@ log_warning :: proc "contextless" (msg: cstring, loc := #caller_location) {
 		cstring(raw_data(loc.file_path)),
 		loc.line,
 		msg,
-	)
-}
-
-log_warningf :: proc(format: string, args: ..any, loc := #caller_location) {
-	log_ext(
-		.WARNING,
-		cstring(raw_data(loc.procedure)),
-		cstring(raw_data(loc.file_path)),
-		loc.line,
-		fmt.ctprintf(format, ..args),
 	)
 }
 
@@ -58,31 +36,12 @@ log_info :: proc "contextless" (msg: cstring, loc := #caller_location) {
 	)
 }
 
-log_infof :: proc(format: string, args: ..any, loc := #caller_location) {
-	log_ext(
-		.INFO,
-		cstring(raw_data(loc.procedure)),
-		cstring(raw_data(loc.file_path)),
-		loc.line,
-		fmt.ctprintf(format, ..args),
-	)
-}
-
 abort :: proc "contextless" (msg: cstring, loc := #caller_location) {
 	abort_ext(
 		cstring(raw_data(loc.procedure)),
 		cstring(raw_data(loc.file_path)),
 		loc.line,
 		msg,
-	)
-}
-
-abortf :: proc(format: string, args: ..any, loc := #caller_location) {
-	abort_ext(
-		cstring(raw_data(loc.procedure)),
-		cstring(raw_data(loc.file_path)),
-		loc.line,
-		fmt.ctprintf(format, ..args),
 	)
 }
 

--- a/core/sys/orca/odin.odin
+++ b/core/sys/orca/odin.odin
@@ -1,0 +1,22 @@
+// File contains Odin specific helpers.
+
+package orca
+
+import "base:runtime"
+
+create_odin_logger :: proc(lowest := runtime.Logger_Level.Debug, ident := "") -> runtime.Logger {
+	return runtime.Logger{odin_logger_proc, nil, lowest, {}}
+}
+
+odin_logger_proc :: proc(logger_data: rawptr, level: runtime.Logger_Level, text: string, options: runtime.Logger_Options, location := #caller_location) {
+	cbuf := make([]byte, len(text)+1, context.temp_allocator)
+	copy(cbuf, text)
+	ctext := cstring(raw_data(cbuf))
+
+	switch level {
+	case .Debug, .Info:  log_info(ctext, location)
+	case .Warning:       log_warning(ctext, location)
+	case:                fallthrough
+	case .Error, .Fatal: log_error(ctext, location)
+	}
+}

--- a/core/time/time_orca.odin
+++ b/core/time/time_orca.odin
@@ -1,0 +1,29 @@
+//+private
+//+build orca
+package time
+
+import "base:intrinsics"
+
+import "core:sys/orca"
+
+_IS_SUPPORTED :: true
+
+_now :: proc "contextless" () -> Time {
+	CLK_JAN_1970 :: 2208988800
+	secs := orca.clock_time(.DATE)
+	return Time{i64((secs - CLK_JAN_1970) * 1e9)}
+}
+
+_sleep :: proc "contextless" (d: Duration) {
+	// NOTE: no way to sleep afaict.
+	if d > 0 {
+		orca.log_warning("core:time 'sleep' is unimplemented for orca")
+	}
+}
+
+_tick_now :: proc "contextless" () -> Tick {
+	secs := orca.clock_time(.MONOTONIC)
+	return Tick{i64(secs * 1e9)}
+}
+
+_yield :: proc "contextless" () {}

--- a/core/time/time_other.odin
+++ b/core/time/time_other.odin
@@ -8,6 +8,7 @@
 //+build !darwin
 //+build !wasi
 //+build !windows
+//+build !orca
 package time
 
 _IS_SUPPORTED :: false


### PR DESCRIPTION
Turns out importing `fmt` from `sys/orca` was a bad idea due to cyclic imports (which made it impossible to implement `time`). What I did now is make the log package plug into the orca log nicely which should still allow nice usage without the imports.

```odin
package main

import    "core:log"
import    "core:time"
import oc "core:sys/orca"

main :: proc() {
	context.logger = oc.create_odin_logger()	

	log.infof("The current time is: %v", time.now())

	start := time.tick_now()
	sum := 0
	for i in 0..<100 {
		sum += i
	}

	log.infof("Calculated %v in %v", sum, time.tick_since(start))
}
```