### PR TITLE
Forbid labelled or-branch expressions within `defer`

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -9131,6 +9131,10 @@ gb_internal ExprKind check_or_branch_expr(CheckerContext *c, Operand *o, Ast *no
 	}
 
 	if (label != nullptr) {
+		if (c->in_defer) {
+			error(label, "A labelled '%.*s' cannot be used within a 'defer'", LIT(name));
+			return Expr_Expr;
+		}
 		if (label->kind != Ast_Ident) {
 			error(label, "A branch statement's label name must be an identifier");
 			return Expr_Expr;


### PR DESCRIPTION
This will prevent stack overflows caused by code such as this:

```odin
package breakdefer

main::proc(){
	w: {
		defer {
			(false) or_break w
		}
	}
}
```