### PR TITLE
Check for zero-length slices in `slice.equal`

### DIFF
--- a/core/slice/slice.odin
+++ b/core/slice/slice.odin
@@ -200,6 +200,17 @@ equal :: proc(a, b: $T/[]$E) -> bool where intrinsics.type_is_comparable(E) #no_
 		return false
 	}
 	when intrinsics.type_is_simple_compare(E) {
+		if len(a) == 0 {
+			// Empty slices are always equivalent to each other.
+			//
+			// This check is here in the event that a slice with a `data` of
+			// nil is compared against a slice with a non-nil `data` but a
+			// length of zero.
+			//
+			// In that case, `memory_compare` would return -1 or +1 because one
+			// of the pointers is nil.
+			return true
+		}
 		return runtime.memory_compare(raw_data(a), raw_data(b), len(a)*size_of(E)) == 0
 	} else {
 		for i in 0..<len(a) {

--- a/tests/core/slice/test_core_slice.odin
+++ b/tests/core/slice/test_core_slice.odin
@@ -276,3 +276,33 @@ test_unique :: proc(t: ^testing.T) {
 		delete(expected)
 	}
 }
+
+@test
+test_compare_empty :: proc(t: ^testing.T) {
+	a := []int{}
+	b := []int{}
+	c: [dynamic]int = { 0 }
+	d: [dynamic]int = { 1 }
+	clear(&c)
+	clear(&d)
+	defer {
+		delete(c)
+		delete(d)
+	}
+
+	testing.expectf(t, len(a) == 0,
+		"Expected length of slice `a` to be zero")
+	testing.expectf(t, len(c) == 0,
+		"Expected length of dynamic array `c` to be zero")
+	testing.expectf(t, len(d) == 0,
+		"Expected length of dynamic array `d` to be zero")
+
+	testing.expectf(t, slice.equal(a, a),
+		"Expected empty slice to be equal to itself")
+	testing.expectf(t, slice.equal(a, b),
+		"Expected two different but empty stack-based slices to be equivalent")
+	testing.expectf(t, slice.equal(a, c[:]),
+		"Expected empty slice to be equal to slice of empty dynamic array")
+	testing.expectf(t, slice.equal(c[:], d[:]),
+		"Expected two separate empty slices of two dynamic arrays to be equal")
+}


### PR DESCRIPTION
I was a bit surprised to find this while writing the tests for #4186. I tried to convert the tests to use `slice.equal`, and there I found out that it considers an empty slice to be distinct from an empty slice made from a dynamic array due to the `data` pointer difference with one of them being `nil`.

I'm not sure if this is something that can (or should?) be solved at the compiler level (such as returning a `Raw_Slice` with its `data` set to zero if the compiler slices a zero-length array), but this fixes the underlying issue. This is probably the safer way to fix it, after some thought.

