### PR TITLE
check if a procedure signature is similar enough before allowing a cast

### DIFF
--- a/src/check_decl.cpp
+++ b/src/check_decl.cpp
@@ -781,6 +781,10 @@ gb_internal bool are_signatures_similar_enough(Type *a_, Type *b_) {
 		return false;
 	}
 
+	if (a->calling_convention != b->calling_convention) {
+		return false;
+	}
+
 	for (isize i = 0; i < a->param_count; i++) {
 		Type *x = core_type(a->params->Tuple.variables[i]->type);
 		Type *y = core_type(b->params->Tuple.variables[i]->type);


### PR DESCRIPTION
Note: consider this a proposal that contains an implementation.

This PR changes the way casting between two procedures is checked and will only allow casts for "similar enough" procedure signatures and otherwise suggest a transmute instead.

For example, this is allowed:
```odin
A :: distinct int
B :: distinct int
foo :: proc(a: A) {}
foo_b := cast(proc(b: B))foo
```

But this won't be allowed:
```odin
foo :: proc(a: u8) {}
foo_b := cast(proc(a: u16))foo
```
```
test.odin(10:29) Error: Cannot cast 'foo' as 'proc(u16)' from 'proc(u8)'
        foo_b := cast(proc(a: u16))foo
                                   ^~^
        Suggestion: the procedure types are not similar enough to allow a safe cast, you may use 'transmute' to do an unsafe cast
```