### PR TITLE
Add #+build darwin to everything in core/sys/darwin and vendor/darwin

### DIFF
--- a/core/sys/darwin/CoreFoundation/CFBase.odin
+++ b/core/sys/darwin/CoreFoundation/CFBase.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package CoreFoundation
 
 foreign import CoreFoundation "system:CoreFoundation.framework"

--- a/core/sys/darwin/CoreFoundation/CFString.odin
+++ b/core/sys/darwin/CoreFoundation/CFString.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package CoreFoundation
 
 foreign import CoreFoundation "system:CoreFoundation.framework"

--- a/core/sys/darwin/Foundation/NSApplication.odin
+++ b/core/sys/darwin/Foundation/NSApplication.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 foreign import "system:Foundation.framework"

--- a/core/sys/darwin/Foundation/NSArray.odin
+++ b/core/sys/darwin/Foundation/NSArray.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 import "base:intrinsics"

--- a/core/sys/darwin/Foundation/NSAutoreleasePool.odin
+++ b/core/sys/darwin/Foundation/NSAutoreleasePool.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 @(objc_class="NSAutoreleasePool")

--- a/core/sys/darwin/Foundation/NSBlock.odin
+++ b/core/sys/darwin/Foundation/NSBlock.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 import "base:intrinsics"

--- a/core/sys/darwin/Foundation/NSBundle.odin
+++ b/core/sys/darwin/Foundation/NSBundle.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 @(objc_class="NSBundle")

--- a/core/sys/darwin/Foundation/NSColor.odin
+++ b/core/sys/darwin/Foundation/NSColor.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 @(objc_class="NSColorSpace")

--- a/core/sys/darwin/Foundation/NSData.odin
+++ b/core/sys/darwin/Foundation/NSData.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 @(objc_class="NSData")

--- a/core/sys/darwin/Foundation/NSDate.odin
+++ b/core/sys/darwin/Foundation/NSDate.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 @(objc_class="NSDate")

--- a/core/sys/darwin/Foundation/NSDictionary.odin
+++ b/core/sys/darwin/Foundation/NSDictionary.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 @(objc_class="NSDictionary")

--- a/core/sys/darwin/Foundation/NSEnumerator.odin
+++ b/core/sys/darwin/Foundation/NSEnumerator.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 import "core:c"

--- a/core/sys/darwin/Foundation/NSError.odin
+++ b/core/sys/darwin/Foundation/NSError.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 foreign import "system:Foundation.framework"

--- a/core/sys/darwin/Foundation/NSEvent.odin
+++ b/core/sys/darwin/Foundation/NSEvent.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 @(objc_class="NSEvent")

--- a/core/sys/darwin/Foundation/NSLock.odin
+++ b/core/sys/darwin/Foundation/NSLock.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 Locking :: struct($T: typeid) {using _: Object}

--- a/core/sys/darwin/Foundation/NSMenu.odin
+++ b/core/sys/darwin/Foundation/NSMenu.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 import "base:builtin"

--- a/core/sys/darwin/Foundation/NSNotification.odin
+++ b/core/sys/darwin/Foundation/NSNotification.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 @(objc_class="NSNotification")

--- a/core/sys/darwin/Foundation/NSNumber.odin
+++ b/core/sys/darwin/Foundation/NSNumber.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 import "core:c"

--- a/core/sys/darwin/Foundation/NSObject.odin
+++ b/core/sys/darwin/Foundation/NSObject.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 import "base:intrinsics"

--- a/core/sys/darwin/Foundation/NSOpenPanel.odin
+++ b/core/sys/darwin/Foundation/NSOpenPanel.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 @(objc_class="NSOpenPanel")

