### PR TITLE
[core/mem]: Document, refactor, reformat!

### DIFF
--- a/base/runtime/internal.odin
+++ b/base/runtime/internal.odin
@@ -118,16 +118,15 @@ mem_copy_non_overlapping :: proc "contextless" (dst, src: rawptr, len: int) -> r
 DEFAULT_ALIGNMENT :: 2*align_of(rawptr)
 
 mem_alloc_bytes :: #force_inline proc(size: int, alignment: int = DEFAULT_ALIGNMENT, allocator := context.allocator, loc := #caller_location) -> ([]byte, Allocator_Error) {
-	if size == 0 {
-		return nil, nil
-	}
-	if allocator.procedure == nil {
+	assert(is_power_of_two_int(alignment), "Alignment must be a power of two", loc)
+	if size == 0 || allocator.procedure == nil{
 		return nil, nil
 	}
 	return allocator.procedure(allocator.data, .Alloc, size, alignment, nil, 0, loc)
 }
 
 mem_alloc :: #force_inline proc(size: int, alignment: int = DEFAULT_ALIGNMENT, allocator := context.allocator, loc := #caller_location) -> ([]byte, Allocator_Error) {
+	assert(is_power_of_two_int(alignment), "Alignment must be a power of two", loc)
 	if size == 0 || allocator.procedure == nil {
 		return nil, nil
 	}
@@ -135,6 +134,7 @@ mem_alloc :: #force_inline proc(size: int, alignment: int = DEFAULT_ALIGNMENT, a
 }
 
 mem_alloc_non_zeroed :: #force_inline proc(size: int, alignment: int = DEFAULT_ALIGNMENT, allocator := context.allocator, loc := #caller_location) -> ([]byte, Allocator_Error) {
+	assert(is_power_of_two_int(alignment), "Alignment must be a power of two", loc)
 	if size == 0 || allocator.procedure == nil {
 		return nil, nil
 	}
@@ -174,6 +174,7 @@ mem_free_all :: #force_inline proc(allocator := context.allocator, loc := #calle
 }
 
 _mem_resize :: #force_inline proc(ptr: rawptr, old_size, new_size: int, alignment: int = DEFAULT_ALIGNMENT, allocator := context.allocator, should_zero: bool, loc := #caller_location) -> (data: []byte, err: Allocator_Error) {
+	assert(is_power_of_two_int(alignment), "Alignment must be a power of two", loc)
 	if allocator.procedure == nil {
 		return nil, nil
 	}
@@ -215,9 +216,11 @@ _mem_resize :: #force_inline proc(ptr: rawptr, old_size, new_size: int, alignmen
 }
 
 mem_resize :: proc(ptr: rawptr, old_size, new_size: int, alignment: int = DEFAULT_ALIGNMENT, allocator := context.allocator, loc := #caller_location) -> (data: []byte, err: Allocator_Error) {
+	assert(is_power_of_two_int(alignment), "Alignment must be a power of two", loc)
 	return _mem_resize(ptr, old_size, new_size, alignment, allocator, true, loc)
 }
 non_zero_mem_resize :: proc(ptr: rawptr, old_size, new_size: int, alignment: int = DEFAULT_ALIGNMENT, allocator := context.allocator, loc := #caller_location) -> (data: []byte, err: Allocator_Error) {
+	assert(is_power_of_two_int(alignment), "Alignment must be a power of two", loc)
 	return _mem_resize(ptr, old_size, new_size, alignment, allocator, false, loc)
 }
 

--- a/core/mem/alloc.odin
+++ b/core/mem/alloc.odin
@@ -2,66 +2,272 @@ package mem
 
 import "base:runtime"
 
-// NOTE(bill, 2019-12-31): These are defined in `package runtime` as they are used in the `context`. This is to prevent an import definition cycle.
+//NOTE(bill, 2019-12-31): These are defined in `package runtime` as they are used in the `context`. This is to prevent an import definition cycle.
+
+/*
+A request to allocator procedure.
+
+This type represents a type of allocation request made to an allocator
+procedure. There is one allocator procedure per allocator, and this value is
+used to discriminate between different functions of the allocator.
+
+The type is defined as follows:
+
+	Allocator_Mode :: enum byte {
+		Alloc,
+		Alloc_Non_Zeroed,
+		Free,
+		Free_All,
+		Resize,
+		Resize_Non_Zeroed,
+		Query_Features,
+	}
+
+Depending on which value is used, the allocator procedure will perform different
+functions:
+
+- `Alloc`: Allocates a memory region with a given `size` and `alignment`.
+- `Alloc_Non_Zeroed`: Same as `Alloc` without explicit zero-initialization of
+	the memory region.
+- `Free`: Free a memory region located at address `ptr` with a given `size`.
+- `Free_All`: Free all memory allocated using this allocator.
+- `Resize`: Resize a memory region located at address `old_ptr` with size
+	`old_size` to be `size` bytes in length and have the specified `alignment`,
+	in case a re-alllocation occurs.
+- `Resize_Non_Zeroed`: Same as `Resize`, without explicit zero-initialization.
+
+*/
 Allocator_Mode :: runtime.Allocator_Mode
-/*
-Allocator_Mode :: enum byte {
-	Alloc,
-	Free,
-	Free_All,
-	Resize,
-	Query_Features,
-	Alloc_Non_Zeroed,
-	Resize_Non_Zeroed,
-}
-*/
 
+/*
+A set of allocator features.
+
+This type represents values that contain a set of features an allocator has.
+Currently the type is defined as follows:
+
+	Allocator_Mode_Set :: distinct bit_set[Allocator_Mode];
+*/
 Allocator_Mode_Set :: runtime.Allocator_Mode_Set
-/*
-Allocator_Mode_Set :: distinct bit_set[Allocator_Mode];
-*/
 
+/*
+Allocator information.
+
+This type represents information about a given allocator at a specific point
+in time. Currently the type is defined as follows:
+
+	Allocator_Query_Info :: struct {
+		pointer:   rawptr,
+		size:      Maybe(int),
+		alignment: Maybe(int),
+	}
+
+- `pointer`: Pointer to a backing buffer.
+- `size`: Size of the backing buffer.
+- `alignment`: The allocator's alignment.
+
+If not applicable, any of these fields may be `nil`.
+*/
 Allocator_Query_Info :: runtime.Allocator_Query_Info
-/*
-Allocator_Query_Info :: struct {
-	pointer:   rawptr,
-	size:      Maybe(int),
-	alignment: Maybe(int),
-}
-*/
 
-Allocator_Error :: runtime.Allocator_Error
 /*
-Allocator_Error :: enum byte {
-	None                 = 0,
-	Out_Of_Memory        = 1,
-	Invalid_Pointer      = 2,
-	Invalid_Argument     = 3,
-	Mode_Not_Implemented = 4,
-}
+An allocation request error.
+
+This type represents error values the allocators may return upon requests.
+
+	Allocator_Error :: enum byte {
+		None                 = 0,
+		Out_Of_Memory        = 1,
+		Invalid_Pointer      = 2,
+		Invalid_Argument     = 3,
+		Mode_Not_Implemented = 4,
+	}
+
+The meaning of the errors is as follows:
+
+- `None`: No error.
+- `Out_Of_Memory`: Either:
+	1. The allocator has ran out of the backing buffer, or the requested
+		allocation size is too large to fit into a backing buffer.
+	2. The operating system error during memory allocation.
+	3. The backing allocator was used to allocate a new backing buffer and the
+		backing allocator returned Out_Of_Memory.
+- `Invalid_Pointer`: The pointer referring to a memory region does not belong
+	to any of the allocators backing buffers or does not point to a valid start
+	of an allocation made in that allocator.
+- `Invalid_Argument`: Can occur if one of the arguments makes it impossible to
+	satisfy a request (i.e. having alignment larger than the backing buffer
+	of the allocation).
+- `Mode_Not_Implemented`: The allocator does not support the specified
+	operation. For example, an arena does not support freeing individual
+	allocations.
+*/
+Allocator_Error :: runtime.Allocator_Error
+
+/*
+The allocator procedure.
+
+This type represents allocation procedures. An allocation procedure is a single
+procedure, implementing all allocator functions such as allocating the memory,
+freeing the memory, etc.
+
+Currently the type is defined as follows:
+
+	Allocator_Proc :: #type proc(
+		allocator_data: rawptr,
+		mode: Allocator_Mode,
+		size: int,
+		alignment: int,
+		old_memory: rawptr,
+		old_size: int,
+		location: Source_Code_Location = #caller_location,
+	) -> ([]byte, Allocator_Error);
+
+The function of this procedure and the meaning of parameters depends on the
+value of the `mode` parameter.
+
+## 1. `.Alloc`, `.Alloc_Non_Zeroed`
+
+Allocates a memory region of size `size`, aligned on a boundary specified by
+`alignment`.
+
+**Inputs**:
+- `allocator_data`: Pointer to the allocator data.
+- `mode`: `.Alloc` or `.Alloc_Non_Zeroed`.
+- `size`: The desired size of the memory region.
+- `alignment`: The desired alignmnet of the allocation.
+- `old_memory`: Unused, should  be `nil`.
+- `old_size`: Unused, should be 0.
+
+**Returns**:
+1. The memory region, if allocated successfully, or `nil` otherwise.
+2. An error, if allocation failed.
+
+**Note**: Some allocators may return `nil`, even if no error is returned.
+Always check both the error and the allocated buffer.
+
+Same as `.Alloc`.
+
+## 2. `Free`
+
+Frees a memory region located at the address specified by `old_memory`. If the
+allocator does not track sizes of allocations, the size should be specified in
+the `old_size` parameter.
+
+**Inputs**:
+- `allocator_data`: Pointer to the allocator data.
+- `mode`: `.Free`.
+- `size`: Unused, should be 0.
+- `alignment`: Unused, should be 0.
+- `old_memory`: Pointer to the memory region to free.
+- `old_size`: The size of the memory region to free. This parameter is optional
+	if the allocator keeps track of the sizes of allocations.
+
+**Returns**:
+1. `nil`
+2. Error, if freeing failed.
+
+## 3. `Free_All`
+
+Frees all allocations, associated with the allocator, making it available for
+further allocations using the same backing buffers.
+
+**Inputs**:
+- `allocator_data`: Pointer to the allocator data.
+- `mode`: `.Free_All`.
+- `size`: Unused, should be 0.
+- `alignment`: Unused, should be 0.
+- `old_memory`: Unused, should be `nil`.
+- `old_size`: Unused, should be `0`.
+
+**Returns**:
+1. `nil`.
+2. Error, if freeing failed.
+
+## 4. `Resize`, `Resize_Non_Zeroed`
+
+Resizes the memory region, of the size `old_size` located at the address
+specified by `old_memory` to have the new size `size`. The slice of the new
+memory region is returned from the procedure. The allocator may attempt to
+keep the new memory region at the same address as the previous allocation,
+however no such guarantee is made. Do not assume the new memory region will
+be at the same address as the old memory region.
+
+If `old_memory` pointer is `nil`, this function acts just like `.Alloc` or
+`.Alloc_Non_Zeroed`, using `size` and `alignment` to allocate a new memory
+region.
+
+If `new_size` is `nil`, the procedure acts just like `.Free`, freeing the
+memory region `old_size` bytes in length, located at the address specified by
+`old_memory`.
+
+**Inputs**:
+- `allocator_data`: Pointer to the allocator data.
+- `mode`: `.Resize` or `.Resize_All`.
+- `size`: The desired new size of the memory region.
+- `alignment`: The alignment of the new memory region, if its allocated
+- `old_memory`: The pointer to the memory region to resize.
+- `old_size`: The size of the memory region to resize. If the allocator
+	keeps track of the sizes of allocations, this parameter is optional.
+
+**Returns**:
+1. The slice of the  memory region after resize operation, if successfull,
+	`nil` otherwise.
+2. An error, if the resize failed.
+
+**Note**: Some allocators may return `nil`, even if no error is returned.
+Always check both the error and the allocated buffer.
 */
 Allocator_Proc :: runtime.Allocator_Proc
-/*
-Allocator_Proc :: #type proc(allocator_data: rawptr, mode: Allocator_Mode,
-                             size, alignment: int,
-                             old_memory: rawptr, old_size: int, location: Source_Code_Location = #caller_location) -> ([]byte, Allocator_Error);
-*/
 
+/*
+Allocator.
+
+This type represents generic interface for all allocators. Currently this type
+is defined as follows:
+
+	Allocator :: struct {
+		procedure: Allocator_Proc,
+		data: rawptr,
+	}
+
+- `procedure`: Pointer to the allocation procedure.
+- `data`: Pointer to the allocator data.
+*/
 Allocator :: runtime.Allocator
-/*
-Allocator :: struct {
-	procedure: Allocator_Proc,
-	data:      rawptr,
-}
-*/
 
+/*
+Default alignment.
+
+This value is the default alignment for all platforms that is used, if the
+alignment is not specified explicitly.
+*/
 DEFAULT_ALIGNMENT :: 2*align_of(rawptr)
 
+/*
+Default page size.
+
+This value is the default page size for the current platform.
+*/
 DEFAULT_PAGE_SIZE ::
 	64 * 1024 when ODIN_ARCH == .wasm32 || ODIN_ARCH == .wasm64p32 else
 	16 * 1024 when ODIN_OS == .Darwin && ODIN_ARCH == .arm64 else
 	4 * 1024
 
