### PR TITLE
Fix for infinite loop in core:odin file tags parser when a file uses \r

### DIFF
--- a/core/odin/parser/file_tags.odin
+++ b/core/odin/parser/file_tags.odin
@@ -129,7 +129,7 @@ parse_file_tags :: proc(file: ast.File, allocator := context.allocator) -> (tags
 						name_start := i
 	
 						switch next_char(text, &i) {
-						case 0, '\n':
+						case 0, '\r', '\n':
 							i -= 1
 							break groups_loop
 						case ',':
@@ -164,7 +164,7 @@ parse_file_tags :: proc(file: ast.File, allocator := context.allocator) -> (tags
 
 						is_notted: bool
 						switch next_char(text, &i) {
-						case 0, '\n':
+						case 0, '\r', '\n':
 							i -= 1
 							break kinds_loop
 						case ',':


### PR DESCRIPTION
Fix for a bug where file tags parser got stuck in infinite loop due to never hitting `\n` due to there being an unrecognized `\r` in the way.

Since I had locally modified some files that used file tags, then that meant they had `\r` in them. That caused the parser to hang in a busy loop, which I discovered by OLS hanging in the background.