### PR TITLE
[core/os] get_current_directory: Add allocator arg to targets where i…

### DIFF
--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -1095,7 +1095,7 @@ unset_env :: proc(key: string) -> Error {
 }
 
 @(require_results)
-get_current_directory :: proc() -> string {
+get_current_directory :: proc(allocator := context.allocator) -> string {
 	page_size := get_page_size() // NOTE(tetra): See note in os_linux.odin/get_current_directory.
 	buf := make([dynamic]u8, page_size)
 	for {

--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -1096,6 +1096,7 @@ unset_env :: proc(key: string) -> Error {
 
 @(require_results)
 get_current_directory :: proc(allocator := context.allocator) -> string {
+	context.allocator = allocator
 	page_size := get_page_size() // NOTE(tetra): See note in os_linux.odin/get_current_directory.
 	buf := make([dynamic]u8, page_size)
 	for {

--- a/core/os/os_freebsd.odin
+++ b/core/os/os_freebsd.odin
@@ -841,6 +841,7 @@ get_env :: proc(key: string, allocator := context.allocator) -> (value: string) 
 
 @(require_results)
 get_current_directory :: proc(allocator := context.allocator) -> string {
+	context.allocator = allocator
 	// NOTE(tetra): I would use PATH_MAX here, but I was not able to find
 	// an authoritative value for it across all systems.
 	// The largest value I could find was 4096, so might as well use the page size.

--- a/core/os/os_freebsd.odin
+++ b/core/os/os_freebsd.odin
@@ -840,7 +840,7 @@ get_env :: proc(key: string, allocator := context.allocator) -> (value: string) 
 }
 
 @(require_results)
-get_current_directory :: proc() -> string {
+get_current_directory :: proc(allocator := context.allocator) -> string {
 	// NOTE(tetra): I would use PATH_MAX here, but I was not able to find
 	// an authoritative value for it across all systems.
 	// The largest value I could find was 4096, so might as well use the page size.

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -985,7 +985,7 @@ unset_env :: proc(key: string) -> Error {
 }
 
 @(require_results)
-get_current_directory :: proc() -> string {
+get_current_directory :: proc(allocator := context.allocator) -> string {
 	// NOTE(tetra): I would use PATH_MAX here, but I was not able to find
 	// an authoritative value for it across all systems.
 	// The largest value I could find was 4096, so might as well use the page size.

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -986,6 +986,7 @@ unset_env :: proc(key: string) -> Error {
 
 @(require_results)
 get_current_directory :: proc(allocator := context.allocator) -> string {
+	context.allocator = allocator
 	// NOTE(tetra): I would use PATH_MAX here, but I was not able to find
 	// an authoritative value for it across all systems.
 	// The largest value I could find was 4096, so might as well use the page size.

--- a/core/os/os_netbsd.odin
+++ b/core/os/os_netbsd.odin
@@ -894,7 +894,7 @@ get_env :: proc(key: string, allocator := context.allocator) -> (value: string) 
 }
 
 @(require_results)
-get_current_directory :: proc() -> string {
+get_current_directory :: proc(allocator := context.allocator) -> string {
 	// NOTE(tetra): I would use PATH_MAX here, but I was not able to find
 	// an authoritative value for it across all systems.
 	// The largest value I could find was 4096, so might as well use the page size.

--- a/core/os/os_netbsd.odin
+++ b/core/os/os_netbsd.odin
@@ -895,6 +895,7 @@ get_env :: proc(key: string, allocator := context.allocator) -> (value: string) 
 
 @(require_results)
 get_current_directory :: proc(allocator := context.allocator) -> string {
+	context.allocator = allocator
 	// NOTE(tetra): I would use PATH_MAX here, but I was not able to find
 	// an authoritative value for it across all systems.
 	// The largest value I could find was 4096, so might as well use the page size.

--- a/core/os/os_openbsd.odin
+++ b/core/os/os_openbsd.odin
@@ -807,6 +807,7 @@ get_env :: proc(key: string, allocator := context.allocator) -> (value: string) 
 
 @(require_results)
 get_current_directory :: proc(allocator := context.allocator) -> string {
+	context.allocator = allocator
 	buf := make([dynamic]u8, MAX_PATH)
 	for {
 		cwd := _unix_getcwd(cstring(raw_data(buf)), c.size_t(len(buf)))

--- a/core/os/os_openbsd.odin
+++ b/core/os/os_openbsd.odin
@@ -806,7 +806,7 @@ get_env :: proc(key: string, allocator := context.allocator) -> (value: string) 
 }
 
 @(require_results)
-get_current_directory :: proc() -> string {
+get_current_directory :: proc(allocator := context.allocator) -> string {
 	buf := make([dynamic]u8, MAX_PATH)
 	for {
 		cwd := _unix_getcwd(cstring(raw_data(buf)), c.size_t(len(buf)))


### PR DESCRIPTION
At the moment, `os.get_current_directory` has different signature on different targets. Only Windows and JS targets has `allocator := context.allocator` argument; all other targets missing it, leading to compilation error of user code if it uses that argument on other targets.

**This PR adds `allocator` argument to implementation of `os.get_current_directory` on targets where it is missing.**