### PR TITLE
Allow import inside `when` statement

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -4948,10 +4948,6 @@ gb_internal Ast *parse_import_decl(AstFile *f, ImportDeclKind kind) {
 		array_add(&f->imports, s);
 	}
 
-	if (f->in_when_statement) {
-		syntax_error(import_name, "Cannot use 'import' within a 'when' statement. Prefer using the file suffixes (e.g. foo_windows.odin) or '//+build' tags");
-	}
-
 	if (kind != ImportDecl_Standard) {
 		syntax_error(import_name, "'using import' is not allowed, please use the import name explicitly");
 	}


### PR DESCRIPTION
Hello,

I am working on a platform that makes it easy to test snippets of code to test portability.

I'd like to be able to stick to a simple single file format, being able to import within `when` makes it easier and less messy.