+/*
+Allocate memory.
+
+This function allocates `size` bytes of memory, aligned to a boundary specified
+by `alignment` using the allocator specified by `allocator`.
+
+**Inputs**:
+- `size`: The desired size of the allocated memory region.
+- `alignment`: The desired alignment of the allocated memory region.
+- `allocator`: The allocator to allocate from.
+
+**Returns**:
+1. Pointer to the allocated memory, or `nil` if allocation failed.
+2. Error, if the allocation failed.
+*/
 @(require_results)
 alloc :: proc(
 	size: int,
@@ -73,6 +279,21 @@ alloc :: proc(
 	return raw_data(data), err
 }
 
+/*
+Allocate memory.
+
+This function allocates `size` bytes of memory, aligned to a boundary specified
+by `alignment` using the allocator specified by `allocator`.
+
+**Inputs**:
+- `size`: The desired size of the allocated memory region.
+- `alignment`: The desired alignment of the allocated memory region.
+- `allocator`: The allocator to allocate from.
+
+**Returns**:
+1. Slice of the allocated memory region, or `nil` if allocation failed.
+2. Error, if the allocation failed.
+*/
 @(require_results)
 alloc_bytes :: proc(
 	size: int,
@@ -83,6 +304,22 @@ alloc_bytes :: proc(
 	return runtime.mem_alloc(size, alignment, allocator, loc)
 }
 
+/*
+Allocate non-zeroed memory.
+
+This function allocates `size` bytes of memory, aligned to a boundary specified
+by `alignment` using the allocator specified by `allocator`. This procedure
+does not explicitly zero-initialize allocated memory region.
+
+**Inputs**:
+- `size`: The desired size of the allocated memory region.
+- `alignment`: The desired alignment of the allocated memory region.
+- `allocator`: The allocator to allocate from.
+
+**Returns**:
+1. Slice of the allocated memory region, or `nil` if allocation failed.
+2. Error, if the allocation failed.
+*/
 @(require_results)
 alloc_bytes_non_zeroed :: proc(
 	size: int,
@@ -93,6 +330,16 @@ alloc_bytes_non_zeroed :: proc(
 	return runtime.mem_alloc_non_zeroed(size, alignment, allocator, loc)
 }
 
+/*
+Free memory.
+
+This procedure frees memory region located at the address, specified by `ptr`,
+allocated from the allocator specified by `allocator`.
+
+**Inputs**:
+- `ptr`: Pointer to the memory region to free.
+- `allocator`: The allocator to free to.
+*/
 free :: proc(
 	ptr: rawptr,
 	allocator := context.allocator,
@@ -101,15 +348,42 @@ free :: proc(
 	return runtime.mem_free(ptr, allocator, loc)
 }
 
+/*
+Free a memory region.
+
+This procedure frees `size` bytes of memory region located at the address,
+specified by `ptr`, allocated from the allocator specified by `allocator`.
+
+**Inputs**:
+- `ptr`: Pointer to the memory region to free.
+- `size`: The size of the memory region to free.
+- `allocator`: The allocator to free to.
+
+**Returns**:
+- The error, if freeing failed.
+*/
 free_with_size :: proc(
 	ptr: rawptr,
-	byte_count: int,
+	size: int,
 	allocator := context.allocator,
 	loc := #caller_location,
 ) -> Allocator_Error {
-	return runtime.mem_free_with_size(ptr, byte_count, allocator, loc)
+	return runtime.mem_free_with_size(ptr, size, allocator, loc)
 }
 
+/*
+Free a memory region.
+
+This procedure frees memory region, specified by `bytes`, allocated from the
+allocator specified by `allocator`.
+
+**Inputs**:
+- `bytes`: The memory region to free.
+- `allocator`: The allocator to free to.
+
+**Returns**:
+- The error, if freeing failed.
+*/
 free_bytes :: proc(
 	bytes: []byte,
 	allocator := context.allocator,
@@ -118,10 +392,45 @@ free_bytes :: proc(
 	return runtime.mem_free_bytes(bytes, allocator, loc)
 }
 
+/*
+Free all allocations.
+
+This procedure frees all allocations made on the allocator specified by
+`allocator` to that allocator, making it available for further allocations.
+*/
 free_all :: proc(allocator := context.allocator, loc := #caller_location) -> Allocator_Error {
 	return runtime.mem_free_all(allocator, loc)
 }
 
+/*
+Resize a memory region.
+
+This procedure resizes a memory region, `old_size` bytes in size, located at
+the address specified by `ptr`, such that it has a new size, specified by
+`new_size` and and is aligned on a boundary specified by `alignment`.
+
+If the `ptr` parameter is `nil`, `resize()` acts just like `alloc`, allocating
+`new_size` bytes, aligned on a boundary specified by `alignment`.
+
+If the `new_size` parameter is `0`, `resize()` acts just like `free`, freeing
+the memory region `old_size` bytes in length, located at the address specified
+by `ptr`.
+
+**Inputs**:
+- `ptr`: Pointer to the memory region to resize.
+- `old_size`: Size of the memory region to resize.
+- `new_size`: The desired size of the resized memory region.
+- `alignment`: The desired alignment of the resized memory region.
+- `allocator`: The owner of the memory region to resize.
+
+**Returns**:
+1. The pointer to the resized memory region, if successfull, `nil` otherwise.
+2. Error, if resize failed.
+
+**Note**: The `alignment` parameter is used to preserve the original alignment
+of the allocation, if `resize()` needs to relocate the memory region. Do not
+use `resize()` to change the alignment of the allocated memory region.
+*/
 @(require_results)
 resize :: proc(
 	ptr: rawptr,
@@ -135,6 +444,33 @@ resize :: proc(
 	return raw_data(data), err
 }
 
+/*
+Resize a memory region.
+
+This procedure resizes a memory region, specified by `old_data`, such that it
+has a new size, specified by `new_size` and and is aligned on a boundary
+specified by `alignment`.
+
+If the `old_data` parameter is `nil`, `resize()` acts just like `alloc`,
+allocating `new_size` bytes, aligned on a boundary specified by `alignment`.
+
+If the `new_size` parameter is `0`, `resize()` acts just like `free`, freeing
+the memory region specified by `old_data`.
+
+**Inputs**:
+- `old_data`: Pointer to the memory region to resize.
+- `new_size`: The desired size of the resized memory region.
+- `alignment`: The desired alignment of the resized memory region.
+- `allocator`: The owner of the memory region to resize.
+
+**Returns**:
+1. The resized memory region, if successfull, `nil` otherwise.
+2. Error, if resize failed.
+
+**Note**: The `alignment` parameter is used to preserve the original alignment
+of the allocation, if `resize()` needs to relocate the memory region. Do not
+use `resize()` to change the alignment of the allocated memory region.
+*/
 @(require_results)
 resize_bytes :: proc(
 	old_data: []byte,
@@ -146,6 +482,9 @@ resize_bytes :: proc(
 	return runtime.mem_resize(raw_data(old_data), len(old_data), new_size, alignment, allocator, loc)
 }
 
+/*
+Query allocator features.
+*/
 @(require_results)
 query_features :: proc(allocator: Allocator, loc := #caller_location) -> (set: Allocator_Mode_Set) {
 	if allocator.procedure != nil {
@@ -155,6 +494,9 @@ query_features :: proc(allocator: Allocator, loc := #caller_location) -> (set: A
 	return nil
 }
 
+/*
+Query allocator information.
+*/
 @(require_results)
 query_info :: proc(
 	pointer: rawptr,
@@ -168,6 +510,9 @@ query_info :: proc(
 	return
 }
 
+/*
+Free a string.
+*/
 delete_string :: proc(
 	str: string,
 	allocator := context.allocator,
@@ -176,6 +521,9 @@ delete_string :: proc(
 	return runtime.delete_string(str, allocator, loc)
 }
 
+/*
+Free a cstring.
+*/
 delete_cstring :: proc(
 	str: cstring,
 	allocator := context.allocator,
@@ -184,6 +532,9 @@ delete_cstring :: proc(
 	return runtime.delete_cstring(str, allocator, loc)
 }
 
+/*
+Free a dynamic array.
+*/
 delete_dynamic_array :: proc(
 	array: $T/[dynamic]$E,
 	loc := #caller_location,
@@ -191,6 +542,9 @@ delete_dynamic_array :: proc(
 	return runtime.delete_dynamic_array(array, loc)
 }
 
+/*
+Free a slice.
+*/
 delete_slice :: proc(
 	array: $T/[]$E,
 	allocator := context.allocator,
@@ -199,6 +553,9 @@ delete_slice :: proc(
 	return runtime.delete_slice(array, allocator, loc)
 }
 
+/*
+Free a map.
+*/
 delete_map :: proc(
 	m: $T/map[$K]$V,
 	loc := #caller_location,
@@ -206,6 +563,9 @@ delete_map :: proc(
 	return runtime.delete_map(m, loc)
 }
 
+/*
+Free.
+*/
 delete :: proc{
 	delete_string,
 	delete_cstring,
@@ -214,6 +574,13 @@ delete :: proc{
 	delete_map,
 }
 
+/*
+Allocate a new object.
+
+This procedure allocates a new object of type `T` using an allocator specified
+by `allocator`, and returns a pointer to the allocated object, if allocated
+successfully, or `nil` otherwise.
+*/
 @(require_results)
 new :: proc(
 	$T: typeid,
@@ -223,6 +590,14 @@ new :: proc(
 	return new_aligned(T, align_of(T), allocator, loc)
 }
 
+/*
+Allocate a new object with alignment.
+
+This procedure allocates a new object of type `T` using an allocator specified
+by `allocator`, and returns a pointer, aligned on a boundary specified by
+`alignment`  to the allocated object, if allocated successfully, or `nil`
+otherwise.
+*/
 @(require_results)
 new_aligned :: proc(
 	$T: typeid,
@@ -233,6 +608,14 @@ new_aligned :: proc(
 	return runtime.new_aligned(T, alignment, allocator, loc)
 }
 
+/*
+Allocate a new object and initialize it with a value.
+
+This procedure allocates a new object of type `T` using an allocator specified
+by `allocator`, and returns a pointer, aligned on a boundary specified by
+`alignment`  to the allocated object, if allocated successfully, or `nil`
+otherwise. The allocated object is initialized with `data`.
+*/
 @(require_results)
 new_clone :: proc(
 	data: $T,
@@ -242,6 +625,13 @@ new_clone :: proc(
 	return runtime.new_clone(data, allocator, loc)
 }
 
+/*
+Allocate a new slice with alignment.
+
+This procedure allocates a new slice of type `T` with length `len`, aligned
+on a boundary specified by `alignment` from an allocator specified by
+`allocator`, and returns the allocated slice.
+*/
 @(require_results)
 make_aligned :: proc(
 	$T: typeid/[]$E,
@@ -253,6 +643,12 @@ make_aligned :: proc(
 	return runtime.make_aligned(T, len, alignment, allocator, loc)
 }
 
+/*
+Allocate a new slice.
+
+This procedure allocates a new slice of type `T` with length `len`, from an
+allocator specified by `allocator`, and returns the allocated slice.
+*/
 @(require_results)
 make_slice :: proc(
 	$T: typeid/[]$E,
@@ -263,6 +659,12 @@ make_slice :: proc(
 	return runtime.make_slice(T, len, allocator, loc)
 }
 
+/*
+Allocate a dynamic array.
+
+This procedure creates a dynamic array of type `T`, with `allocator` as its
+backing allocator, and initial length and capacity of `0`.
+*/
 @(require_results)
 make_dynamic_array :: proc(
 	$T: typeid/[dynamic]$E,
@@ -272,6 +674,13 @@ make_dynamic_array :: proc(
 	return runtime.make_dynamic_array(T, allocator, loc)
 }
 
+/*
+Allocate a dynamic array with initial length.
+
+This procedure creates a dynamic array of type `T`, with `allocator` as its
+backing allocator, and initial capacity of `0`, and initial length specified by
+`len`.
+*/
 @(require_results)
 make_dynamic_array_len :: proc(
 	$T: typeid/[dynamic]$E,
@@ -282,6 +691,13 @@ make_dynamic_array_len :: proc(
 	return runtime.make_dynamic_array_len_cap(T, len, len, allocator, loc)
 }
 
+/*
+Allocate a dynamic array with initial length and capacity.
+
+This procedure creates a dynamic array of type `T`, with `allocator` as its
+backing allocator, and initial capacity specified by `cap`, and initial length
+specified by `len`.
+*/
 @(require_results)
 make_dynamic_array_len_cap :: proc(
 	$T: typeid/[dynamic]$E,
@@ -293,6 +709,13 @@ make_dynamic_array_len_cap :: proc(
 	return runtime.make_dynamic_array_len_cap(T, len, cap, allocator, loc)
 }
 
+/*
+Allocate a map.
+
+This procedure creates a map of type `T` with initial capacity specified by
+`cap`, that is using an allocator specified by `allocator` as its backing
+allocator.
+*/
 @(require_results)
 make_map :: proc(
 	$T: typeid/map[$K]$E,
@@ -303,6 +726,12 @@ make_map :: proc(
 	return runtime.make_map(T, cap, allocator, loc)
 }
 
+/*
+Allocate a multi pointer.
+
+This procedure allocates a multipointer of type `T` pointing to `len` elements,
+from an allocator specified by `allocator`.
+*/
 @(require_results)
 make_multi_pointer :: proc(
 	$T: typeid/[^]$E,
@@ -313,6 +742,9 @@ make_multi_pointer :: proc(
 	return runtime.make_multi_pointer(T, len, allocator, loc)
 }
 
+/*
+Allocate.
+*/
 make :: proc{
 	make_slice,
 	make_dynamic_array,
@@ -322,6 +754,23 @@ make :: proc{
 	make_multi_pointer,
 }
 
+/*
+Default resize procedure.
+
+When allocator does not support resize operation, but supports `.Alloc` and
+`.Free`, this procedure is used to implement allocator's default behavior on
+resize.
+
+The behavior of the function is as follows:
+
+- If `new_size` is `0`, the function acts like `free()`, freeing the memory
+	region of `old_size` bytes located at `old_memory`.
+- If `old_memory` is `nil`, the function acts like `alloc()`, allocating
+	`new_size` bytes of memory aligned on a boundary specified by `alignment`.
+- Otherwise, a new memory region of size `new_size` is allocated, then the
+	data from the old memory region is copied and the old memory region is
+	freed.
+*/
 @(require_results)
 default_resize_align :: proc(
 	old_memory: rawptr,
@@ -343,6 +792,27 @@ default_resize_align :: proc(
 	return
 }
 
+/*
+Default resize procedure.
+
+When allocator does not support resize operation, but supports
+`.Alloc_Non_Zeroed` and `.Free`, this procedure is used to implement allocator's
+default behavior on
+resize.
+
+Unlike `default_resize_align` no new memory is being explicitly
+zero-initialized.
+
+The behavior of the function is as follows:
+
+- If `new_size` is `0`, the function acts like `free()`, freeing the memory
+	region of `old_size` bytes located at `old_memory`.
+- If `old_memory` is `nil`, the function acts like `alloc()`, allocating
+	`new_size` bytes of memory aligned on a boundary specified by `alignment`.
+- Otherwise, a new memory region of size `new_size` is allocated, then the
+	data from the old memory region is copied and the old memory region is
+	freed.
+*/
 @(require_results)
 default_resize_bytes_align_non_zeroed :: proc(
 	old_data: []byte,
@@ -354,6 +824,23 @@ default_resize_bytes_align_non_zeroed :: proc(
 	return _default_resize_bytes_align(old_data, new_size, alignment, false, allocator, loc)
 }
 
+/*
+Default resize procedure.
+
+When allocator does not support resize operation, but supports `.Alloc` and
+`.Free`, this procedure is used to implement allocator's default behavior on
+resize.
+
+The behavior of the function is as follows:
+
+- If `new_size` is `0`, the function acts like `free()`, freeing the memory
+	region specified by `old_data`.
+- If `old_data` is `nil`, the function acts like `alloc()`, allocating
+	`new_size` bytes of memory aligned on a boundary specified by `alignment`.
+- Otherwise, a new memory region of size `new_size` is allocated, then the
+	data from the old memory region is copied and the old memory region is
+	freed.
+*/
 @(require_results)
 default_resize_bytes_align :: proc(
 	old_data: []byte,
@@ -383,16 +870,13 @@ _default_resize_bytes_align :: #force_inline proc(
 			return alloc_bytes_non_zeroed(new_size, alignment, allocator, loc)
 		}
 	}
-
 	if new_size == 0 {
 		err := free_bytes(old_data, allocator, loc)
 		return nil, err
 	}
-
 	if new_size == old_size {
 		return old_data, .None
 	}
-
 	new_memory : []byte
 	err : Allocator_Error
 	if should_zero {
@@ -403,7 +887,6 @@ _default_resize_bytes_align :: #force_inline proc(
 	if new_memory == nil || err != nil {
 		return nil, err
 	}
-
 	runtime.copy(new_memory, old_data)
 	free_bytes(old_data, allocator, loc)
 	return new_memory, err

--- a/core/mem/alloc.odin
+++ b/core/mem/alloc.odin
@@ -1019,8 +1019,7 @@ Default resize procedure.
 
 When allocator does not support resize operation, but supports
 `.Alloc_Non_Zeroed` and `.Free`, this procedure is used to implement allocator's
-default behavior on
-resize.
+default behavior on resize.
 
 Unlike `default_resize_align` no new memory is being explicitly
 zero-initialized.

--- a/core/mem/alloc.odin
+++ b/core/mem/alloc.odin
@@ -63,30 +63,58 @@ DEFAULT_PAGE_SIZE ::
 	4 * 1024
 
 @(require_results)
-alloc :: proc(size: int, alignment: int = DEFAULT_ALIGNMENT, allocator := context.allocator, loc := #caller_location) -> (rawptr, Allocator_Error) {
+alloc :: proc(
+	size: int,
+	alignment: int = DEFAULT_ALIGNMENT,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> (rawptr, Allocator_Error) {
 	data, err := runtime.mem_alloc(size, alignment, allocator, loc)
 	return raw_data(data), err
 }
 
 @(require_results)
-alloc_bytes :: proc(size: int, alignment: int = DEFAULT_ALIGNMENT, allocator := context.allocator, loc := #caller_location) -> ([]byte, Allocator_Error) {
+alloc_bytes :: proc(
+	size: int,
+	alignment: int = DEFAULT_ALIGNMENT,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> ([]byte, Allocator_Error) {
 	return runtime.mem_alloc(size, alignment, allocator, loc)
 }
 
 @(require_results)
-alloc_bytes_non_zeroed :: proc(size: int, alignment: int = DEFAULT_ALIGNMENT, allocator := context.allocator, loc := #caller_location) -> ([]byte, Allocator_Error) {
+alloc_bytes_non_zeroed :: proc(
+	size: int,
+	alignment: int = DEFAULT_ALIGNMENT,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> ([]byte, Allocator_Error) {
 	return runtime.mem_alloc_non_zeroed(size, alignment, allocator, loc)
 }
 
-free :: proc(ptr: rawptr, allocator := context.allocator, loc := #caller_location) -> Allocator_Error {
+free :: proc(
+	ptr: rawptr,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> Allocator_Error {
 	return runtime.mem_free(ptr, allocator, loc)
 }
 
-free_with_size :: proc(ptr: rawptr, byte_count: int, allocator := context.allocator, loc := #caller_location) -> Allocator_Error {
+free_with_size :: proc(
+	ptr: rawptr,
+	byte_count: int,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> Allocator_Error {
 	return runtime.mem_free_with_size(ptr, byte_count, allocator, loc)
 }
 
-free_bytes :: proc(bytes: []byte, allocator := context.allocator, loc := #caller_location) -> Allocator_Error {
+free_bytes :: proc(
+	bytes: []byte,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> Allocator_Error {
 	return runtime.mem_free_bytes(bytes, allocator, loc)
 }
 
@@ -95,13 +123,26 @@ free_all :: proc(allocator := context.allocator, loc := #caller_location) -> All
 }
 
 @(require_results)
-resize :: proc(ptr: rawptr, old_size, new_size: int, alignment: int = DEFAULT_ALIGNMENT, allocator := context.allocator, loc := #caller_location) -> (rawptr, Allocator_Error) {
+resize :: proc(
+	ptr: rawptr,
+	old_size: int,
+	new_size: int,
+	alignment: int = DEFAULT_ALIGNMENT,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> (rawptr, Allocator_Error) {
 	data, err := runtime.mem_resize(ptr, old_size, new_size, alignment, allocator, loc)
 	return raw_data(data), err
 }
 
 @(require_results)
-resize_bytes :: proc(old_data: []byte, new_size: int, alignment: int = DEFAULT_ALIGNMENT, allocator := context.allocator, loc := #caller_location) -> ([]byte, Allocator_Error) {
+resize_bytes :: proc(
+	old_data: []byte,
+	new_size: int,
+	alignment: int = DEFAULT_ALIGNMENT,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> ([]byte, Allocator_Error) {
 	return runtime.mem_resize(raw_data(old_data), len(old_data), new_size, alignment, allocator, loc)
 }
 
@@ -115,7 +156,11 @@ query_features :: proc(allocator: Allocator, loc := #caller_location) -> (set: A
 }
 
 @(require_results)
-query_info :: proc(pointer: rawptr, allocator: Allocator, loc := #caller_location) -> (props: Allocator_Query_Info) {
+query_info :: proc(
+	pointer: rawptr,
+	allocator: Allocator,
+	loc := #caller_location,
+) -> (props: Allocator_Query_Info) {
 	props.pointer = pointer
 	if allocator.procedure != nil {
 		allocator.procedure(allocator.data, .Query_Info, 0, 0, &props, 0, loc)
@@ -123,24 +168,43 @@ query_info :: proc(pointer: rawptr, allocator: Allocator, loc := #caller_locatio
 	return
 }
 
-
-
-delete_string :: proc(str: string, allocator := context.allocator, loc := #caller_location) -> Allocator_Error {
+delete_string :: proc(
+	str: string,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> Allocator_Error {
 	return runtime.delete_string(str, allocator, loc)
 }
-delete_cstring :: proc(str: cstring, allocator := context.allocator, loc := #caller_location) -> Allocator_Error {
+
+delete_cstring :: proc(
+	str: cstring,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> Allocator_Error {
 	return runtime.delete_cstring(str, allocator, loc)
 }
-delete_dynamic_array :: proc(array: $T/[dynamic]$E, loc := #caller_location) -> Allocator_Error {
+
+delete_dynamic_array :: proc(
+	array: $T/[dynamic]$E,
+	loc := #caller_location,
+) -> Allocator_Error {
 	return runtime.delete_dynamic_array(array, loc)
 }
-delete_slice :: proc(array: $T/[]$E, allocator := context.allocator, loc := #caller_location) -> Allocator_Error {
+
+delete_slice :: proc(
+	array: $T/[]$E,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> Allocator_Error {
 	return runtime.delete_slice(array, allocator, loc)
 }
-delete_map :: proc(m: $T/map[$K]$V, loc := #caller_location) -> Allocator_Error {
+
+delete_map :: proc(
+	m: $T/map[$K]$V,
+	loc := #caller_location,
+) -> Allocator_Error {
 	return runtime.delete_map(m, loc)
 }
-
 
 delete :: proc{
 	delete_string,
@@ -150,46 +214,102 @@ delete :: proc{
 	delete_map,
 }
 
-
 @(require_results)
-new :: proc($T: typeid, allocator := context.allocator, loc := #caller_location) -> (^T, Allocator_Error) {
+new :: proc(
+	$T: typeid,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> (^T, Allocator_Error) {
 	return new_aligned(T, align_of(T), allocator, loc)
 }
+
 @(require_results)
-new_aligned :: proc($T: typeid, alignment: int, allocator := context.allocator, loc := #caller_location) -> (t: ^T, err: Allocator_Error) {
+new_aligned :: proc(
+	$T: typeid,
+	alignment: int,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> (t: ^T, err: Allocator_Error) {
 	return runtime.new_aligned(T, alignment, allocator, loc)
 }
+
 @(require_results)
-new_clone :: proc(data: $T, allocator := context.allocator, loc := #caller_location) -> (t: ^T, err: Allocator_Error) {
+new_clone :: proc(
+	data: $T,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> (t: ^T, err: Allocator_Error) {
 	return runtime.new_clone(data, allocator, loc)
 }
 
 @(require_results)
-make_aligned :: proc($T: typeid/[]$E, #any_int len: int, alignment: int, allocator := context.allocator, loc := #caller_location) -> (slice: T, err: Allocator_Error) {
+make_aligned :: proc(
+	$T: typeid/[]$E,
+	#any_int len: int,
+	alignment: int,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> (slice: T, err: Allocator_Error) {
 	return runtime.make_aligned(T, len, alignment, allocator, loc)
 }
+
 @(require_results)
-make_slice :: proc($T: typeid/[]$E, #any_int len: int, allocator := context.allocator, loc := #caller_location) -> (T, Allocator_Error) {
+make_slice :: proc(
+	$T: typeid/[]$E,
+	#any_int len: int,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> (T, Allocator_Error) {
 	return runtime.make_slice(T, len, allocator, loc)
 }
+
 @(require_results)
-make_dynamic_array :: proc($T: typeid/[dynamic]$E, allocator := context.allocator, loc := #caller_location) -> (T, Allocator_Error) {
+make_dynamic_array :: proc(
+	$T: typeid/[dynamic]$E,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> (T, Allocator_Error) {
 	return runtime.make_dynamic_array(T, allocator, loc)
 }
+
 @(require_results)
-make_dynamic_array_len :: proc($T: typeid/[dynamic]$E, #any_int len: int, allocator := context.allocator, loc := #caller_location) -> (T, Allocator_Error) {
+make_dynamic_array_len :: proc(
+	$T: typeid/[dynamic]$E,
+	#any_int len: int,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> (T, Allocator_Error) {
 	return runtime.make_dynamic_array_len_cap(T, len, len, allocator, loc)
 }
+
 @(require_results)
-make_dynamic_array_len_cap :: proc($T: typeid/[dynamic]$E, #any_int len: int, #any_int cap: int, allocator := context.allocator, loc := #caller_location) -> (array: T, err: Allocator_Error) {
+make_dynamic_array_len_cap :: proc(
+	$T: typeid/[dynamic]$E,
+	#any_int len: int,
+	#any_int cap: int,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> (array: T, err: Allocator_Error) {
 	return runtime.make_dynamic_array_len_cap(T, len, cap, allocator, loc)
 }
+
 @(require_results)
-make_map :: proc($T: typeid/map[$K]$E, #any_int cap: int = 1<<runtime.MAP_MIN_LOG2_CAPACITY, allocator := context.allocator, loc := #caller_location) -> (m: T, err: Allocator_Error) {
+make_map :: proc(
+	$T: typeid/map[$K]$E,
+	#any_int cap: int = 1<<runtime.MAP_MIN_LOG2_CAPACITY,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> (m: T, err: Allocator_Error) {
 	return runtime.make_map(T, cap, allocator, loc)
 }
+
 @(require_results)
-make_multi_pointer :: proc($T: typeid/[^]$E, #any_int len: int, allocator := context.allocator, loc := #caller_location) -> (mp: T, err: Allocator_Error) {
+make_multi_pointer :: proc(
+	$T: typeid/[^]$E,
+	#any_int len: int,
+	allocator := context.allocator,
+	loc := #caller_location
+) -> (mp: T, err: Allocator_Error) {
 	return runtime.make_multi_pointer(T, len, allocator, loc)
 }
 
@@ -202,26 +322,58 @@ make :: proc{
 	make_multi_pointer,
 }
 
-
 @(require_results)
-default_resize_align :: proc(old_memory: rawptr, old_size, new_size, alignment: int, allocator := context.allocator, loc := #caller_location) -> (res: rawptr, err: Allocator_Error) {
+default_resize_align :: proc(
+	old_memory: rawptr,
+	old_size: int,
+	new_size: int,
+	alignment: int,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> (res: rawptr, err: Allocator_Error) {
 	data: []byte
-	data, err = default_resize_bytes_align(([^]byte)(old_memory)[:old_size], new_size, alignment, allocator, loc)
+	data, err = default_resize_bytes_align(
+		([^]byte) (old_memory)[:old_size],
+		new_size,
+		alignment,
+		allocator,
+		loc,
+	)
 	res = raw_data(data)
 	return
 }
 
 @(require_results)
-default_resize_bytes_align_non_zeroed :: proc(old_data: []byte, new_size, alignment: int, allocator := context.allocator, loc := #caller_location) -> ([]byte, Allocator_Error) {
+default_resize_bytes_align_non_zeroed :: proc(
+	old_data: []byte,
+	new_size: int,
+	alignment: int,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> ([]byte, Allocator_Error) {
 	return _default_resize_bytes_align(old_data, new_size, alignment, false, allocator, loc)
 }
+
 @(require_results)
-default_resize_bytes_align :: proc(old_data: []byte, new_size, alignment: int, allocator := context.allocator, loc := #caller_location) -> ([]byte, Allocator_Error) {
+default_resize_bytes_align :: proc(
+	old_data: []byte,
+	new_size: int,
+	alignment: int,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> ([]byte, Allocator_Error) {
 	return _default_resize_bytes_align(old_data, new_size, alignment, true, allocator, loc)
 }
 
 @(require_results)
-_default_resize_bytes_align :: #force_inline proc(old_data: []byte, new_size, alignment: int, should_zero: bool, allocator := context.allocator, loc := #caller_location) -> ([]byte, Allocator_Error) {
+_default_resize_bytes_align :: #force_inline proc(
+	old_data: []byte,
+	new_size: int,
+	alignment: int,
+	should_zero: bool,
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> ([]byte, Allocator_Error) {
 	old_memory := raw_data(old_data)
 	old_size := len(old_data)
 	if old_memory == nil {

--- a/core/mem/alloc.odin
+++ b/core/mem/alloc.odin
@@ -1096,7 +1096,7 @@ _default_resize_bytes_align :: #force_inline proc(
 		err := free_bytes(old_data, allocator, loc)
 		return nil, err
 	}
-	if new_size == old_size {
+	if new_size == old_size && is_aligned(old_memory, alignment) {
 		return old_data, .None
 	}
 	new_memory : []byte

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -1133,7 +1133,6 @@ buddy_block_coalescence :: proc(head, tail: ^Buddy_Block) {
 		// Keep looping until there are no more buddies to coalesce
 		block := head
 		buddy := buddy_block_next(block)
-
 		no_coalescence := true
 		for block < tail && buddy < tail { // make sure the buddies are within the range
 			if block.is_free && buddy.is_free && block.size == buddy.size {
@@ -1156,7 +1155,6 @@ buddy_block_coalescence :: proc(head, tail: ^Buddy_Block) {
 				}
 			}
 		}
-
 		if no_coalescence {
 			return
 		}
@@ -1166,17 +1164,14 @@ buddy_block_coalescence :: proc(head, tail: ^Buddy_Block) {
 @(require_results)
 buddy_block_find_best :: proc(head, tail: ^Buddy_Block, size: uint) -> ^Buddy_Block {
 	assert(size != 0)
-
 	best_block: ^Buddy_Block
 	block := head                    // left
 	buddy := buddy_block_next(block) // right
-
 	// The entire memory section between head and tail is free,
 	// just call 'buddy_block_split' to get the allocation
 	if buddy == tail && block.is_free {
 		return buddy_block_split(block, size)
 	}
-
 	// Find the block which is the 'best_block' to requested allocation sized
 	for block < tail && buddy < tail { // make sure the buddies are within the range
 		// If both buddies are free, coalesce them together
@@ -1187,7 +1182,6 @@ buddy_block_find_best :: proc(head, tail: ^Buddy_Block, size: uint) -> ^Buddy_Bl
 			if size <= block.size && (best_block == nil || block.size <= best_block.size) {
 				best_block = block
 			}
-
 			block = buddy_block_next(buddy)
 			if block < tail {
 				// Delay the buddy block for the next iteration
@@ -1195,20 +1189,16 @@ buddy_block_find_best :: proc(head, tail: ^Buddy_Block, size: uint) -> ^Buddy_Bl
 			}
 			continue
 		}
-
-
 		if block.is_free && size <= block.size &&
 		   (best_block == nil || block.size <= best_block.size) {
 			best_block = block
 		}
-
 		if buddy.is_free && size <= buddy.size &&
 		   (best_block == nil || buddy.size < best_block.size) {
 			// If each buddy are the same size, then it makes more sense
 			// to pick the buddy as it "bounces around" less
 			best_block = buddy
 		}
-
 		if (block.size <= buddy.size) {
 			block = buddy_block_next(buddy)
 			if (block < tail) {
@@ -1221,12 +1211,10 @@ buddy_block_find_best :: proc(head, tail: ^Buddy_Block, size: uint) -> ^Buddy_Bl
 			buddy = buddy_block_next(buddy)
 		}
 	}
-
 	if best_block != nil {
 		// This will handle the case if the 'best_block' is also the perfect fit
 		return buddy_block_split(best_block, size)
 	}
-
 	// Maybe out of memory
 	return nil
 }
@@ -1245,26 +1233,20 @@ buddy_allocator :: proc(b: ^Buddy_Allocator) -> Allocator {
 	}
 }
 
-buddy_allocator_init :: proc(b: ^Buddy_Allocator, data: []byte, alignment: uint) {
+buddy_allocator_init :: proc(b: ^Buddy_Allocator, data: []byte, alignment: uint, loc := #caller_location) {
 	assert(data != nil)
-	assert(is_power_of_two(uintptr(len(data))))
-	assert(is_power_of_two(uintptr(alignment)))
-
+	assert(is_power_of_two(uintptr(len(data))), "Size of the backing buffer must be power of two", loc)
+	assert(is_power_of_two(uintptr(alignment)), "Alignment must be a power of two", loc)
 	alignment := alignment
 	if alignment < size_of(Buddy_Block) {
 		alignment = size_of(Buddy_Block)
 	}
-
 	ptr := raw_data(data)
-	assert(uintptr(ptr) % uintptr(alignment) == 0, "data is not aligned to minimum alignment")
-
+	assert(uintptr(ptr) % uintptr(alignment) == 0, "data is not aligned to minimum alignment", loc)
 	b.head = (^Buddy_Block)(ptr)
-
 	b.head.size = len(data)
 	b.head.is_free = true
-
 	b.tail = buddy_block_next(b.head)
-
 	b.alignment = alignment
 }
 
@@ -1274,19 +1256,25 @@ buddy_block_size_required :: proc(b: ^Buddy_Allocator, size: uint) -> uint {
 	actual_size := b.alignment
 	size += size_of(Buddy_Block)
 	size = align_forward_uint(size, b.alignment)
-
 	for size > actual_size {
 		actual_size <<= 1
 	}
-
 	return actual_size
 }
 
 @(require_results)
-buddy_allocator_alloc :: proc(b: ^Buddy_Allocator, size: uint, zeroed: bool) -> ([]byte, Allocator_Error) {
+buddy_allocator_alloc :: proc(b: ^Buddy_Allocator, size: uint) -> ([]byte, Allocator_Error) {
+	bytes, err := buddy_allocator_alloc_non_zeroed(b, size)
+	if bytes != nil {
+		zero_slice(bytes)
+	}
+	return bytes, err
+}
+
+@(require_results)
+buddy_allocator_alloc_non_zeroed :: proc(b: ^Buddy_Allocator, size: uint) -> ([]byte, Allocator_Error) {
 	if size != 0 {
 		actual_size := buddy_block_size_required(b, size)
-
 		found := buddy_block_find_best(b.head, b.tail, actual_size)
 		if found != nil {
 			// Try to coalesce all the free buddy blocks and then search again
@@ -1297,32 +1285,28 @@ buddy_allocator_alloc :: proc(b: ^Buddy_Allocator, size: uint, zeroed: bool) -> 
 			return nil, .Out_Of_Memory
 		}
 		found.is_free = false
-
 		data := ([^]byte)(found)[b.alignment:][:size]
-		if zeroed {
-			zero_slice(data)
-		}
 		return data, nil
 	}
 	return nil, nil
 }
 
+@(require_results)
 buddy_allocator_free :: proc(b: ^Buddy_Allocator, ptr: rawptr) -> Allocator_Error {
 	if ptr != nil {
 		if !(b.head <= ptr && ptr <= b.tail) {
 			return .Invalid_Pointer
 		}
-
 		block := (^Buddy_Block)(([^]byte)(ptr)[-b.alignment:])
 		block.is_free = true
-
 		buddy_block_coalescence(b.head, b.tail)
 	}
 	return nil
 }
 
 buddy_allocator_proc :: proc(
-	allocator_data: rawptr, mode: Allocator_Mode,
+	allocator_data: rawptr,
+	mode: Allocator_Mode,
 	size, alignment: int,
 	old_memory: rawptr,
 	old_size: int,
@@ -1330,10 +1314,11 @@ buddy_allocator_proc :: proc(
 ) -> ([]byte, Allocator_Error) {
 
 	b := (^Buddy_Allocator)(allocator_data)
-
 	switch mode {
-	case .Alloc, .Alloc_Non_Zeroed:
-		return buddy_allocator_alloc(b, uint(size), mode == .Alloc)
+	case .Alloc:
+		return buddy_allocator_alloc(b, uint(size))
+	case .Alloc_Non_Zeroed:
+		return buddy_allocator_alloc_non_zeroed(b, uint(size))
 	case .Resize:
 		return default_resize_bytes_align(byte_slice(old_memory, old_size), size, alignment, buddy_allocator(b))
 	case .Resize_Non_Zeroed:
@@ -1341,13 +1326,11 @@ buddy_allocator_proc :: proc(
 	case .Free:
 		return nil, buddy_allocator_free(b, old_memory)
 	case .Free_All:
-
 		alignment := b.alignment
 		head := ([^]byte)(b.head)
 		tail := ([^]byte)(b.tail)
 		data := head[:ptr_sub(tail, head)]
 		buddy_allocator_init(b, data, alignment)
-
 	case .Query_Features:
 		set := (^Allocator_Mode_Set)(old_memory)
 		if set != nil {

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -402,7 +402,6 @@ scratch_resize_bytes_non_zeroed :: proc(
 	}
 	begin := uintptr(raw_data(s.data))
 	end := begin + uintptr(len(s.data))
-	// TODO(flysand): Doesn't handle old_memory == nil
 	old_ptr := uintptr(old_memory)
 	if begin <= old_ptr && old_ptr < end && old_ptr+uintptr(size) < end {
 		s.curr_offset = int(old_ptr-begin)+size
@@ -412,7 +411,6 @@ scratch_resize_bytes_non_zeroed :: proc(
 	if err != nil {
 		return data, err
 	}
-	// TODO(flysand): OOB access on size < old_size.
 	runtime.copy(data, byte_slice(old_memory, old_size))
 	err = scratch_free(s, old_memory, loc)
 	return data, err

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -1564,20 +1564,20 @@ arrays of blocks and out-band blocks. The blocks have the default size of
 will be aligned to a boundary specified by `alignment`.
 */
 dynamic_arena_init :: proc(
-	a: ^Dynamic_Arena,
+	pool: ^Dynamic_Arena,
 	block_allocator := context.allocator,
 	array_allocator := context.allocator,
 	block_size := DYNAMIC_ARENA_BLOCK_SIZE_DEFAULT,
 	out_band_size := DYNAMIC_ARENA_OUT_OF_BAND_SIZE_DEFAULT,
 	alignment := DEFAULT_ALIGNMENT,
 ) {
-	a.block_size = block_size
-	a.out_band_size = out_band_size
-	a.alignment = alignment
-	a.block_allocator = block_allocator
-	a.out_band_allocations.allocator = array_allocator
-	a.unused_blocks.allocator = array_allocator
-	a.used_blocks.allocator = array_allocator
+	pool.block_size = block_size
+	pool.out_band_size = out_band_size
+	pool.alignment = alignment
+	pool.block_allocator = block_allocator
+	pool.out_band_allocations.allocator = array_allocator
+	pool.unused_blocks.allocator = array_allocator
+	pool.used_blocks.allocator = array_allocator
 }
 
 /*

--- a/core/mem/doc.odin
+++ b/core/mem/doc.odin
@@ -1,34 +1,99 @@
 /*
-package mem implements various types of allocators.
+The `mem` package implements various allocators and provides utility functions
+for dealing with memory, pointers and slices.
 
+The documentation below describes basic concepts, applicable to the `mem`
+package.
 
-An example of how to use the `Tracking_Allocator` to track subsequent allocations
-in your program and report leaks and bad frees:
+## Pointers, multipointers, and slices
 
-Example:
-	package foo
+A *pointer* is an abstraction of an *address*, a numberic value representing the
+location of an object in memory. That object is said to be *pointed to* by the
+pointer. To obtain the address of a pointer, cast it to `uintptr`.
 
-	import "core:mem"
-	import "core:fmt"
+A multipointer is a pointer that points to multiple objects. Unlike a pointer,
+a multipointer can be indexed, but does not have a definite length. A slice is
+a pointer that points to multiple objects equipped with the length, specifying
+the amount of objects a slice points to.
 
-	_main :: proc() {
-		// do stuff
-	}
+When object's values are read through a pointer, that operation is called a
+*load* operation. When memory is read through a pointer, that operation is
+called a *store* operation. Both of these operations can be called a *memory
+access operation*.
 
-	main :: proc() {
-		track: mem.Tracking_Allocator
-		mem.tracking_allocator_init(&track, context.allocator)
-		defer mem.tracking_allocator_destroy(&track)
-		context.allocator = mem.tracking_allocator(&track)
+## Allocators
 
-		_main()
+In C and C++ memory models, allocations of objects in memory are typically
+treated individually with a generic allocator (The `malloc` function). Which in
+some scenarios can lead to poor cache utilization, slowdowns on individual
+objects' memory management and growing complexity of the code needing to keep
+track of the pointers and their lifetimes.
 
-		for _, leak in track.allocation_map {
-			fmt.printf("%v leaked %m\n", leak.location, leak.size)
-		}
-		for bad_free in track.bad_free_array {
-			fmt.printf("%v allocation %p was freed badly\n", bad_free.location, bad_free.memory)
-		}
-	}
+Using different kinds of *allocators* for different purposes can solve these
+problems. The allocators are typically optimized for specific use-cases and
+can potentially simplify the memory management code.
+
+For example, in the context of making a game, having an Arena allocator could
+simplify allocations of any temporary memory, because the programmer doesn't
+have to keep track of which objects need to be freed every time they are
+allocated, because at the end of every frame the whole allocator is reset to
+its initial state and all objects are freed at once.
+
+The allocators have different kinds of restrictions on object lifetimes, sizes,
+alignment and can be a significant gain, if used properly. Odin supports
+allocators on a language level.
+
+Operations such as `new`, `free` and `delete` by default will use
+`context.allocator`, which can be overridden by the user. When an override
+happens all called functions will inherit the new context and use the same
+allocator.
+
+## Alignment
+
+An address is said to be *aligned to `N` bytes*, if the addresses's numeric
+value is divisible by `N`. The number `N` in this case can be referred to as
+the *alignment boundary*. Typically an alignment is a power of two integer
+value.
+
+A *natural alignment* of an object is typically equal to its size. For example
+a 16 bit integer has a natural alignment of 2 bytes. When an object is not
+located on its natural alignment boundary, accesses to that object are
+considered *unaligned*.
+
+Some machines issue a hardware **exception**, or experience **slowdowns** when a
+memory access operation occurs from an unaligned address. Examples of such
+operations are:
+
+- SIMD instructions on x86. These instructions require all memory accesses to be
+  on an address that is aligned to 16 bytes.
+- On ARM unaligned loads have an extra cycle penalty.
+
+As such, many operations that allocate memory in this package allow to
+explicitly specify the alignment of allocated pointers/slices. The default
+alignment for all operations is specified in a constant `mem.DEFAULT_ALIGNMENT`.
+
+## Zero by default
+
+Whenever new memory is allocated, via an allocator, or on the stack, by default
+Odin will zero-initialize that memory, even if it wasn't explicitly
+initialized. This allows for some convenience in certain scenarios and ease of
+debugging, which will not be described in detail here.
+
+However zero-initialization can be a cause of slowdowns, when allocating large
+buffers. For this reason, allocators have `*_non_zeroed` modes of allocation
+that allow the user to request for uninitialized memory and will avoid a
+relatively expensive zero-filling of the buffer.
+
+## Naming conventions
+
+The word `size` is used to denote the **size in bytes**. The word `length` is
+used to denote the count of objects.
+
+Higher-level allocation functions follow the following naming scheme:
+
+- `new`: Allocates a single object
+- `free`: Free a single object (opposite of `new`)
+- `make`: Allocate a group of objects
+- `delete`: Free a group of objects (opposite of `make`)
 */
 package mem

--- a/core/mem/doc.odin
+++ b/core/mem/doc.odin
@@ -48,6 +48,11 @@ Operations such as `new`, `free` and `delete` by default will use
 happens all called procedures will inherit the new context and use the same
 allocator.
 
+We will define one concept to simplify the description of some allocator-related
+procedures, which is ownership. If the memory was allocated via a specific
+allocator, that allocator is said to be the *owner* of that memory region. To
+note, unlike Rust, in Odin the memory ownership model is not strict.
+
 ## Alignment
 
 An address is said to be *aligned to `N` bytes*, if the addresses's numeric

--- a/core/mem/doc.odin
+++ b/core/mem/doc.odin
@@ -1,5 +1,5 @@
 /*
-The `mem` package implements various allocators and provides utility functions
+The `mem` package implements various allocators and provides utility procedures
 for dealing with memory, pointers and slices.
 
 The documentation below describes basic concepts, applicable to the `mem`
@@ -24,7 +24,7 @@ access operation*.
 ## Allocators
 
 In C and C++ memory models, allocations of objects in memory are typically
-treated individually with a generic allocator (The `malloc` function). Which in
+treated individually with a generic allocator (The `malloc` procedure). Which in
 some scenarios can lead to poor cache utilization, slowdowns on individual
 objects' memory management and growing complexity of the code needing to keep
 track of the pointers and their lifetimes.
@@ -45,7 +45,7 @@ allocators on a language level.
 
 Operations such as `new`, `free` and `delete` by default will use
 `context.allocator`, which can be overridden by the user. When an override
-happens all called functions will inherit the new context and use the same
+happens all called procedures will inherit the new context and use the same
 allocator.
 
 ## Alignment
@@ -89,7 +89,17 @@ relatively expensive zero-filling of the buffer.
 The word `size` is used to denote the **size in bytes**. The word `length` is
 used to denote the count of objects.
 
-Higher-level allocation functions follow the following naming scheme:
+The allocation procedures use the following conventions:
+
+- If the name contains `alloc_bytes` or `resize_bytes`, then the procedure takes
+  in slice parameters and returns slices.
+- If the procedure name contains `alloc` or `resize`, then the procedure takes
+  in a raw pointer and returns raw pointers.
+- If the procedure name contains `free_bytes`, then the procedure takes in a
+  slice.
+- If the procedure name contains `free`, then the procedure takes in a pointer.
+
+Higher-level allocation procedures follow the following naming scheme:
 
 - `new`: Allocates a single object
 - `free`: Free a single object (opposite of `new`)

--- a/core/mem/mem.odin
+++ b/core/mem/mem.odin
@@ -14,10 +14,12 @@ Exabyte  :: runtime.Exabyte
 set :: proc "contextless" (data: rawptr, value: byte, len: int) -> rawptr {
 	return runtime.memset(data, i32(value), len)
 }
+
 zero :: proc "contextless" (data: rawptr, len: int) -> rawptr {
 	intrinsics.mem_zero(data, len)
 	return data
 }
+
 zero_explicit :: proc "contextless" (data: rawptr, len: int) -> rawptr {
 	// This routine tries to avoid the compiler optimizing away the call,
 	// so that it is always executed.  It is intended to provided
@@ -27,20 +29,22 @@ zero_explicit :: proc "contextless" (data: rawptr, len: int) -> rawptr {
 	intrinsics.atomic_thread_fence(.Seq_Cst) // Prevent reordering
 	return data
 }
+
 zero_item :: proc "contextless" (item: $P/^$T) -> P {
 	intrinsics.mem_zero(item, size_of(T))
 	return item
 }
+
 zero_slice :: proc "contextless" (data: $T/[]$E) -> T {
 	zero(raw_data(data), size_of(E)*len(data))
 	return data
 }
 
-
 copy :: proc "contextless" (dst, src: rawptr, len: int) -> rawptr {
 	intrinsics.mem_copy(dst, src, len)
 	return dst
 }
+
 copy_non_overlapping :: proc "contextless" (dst, src: rawptr, len: int) -> rawptr {
 	intrinsics.mem_copy_non_overlapping(dst, src, len)
 	return dst
@@ -120,6 +124,7 @@ compare_ptrs :: proc "contextless" (a, b: rawptr, n: int) -> int {
 }
 
 ptr_offset :: intrinsics.ptr_offset
+
 ptr_sub :: intrinsics.ptr_sub
 
 @(require_results)
@@ -211,6 +216,7 @@ align_forward_uintptr :: proc(ptr, align: uintptr) -> uintptr {
 align_forward_int :: proc(ptr, align: int) -> int {
 	return int(align_forward_uintptr(uintptr(ptr), uintptr(align)))
 }
+
 @(require_results)
 align_forward_uint :: proc(ptr, align: uint) -> uint {
 	return uint(align_forward_uintptr(uintptr(ptr), uintptr(align)))
@@ -230,6 +236,7 @@ align_backward_uintptr :: proc(ptr, align: uintptr) -> uintptr {
 align_backward_int :: proc(ptr, align: int) -> int {
 	return int(align_backward_uintptr(uintptr(ptr), uintptr(align)))
 }
+
 @(require_results)
 align_backward_uint :: proc(ptr, align: uint) -> uint {
 	return uint(align_backward_uintptr(uintptr(ptr), uintptr(align)))
@@ -247,7 +254,6 @@ reinterpret_copy :: proc "contextless" ($T: typeid, ptr: rawptr) -> (value: T) {
 	return
 }
 
-
 Fixed_Byte_Buffer :: distinct [dynamic]byte
 
 @(require_results)
@@ -264,8 +270,6 @@ make_fixed_byte_buffer :: proc "contextless" (backing: []byte) -> Fixed_Byte_Buf
 	return transmute(Fixed_Byte_Buffer)d
 }
 
-
-
 @(require_results)
 align_formula :: proc "contextless" (size, align: int) -> int {
 	result := size + align-1
@@ -276,12 +280,10 @@ align_formula :: proc "contextless" (size, align: int) -> int {
 calc_padding_with_header :: proc "contextless" (ptr: uintptr, align: uintptr, header_size: int) -> int {
 	p, a := ptr, align
 	modulo := p & (a-1)
-
 	padding := uintptr(0)
 	if modulo != 0 {
 		padding = a - modulo
 	}
-
 	needed_space := uintptr(header_size)
 	if padding < needed_space {
 		needed_space -= padding
@@ -295,8 +297,6 @@ calc_padding_with_header :: proc "contextless" (ptr: uintptr, align: uintptr, he
 
 	return int(padding)
 }
-
-
 
 @(require_results, deprecated="prefer 'slice.clone'")
 clone_slice :: proc(slice: $T/[]$E, allocator := context.allocator, loc := #caller_location) -> (new_slice: T) {

--- a/core/mem/mem.odin
+++ b/core/mem/mem.odin
@@ -644,10 +644,26 @@ align_formula :: proc "contextless" (size, align: int) -> int {
 }
 
 /*
-Calculate the padding after the pointer with a header.
+Calculate the padding for header preceding aligned data.
 
-This procedure returns the next address, following `ptr` and `header_size`
-bytes of space that is aligned to a boundary specified by `align`.
+This procedure returns the padding, following the specified pointer `ptr` that
+will be able to fit in a header of the size `header_size`, immediately
+preceding the memory region, aligned on a boundary specified by `align`. See
+the following diagram for a visual representation.
+
+        header size
+	    |<------>|
+	+---+--------+------------- - - -
+	    | HEADER |  DATA...
+	+---+--------+------------- - - -
+	^            ^
+	|<---------->|
+	|  padding   |
+	ptr          aligned ptr
+
+The function takes in `ptr` and `header_size`, as well as the required
+alignment for `DATA`. The return value of the function is the padding between
+`ptr` and `aligned_ptr` that will be able to fit the header.
 */
 @(require_results)
 calc_padding_with_header :: proc "contextless" (ptr: uintptr, align: uintptr, header_size: int) -> int {

--- a/core/mem/mem.odin
+++ b/core/mem/mem.odin
@@ -3,23 +3,99 @@ package mem
 import "base:runtime"
 import "base:intrinsics"
 
-Byte     :: runtime.Byte
-Kilobyte :: runtime.Kilobyte
-Megabyte :: runtime.Megabyte
-Gigabyte :: runtime.Gigabyte
-Terabyte :: runtime.Terabyte
-Petabyte :: runtime.Petabyte
-Exabyte  :: runtime.Exabyte
+/*
+The size, in bytes, of a single byte.
 
+This constant is equal to the value of `1`.
+*/
+Byte :: runtime.Byte
+
+/*
+The size, in bytes, of one kilobyte.
+
+This constant is equal to the amount of bytes in one kilobyte (also known as
+kibibyte), which is equal to 1024 bytes.
+*/
+Kilobyte :: runtime.Kilobyte
+
+/*
+The size, in bytes, of one megabyte.
+
+This constant is equal to the amount of bytes in one megabyte (also known as
+mebibyte), which is equal to 1024 kilobyte.
+*/
+Megabyte :: runtime.Megabyte
+
+/*
+The size, in bytes, of one gigabyte.
+
+This constant is equal to the amount of bytes in one gigabyte (also known as
+gibiibyte), which is equal to 1024 megabytes.
+*/
+Gigabyte :: runtime.Gigabyte
+
+/*
+The size, in bytes, of one terabyte.
+
+This constant is equal to the amount of bytes in one terabyte (also known as
+tebiibyte), which is equal to 1024 gigabytes.
+*/
+Terabyte :: runtime.Terabyte
+
+/*
+The size, in bytes, of one petabyte.
+
+This constant is equal to the amount of bytes in one petabyte (also known as
+pebiibyte), which is equal to 1024 terabytes.
+*/
+Petabyte :: runtime.Petabyte
+
+/*
+The size, in bytes, of one exabyte.
+
+This constant is equal to the amount of bytes in one exabyte (also known as
+exbibyte), which is equal to 1024 petabytes.
+*/
+Exabyte :: runtime.Exabyte
+
+/*
+Set each byte of a memory range to a specific value.
+
+This procedure copies value specified by the `value` parameter into each of the
+`len` bytes of a memory range, located at address `data`.
+
+This procedure returns the pointer to `data`.
+*/
 set :: proc "contextless" (data: rawptr, value: byte, len: int) -> rawptr {
 	return runtime.memset(data, i32(value), len)
 }
 
+/*
+Set each byte of a memory range to zero.
+
+This procedure copies the value `0` into the `len` bytes of a memory range,
+starting at address `data`.
+
+This procedure returns the pointer to `data`.
+*/
 zero :: proc "contextless" (data: rawptr, len: int) -> rawptr {
 	intrinsics.mem_zero(data, len)
 	return data
 }
 
+/*
+Set each byte of a memory range to zero.
+
+This procedure copies the value `0` into the `len` bytes of a memory range,
+starting at address `data`.
+
+This procedure returns the pointer to `data`.
+
+Unlike the `zero()` procedure, which can be optimized away or reordered by the
+compiler under certain circumstances, `zero_explicit()` procedure can not be
+optimized away or reordered with other memory access operations, and the
+compiler assumes volatile semantics of the memory.
+*/
 zero_explicit :: proc "contextless" (data: rawptr, len: int) -> rawptr {
 	// This routine tries to avoid the compiler optimizing away the call,
 	// so that it is always executed.  It is intended to provided
@@ -30,26 +106,82 @@ zero_explicit :: proc "contextless" (data: rawptr, len: int) -> rawptr {
 	return data
 }
 
+/*
+Zero-fill the memory of an object.
+
+This procedure sets each byte of the object pointed to by the pointer `item`
+to zero, and returns the pointer to `item`.
+*/
 zero_item :: proc "contextless" (item: $P/^$T) -> P {
 	intrinsics.mem_zero(item, size_of(T))
 	return item
 }
 
+/*
+Zero-fill the memory of the slice.
+
+This procedure sets each byte of the slice pointed to by the slice `data`
+to zero, and returns the slice `data`.
+*/
 zero_slice :: proc "contextless" (data: $T/[]$E) -> T {
 	zero(raw_data(data), size_of(E)*len(data))
 	return data
 }
 
+/*
+Copy bytes from one memory range to another.
+
+This procedure copies `len` bytes of data, from the memory range pointed to by
+the `src` pointer into the memory range pointed to by the `dst` pointer, and
+returns the `dst` pointer.
+*/
 copy :: proc "contextless" (dst, src: rawptr, len: int) -> rawptr {
 	intrinsics.mem_copy(dst, src, len)
 	return dst
 }
 
+/*
+Copy bytes between two non-overlapping memory ranges.
+
+This procedure copies `len` bytes of data, from the memory range pointed to by
+the `src` pointer into the memory range pointed to by the `dst` pointer, and
+returns the `dst` pointer.
+
+This is a slightly more optimized version of the `copy` procedure that requires
+that memory ranges specified by the parameters to this procedure are not
+overlapping. If the memory ranges specified by `dst` and `src` pointers overlap,
+the behavior of this function may be unpredictable.
+*/
 copy_non_overlapping :: proc "contextless" (dst, src: rawptr, len: int) -> rawptr {
 	intrinsics.mem_copy_non_overlapping(dst, src, len)
 	return dst
 }
 
+/*
+Compare two memory ranges defined by slices.
+
+This procedure performs a byte-by-byte comparison between memory ranges
+specified by slices `a` and `b`, and returns a value, specifying their relative
+ordering.
+
+If the return value is:
+- Equal to `-1`, then `a` is "smaller" than `b`.
+- Equal to `+1`, then `a` is "bigger"  than `b`.
+- Equal to `0`, then `a` and `b` are equal.
+
+The comparison is performed as follows:
+1. Each byte, upto `min(len(a), len(b))` bytes is compared between `a` and `b`.
+  - If the byte in slice `a` is smaller than a byte in slice `b`, then comparison
+  stops and this procedure returns `-1`.
+  - If the byte in slice `a` is bigger than a byte in slice `b`, then comparison
+  stops and this procedure returns `+1`.
+  - Otherwise the comparison continues until `min(len(a), len(b))` are compared.
+2. If all the bytes in the range are equal, then the lengths of the slices are
+  compared.
+  - If the length of slice `a` is smaller than the length of slice `b`, then `-1` is returned.
+  - If the length of slice `b` is smaller than the length of slice `b`, then `+1` is returned.
+  - Otherwise `0` is returned.
+*/
 @(require_results)
 compare :: proc "contextless" (a, b: []byte) -> int {
 	res := compare_byte_ptrs(raw_data(a), raw_data(b), min(len(a), len(b)))
@@ -61,16 +193,89 @@ compare :: proc "contextless" (a, b: []byte) -> int {
 	return res
 }
 
+/*
+Compare two memory ranges defined by byte pointers.
+
+This procedure performs a byte-by-byte comparison between memory ranges of size
+`n` located at addresses `a` and `b`, and returns a value, specifying their relative
+ordering.
+
+If the return value is:
+- Equal to `-1`, then `a` is "smaller" than `b`.
+- Equal to `+1`, then `a` is "bigger"  than `b`.
+- Equal to `0`, then `a` and `b` are equal.
+
+The comparison is performed as follows:
+1. Each byte, upto `n` bytes is compared between `a` and `b`.
+  - If the byte in `a` is smaller than a byte in `b`, then comparison stops
+  and this procedure returns `-1`.
+  - If the byte in `a` is bigger than a byte in `b`, then comparison stops
+  and this procedure returns `+1`.
+  - Otherwise the comparison continues until `n` bytes are compared.
+2. If all the bytes in the range are equal, this procedure returns `0`.
+*/
 @(require_results)
 compare_byte_ptrs :: proc "contextless" (a, b: ^byte, n: int) -> int #no_bounds_check {
 	return runtime.memory_compare(a, b, n)
 }
 
+/*
+Compare two memory ranges defined by pointers.
+
+This procedure performs a byte-by-byte comparison between memory ranges of size
+`n` located at addresses `a` and `b`, and returns a value, specifying their relative
+ordering.
+
+If the return value is:
+- Equal to `-1`, then `a` is "smaller" than `b`.
+- Equal to `+1`, then `a` is "bigger"  than `b`.
+- Equal to `0`, then `a` and `b` are equal.
+
+The comparison is performed as follows:
+1. Each byte, upto `n` bytes is compared between `a` and `b`.
+  - If the byte in `a` is smaller than a byte in `b`, then comparison stops
+  and this procedure returns `-1`.
+  - If the byte in `a` is bigger than a byte in `b`, then comparison stops
+  and this procedure returns `+1`.
+  - Otherwise the comparison continues until `n` bytes are compared.
+2. If all the bytes in the range are equal, this procedure returns `0`.
+*/
+@(require_results)
+compare_ptrs :: proc "contextless" (a, b: rawptr, n: int) -> int {
+	return compare_byte_ptrs((^byte)(a), (^byte)(b), n)
+}
+
+/*
+Check whether two objects are equal on binary level.
+
+This procedure checks whether the memory ranges occupied by objects `a` and
+`b` are equal. See `compare_byte_ptrs()` for how this comparison is done.
+*/
+@(require_results)
+simple_equal :: proc "contextless" (a, b: $T) -> bool where intrinsics.type_is_simple_compare(T) {
+	a, b := a, b
+	return compare_byte_ptrs((^byte)(&a), (^byte)(&b), size_of(T)) == 0
+}
+
+/*
+Check if the memory range defined by a slice is zero-filled.
+
+This procedure checks whether every byte, pointed to by the slice, specified
+by the parameter `data`, is zero. If all bytes of the slice are zero, this
+procedure returns `true`. Otherwise this procedure returns `false`.
+*/
 @(require_results)
 check_zero :: proc(data: []byte) -> bool {
 	return check_zero_ptr(raw_data(data), len(data))
 }
 
+/*
+Check if the memory range defined defined by a pointer is zero-filled.
+
+This procedure checks whether each of the `len` bytes, starting at address
+`ptr` is zero. If all bytes of this range are zero, this procedure returns
+`true`. Otherwise this procedure returns `false`.
+*/
 @(require_results)
 check_zero_ptr :: proc(ptr: rawptr, len: int) -> bool {
 	switch {
@@ -85,58 +290,99 @@ check_zero_ptr :: proc(ptr: rawptr, len: int) -> bool {
 	case 4: return intrinsics.unaligned_load((^u32)(ptr)) == 0
 	case 8: return intrinsics.unaligned_load((^u64)(ptr)) == 0
 	}
-
 	start := uintptr(ptr)
 	start_aligned := align_forward_uintptr(start, align_of(uintptr))
 	end := start + uintptr(len)
 	end_aligned := align_backward_uintptr(end, align_of(uintptr))
-
 	for b in start..<start_aligned {
 		if (^byte)(b)^ != 0 {
 			return false
 		}
 	}
-
 	for b := start_aligned; b < end_aligned; b += size_of(uintptr) {
 		if (^uintptr)(b)^ != 0 {
 			return false
 		}
 	}
-
 	for b in end_aligned..<end {
 		if (^byte)(b)^ != 0 {
 			return false
 		}
 	}
-
 	return true
 }
 
-@(require_results)
-simple_equal :: proc "contextless" (a, b: $T) -> bool where intrinsics.type_is_simple_compare(T) {
-	a, b := a, b
-	return compare_byte_ptrs((^byte)(&a), (^byte)(&b), size_of(T)) == 0
-}
+/*
+Offset a given pointer by a given amount.
 
-@(require_results)
-compare_ptrs :: proc "contextless" (a, b: rawptr, n: int) -> int {
-	return compare_byte_ptrs((^byte)(a), (^byte)(b), n)
-}
+This procedure offsets the pointer `ptr` to an object of type `T`, by the amount
+of bytes specified by `offset*size_of(T)`, and returns the pointer `ptr`.
 
+**Note**: Prefer to use multipointer types, if possible.
+*/
 ptr_offset :: intrinsics.ptr_offset
 
+/*
+Offset a given pointer by a given amount backwards.
+
+This procedure offsets the pointer `ptr` to an object of type `T`, by the amount
+of bytes specified by `offset*size_of(T)` in the negative direction, and
+returns the pointer `ptr`.
+*/
 ptr_sub :: intrinsics.ptr_sub
 
+/*
+Construct a slice from pointer and length.
+
+This procedure creates a slice, that points to `len` amount of objects located
+at an address, specified by `ptr`.
+*/
 @(require_results)
 slice_ptr :: proc "contextless" (ptr: ^$T, len: int) -> []T {
 	return ([^]T)(ptr)[:len]
 }
 
+/*
+Construct a byte slice from raw pointer and length.
+
+This procedure creates a byte slice, that points to `len` amount of bytes
+located at an address specified by `data`.
+*/
 @(require_results)
 byte_slice :: #force_inline proc "contextless" (data: rawptr, #any_int len: int) -> []byte {
 	return ([^]u8)(data)[:max(len, 0)]
 }
 
+/*
+Create a byte slice from pointer and length.
+
+This procedure creates a byte slice, pointing to `len` objects, starting from
+the address specified by `ptr`.
+*/
+@(require_results)
+ptr_to_bytes :: proc "contextless" (ptr: ^$T, len := 1) -> []byte {
+	return transmute([]byte)Raw_Slice{ptr, len*size_of(T)}
+}
+
+/*
+Obtain the slice, pointing to the contents of `any`.
+
+This procedure returns the slice, pointing to the contents of the specified
+value of the `any` type.
+*/
+@(require_results)
+any_to_bytes :: proc "contextless" (val: any) -> []byte {
+	ti := type_info_of(val.id)
+	size := ti != nil ? ti.size : 0
+	return transmute([]byte)Raw_Slice{val.data, size}
+}
+
+/*
+Obtain a byte slice from any slice.
+
+This procedure returns a slice, that points to the same bytes as the slice,
+specified by `slice` and returns the resulting byte slice.
+*/
 @(require_results)
 slice_to_bytes :: proc "contextless" (slice: $E/[]$T) -> []byte {
 	s := transmute(Raw_Slice)slice
@@ -144,6 +390,15 @@ slice_to_bytes :: proc "contextless" (slice: $E/[]$T) -> []byte {
 	return transmute([]byte)s
 }
 
+/*
+Transmute slice to a different type.
+
+This procedure performs an operation similar to transmute, returning a slice of
+type `T` that points to the same bytes as the slice specified by `slice`
+parameter. Unlike plain transmute operation, this procedure adjusts the length
+of the resulting slice, such that the resulting slice points to the correct
+amount of objects to cover the memory region pointed to by `slice`.
+*/
 @(require_results)
 slice_data_cast :: proc "contextless" ($T: typeid/[]$A, slice: $S/[]$B) -> T {
 	when size_of(A) == 0 || size_of(B) == 0 {
@@ -155,12 +410,25 @@ slice_data_cast :: proc "contextless" ($T: typeid/[]$A, slice: $S/[]$B) -> T {
 	}
 }
 
+/*
+Obtain data and length of a slice.
+
+This procedure returns the pointer to the start of the memory region pointed to
+by slice `slice` and the length of the slice.
+*/
 @(require_results)
 slice_to_components :: proc "contextless" (slice: $E/[]$T) -> (data: ^T, len: int) {
 	s := transmute(Raw_Slice)slice
 	return (^T)(s.data), s.len
 }
 
+/*
+Create a dynamic array from slice.
+
+This procedure creates a dynamic array, using slice `backing` as the backing
+buffer for the dynamic array. The resulting dynamic array can not grow beyond
+the size of the specified slice.
+*/
 @(require_results)
 buffer_from_slice :: proc "contextless" (backing: $T/[]$E) -> [dynamic]E {
 	return transmute([dynamic]E)Raw_Dynamic_Array{
@@ -174,19 +442,12 @@ buffer_from_slice :: proc "contextless" (backing: $T/[]$E) -> [dynamic]E {
 	}
 }
 
-@(require_results)
-ptr_to_bytes :: proc "contextless" (ptr: ^$T, len := 1) -> []byte {
-	return transmute([]byte)Raw_Slice{ptr, len*size_of(T)}
-}
+/*
+Check whether a number is a power of two.
 
-@(require_results)
-any_to_bytes :: proc "contextless" (val: any) -> []byte {
-	ti := type_info_of(val.id)
-	size := ti != nil ? ti.size : 0
-	return transmute([]byte)Raw_Slice{val.data, size}
-}
-
-
+This procedure checks whether a given pointer-sized unsigned integer contains
+a power-of-two value.
+*/
 @(require_results)
 is_power_of_two :: proc "contextless" (x: uintptr) -> bool {
 	if x <= 0 {
@@ -195,67 +456,156 @@ is_power_of_two :: proc "contextless" (x: uintptr) -> bool {
 	return (x & (x-1)) == 0
 }
 
+/*
+Align uintptr forward.
+
+This procedure returns the next address after `ptr`, that is located on the
+alignment boundary specified by `align`. If `ptr` is already aligned to `align`
+bytes, `ptr` is returned.
+
+The specified alignment must be a power of 2.
+*/
+@(require_results)
+align_forward_uintptr :: proc(ptr, align: uintptr) -> uintptr {
+	assert(is_power_of_two(align))
+	return (p + align-1) & ~(align-1)
+}
+
+/*
+Align pointer forward.
+
+This procedure returns the next address after `ptr`, that is located on the
+alignment boundary specified by `align`. If `ptr` is already aligned to `align`
+bytes, `ptr` is returned.
+
+The specified alignment must be a power of 2.
+*/
 @(require_results)
 align_forward :: proc(ptr: rawptr, align: uintptr) -> rawptr {
 	return rawptr(align_forward_uintptr(uintptr(ptr), align))
 }
 
-@(require_results)
-align_forward_uintptr :: proc(ptr, align: uintptr) -> uintptr {
-	assert(is_power_of_two(align))
+/*
+Align int forward.
 
-	p := ptr
-	modulo := p & (align-1)
-	if modulo != 0 {
-		p += align - modulo
-	}
-	return p
-}
+This procedure returns the next address after `ptr`, that is located on the
+alignment boundary specified by `align`. If `ptr` is already aligned to `align`
+bytes, `ptr` is returned.
 
+The specified alignment must be a power of 2.
+*/
 @(require_results)
 align_forward_int :: proc(ptr, align: int) -> int {
 	return int(align_forward_uintptr(uintptr(ptr), uintptr(align)))
 }
 
+/*
+Align uint forward.
+
+This procedure returns the next address after `ptr`, that is located on the
+alignment boundary specified by `align`. If `ptr` is already aligned to `align`
+bytes, `ptr` is returned.
+
+The specified alignment must be a power of 2.
+*/
 @(require_results)
 align_forward_uint :: proc(ptr, align: uint) -> uint {
 	return uint(align_forward_uintptr(uintptr(ptr), uintptr(align)))
 }
 
+/*
+Align uintptr backwards.
+
+This procedure returns the previous address before `ptr`, that is located on the
+alignment boundary specified by `align`. If `ptr` is already aligned to `align`
+bytes, `ptr` is returned.
+
+The specified alignment must be a power of 2.
+*/
+@(require_results)
+align_backward_uintptr :: proc(ptr, align: uintptr) -> uintptr {
+	assert(is_power_of_two(align))
+	return ptr & ~(align-1)
+}
+
+/*
+Align rawptr backwards.
+
+This procedure returns the previous address before `ptr`, that is located on the
+alignment boundary specified by `align`. If `ptr` is already aligned to `align`
+bytes, `ptr` is returned.
+
+The specified alignment must be a power of 2.
+*/
 @(require_results)
 align_backward :: proc(ptr: rawptr, align: uintptr) -> rawptr {
 	return rawptr(align_backward_uintptr(uintptr(ptr), align))
 }
 
-@(require_results)
-align_backward_uintptr :: proc(ptr, align: uintptr) -> uintptr {
-	return align_forward_uintptr(ptr - align + 1, align)
-}
+/*
+Align int backwards.
 
+This procedure returns the previous address before `ptr`, that is located on the
+alignment boundary specified by `align`. If `ptr` is already aligned to `align`
+bytes, `ptr` is returned.
+
+The specified alignment must be a power of 2.
+*/
 @(require_results)
 align_backward_int :: proc(ptr, align: int) -> int {
 	return int(align_backward_uintptr(uintptr(ptr), uintptr(align)))
 }
 
+/*
+Align uint backwards.
+
+This procedure returns the previous address before `ptr`, that is located on the
+alignment boundary specified by `align`. If `ptr` is already aligned to `align`
+bytes, `ptr` is returned.
+
+The specified alignment must be a power of 2.
+*/
 @(require_results)
 align_backward_uint :: proc(ptr, align: uint) -> uint {
 	return uint(align_backward_uintptr(uintptr(ptr), uintptr(align)))
 }
 
+/*
+Create a context with a given allocator.
+
+This procedure returns a copy of the current context with the allocator replaced
+by the allocator `a`.
+*/
 @(require_results)
 context_from_allocator :: proc(a: Allocator) -> type_of(context) {
 	context.allocator = a
 	return context
 }
 
+/*
+Copy the value from a pointer into a value.
+
+This procedure copies the object of type `T` pointed to by the pointer `ptr`
+into a new stack-allocated value and returns that value.
+*/
 @(require_results)
 reinterpret_copy :: proc "contextless" ($T: typeid, ptr: rawptr) -> (value: T) {
 	copy(&value, ptr, size_of(T))
 	return
 }
 
+/*
+Dynamic array with a fixed capacity buffer.
+
+This type represents dynamic arrays with a fixed-size backing buffer. Upon
+allocating memory beyond reaching the maximum capacity, allocations from fixed
+byte buffers return `nil` and no error.
+*/
 Fixed_Byte_Buffer :: distinct [dynamic]byte
 
+/*
+Create a fixed byte buffer from a slice.
+*/
 @(require_results)
 make_fixed_byte_buffer :: proc "contextless" (backing: []byte) -> Fixed_Byte_Buffer {
 	s := transmute(Raw_Slice)backing
@@ -270,12 +620,24 @@ make_fixed_byte_buffer :: proc "contextless" (backing: []byte) -> Fixed_Byte_Buf
 	return transmute(Fixed_Byte_Buffer)d
 }
 
+/*
+General-purpose align formula.
+
+This procedure is equivalent to `align_forward`, but it does not require the
+alignment to be a power of two.
+*/
 @(require_results)
 align_formula :: proc "contextless" (size, align: int) -> int {
 	result := size + align-1
 	return result - result%align
 }
 
+/*
+Calculate the padding after the pointer with a header.
+
+This procedure returns the next address, following `ptr` and `header_size`
+bytes of space that is aligned to a boundary specified by `align`.
+*/
 @(require_results)
 calc_padding_with_header :: proc "contextless" (ptr: uintptr, align: uintptr, header_size: int) -> int {
 	p, a := ptr, align
@@ -287,14 +649,12 @@ calc_padding_with_header :: proc "contextless" (ptr: uintptr, align: uintptr, he
 	needed_space := uintptr(header_size)
 	if padding < needed_space {
 		needed_space -= padding
-
 		if needed_space & (a-1) > 0 {
 			padding += align * (1+(needed_space/align))
 		} else {
 			padding += align * (needed_space/align)
 		}
 	}
-
 	return int(padding)
 }
 

--- a/core/mem/mem.odin
+++ b/core/mem/mem.odin
@@ -468,7 +468,7 @@ The specified alignment must be a power of 2.
 @(require_results)
 align_forward_uintptr :: proc(ptr, align: uintptr) -> uintptr {
 	assert(is_power_of_two(align))
-	return (p + align-1) & ~(align-1)
+	return (ptr + align-1) & ~(align-1)
 }
 
 /*

--- a/core/mem/mem.odin
+++ b/core/mem/mem.odin
@@ -98,7 +98,7 @@ compiler assumes volatile semantics of the memory.
 */
 zero_explicit :: proc "contextless" (data: rawptr, len: int) -> rawptr {
 	// This routine tries to avoid the compiler optimizing away the call,
-	// so that it is always executed.  It is intended to provided
+	// so that it is always executed.  It is intended to provide
 	// equivalent semantics to those provided by the C11 Annex K 3.7.4.1
 	// memset_s call.
 	intrinsics.mem_zero_volatile(data, len) // Use the volatile mem_zero

--- a/core/mem/mem.odin
+++ b/core/mem/mem.odin
@@ -457,6 +457,17 @@ is_power_of_two :: proc "contextless" (x: uintptr) -> bool {
 }
 
 /*
+Check if a pointer is aligned.
+
+This procedure checks whether a pointer `x` is aligned to a boundary specified
+by `align`, and returns `true` if the pointer is aligned, and false otherwise.
+*/
+is_aligned :: proc "contextless" (x: rawptr, align: int) -> bool {
+	p := uintptr(x)
+	return (p & (1<<uintptr(align) - 1)) == 0
+}
+
+/*
 Align uintptr forward.
 
 This procedure returns the next address after `ptr`, that is located on the

--- a/core/mem/mutex_allocator.odin
+++ b/core/mem/mutex_allocator.odin
@@ -3,16 +3,31 @@ package mem
 
 import "core:sync"
 
+/*
+The data for mutex allocator.
+*/
 Mutex_Allocator :: struct {
 	backing: Allocator,
 	mutex:   sync.Mutex,
 }
 
+/*
+Initialize the mutex allocator.
+
+This procedure initializes the mutex allocator using `backin_allocator` as the
+allocator that will be used to pass all allocation requests through.
+*/
 mutex_allocator_init :: proc(m: ^Mutex_Allocator, backing_allocator: Allocator) {
 	m.backing = backing_allocator
 	m.mutex = {}
 }
 
+/*
+Mutex allocator.
+
+The mutex allocator is a wrapper for allocators that is used to serialize all
+allocator requests across multiple threads.
+*/
 @(require_results)
 mutex_allocator :: proc(m: ^Mutex_Allocator) -> Allocator {
 	return Allocator{

--- a/core/mem/mutex_allocator.odin
+++ b/core/mem/mutex_allocator.odin
@@ -13,7 +13,6 @@ mutex_allocator_init :: proc(m: ^Mutex_Allocator, backing_allocator: Allocator) 
 	m.mutex = {}
 }
 
-
 @(require_results)
 mutex_allocator :: proc(m: ^Mutex_Allocator) -> Allocator {
 	return Allocator{
@@ -22,11 +21,16 @@ mutex_allocator :: proc(m: ^Mutex_Allocator) -> Allocator {
 	}
 }
 
-mutex_allocator_proc :: proc(allocator_data: rawptr, mode: Allocator_Mode,
-                             size, alignment: int,
-                             old_memory: rawptr, old_size: int, loc := #caller_location) -> (result: []byte, err: Allocator_Error) {
+mutex_allocator_proc :: proc(
+	allocator_data: rawptr,
+	mode: Allocator_Mode,
+	size: int,
+	alignment: int,
+	old_memory: rawptr,
+	old_size: int,
+	loc := #caller_location,
+) -> (result: []byte, err: Allocator_Error) {
 	m := (^Mutex_Allocator)(allocator_data)
-
 	sync.mutex_guard(&m.mutex)
 	return m.backing.procedure(m.backing.data, mode, size, alignment, old_memory, old_size, loc)
 }

--- a/core/mem/raw.odin
+++ b/core/mem/raw.odin
@@ -4,68 +4,82 @@ import "base:builtin"
 import "base:runtime"
 
 /*
-Mamory layout of the `any` type.
+Memory layout of the `any` type.
 */
 Raw_Any :: runtime.Raw_Any
 
 /*
-Mamory layout of the `string` type.
+Memory layout of the `string` type.
 */
 Raw_String :: runtime.Raw_String
+
 /*
-Mamory layout of the `cstring` type.
+Memory layout of the `cstring` type.
 */
 Raw_Cstring :: runtime.Raw_Cstring
+
 /*
-Mamory layout of `[]T` types.
+Memory layout of `[]T` types.
 */
 Raw_Slice :: runtime.Raw_Slice
+
 /*
-Mamory layout of `[dynamic]T` types.
+Memory layout of `[dynamic]T` types.
 */
 Raw_Dynamic_Array :: runtime.Raw_Dynamic_Array
+
 /*
-Mamory layout of `map[K]V` types.
+Memory layout of `map[K]V` types.
 */
 Raw_Map :: runtime.Raw_Map
+
 /*
-Mamory layout of `#soa []T` types.
+Memory layout of `#soa []T` types.
 */
 Raw_Soa_Pointer :: runtime.Raw_Soa_Pointer
+
 /*
-Mamory layout of the `complex32` type.
+Memory layout of the `complex32` type.
 */
 Raw_Complex32 :: runtime.Raw_Complex32
+
 /*
-Mamory layout of the `complex64` type.
+Memory layout of the `complex64` type.
 */
 Raw_Complex64 :: runtime.Raw_Complex64
+
 /*
-Mamory layout of the `complex128` type.
+Memory layout of the `complex128` type.
 */
 Raw_Complex128 :: runtime.Raw_Complex128
+
 /*
-Mamory layout of the `quaternion64` type.
+Memory layout of the `quaternion64` type.
 */
 Raw_Quaternion64 :: runtime.Raw_Quaternion64
+
 /*
-Mamory layout of the `quaternion128` type.
+Memory layout of the `quaternion128` type.
 */
 Raw_Quaternion128 :: runtime.Raw_Quaternion128
+
 /*
-Mamory layout of the `quaternion256` type.
+Memory layout of the `quaternion256` type.
 */
 Raw_Quaternion256 :: runtime.Raw_Quaternion256
+
 /*
-Mamory layout of the `quaternion64` type.
+Memory layout of the `quaternion64` type.
 */
 Raw_Quaternion64_Vector_Scalar :: runtime.Raw_Quaternion64_Vector_Scalar
+
 /*
-Mamory layout of the `quaternion128` type.
+Memory layout of the `quaternion128` type.
 */
 Raw_Quaternion128_Vector_Scalar :: runtime.Raw_Quaternion128_Vector_Scalar
+
 /*
-Mamory layout of the `quaternion256` type.
+Memory layout of the `quaternion256` type.
 */
 Raw_Quaternion256_Vector_Scalar :: runtime.Raw_Quaternion256_Vector_Scalar
 

--- a/core/mem/raw.odin
+++ b/core/mem/raw.odin
@@ -3,40 +3,86 @@ package mem
 import "base:builtin"
 import "base:runtime"
 
+/*
+Mamory layout of the `any` type.
+*/
 Raw_Any :: runtime.Raw_Any
 
+/*
+Mamory layout of the `string` type.
+*/
 Raw_String :: runtime.Raw_String
-
+/*
+Mamory layout of the `cstring` type.
+*/
 Raw_Cstring :: runtime.Raw_Cstring
-
+/*
+Mamory layout of `[]T` types.
+*/
 Raw_Slice :: runtime.Raw_Slice
-
+/*
+Mamory layout of `[dynamic]T` types.
+*/
 Raw_Dynamic_Array :: runtime.Raw_Dynamic_Array
-
+/*
+Mamory layout of `map[K]V` types.
+*/
 Raw_Map :: runtime.Raw_Map
-
+/*
+Mamory layout of `#soa []T` types.
+*/
 Raw_Soa_Pointer :: runtime.Raw_Soa_Pointer
-
+/*
+Mamory layout of the `complex32` type.
+*/
 Raw_Complex32 :: runtime.Raw_Complex32
-
+/*
+Mamory layout of the `complex64` type.
+*/
 Raw_Complex64 :: runtime.Raw_Complex64
-
+/*
+Mamory layout of the `complex128` type.
+*/
 Raw_Complex128 :: runtime.Raw_Complex128
-
+/*
+Mamory layout of the `quaternion64` type.
+*/
 Raw_Quaternion64 :: runtime.Raw_Quaternion64
-
+/*
+Mamory layout of the `quaternion128` type.
+*/
 Raw_Quaternion128 :: runtime.Raw_Quaternion128
-
+/*
+Mamory layout of the `quaternion256` type.
+*/
 Raw_Quaternion256 :: runtime.Raw_Quaternion256
-
+/*
+Mamory layout of the `quaternion64` type.
+*/
 Raw_Quaternion64_Vector_Scalar :: runtime.Raw_Quaternion64_Vector_Scalar
-
+/*
+Mamory layout of the `quaternion128` type.
+*/
 Raw_Quaternion128_Vector_Scalar :: runtime.Raw_Quaternion128_Vector_Scalar
-
+/*
+Mamory layout of the `quaternion256` type.
+*/
 Raw_Quaternion256_Vector_Scalar :: runtime.Raw_Quaternion256_Vector_Scalar
 
+/*
+Create a value of the any type.
+
+This procedure creates a value with type `any` that points to an object with
+typeid `id` located at an address specified by `data`.
+*/
 make_any :: proc "contextless" (data: rawptr, id: typeid) -> any {
 	return transmute(any)Raw_Any{data, id}
 }
 
+/*
+Obtain pointer to the data.
+
+This procedure returns the pointer to the data of a slice, string, or a dynamic
+array.
+*/
 raw_data :: builtin.raw_data

--- a/core/mem/raw.odin
+++ b/core/mem/raw.odin
@@ -3,22 +3,36 @@ package mem
 import "base:builtin"
 import "base:runtime"
 
-Raw_Any           :: runtime.Raw_Any
-Raw_String        :: runtime.Raw_String
-Raw_Cstring       :: runtime.Raw_Cstring
-Raw_Slice         :: runtime.Raw_Slice
-Raw_Dynamic_Array :: runtime.Raw_Dynamic_Array
-Raw_Map           :: runtime.Raw_Map
-Raw_Soa_Pointer   :: runtime.Raw_Soa_Pointer
+Raw_Any :: runtime.Raw_Any
 
-Raw_Complex32     :: runtime.Raw_Complex32
-Raw_Complex64     :: runtime.Raw_Complex64
-Raw_Complex128    :: runtime.Raw_Complex128
-Raw_Quaternion64  :: runtime.Raw_Quaternion64
+Raw_String :: runtime.Raw_String
+
+Raw_Cstring :: runtime.Raw_Cstring
+
+Raw_Slice :: runtime.Raw_Slice
+
+Raw_Dynamic_Array :: runtime.Raw_Dynamic_Array
+
+Raw_Map :: runtime.Raw_Map
+
+Raw_Soa_Pointer :: runtime.Raw_Soa_Pointer
+
+Raw_Complex32 :: runtime.Raw_Complex32
+
+Raw_Complex64 :: runtime.Raw_Complex64
+
+Raw_Complex128 :: runtime.Raw_Complex128
+
+Raw_Quaternion64 :: runtime.Raw_Quaternion64
+
 Raw_Quaternion128 :: runtime.Raw_Quaternion128
+
 Raw_Quaternion256 :: runtime.Raw_Quaternion256
-Raw_Quaternion64_Vector_Scalar  :: runtime.Raw_Quaternion64_Vector_Scalar
+
+Raw_Quaternion64_Vector_Scalar :: runtime.Raw_Quaternion64_Vector_Scalar
+
 Raw_Quaternion128_Vector_Scalar :: runtime.Raw_Quaternion128_Vector_Scalar
+
 Raw_Quaternion256_Vector_Scalar :: runtime.Raw_Quaternion256_Vector_Scalar
 
 make_any :: proc "contextless" (data: rawptr, id: typeid) -> any {

--- a/core/mem/tracking_allocator.odin
+++ b/core/mem/tracking_allocator.odin
@@ -12,22 +12,23 @@ Tracking_Allocator_Entry :: struct {
 	err:       Allocator_Error,
 	location:  runtime.Source_Code_Location,
 }
+
 Tracking_Allocator_Bad_Free_Entry :: struct {
 	memory:   rawptr,
 	location: runtime.Source_Code_Location,
 }
-Tracking_Allocator :: struct {
-	backing:           Allocator,
-	allocation_map:    map[rawptr]Tracking_Allocator_Entry,
-	bad_free_array:    [dynamic]Tracking_Allocator_Bad_Free_Entry,
-	mutex:             sync.Mutex,
-	clear_on_free_all: bool,
 
-	total_memory_allocated:   i64,
-	total_allocation_count:   i64,
-	total_memory_freed:       i64,
-	total_free_count:         i64,
-	peak_memory_allocated:    i64,
+Tracking_Allocator :: struct {
+	backing: Allocator,
+	allocation_map: map[rawptr]Tracking_Allocator_Entry,
+	bad_free_array: [dynamic]Tracking_Allocator_Bad_Free_Entry,
+	mutex: sync.Mutex,
+	clear_on_free_all: bool,
+	total_memory_allocated: i64,
+	total_allocation_count: i64,
+	total_memory_freed: i64,
+	total_free_count: i64,
+	peak_memory_allocated: i64,
 	current_memory_allocated: i64,
 }
 
@@ -35,7 +36,6 @@ tracking_allocator_init :: proc(t: ^Tracking_Allocator, backing_allocator: Alloc
 	t.backing = backing_allocator
 	t.allocation_map.allocator = internals_allocator
 	t.bad_free_array.allocator = internals_allocator
-
 	if .Free_All in query_features(t.backing) {
 		t.clear_on_free_all = true
 	}
@@ -45,7 +45,6 @@ tracking_allocator_destroy :: proc(t: ^Tracking_Allocator) {
 	delete(t.allocation_map)
 	delete(t.bad_free_array)
 }
-
 
 // Clear only the current allocation data while keeping the totals intact.
 tracking_allocator_clear :: proc(t: ^Tracking_Allocator) {
@@ -78,9 +77,14 @@ tracking_allocator :: proc(data: ^Tracking_Allocator) -> Allocator {
 	}
 }
 
-tracking_allocator_proc :: proc(allocator_data: rawptr, mode: Allocator_Mode,
-                                size, alignment: int,
-                                old_memory: rawptr, old_size: int, loc := #caller_location) -> (result: []byte, err: Allocator_Error) {
+tracking_allocator_proc :: proc(
+	allocator_data: rawptr,
+	mode: Allocator_Mode,
+	size, alignment: int,
+	old_memory: rawptr,
+	old_size: int,
+	loc := #caller_location,
+) -> (result: []byte, err: Allocator_Error) {
 	track_alloc :: proc(data: ^Tracking_Allocator, entry: ^Tracking_Allocator_Entry) {
 		data.total_memory_allocated += i64(entry.size)
 		data.total_allocation_count += 1

--- a/core/mem/tracking_allocator.odin
+++ b/core/mem/tracking_allocator.odin
@@ -18,6 +18,37 @@ Tracking_Allocator_Bad_Free_Entry :: struct {
 	location: runtime.Source_Code_Location,
 }
 
+/*
+An example of how to use the `Tracking_Allocator` to track subsequent allocations
+in your program and report leaks and bad frees:
+
+Example:
+
+	package foo
+
+	import "core:mem"
+	import "core:fmt"
+
+	_main :: proc() {
+		// do stuff
+	}
+
+	main :: proc() {
+		track: mem.Tracking_Allocator
+		mem.tracking_allocator_init(&track, context.allocator)
+		defer mem.tracking_allocator_destroy(&track)
+		context.allocator = mem.tracking_allocator(&track)
+
+		_main()
+
+		for _, leak in track.allocation_map {
+			fmt.printf("%v leaked %m\n", leak.location, leak.size)
+		}
+		for bad_free in track.bad_free_array {
+			fmt.printf("%v allocation %p was freed badly\n", bad_free.location, bad_free.memory)
+		}
+	}
+*/
 Tracking_Allocator :: struct {
 	backing: Allocator,
 	allocation_map: map[rawptr]Tracking_Allocator_Entry,

--- a/tests/core/mem/test_mem_dynamic_pool.odin
+++ b/tests/core/mem/test_mem_dynamic_pool.odin
@@ -6,7 +6,7 @@ import "core:mem"
 
 expect_pool_allocation :: proc(t: ^testing.T, expected_used_bytes, num_bytes, alignment: int) {
 	pool: mem.Dynamic_Pool
-	mem.dynamic_pool_init(pool = &pool, alignment = alignment)
+	mem.dynamic_pool_init(&pool, alignment = alignment)
 	pool_allocator := mem.dynamic_pool_allocator(&pool)
 
 	element, err := mem.alloc(num_bytes, alignment, pool_allocator)
@@ -48,7 +48,7 @@ expect_pool_allocation_out_of_band :: proc(t: ^testing.T, num_bytes, out_band_si
 	testing.expect(t, num_bytes >= out_band_size, "Sanity check failed, your test call is flawed! Make sure that num_bytes >= out_band_size!")
 
 	pool: mem.Dynamic_Pool
-	mem.dynamic_pool_init(pool = &pool, out_band_size = out_band_size)
+	mem.dynamic_pool_init(&pool, out_band_size = out_band_size)
 	pool_allocator := mem.dynamic_pool_allocator(&pool)
 
 	element, err := mem.alloc(num_bytes, allocator = pool_allocator)


### PR DESCRIPTION
This PR makes a few small changes to the `core:mem` package. The changes are not supposed to alter the way existing code works, but if I find some bugs in the process I'll fix them in this PR too.

The changes include the following:

## 1. Formatting

Empty line gaps between procedures have been made consistent across all procedures. For now it is one empty line between two adjacent procedures, in the future I may add a two empty lines between procedures relating to different allocators.

Calls and declarations of procedures with parameters on multiple lines have been properly formatted at +1 indent from the start of the declaration/call, rather than aligned to the first parameter. There were also indentation issues relating to previous aligned that have been fixed due to this (alignment spaces started from the start of the line, instead of the first tab).

Lines over 120 characters in length that involve function calls have been wrapped.

## 2. API for using allocators directly

To make the behavior consistent, all allocators have their own API. This simplifies the internal code that calls itself a little bit, because now we have concrete functions to call, instead of calling allocator proc directly, and it makes things a little bit less crowded in the allocator procedures.

I chose to expose those functions not only because Odin prefers to expose things even if they are "internal", but also because these functions can get you going with using an allocator quicker if you aren't hooking into context/allocator system and just want a thing to quickly create and use. For example you can create a stack allocator for a few loops and then dispose of it quickly, without having to convert it into an allocator, reassigning it to context and any of that stuff. I see some potential of it being used for making the code a little bit more explicit in times of need.

All allocators will be provided with the following functions:

- `*_alloc`, `*_alloc_bytes`, `*_alloc_non_zeroed`, `*_alloc_bytes_non_zeroed`
- (if supported) `*_free`
- (if supported) `*_free_all`
- (if supported) `*_resize`, `*_resize_bytes`, `*_resize_non_zeroed`, `*_resize_bytes_non_zeroed`

The `resize` procedures are only exposed if non-default implementation is used in the allocator.

The word `allocator` has been omitted in all of these procedures, except for `buddy_allocator_*` procedures, which I don't want to alter too much. So, for example in case of stack allocator, the allocation function would be called `stack_alloc`.

The the types of parameters will be according to conventions from `alloc.odin`, i.e. `*bytes*` in the name specifies the usage of slice types, otherwise pointer types. The parameters to each of these procedures would be the minimum necessary amount needed for the procedure to work. The `old_size` in resize functions will not be a parameter, if allocator stores that information in the header.

## 3. Bugs and issue fixes.

* Scratch allocator's `alloc_non_zeroed` mode would zero-out memory for all allocations when it uses the backing allocator, even if non-zeroed mode is used.
* Dynamic pool's `alloc_non_zeroed` mode would zero-out memory for all allocations, even if non-zeroed mode is used.
* Some of the allocator procedures that call `panic`, `assert`, a backing allocator, and some calls to `default_resize_bytes_align`, would not correctly pass the location of the user's code that called those allocator procedures, that would theorhetically result in the error being printed for a wrong line of code. Panics and asserts related to user's errors are now all called with a passing of the `loc` parameter.
* `align_forward` and `align_backward` families of functions have been rewritten using branchless code. The missing assertion (alignment must be a power of 2) in `align_backward_uintptr` was added.
* Added `resize_non_zeroed` and `resize_bytes_non_zeroed` procedures as these weren't exposed via `mem` package.
* Made arena and small stack panic upon allocations where the backing buffer wasn't properly initialized.
* Default memory resize procedure was not properly relocating the allocation if the old memory pointer wasn't aligned to the specified alignment.
* Enforced checks on parameter values in the runtime memory procedures, i.e. when alignment wasn't a power of two, because otherwise the location wouldn't be passed properly.
* Rollback stack allocator's `alloc` and `resize` procedures were renamed to `alloc_non_zeroed` and `resize_non_zeroed` to highlight their zeroing behaviour.

## 4. Changes to Dynamic Pool (Dynamic Arena)

Dynamic pool allocator was a misnomer. It is in fact not a pool, but renaming it outright could cause a lot of code to break. In this PR the dynamic pool was renamed into dynamic arena and the old declarations were preserved via aliases.

Dynamic pool has also obtained two function variants that have been missing, `alloc_non_zeroed` and `resize_non_zeroed`. Previously this allocator was always zeroing-out memory, even on non-zero requests

As described in the above section, the source code location was more properly handled in the functions relating to the dynamic arena. The backing allocator functions pass the source code location into all functions of the underlying allocations.

## 5. Package documentation

The `mem` package has been given a proper documentation, for now containing a basic overview of addresses and abstractions over them (pointers, multipointers, slices), as well as some basic concepts like alignment and allocators.

All functions have been documented, according to the style I described in one of my previous PR's.

The allocator interface has been documented more thoroughly. The motivations and the main ideas were described in discussion #4216.

---

I'll add more stuff to the list as I work through the package