### PR TITLE
Fix thread sanitizer errors surfaced by tests/core/io

### DIFF
--- a/core/sync/primitives_atomic.odin
+++ b/core/sync/primitives_atomic.odin
@@ -338,7 +338,7 @@ atomic_sema_wait :: proc "contextless" (s: ^Atomic_Sema) {
 		original_count := atomic_load_explicit(&s.count, .Relaxed)
 		for original_count == 0 {
 			futex_wait(&s.count, u32(original_count))
-			original_count = s.count
+			original_count = atomic_load_explicit(&s.count, .Relaxed)
 		}
 		if original_count == atomic_compare_exchange_strong_explicit(&s.count, original_count, original_count-1, .Acquire, .Acquire) {
 			return

--- a/core/thread/thread_pool.odin
+++ b/core/thread/thread_pool.odin
@@ -122,9 +122,10 @@ pool_join :: proc(pool: ^Pool) {
 	for started_count < len(pool.threads) {
 		started_count = 0
 		for t in pool.threads {
-			if .Started in t.flags {
+			flags := intrinsics.atomic_load(&t.flags)
+			if .Started in flags {
 				started_count += 1
-				if .Joined not_in t.flags {
+				if .Joined not_in flags {
 					join(t)
 				}
 			}


### PR DESCRIPTION
I was looking at #4161 when I ran into other thread sanitizer data races when running `./odin test tests/core/io -debug -sanitize:thread`. These changes get rid of the errors, tested on mac arm64 and linux x64.

Core sync data race:

```
WARNING: ThreadSanitizer: data race (pid=14246)
  Read of size 4 at 0x00016f137114 by thread T3:
    #0 sync.atomic_sema_wait primitives_atomic.odin:341 (io:arm64+0x100045954)
    #1 sync._sema_wait-1670 primitives_internal.odin:20 (io:arm64+0x100012850)
    #2 sync.sema_wait primitives.odin:521 (io:arm64+0x1000611c0)
    #3 thread.pool_thread_runner-3747 thread_pool.odin:58 (io:arm64+0x100017574)
    #4 thread._create-3823.__unix_thread_entry_proc-0 thread_unix.odin:64 (io:arm64+0x1000806e0)

  Previous atomic write of size 4 at 0x00016f137114 by main thread:
    #0 sync.atomic_sema_post primitives_atomic.odin:328 (io:arm64+0x1000456c4)
    #1 sync._sema_post-1663 primitives_internal.odin:16 (io:arm64+0x1000058a0)
    #2 sync.sema_post primitives.odin:510 (io:arm64+0x100060f08)
    #3 thread.pool_join thread_pool.odin:117 (io:arm64+0x100022350)
    #4 testing.runner-827 runner.odin:816 (io:arm64+0x100039074)
    #5 main <null>:22449796 (io:arm64+0x100087408)

  Location is stack of main thread.

  Thread T3 (tid=130539, running) created by main thread at:
    #0 pthread_create <null>:22449796 (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x3062c)
    #1 thread._create-3823 thread_unix.odin:125 (io:arm64+0x100014468)
    #2 thread.create thread.odin:105 (io:arm64+0x100023810)
    #3 thread.pool_init thread_pool.odin:84 (io:arm64+0x10001b050)
    #4 testing.runner-827 runner.odin:313 (io:arm64+0x1000346f4)
    #5 main <null>:22449796 (io:arm64+0x100087408)

SUMMARY: ThreadSanitizer: data race primitives_atomic.odin:341 in sync.atomic_sema_wait
```

Thread pool data race:

```
WARNING: ThreadSanitizer: data race (pid=14246)
  Atomic write of size 1 at 0x000100f000a0 by thread T1:
    #0 thread._create-3823.__unix_thread_entry_proc-0 thread_unix.odin:67 (io:arm64+0x100080718)

  Previous read of size 1 at 0x000100f000a0 by main thread:
    #0 thread.pool_join thread_pool.odin:125 (io:arm64+0x100022430)
    #1 testing.runner-827 runner.odin:816 (io:arm64+0x100039074)
    #2 main <null>:22449796 (io:arm64+0x100087408)

  Location is heap block of size 16439 at 0x000100f00000 allocated by main thread:
    #0 calloc <null>:22449796 (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x562cc)
    #1 runtime._heap_alloc-462 heap_allocator_unix.odin:24 (io:arm64+0x1000135c0)
    #2 runtime.heap_alloc heap_allocator.odin:108 (io:arm64+0x1000237a4)
    #3 runtime.heap_allocator_proc.aligned_alloc-0 heap_allocator.odin:34 (io:arm64+0x10007f30c)
    #4 runtime.heap_allocator_proc heap_allocator.odin:81 (io:arm64+0x100005bf0)
    #5 runtime.mem_alloc internal.odin:134 (io:arm64+0x100023054)
    #6 mem.rb_make_block-2237 rollback_stack_allocator.odin:231 (io:arm64+0x1000416a4)
    #7 mem.rollback_stack_init_dynamic rollback_stack_allocator.odin:265 (io:arm64+0x100044a0c)
    #8 testing.runner-827 runner.odin:308 (io:arm64+0x100034594)
    #9 main <null>:22449796 (io:arm64+0x100087408)

  Thread T1 (tid=130537, running) created by main thread at:
    #0 pthread_create <null>:22449796 (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x3062c)
    #1 thread._create-3823 thread_unix.odin:125 (io:arm64+0x100014468)
    #2 thread.create thread.odin:105 (io:arm64+0x100023810)
    #3 thread.pool_init thread_pool.odin:84 (io:arm64+0x10001b050)
    #4 testing.runner-827 runner.odin:313 (io:arm64+0x1000346f4)
    #5 main <null>:22449796 (io:arm64+0x100087408)

SUMMARY: ThreadSanitizer: data race thread_unix.odin:67 in thread._create-3823.__unix_thread_entry_proc-0
```