### PR TITLE
Fix wgpu on Windows - missing links to ole32.lib and oleaut32.lib

### DIFF
--- a/vendor/wgpu/wgpu.odin
+++ b/vendor/wgpu/wgpu.odin
@@ -27,6 +27,8 @@ when ODIN_OS == .Windows {
 		"system:advapi32.lib",
 		"system:user32.lib",
 		"system:gdi32.lib",
+		"system:ole32.lib",
+		"system:oleaut32.lib",
 	}
 } else when ODIN_OS == .Darwin {
 	@(private) ARCH :: "x86_64" when ODIN_ARCH == .amd64 else "aarch64" when ODIN_ARCH == .arm64 else #panic("unsupported WGPU Native architecture")


### PR DESCRIPTION
Adding these two libraries gets things linking again for me on Windows 11.