### PR TITLE
Float emulation start for more embedded support

### DIFF
--- a/base/runtime/internal.odin
+++ b/base/runtime/internal.odin
@@ -1103,3 +1103,24 @@ __read_bits :: proc "contextless" (dst, src: [^]byte, offset: uintptr, size: uin
 		dst[j>>3]  |= the_bit<<(j&7)
 	}
 }
+
+// when !F64_SUPPORTED {
+	@(link_name="__truncdfsf2", linkage=RUNTIME_LINKAGE, require=RUNTIME_REQUIRE)
+	truncdfsf2 :: proc "c" (value: f64) -> f32 {
+		return 0
+	}
+// }
+
+// when !F32_SUPPORTED {
+	CMP_RESULT :: i32 when ODIN_ARCH == .arm64 else i64
+
+	@(link_name="__mulsf3", linkage=RUNTIME_LINKAGE, require=RUNTIME_REQUIRE)
+	mulsf3 :: proc "c" (a, b: f32) -> f32 {
+		return 0
+	}
+
+	@(link_name="__gesf2", linkage=RUNTIME_LINKAGE, require=RUNTIME_REQUIRE)
+	gesf2 :: proc "c" (a, b: f32) -> CMP_RESULT {
+		return 0
+	}
+// }

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1803,6 +1803,22 @@ gb_internal bool check_target_feature_is_superset_of(String const &superset, Str
 	return true;
 }
 
