### PR TITLE
Delay lexical checking for foreign blocks that are in file scope

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -6446,7 +6446,7 @@ gb_internal bool parse_file(Parser *p, AstFile *f) {
 				}
 
 				f->total_file_decl_count += calc_decl_count(stmt);
-				if (stmt->kind == Ast_WhenStmt || stmt->kind == Ast_ExprStmt || stmt->kind == Ast_ImportDecl) {
+				if (stmt->kind == Ast_WhenStmt || stmt->kind == Ast_ExprStmt || stmt->kind == Ast_ImportDecl || stmt->kind == Ast_ForeignBlockDecl) {
 					f->delayed_decl_count += 1;
 				}
 			}

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -82,6 +82,7 @@ enum AstFileFlag : u32 {
 enum AstDelayQueueKind {
 	AstDelayQueue_Import,
 	AstDelayQueue_Expr,
+	AstDelayQueue_ForeignBlock,
 	AstDelayQueue_COUNT,
 };
 


### PR DESCRIPTION
this PR changes the checker evaluation order which caused foreign block statements being evaluated before constants, leading to errors when using constants in foreign block attributes (like if they were not declared in the scope yet)

now this is possible:
```go
PREFIX :: "lib_"
@(link_prefix=PREFIX)
foreign lib { ... }
```

also trim whitespace on foreign attributes strings (whitespace is not allowed here anyway, but simplifies passing strings as `-define`s to attributes)

(THIS IS A PROPOSAL PR)
(all tests that i could find in the repo are passed, on windows and linux)
