### PR TITLE
[os2/process]: Don't free process info fields in partial success scenarios

### DIFF
--- a/core/os/os2/process.odin
+++ b/core/os/os2/process.odin
@@ -169,7 +169,7 @@ Process_Info :: struct {
 
 	Use `free_process_info` to free the memory allocated by this procedure. The
 	`free_process_info` procedure needs to be called, even if this procedure
-	returned an error, as some of the fields have been allocated.
+	returned an error, as some of the fields may have been allocated.
 
 	**Note**: The resulting information may or may contain the fields specified
 	by the `selection` parameter. Always check whether the returned
@@ -190,7 +190,7 @@ process_info_by_pid :: proc(pid: int, selection: Process_Info_Fields, allocator:
 
 	Use `free_process_info` to free the memory allocated by this procedure. The
 	`free_process_info` procedure needs to be called, even if this procedure
-	returned an error, as some of the fields have been allocated.
+	returned an error, as some of the fields may have been allocated.
 
 	**Note**: The resulting information may or may contain the fields specified
 	by the `selection` parameter. Always check whether the returned
@@ -210,7 +210,7 @@ process_info_by_handle :: proc(process: Process, selection: Process_Info_Fields,
 
 	Use `free_process_info` to free the memory allocated by this procedure. The
 	`free_process_info` procedure needs to be called, even if this procedure
-	returned an error, as some of the fields have been allocated.
+	returned an error, as some of the fields may have been allocated.
 
 	**Note**: The resulting information may or may contain the fields specified
 	by the `selection` parameter. Always check whether the returned

--- a/core/os/os2/process.odin
+++ b/core/os/os2/process.odin
@@ -166,15 +166,15 @@ Process_Info :: struct {
 
 	This procedure obtains an information, specified by `selection` parameter of
 	a process given by `pid`.
-	
-	Use `free_process_info` to free the memory allocated by this procedure. In
-	case the function returns an error it may only have been an error for one part
-	of the information and you would still need to call it to free the other parts.
+
+	Use `free_process_info` to free the memory allocated by this procedure. The
+	`free_process_info` procedure needs to be called, even if this procedure
+	returned an error, as some of the fields have been allocated.
 
 	**Note**: The resulting information may or may contain the fields specified
 	by the `selection` parameter. Always check whether the returned
 	`Process_Info` struct has the required fields before checking the error code
-	returned by this function.
+	returned by this procedure.
 */
 @(require_results)
 process_info_by_pid :: proc(pid: int, selection: Process_Info_Fields, allocator: runtime.Allocator) -> (Process_Info, Error) {
@@ -188,14 +188,14 @@ process_info_by_pid :: proc(pid: int, selection: Process_Info_Fields, allocator:
 	about a process that has been opened by the application, specified in
 	the `process` parameter.
 
-	Use `free_process_info` to free the memory allocated by this procedure. In
-	case the function returns an error it may only have been an error for one part
-	of the information and you would still need to call it to free the other parts.
+	Use `free_process_info` to free the memory allocated by this procedure. The
+	`free_process_info` procedure needs to be called, even if this procedure
+	returned an error, as some of the fields have been allocated.
 
 	**Note**: The resulting information may or may contain the fields specified
 	by the `selection` parameter. Always check whether the returned
 	`Process_Info` struct has the required fields before checking the error code
-	returned by this function.
+	returned by this procedure.
 */
 @(require_results)
 process_info_by_handle :: proc(process: Process, selection: Process_Info_Fields, allocator: runtime.Allocator) -> (Process_Info, Error) {
@@ -208,14 +208,14 @@ process_info_by_handle :: proc(process: Process, selection: Process_Info_Fields,
 	This procedure obtains the information, specified by `selection` parameter
 	about the currently running process.
 
-	Use `free_process_info` to free the memory allocated by this procedure. In
-	case the function returns an error it may only have been an error for one part
-	of the information and you would still need to call it to free the other parts.
+	Use `free_process_info` to free the memory allocated by this procedure. The
+	`free_process_info` procedure needs to be called, even if this procedure
+	returned an error, as some of the fields have been allocated.
 
 	**Note**: The resulting information may or may contain the fields specified
 	by the `selection` parameter. Always check whether the returned
 	`Process_Info` struct has the required fields before checking the error code
-	returned by this function.
+	returned by this procedure.
 */
 @(require_results)
 current_process_info :: proc(selection: Process_Info_Fields, allocator: runtime.Allocator) -> (Process_Info, Error) {

--- a/core/os/os2/process_windows.odin
+++ b/core/os/os2/process_windows.odin
@@ -93,26 +93,9 @@ read_memory_as_slice :: proc(h: win32.HANDLE, addr: rawptr, dest: []$T) -> (byte
 @(private="package")
 _process_info_by_pid :: proc(pid: int, selection: Process_Info_Fields, allocator: runtime.Allocator) -> (info: Process_Info, err: Error) {
 	info.pid = pid
-	// Data obtained from process snapshots
-	snapshot_process: if selection >= {.PPid, .Priority} {
-		entry, entry_err := _process_entry_by_pid(info.pid)
-		if entry_err != nil {
-			err = General_Error.Not_Exist
-			return
-		}
-		if .PPid in selection {
-			info.fields += {.PPid}
-			info.ppid = int(entry.th32ParentProcessID)
-		}
-		if .Priority in selection {
-			info.fields += {.Priority}
-			info.priority = int(entry.pcPriClassBase)
-		}
-	}
-	snapshot_modules: if .Executable_Path in selection {
-		info.executable_path = _process_exe_by_pid(pid, allocator) or_break snapshot_modules
-		info.fields += {.Executable_Path}
-	}
+	// Note(flysand): Open the process handle right away to prevent some race
+	// conditions. Once the handle is open, the process will be kept alive by
+	// the OS.
 	ph := win32.INVALID_HANDLE_VALUE
 	if selection >= {.Command_Line, .Environment, .Working_Dir, .Username} {
 		ph = win32.OpenProcess(
@@ -128,6 +111,36 @@ _process_info_by_pid :: proc(pid: int, selection: Process_Info_Fields, allocator
 	defer if ph != win32.INVALID_HANDLE_VALUE {
 		win32.CloseHandle(ph)
 	}
+	snapshot_process: if selection >= {.PPid, .Priority} {
+		entry, entry_err := _process_entry_by_pid(info.pid)
+		if entry_err != nil {
+			err = entry_err
+			if entry_err == General_Error.Not_Exist {
+				return
+			} else {
+				break snapshot_process
+			}
+		}
+		if .PPid in selection {
+			info.fields += {.PPid}
+			info.ppid = int(entry.th32ParentProcessID)
+		}
+		if .Priority in selection {
+			info.fields += {.Priority}
+			info.priority = int(entry.pcPriClassBase)
+		}
+	}
+	snapshot_modules: if .Executable_Path in selection {
+		exe_path: string
+		exe_path, err = _process_exe_by_pid(pid, allocator)
+		if _, ok := err.(runtime.Allocator_Error); ok {
+			return
+		} else if err != nil {
+			break snapshot_modules
+		}
+		info.executable_path = exe_path
+		info.fields += {.Executable_Path}
+	}
 	read_peb: if selection >= {.Command_Line, .Environment, .Working_Dir} {
 		process_info_size: u32
 		process_info: win32.PROCESS_BASIC_INFORMATION
@@ -136,44 +149,66 @@ _process_info_by_pid :: proc(pid: int, selection: Process_Info_Fields, allocator
 			// TODO(flysand): There's probably a mismatch between NTSTATUS and
 			// windows userland error codes, I haven't checked.
 			err = Platform_Error(status)
-			return
+			break read_peb
 		}
 		assert(process_info.PebBaseAddress != nil)
 		process_peb: win32.PEB
-		_ = read_memory_as_struct(ph, process_info.PebBaseAddress, &process_peb) or_break read_peb
+		_, err = read_memory_as_struct(ph, process_info.PebBaseAddress, &process_peb)
+		if err != nil {
+			break read_peb
+		}
 		process_params: win32.RTL_USER_PROCESS_PARAMETERS
-		_ = read_memory_as_struct(ph, process_peb.ProcessParameters, &process_params) or_break read_peb
+		_, err = read_memory_as_struct(ph, process_peb.ProcessParameters, &process_params)
+		if err != nil {
+			break read_peb
+		}
 		if selection >= {.Command_Line, .Command_Args} {
 			TEMP_ALLOCATOR_GUARD()
-			cmdline_w := make([]u16, process_params.CommandLine.Length, temp_allocator()) or_break read_peb
-			_ = read_memory_as_slice(ph, process_params.CommandLine.Buffer, cmdline_w) or_break read_peb
+			cmdline_w := make([]u16, process_params.CommandLine.Length, temp_allocator()) or_return
+			_, err = read_memory_as_slice(ph, process_params.CommandLine.Buffer, cmdline_w)
+			if err != nil {
+				break read_peb
+			}
 			if .Command_Line in selection {
-				info.command_line = win32_utf16_to_utf8(cmdline_w, allocator) or_break read_peb
+				info.command_line = win32_utf16_to_utf8(cmdline_w, allocator) or_return
 				info.fields += {.Command_Line}
 			}
 			if .Command_Args in selection {
-				info.command_args = _parse_command_line(raw_data(cmdline_w), allocator) or_break read_peb
+				info.command_args = _parse_command_line(raw_data(cmdline_w), allocator) or_return
 				info.fields += {.Command_Args}
 			}
 		}
 		if .Environment in selection {
 			TEMP_ALLOCATOR_GUARD()
 			env_len := process_params.EnvironmentSize / 2
-			envs_w := make([]u16, env_len, temp_allocator()) or_break read_peb
-			_ = read_memory_as_slice(ph, process_params.Environment, envs_w) or_break read_peb
-			info.environment = _parse_environment_block(raw_data(envs_w), allocator) or_break read_peb
+			envs_w := make([]u16, env_len, temp_allocator()) or_return
+			_, err = read_memory_as_slice(ph, process_params.Environment, envs_w)
+			if err != nil {
+				break read_peb
+			}
+			info.environment = _parse_environment_block(raw_data(envs_w), allocator) or_return
 			info.fields += {.Environment}
 		}
 		if .Working_Dir in selection {
 			TEMP_ALLOCATOR_GUARD()
-			cwd_w := make([]u16, process_params.CurrentDirectoryPath.Length, temp_allocator()) or_break read_peb
-			_ = read_memory_as_slice(ph, process_params.CurrentDirectoryPath.Buffer, cwd_w) or_break read_peb
-			info.working_dir = win32_utf16_to_utf8(cwd_w, allocator) or_break read_peb
+			cwd_w := make([]u16, process_params.CurrentDirectoryPath.Length, temp_allocator()) or_return
+			_, err = read_memory_as_slice(ph, process_params.CurrentDirectoryPath.Buffer, cwd_w)
+			if err != nil {
+				break read_peb
+			}
+			info.working_dir = win32_utf16_to_utf8(cwd_w, allocator) or_return
 			info.fields += {.Working_Dir}
 		}
 	}
 	read_username: if .Username in selection {
-		info.username = _get_process_user(ph, allocator) or_break read_username
+		username: string
+		username, err = _get_process_user(ph, allocator)
+		if _, ok := err.(runtime.Allocator_Error); ok {
+			return
+		} else if err != nil {
+			break read_username
+		}
+		info.username = username
 		info.fields += {.Username}
 	}
 	err = nil
@@ -188,8 +223,12 @@ _process_info_by_handle :: proc(process: Process, selection: Process_Info_Fields
 	snapshot_process: if selection >= {.PPid, .Priority} {
 		entry, entry_err := _process_entry_by_pid(info.pid)
 		if entry_err != nil {
-			err = General_Error.Not_Exist
-			return
+			err = entry_err
+			if entry_err == General_Error.Not_Exist {
+				return
+			} else {
+				break snapshot_process
+			}
 		}
 		if .PPid in selection {
 			info.fields += {.PPid}
@@ -201,7 +240,14 @@ _process_info_by_handle :: proc(process: Process, selection: Process_Info_Fields
 		}
 	}
 	snapshot_module: if .Executable_Path in selection {
-		info.executable_path = _process_exe_by_pid(pid, allocator) or_break snapshot_module
+		exe_path: string
+		exe_path, err = _process_exe_by_pid(pid, allocator)
+		if _, ok := err.(runtime.Allocator_Error); ok {
+			return
+		} else if err != nil {
+			break snapshot_module
+		}
+		info.executable_path = exe_path
 		info.fields += {.Executable_Path}
 	}
 	ph := win32.HANDLE(process.handle)
@@ -217,40 +263,62 @@ _process_info_by_handle :: proc(process: Process, selection: Process_Info_Fields
 		}
 		assert(process_info.PebBaseAddress != nil)
 		process_peb: win32.PEB
-		_ = read_memory_as_struct(ph, process_info.PebBaseAddress, &process_peb) or_break read_peb
+		_, err = read_memory_as_struct(ph, process_info.PebBaseAddress, &process_peb)
+		if err != nil {
+			break read_peb
+		}
 		process_params: win32.RTL_USER_PROCESS_PARAMETERS
-		_ = read_memory_as_struct(ph, process_peb.ProcessParameters, &process_params) or_break read_peb
+		_, err = read_memory_as_struct(ph, process_peb.ProcessParameters, &process_params)
+		if err != nil {
+			break read_peb
+		}
 		if selection >= {.Command_Line, .Command_Args} {
 			TEMP_ALLOCATOR_GUARD()
-			cmdline_w := make([]u16, process_params.CommandLine.Length, temp_allocator()) or_break read_peb
-			_ = read_memory_as_slice(ph, process_params.CommandLine.Buffer, cmdline_w) or_break read_peb
+			cmdline_w := make([]u16, process_params.CommandLine.Length, temp_allocator()) or_return
+			_, err = read_memory_as_slice(ph, process_params.CommandLine.Buffer, cmdline_w)
+			if err != nil {
+				break read_peb
+			}
 			if .Command_Line in selection {
-				info.command_line = win32_utf16_to_utf8(cmdline_w, allocator) or_break read_peb
+				info.command_line = win32_utf16_to_utf8(cmdline_w, allocator) or_return
 				info.fields += {.Command_Line}
 			}
 			if .Command_Args in selection {
-				info.command_args = _parse_command_line(raw_data(cmdline_w), allocator) or_break read_peb
+				info.command_args = _parse_command_line(raw_data(cmdline_w), allocator) or_return
 				info.fields += {.Command_Args}
 			}
 		}
 		if .Environment in selection {
 			TEMP_ALLOCATOR_GUARD()
 			env_len := process_params.EnvironmentSize / 2
-			envs_w := make([]u16, env_len, temp_allocator()) or_break read_peb
-			_ = read_memory_as_slice(ph, process_params.Environment, envs_w) or_break read_peb
-			info.environment =  _parse_environment_block(raw_data(envs_w), allocator) or_break read_peb
+			envs_w := make([]u16, env_len, temp_allocator()) or_return
+			_, err = read_memory_as_slice(ph, process_params.Environment, envs_w)
+			if err != nil {
+				break read_peb
+			}
+			info.environment =  _parse_environment_block(raw_data(envs_w), allocator) or_return
 			info.fields += {.Environment}
 		}
 		if .Working_Dir in selection {
 			TEMP_ALLOCATOR_GUARD()
-			cwd_w := make([]u16, process_params.CurrentDirectoryPath.Length, temp_allocator()) or_break read_peb
-			_ = read_memory_as_slice(ph, process_params.CurrentDirectoryPath.Buffer, cwd_w) or_break read_peb
-			info.working_dir = win32_utf16_to_utf8(cwd_w, allocator) or_break read_peb
+			cwd_w := make([]u16, process_params.CurrentDirectoryPath.Length, temp_allocator()) or_return
+			_, err = read_memory_as_slice(ph, process_params.CurrentDirectoryPath.Buffer, cwd_w)
+			if err != nil {
+				break read_peb
+			}
+			info.working_dir = win32_utf16_to_utf8(cwd_w, allocator) or_return
 			info.fields += {.Working_Dir}
 		}
 	}
 	read_username: if .Username in selection {
-		info.username = _get_process_user(ph, allocator) or_break read_username
+		username: string
+		username, err = _get_process_user(ph, allocator)
+		if _, ok := err.(runtime.Allocator_Error); ok {
+			return
+		} else if err != nil {
+			break read_username
+		}
+		info.username = username
 		info.fields += {.Username}
 	}
 	err = nil
@@ -263,8 +331,12 @@ _current_process_info :: proc(selection: Process_Info_Fields, allocator: runtime
 	snapshot_process: if selection >= {.PPid, .Priority} {
 		entry, entry_err := _process_entry_by_pid(info.pid)
 		if entry_err != nil {
-			err = General_Error.Not_Exist
-			return
+			err = entry_err
+			if entry_err == General_Error.Not_Exist {
+				return
+			} else {
+				break snapshot_process
+			}
 		}
 		if .PPid in selection {
 			info.fields += {.PPid}
@@ -278,28 +350,38 @@ _current_process_info :: proc(selection: Process_Info_Fields, allocator: runtime
 	module_filename: if .Executable_Path in selection {
 		exe_filename_w: [256]u16
 		path_len := win32.GetModuleFileNameW(nil, raw_data(exe_filename_w[:]), len(exe_filename_w))
-		info.executable_path = win32_utf16_to_utf8(exe_filename_w[:path_len], allocator) or_break module_filename
+		assert(path_len > 0)
+		info.executable_path = win32_utf16_to_utf8(exe_filename_w[:path_len], allocator) or_return
 		info.fields += {.Executable_Path}
 	}
 	command_line: if selection >= {.Command_Line,  .Command_Args} {
 		command_line_w := win32.GetCommandLineW()
+		assert(command_line_w != nil)
 		if .Command_Line in selection {
-			info.command_line = win32_wstring_to_utf8(command_line_w, allocator) or_break command_line
+			info.command_line = win32_wstring_to_utf8(command_line_w, allocator) or_return
 			info.fields += {.Command_Line}
 		}
 		if .Command_Args in selection {
-			info.command_args = _parse_command_line(command_line_w, allocator) or_break command_line
+			info.command_args = _parse_command_line(command_line_w, allocator) or_return
 			info.fields += {.Command_Args}
 		}
 	}
-	environment: if .Environment in selection {
+	read_environment: if .Environment in selection {
 		env_block := win32.GetEnvironmentStringsW()
-		info.environment = _parse_environment_block(env_block, allocator) or_break environment
+		assert(env_block != nil)
+		info.environment = _parse_environment_block(env_block, allocator) or_return
 		info.fields += {.Environment}
 	}
-	username: if .Username in selection {
+	read_username: if .Username in selection {
 		process_handle := win32.GetCurrentProcess()
-		info.username = _get_process_user(process_handle, allocator) or_break username
+		username: string
+		username, err := _get_process_user(process_handle, allocator)
+		if _, ok := err.(runtime.Allocator_Error); ok {
+			return
+		} else if err != nil {
+			break read_username
+		}
+		info.username = username
 		info.fields += {.Username}
 	}
 	if .Working_Dir in selection {

--- a/core/os/os2/process_windows.odin
+++ b/core/os/os2/process_windows.odin
@@ -375,7 +375,7 @@ _current_process_info :: proc(selection: Process_Info_Fields, allocator: runtime
 	read_username: if .Username in selection {
 		process_handle := win32.GetCurrentProcess()
 		username: string
-		username, err := _get_process_user(process_handle, allocator)
+		username, err = _get_process_user(process_handle, allocator)
 		if _, ok := err.(runtime.Allocator_Error); ok {
 			return
 		} else if err != nil {


### PR DESCRIPTION
This PR makes the behavior of `get_process_info` procedure consistent with linux and other platforms' implementations by not freeing all the fields if an error has occurred during retrieval of requested information, after other information has been successfully retrieved.

It also allows for the procedure to complete with "partial success" state, where the function will complete successfully, even if not all of the requested information has been obtained.

The error handling has been altered according to the following logic. Depending on which errors has happened internally, the handling of it will differ, according to the following rules:

- Allocator errors: `process_info` returns immediately with the error
- Process isn't running: `process_info` returns immediately with `General_Error.Not_Found`
- Permissions and other similar issues: `process_info` records the error, but continues to fetch other data
- Unexpected situations (address in PEB is `nil`, length of command line is 0, etc): Panic

Which is the behavior currently implemented for other platforms (more or less)
