### PR TITLE
Fix core sync test deadlock on darwin

### DIFF
--- a/core/sync/futex_darwin.odin
+++ b/core/sync/futex_darwin.odin
@@ -12,7 +12,7 @@ foreign System {
 	// __ulock_wait is not available on 10.15
 	// See https://github.com/odin-lang/Odin/issues/1959
 	__ulock_wait  :: proc "c" (operation: u32, addr: rawptr, value: u64, timeout_us: u32) -> c.int ---
-	__ulock_wait2  :: proc "c" (operation: u32, addr: rawptr, value: u64, timeout_ns: u64, value2: u64) -> c.int ---
+	__ulock_wait2 :: proc "c" (operation: u32, addr: rawptr, value: u64, timeout_ns: u64, value2: u64) -> c.int ---
 	__ulock_wake  :: proc "c" (operation: u32, addr: rawptr, wake_value: u64) -> c.int ---
 }
 

--- a/core/sync/futex_darwin.odin
+++ b/core/sync/futex_darwin.odin
@@ -57,7 +57,7 @@ _futex_wait_with_timeout :: proc "contextless" (f: ^Futex, expected: u32, durati
 		timeout_ns := u64(duration)
 		s := __ulock_wait2(UL_COMPARE_AND_WAIT | ULF_NO_ERRNO, f, u64(expected), timeout_ns, 0)
 	} else {
-		timeout_us := u32(duration)
+		timeout_us := u32(duration) * 1000
 		s := __ulock_wait(UL_COMPARE_AND_WAIT | ULF_NO_ERRNO, f, u64(expected), timeout_us)
 	}
 	if s >= 0 {

--- a/core/sys/darwin/sync.odin
+++ b/core/sys/darwin/sync.odin
@@ -12,8 +12,15 @@ when ODIN_OS == .Darwin {
 	} else {
 		WAIT_ON_ADDRESS_AVAILABLE :: false
 	}
+	when ODIN_MINIMUM_OS_VERSION >= 11_00_00 {
+		ULOCK_WAIT_2_AVAILABLE :: true
+	} else {
+		ULOCK_WAIT_2_AVAILABLE :: false
+	}
+
 } else {
 	WAIT_ON_ADDRESS_AVAILABLE :: false
+	ULOCK_WAIT_2_AVAILABLE :: false
 }
 
 os_sync_wait_on_address_flag :: enum u32 {

--- a/tests/core/sync/test_core_sync.odin
+++ b/tests/core/sync/test_core_sync.odin
@@ -4,9 +4,6 @@
 // Keep in mind that running with the debug logs uncommented can result in
 // failures disappearing due to the delay of sending the log message causing
 // different synchronization patterns.
-//
-// These tests are temporarily disabled on Darwin, as there is currently a
-// stall occurring which I cannot debug.
 
 package test_core_sync
 

--- a/tests/core/sync/test_core_sync.odin
+++ b/tests/core/sync/test_core_sync.odin
@@ -8,7 +8,6 @@
 // These tests are temporarily disabled on Darwin, as there is currently a
 // stall occurring which I cannot debug.
 
-//+build !darwin
 package test_core_sync
 
 import "base:intrinsics"


### PR DESCRIPTION
The deadlock was discussed in #4232.

I'm running macos 14.6.1 and `__ulock_wait` randomly deadlocks in the core sync tests. I guess it shouldn't be too surprising since this isn't really a public API and as [the zig guys discovered](https://github.com/ziglang/zig/blob/812557bfde3c577b5f00cb556201c71ad5ed6fa4/lib/std/Thread/Futex.zig#L175-L179) Apple has been migrating to `__ulock_wait2`.

In any case using `__ulock_wait2` seems to fix the problem. The corresponding change should probably be made to the C++ code as well.