### PR TITLE
Fix build tags that use ! multiple times on one line.

### DIFF
--- a/core/debug/trace/trace_nil.odin
+++ b/core/debug/trace/trace_nil.odin
@@ -1,4 +1,6 @@
-//+build !windows !linux !darwin
+//+build !windows
+//+build !linux
+//+build !darwin
 package debug_trace
 
 import "base:runtime"

--- a/core/flags/errors_nonbsd.odin
+++ b/core/flags/errors_nonbsd.odin
@@ -1,4 +1,5 @@
-//+build !netbsd !openbsd
+//+build !netbsd
+//+build !openbsd
 package flags
 
 import "base:runtime"

--- a/core/flags/internal_rtti_nonbsd.odin
+++ b/core/flags/internal_rtti_nonbsd.odin
@@ -1,5 +1,6 @@
 //+private
-//+build !netbsd !openbsd
+//+build !netbsd
+//+build !openbsd
 package flags
 
 import "core:net"

--- a/core/testing/signal_handler_other.odin
+++ b/core/testing/signal_handler_other.odin
@@ -1,5 +1,11 @@
 //+private
-//+build !windows !linux !darwin !freebsd !openbsd !netbsd !haiku
+//+build !windows
+//+build !linux
+//+build !darwin
+//+build !freebsd
+//+build !openbsd
+//+build !netbsd
+//+build !haiku
 package testing
 
 /*

--- a/tests/core/net/test_core_net.odin
+++ b/tests/core/net/test_core_net.odin
@@ -10,7 +10,8 @@
 
 	A test suite for `core:net`
 */
-//+build !netbsd !openbsd
+//+build !netbsd
+//+build !openbsd
 package test_core_net
 
 import "core:testing"


### PR DESCRIPTION
These build tags don't actually do anything since build tags use OR within the line. So something like `//+build !windows, !linux` would actually build on both linux and windows. What was intended in all these cases was probably AND, which you get by splitting them into separate lines.