+gb_internal bool target_supports_f32() {
+	switch (build_context.metrics.arch) {
+	case TargetArch_riscv64:
+		return check_target_feature_is_enabled(str_lit("f"), nullptr);
+	}
+	return false;
+}
+
+gb_internal bool target_supports_f64() {
+	switch (build_context.metrics.arch) {
+	case TargetArch_riscv64:
+		return check_target_feature_is_enabled(str_lit("d"), nullptr);
+	}
+	return false;
+}
+
 // NOTE(Jeroen): Set/create the output and other paths and report an error as appropriate.
 // We've previously called `parse_build_flags`, so `out_filepath` should be set.
 gb_internal bool init_build_paths(String init_filename) {

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -2006,8 +2006,7 @@ gb_internal bool check_binary_op(CheckerContext *c, Operand *o, Token op) {
 		switch (op.kind) {
 		case Token_Mul:
 		case Token_MulEq:
-			if (ct == t_f32) {
-				// TODO: only if target does not support f32.
+			if (ct == t_f32 && !target_supports_f32()) {
 				add_package_dependency(c, "runtime", "mulsf3", true);
 			}
 		}
@@ -2983,8 +2982,7 @@ gb_internal void check_comparison(CheckerContext *c, Ast *node, Operand *x, Oper
 					}
 					break;
 				}
-			} else if (xcore == t_f32 || ycore == t_f32) {
-				// TODO: only if target doesn't support f32.
+			} else if ((xcore == t_f32 || ycore == t_f32) && !target_supports_f32()) {
 				switch (op) {
 				case Token_GtEq: add_package_dependency(c, "runtime", "gesf2", true); break;
 				}
@@ -3463,8 +3461,7 @@ gb_internal void check_cast(CheckerContext *c, Operand *x, Type *type, bool forb
 				add_package_dependency(c, "runtime", "truncsfhf2",         REQUIRE);
 				add_package_dependency(c, "runtime", "truncdfhf2",         REQUIRE);
 				add_package_dependency(c, "runtime", "gnu_f2h_ieee",       REQUIRE);
-			} else if (src == t_f64 && dst == t_f32) {
-				// TODO: only if target doesn't have f64 floats hardware (riscv without the "d").
+			} else if (src == t_f64 && dst == t_f32 && !target_supports_f64()) {
 				add_package_dependency(c, "runtime", "truncdfsf2",         REQUIRE);
 			}
 		}

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -465,10 +465,11 @@ gb_internal i32 linker_stage(LinkerData *gen) {
 					#endif // GB_ARCH_*_BIT
 
 						if (build_context.metrics.arch == TargetArch_riscv64) {
+							// TODO: create -march based on -enable-target-feature and -microarch.
 							result = system_exec_command_line_app("clang",
 								"%s \"%.*s\" "
 								"-c -o \"%.*s\" "
-								"-target %.*s -march=rv64gc "
+								"-target %.*s -march=rv64imac "
 								"%.*s "
 								"",
 								clang_path,

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -465,17 +465,34 @@ gb_internal i32 linker_stage(LinkerData *gen) {
 					#endif // GB_ARCH_*_BIT
 
 						if (build_context.metrics.arch == TargetArch_riscv64) {
-							// TODO: create -march based on -enable-target-feature and -microarch.
+							gbString clang_march = gb_string_make(heap_allocator(), "rv64i");
+							if (check_target_feature_is_enabled(str_lit("m"), nullptr)) {
+								clang_march = gb_string_appendc(clang_march, "m");
+							}
+							if (check_target_feature_is_enabled(str_lit("a"), nullptr)) {
+								clang_march = gb_string_appendc(clang_march, "a");
+							}
+							if (check_target_feature_is_enabled(str_lit("f"), nullptr)) {
+								clang_march = gb_string_appendc(clang_march, "f");
+							}
+							if (check_target_feature_is_enabled(str_lit("d"), nullptr)) {
+								clang_march = gb_string_appendc(clang_march, "d");
+							}
+							if (check_target_feature_is_enabled(str_lit("c"), nullptr)) {
+								clang_march = gb_string_appendc(clang_march, "c");
+							}
+
 							result = system_exec_command_line_app("clang",
 								"%s \"%.*s\" "
 								"-c -o \"%.*s\" "
-								"-target %.*s -march=rv64imac "
+								"-target %.*s -march=%s "
 								"%.*s "
 								"",
 								clang_path,
 								LIT(asm_file),
 								LIT(obj_file),
 								LIT(build_context.metrics.target_triplet),
+								clang_march,
 								LIT(build_context.extra_assembler_flags)
 							);
 						} else if (is_osx) {

--- a/src/llvm_abi.cpp
+++ b/src/llvm_abi.cpp
@@ -1573,14 +1573,12 @@ namespace lbAbiRiscv64 {
 
 		int xlen = 8; // 8 byte int register size for riscv64.
 
-		// NOTE: we are requiring both of these to be enabled so we can just hard-code 8.
-		// int flen = 0;
-		// if (check_target_feature_is_enabled(str_lit("d"), nullptr)) {
-		// 	flen = 8; // Double precision floats are enabled.
-		// } else if (check_target_feature_is_enabled(str_lit("f"), nullptr)) {
-		// 	flen = 4; // Single precision floats are enabled.
-		// }
-		int flen = 8;
+		int flen = 0;
+		if (check_target_feature_is_enabled(str_lit("d"), nullptr)) {
+			flen = 8; // Double precision floats are enabled.
+		} else if (check_target_feature_is_enabled(str_lit("f"), nullptr)) {
+			flen = 4; // Single precision floats are enabled.
+		}
 
 		LLVMTypeKind kind = LLVMGetTypeKind(type);
 		i64 size = lb_sizeof(type);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3248,7 +3248,7 @@ int main(int arg_count, char const **arg_ptr) {
 	// NOTE(laytan): on riscv64 we want to enforce some features.
 	if (build_context.metrics.arch == TargetArch_riscv64) {
 		String disabled;
-		if (!check_target_feature_is_enabled(str_lit("64bit,f,d,m"), &disabled)) { // 64bit, floats, doubles, integer multiplication.
+		if (!check_target_feature_is_enabled(str_lit("64bit,m"), &disabled)) { // 64bit, integer multiplication.
 			gb_printf_err("missing required target feature: \"%.*s\", enable it by setting a different -microarch or explicitly adding it through -target-features\n", LIT(disabled));
 			gb_exit(1);
 		}


### PR DESCRIPTION
Had a quick look at float emulation today so we can support use cases where targets don't support floats in the future. With the current progress in this PR a simple hello world compiles for riscv64 without floats:

```odin
package main

import "base:runtime"

main :: proc() {
	runtime.print_string("Hello")
}
```
`odin run test.odin -file -target:linux_riscv64 -no-crt -default-to-nil-allocator -reloc-mode:static -microarch:generic -target-features:"m"` (you want to have qemu user mode emulation if you are on another architecture for your host `sudo apt install qemu-user qemu-user-static`)

When you start importing more packages and using more float features you will keep getting more linker errors about functions that are needed. The basic process is adding them to the runtime package and to the checker (in order to add it to the final output).

We think the implementations can just be ported from LLVM's compiler-rt https://github.com/llvm/llvm-project/tree/main/compiler-rt which uses the same license as llvm as a backend itself, so there shouldn't be any licensing issues.

Once we have float emulation for one target, adding it for other targets should be fairly simple.

I am making this a draft so somebody else can pick it up if they want to, because I don't have much time to spend on this in the near future.

So if anybody wants to pick this up further, you can just take the changes here as a base and add to it.