### PR TITLE
Enable -out:<filename> for doc subcommand

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -509,7 +509,7 @@ gb_internal bool parse_build_flags(Array<String> args) {
 	auto build_flags = array_make<BuildFlag>(heap_allocator(), 0, BuildFlag_COUNT);
 	add_flag(&build_flags, BuildFlag_Help,                    str_lit("help"),                      BuildFlagParam_None,    Command_all);
 	add_flag(&build_flags, BuildFlag_SingleFile,              str_lit("file"),                      BuildFlagParam_None,    Command__does_build | Command__does_check);
-	add_flag(&build_flags, BuildFlag_OutFile,                 str_lit("out"),                       BuildFlagParam_String,  Command__does_build | Command_test);
+	add_flag(&build_flags, BuildFlag_OutFile,                 str_lit("out"),                       BuildFlagParam_String,  Command__does_build | Command_test | Command_doc);
 	add_flag(&build_flags, BuildFlag_OptimizationMode,        str_lit("o"),                         BuildFlagParam_String,  Command__does_build);
 	add_flag(&build_flags, BuildFlag_ShowTimings,             str_lit("show-timings"),              BuildFlagParam_None,    Command__does_check);
 	add_flag(&build_flags, BuildFlag_ShowMoreTimings,         str_lit("show-more-timings"),         BuildFlagParam_None,    Command__does_check);
@@ -2163,6 +2163,12 @@ gb_internal void print_show_help(String const arg0, String const &command) {
 
 		print_usage_line(1, "-doc-format");
 		print_usage_line(2, "Generates documentation as the .odin-doc format (useful for external tooling).");
+		print_usage_line(0, "");
+
+		print_usage_line(1, "-out:<filepath>");
+		print_usage_line(2, "Sets the base name of the resultig .odin-doc file.");
+		print_usage_line(2, "The extension can be optionally included; the resulting file will always have an extension of '.odin-doc'.");
+		print_usage_line(2, "Example: -out:foo");
 		print_usage_line(0, "");
 	}
 


### PR DESCRIPTION
The logic for writing the .odin-doc file to the value assigned to out_filepath already exists, this just enables it on the CLI frontend.