### PR TITLE
Fix use-after-free in `thread.Pool`

### DIFF
--- a/core/thread/thread_pool.odin
+++ b/core/thread/thread_pool.odin
@@ -175,10 +175,12 @@ pool_stop_task :: proc(pool: ^Pool, user_index: int, exit_code: int = 1) -> bool
 			intrinsics.atomic_sub(&pool.num_outstanding, 1)
 			intrinsics.atomic_sub(&pool.num_in_processing, 1)
 
+			old_thread_user_index := t.user_index
+
 			destroy(t)
 
 			replacement := create(pool_thread_runner)
-			replacement.user_index = t.user_index
+			replacement.user_index = old_thread_user_index
 			replacement.data = data
 			data.task = {}
 			pool.threads[i] = replacement
@@ -207,10 +209,12 @@ pool_stop_all_tasks :: proc(pool: ^Pool, exit_code: int = 1) {
 			intrinsics.atomic_sub(&pool.num_outstanding, 1)
 			intrinsics.atomic_sub(&pool.num_in_processing, 1)
 
+			old_thread_user_index := t.user_index
+
 			destroy(t)
 
 			replacement := create(pool_thread_runner)
-			replacement.user_index = t.user_index
+			replacement.user_index = old_thread_user_index
 			replacement.data = data
 			data.task = {}
 			pool.threads[i] = replacement


### PR DESCRIPTION
I found this by a fluke while using `-sanitize:address` on the core test suite. I'm unable to replicate the conditions that led to the report though.