### PR TITLE
fix(os2): mkdir_all on path_posix

### DIFF
--- a/core/os/os2/path_posix.odin
+++ b/core/os/os2/path_posix.odin
@@ -39,12 +39,12 @@ _mkdir_all :: proc(path: string, perm: int) -> Error {
 	return internal_mkdir_all(clean_path, perm)
 
 	internal_mkdir_all :: proc(path: string, perm: int) -> Error {
-		a, _ := filepath.split(path)
-		if a != path {
-			if len(a) > 1 && a[len(a)-1] == '/' {
-				a = a[:len(a)-1]
+		dir, file := filepath.split(path)
+		if file != path {
+			if len(dir) > 1 && dir[len(dir) - 1] == '/' {
+				dir = dir[:len(dir) - 1]
 			}
-			internal_mkdir_all(a, perm) or_return
+			internal_mkdir_all(dir, perm) or_return
 		}
 
 		err := _mkdir(path, perm)


### PR DESCRIPTION
## Changes

* Fixes `mkdir_all` logic on `os2.path_posix`. Currently it does not execute correctly, since the `internal_mkdir_all` function checks the `dir` against the `path` instead of the `file` this means that it eventually tries to run `_mkdir` on empty strings and doesn't create any directory and returns a `.Not_exist` error