### PR TITLE
mem/virtual: make sure the given size is used for subsequent blocks

### DIFF
--- a/core/mem/virtual/arena.odin
+++ b/core/mem/virtual/arena.odin
@@ -49,6 +49,10 @@ arena_init_growing :: proc(arena: ^Arena, reserved: uint = DEFAULT_ARENA_GROWING
 	arena.curr_block     = memory_block_alloc(0, reserved, {}) or_return
 	arena.total_used     = 0
 	arena.total_reserved = arena.curr_block.reserved
+
+	if arena.minimum_block_size == 0 {
+		arena.minimum_block_size = reserved
+	}
 	return
 }
 


### PR DESCRIPTION
Currently `arena_init_growing(&arena, mem.Gigabyte)` only says the first block would be a gigabyte, subsequent blocks would go back to the default value here: https://github.com/odin-lang/Odin/blob/942017b9585841cc9d90e1e2627e99ad3371a42e/core/mem/virtual/arena.odin#L108-L111