### PR TITLE
Added missing slice advancing.

### DIFF
--- a/core/image/common.odin
+++ b/core/image/common.odin
@@ -1393,6 +1393,7 @@ expand_grayscale :: proc(img: ^Image, allocator := context.allocator) -> (ok: bo
 			for p in inp {
 				out[0].rgb = p.r // Gray component.
 				out[0].a   = p.g // Alpha component.
+				out    = out[1:]
 			}
 
 		case:
@@ -1417,6 +1418,7 @@ expand_grayscale :: proc(img: ^Image, allocator := context.allocator) -> (ok: bo
 			for p in inp {
 				out[0].rgb = p.r // Gray component.
 				out[0].a   = p.g // Alpha component.
+				out    = out[1:]
 			}
 
 		case:


### PR DESCRIPTION
Added missing slice advancing in expand_grayscale procedure in image module for two cases:
1. 8 Bit, Turn Gray + Alpha into RGBA
2. 16 Bit, Turn Gray + Alpha into RGBA

