### PR TITLE
fix ambiguous generic type names

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -7625,7 +7625,7 @@ gb_internal CallArgumentError check_polymorphic_record_type(CheckerContext *c, O
 			gbString s = gb_string_make_reserve(heap_allocator(), e->token.string.len+3);
 			s = gb_string_append_fmt(s, "%.*s(", LIT(e->token.string));
 
-			TypeTuple *tuple = get_record_polymorphic_params(e->type);
+			TypeTuple *tuple = get_record_polymorphic_params(bt);
 			if (tuple != nullptr) for_array(i, tuple->variables) {
 				Entity *v = tuple->variables[i];
 				String name = v->token.string;
@@ -7640,8 +7640,10 @@ gb_internal CallArgumentError check_polymorphic_record_type(CheckerContext *c, O
 						s = write_type_to_string(s, v->type, false);
 					}
 				} else if (v->kind == Entity_Constant) {
-					s = gb_string_append_fmt(s, "=");
-					s = write_exact_value_to_string(s, v->Constant.value);
+					if (v->type->kind != ExactValue_Invalid) {
+						s = gb_string_append_fmt(s, "=");
+						s = write_exact_value_to_string(s, v->Constant.value);
+					}
 				}
 			}
 			s = gb_string_append_fmt(s, ")");

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -7640,7 +7640,7 @@ gb_internal CallArgumentError check_polymorphic_record_type(CheckerContext *c, O
 						s = write_type_to_string(s, v->type, false);
 					}
 				} else if (v->kind == Entity_Constant) {
-					if (v->type->kind != ExactValue_Invalid) {
+					if (v->Constant.value.kind != ExactValue_Invalid) {
 						s = gb_string_append_fmt(s, "=");
 						s = write_exact_value_to_string(s, v->Constant.value);
 					}


### PR DESCRIPTION
I noticed some ambiguous error messages when trying to mix polymorphic structs with different polymorphic parameters. I included a small snippet to highlight the type of error I encountered and the error messages before and after the proposed change:

```odin
package main

import "core:fmt"

Creature :: struct{}
Item :: struct{}

EntityRef :: struct($T: typeid) {
	index: u32,
	version: u32,
}

main :: proc() {
	a := EntityRef(Creature){}
	b := EntityRef(Item){}

	if a == b do fmt.println("wont compile")
}
```

BEFORE:
```
Error: Cannot compare expression, mismatched types 'EntityRef($T)' and 'EntityRef($T)'
```

AFTER:
```
Error: Cannot compare expression, mismatched types 'EntityRef($T=Item)' and 'EntityRef($T=Creature)'
```