### PR TITLE
Fix binding: Make rl.LoadImageAnim take a pointer instead of a multi-pointer. 

### DIFF
--- a/vendor/raylib/raylib.odin
+++ b/vendor/raylib/raylib.odin
@@ -1256,7 +1256,7 @@ foreign lib {
 	LoadImage            :: proc(fileName: cstring) -> Image ---                                                               // Load image from file into CPU memory (RAM)
 	LoadImageRaw         :: proc(fileName: cstring, width, height: c.int, format: PixelFormat, headerSize: c.int) -> Image --- // Load image from RAW file data
 	LoadImageSvg         :: proc(fileNameOrString: cstring, width, height: c.int) -> Image ---                                 // Load image from SVG file data or string with specified size
-	LoadImageAnim        :: proc(fileName: cstring, frames: ^c.int) -> Image ---                                             // Load image sequence from file (frames appended to image.data)
+	LoadImageAnim        :: proc(fileName: cstring, frames: ^c.int) -> Image ---                                               // Load image sequence from file (frames appended to image.data)
 	LoadImageFromMemory  :: proc(fileType: cstring, fileData: rawptr, dataSize: c.int) -> Image ---                            // Load image from memory buffer, fileType refers to extension: i.e. '.png'
 	LoadImageFromTexture :: proc(texture: Texture2D) -> Image ---                                                              // Load image from GPU texture data
 	LoadImageFromScreen  :: proc() -> Image ---                                                                                // Load image from screen buffer and (screenshot)

--- a/vendor/raylib/raylib.odin
+++ b/vendor/raylib/raylib.odin
@@ -1256,7 +1256,7 @@ foreign lib {
 	LoadImage            :: proc(fileName: cstring) -> Image ---                                                               // Load image from file into CPU memory (RAM)
 	LoadImageRaw         :: proc(fileName: cstring, width, height: c.int, format: PixelFormat, headerSize: c.int) -> Image --- // Load image from RAW file data
 	LoadImageSvg         :: proc(fileNameOrString: cstring, width, height: c.int) -> Image ---                                 // Load image from SVG file data or string with specified size
-	LoadImageAnim        :: proc(fileName: cstring, frames: [^]c.int) -> Image ---                                             // Load image sequence from file (frames appended to image.data)
+	LoadImageAnim        :: proc(fileName: cstring, frames: ^c.int) -> Image ---                                             // Load image sequence from file (frames appended to image.data)
 	LoadImageFromMemory  :: proc(fileType: cstring, fileData: rawptr, dataSize: c.int) -> Image ---                            // Load image from memory buffer, fileType refers to extension: i.e. '.png'
 	LoadImageFromTexture :: proc(texture: Texture2D) -> Image ---                                                              // Load image from GPU texture data
 	LoadImageFromScreen  :: proc() -> Image ---                                                                                // Load image from screen buffer and (screenshot)


### PR DESCRIPTION
The param `frames` is just for returning an int, it's not for passing a multi-pointer into the proc.