### PR TITLE
Make math.remap clamp the result in range [new_min, new_max]

### DIFF
--- a/core/math/math.odin
+++ b/core/math/math.odin
@@ -402,7 +402,8 @@ remap :: proc "contextless" (old_value, old_min, old_max, new_min, new_max: $T) 
 	if old_range == 0 {
 		return new_range / 2
 	}
-	return ((old_value - old_min) / old_range) * new_range + new_min
+	remapped := ((old_value - old_min) / old_range) * new_range + new_min
+	return clamp(remapped, new_min, new_max)
 }
 
 @(require_results)


### PR DESCRIPTION
Since the parameter names are new_min and new_max, I assume that remap would return a value clamped in that range.