### PR TITLE
[core:math/ease] Corrected tween/flux time advancing in case delay is finished.

### DIFF
--- a/core/image/common.odin
+++ b/core/image/common.odin
@@ -1393,6 +1393,7 @@ expand_grayscale :: proc(img: ^Image, allocator := context.allocator) -> (ok: bo
 			for p in inp {
 				out[0].rgb = p.r // Gray component.
 				out[0].a   = p.g // Alpha component.
+				out    = out[1:]
 			}
 
 		case:
@@ -1417,6 +1418,7 @@ expand_grayscale :: proc(img: ^Image, allocator := context.allocator) -> (ok: bo
 			for p in inp {
 				out[0].rgb = p.r // Gray component.
 				out[0].a   = p.g // Alpha component.
+				out    = out[1:]
 			}
 
 		case:


### PR DESCRIPTION
I already created an issue about this and now I created a pull request which resolves the issue.

See the following link on details about the issue:
[https://github.com/odin-lang/Odin/issues/3321#issue-2204261630](https://github.com/odin-lang/Odin/issues/3321#issue-2204261630)