--- a/core/sys/darwin/Foundation/NSPanel.odin
+++ b/core/sys/darwin/Foundation/NSPanel.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 ModalResponse :: enum UInteger {

--- a/core/sys/darwin/Foundation/NSPasteboard.odin
+++ b/core/sys/darwin/Foundation/NSPasteboard.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 @(objc_class="NSPasteboard")

--- a/core/sys/darwin/Foundation/NSRange.odin
+++ b/core/sys/darwin/Foundation/NSRange.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 Range :: struct {

--- a/core/sys/darwin/Foundation/NSSavePanel.odin
+++ b/core/sys/darwin/Foundation/NSSavePanel.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 @(objc_class="NSSavePanel")

--- a/core/sys/darwin/Foundation/NSScreen.odin
+++ b/core/sys/darwin/Foundation/NSScreen.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 @(objc_class="NSScreen")

--- a/core/sys/darwin/Foundation/NSSet.odin
+++ b/core/sys/darwin/Foundation/NSSet.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 @(objc_class="NSSet")

--- a/core/sys/darwin/Foundation/NSString.odin
+++ b/core/sys/darwin/Foundation/NSString.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 foreign import "system:Foundation.framework"

--- a/core/sys/darwin/Foundation/NSTypes.odin
+++ b/core/sys/darwin/Foundation/NSTypes.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 import "base:intrinsics"

--- a/core/sys/darwin/Foundation/NSURL.odin
+++ b/core/sys/darwin/Foundation/NSURL.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 @(objc_class="NSURL")

--- a/core/sys/darwin/Foundation/NSUndoManager.odin
+++ b/core/sys/darwin/Foundation/NSUndoManager.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 @(objc_class="NSUndoManager")

--- a/core/sys/darwin/Foundation/NSUserActivity.odin
+++ b/core/sys/darwin/Foundation/NSUserActivity.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 @(objc_class="NSUserActivity")

--- a/core/sys/darwin/Foundation/NSUserDefaults.odin
+++ b/core/sys/darwin/Foundation/NSUserDefaults.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 @(objc_class="NSUserDefaults")

--- a/core/sys/darwin/Foundation/NSWindow.odin
+++ b/core/sys/darwin/Foundation/NSWindow.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 import "core:strings"

--- a/core/sys/darwin/Foundation/objc.odin
+++ b/core/sys/darwin/Foundation/objc.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 foreign import "system:Foundation.framework"

--- a/core/sys/darwin/Security/SecBase.odin
+++ b/core/sys/darwin/Security/SecBase.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package Security
 
 OSStatus :: distinct i32

--- a/core/sys/darwin/Security/SecRandom.odin
+++ b/core/sys/darwin/Security/SecRandom.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package Security
 
 import CF "core:sys/darwin/CoreFoundation"

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package darwin
 
 foreign import pthread "system:System.framework"

--- a/core/sys/darwin/proc.odin
+++ b/core/sys/darwin/proc.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package darwin
 
 import "base:intrinsics"

--- a/core/sys/darwin/sync.odin
+++ b/core/sys/darwin/sync.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package darwin
 
 foreign import system "system:System.framework"

--- a/core/sys/darwin/xnu_system_call_helpers.odin
+++ b/core/sys/darwin/xnu_system_call_helpers.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package darwin
 
 import "core:c"

--- a/core/sys/darwin/xnu_system_call_numbers.odin
+++ b/core/sys/darwin/xnu_system_call_numbers.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package darwin
 
 // IMPORTANT NOTE: direct syscall usage is not allowed by Apple's review process of apps and should

--- a/core/sys/darwin/xnu_system_call_wrappers.odin
+++ b/core/sys/darwin/xnu_system_call_wrappers.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package darwin
 
 import "core:c"

--- a/vendor/darwin/CoreVideo/CVDisplayLink.odin
+++ b/vendor/darwin/CoreVideo/CVDisplayLink.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package CoreVideo
 
 DisplayLinkRef :: distinct rawptr

--- a/vendor/darwin/Foundation/dummy.odin
+++ b/vendor/darwin/Foundation/dummy.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package vendor_darwin_foundation
 
 #panic(`Package moved to "core:sys/darwin/Foundation"`)

--- a/vendor/darwin/Metal/MetalClasses.odin
+++ b/vendor/darwin/Metal/MetalClasses.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Metal
 
 import NS "core:sys/darwin/Foundation"

--- a/vendor/darwin/Metal/MetalEnums.odin
+++ b/vendor/darwin/Metal/MetalEnums.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Metal
 
 import NS "core:sys/darwin/Foundation"

--- a/vendor/darwin/Metal/MetalErrors.odin
+++ b/vendor/darwin/Metal/MetalErrors.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Metal
 
 import NS "core:sys/darwin/Foundation"

--- a/vendor/darwin/Metal/MetalProcedures.odin
+++ b/vendor/darwin/Metal/MetalProcedures.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Metal
 
 import NS "core:sys/darwin/Foundation"

--- a/vendor/darwin/Metal/MetalTypes.odin
+++ b/vendor/darwin/Metal/MetalTypes.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Metal
 
 import NS "core:sys/darwin/Foundation"

--- a/vendor/darwin/MetalKit/MetalKit.odin
+++ b/vendor/darwin/MetalKit/MetalKit.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_MetalKit
 
 import NS "core:sys/darwin/Foundation"

--- a/vendor/darwin/QuartzCore/QuartzCore.odin
+++ b/vendor/darwin/QuartzCore/QuartzCore.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_QuartzCore
 
 import NS "core:sys/darwin/Foundation"


### PR DESCRIPTION
I tried to compile the package `examples/all` and hit compilation errors because of imports of packages in `vendor/darwin` and `core/sys/darwin`. So I added in `#+build darwin` in those files.