### PR TITLE
init ansi on a standalone testing exe

### DIFF
--- a/core/testing/runner.odin
+++ b/core/testing/runner.odin
@@ -204,6 +204,10 @@ runner :: proc(internal_tests: []Internal_Test) -> bool {
 		}
 	}
 
+	when ODIN_OS == .Windows {
+		console_ansi_init()
+	}
+
 	stdout := io.to_writer(os.stream_from_handle(os.stdout))
 	stderr := io.to_writer(os.stream_from_handle(os.stderr))
 

--- a/core/testing/runner_windows.odin
+++ b/core/testing/runner_windows.odin
@@ -1,0 +1,22 @@
+//+private
+package testing
+
+import win32 "core:sys/windows"
+
+console_ansi_init :: proc() {
+	stdout := win32.GetStdHandle(win32.STD_OUTPUT_HANDLE)
+	if stdout != win32.INVALID_HANDLE && stdout != nil {
+		old_console_mode: u32
+		if win32.GetConsoleMode(stdout, &old_console_mode) {
+			win32.SetConsoleMode(stdout, old_console_mode | win32.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+		}
+	}
+
+	stderr := win32.GetStdHandle(win32.STD_ERROR_HANDLE)
+	if stderr != win32.INVALID_HANDLE && stderr != nil {
+		old_console_mode: u32
+		if win32.GetConsoleMode(stderr, &old_console_mode) {
+			win32.SetConsoleMode(stderr, old_console_mode | win32.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+		}
+	}
+}


### PR DESCRIPTION
Previously terminal ansi in tests worked on windows because it ran after `odin` exe itself initializes it (windows requirement), but when the testing exe was run as a standalone application it didn't do this init step (leads to unescaped VT sequences like `←[0m[INFO ] --- ←[0m[`).
Now its fixed.