### PR TITLE
JSON: Optionally write union variant tags and names

### DIFF
--- a/core/encoding/json/parser.odin
+++ b/core/encoding/json/parser.odin
@@ -176,6 +176,97 @@ parse_value :: proc(p: ^Parser, loc := #caller_location) -> (value: Value, err: 
 	return
 }
 
+skip_value :: proc(p: ^Parser, loc := #caller_location) -> (err: Error) {
+	err = .None
+	token := p.curr_token
+	#partial switch token.kind {
+	case .Null:
+		advance_token(p)
+		return
+	case .False:
+		advance_token(p)
+		return
+	case .True:
+		advance_token(p)
+		return
+
+	case .Integer:
+		advance_token(p)
+		return
+	case .Float:
+		advance_token(p)
+		return
+
+	case .Ident:
+		if p.spec == .MJSON {
+			advance_token(p)
+			return
+		}
+
+	case .String:
+		advance_token(p)
+		return
+
+	case .Open_Brace:
+		num_braces := 1
+
+		for num_braces > 0 {
+			advance_token(p)
+
+			ct := p.curr_token
+
+			if ct.kind == .Invalid || ct.kind == .EOF {
+				break
+			}
+
+			if ct.kind == .Open_Brace {
+				num_braces += 1
+			} else if ct.kind == .Close_Brace {
+				num_braces -= 1
+			}
+		}
+
+		advance_token(p)
+		return
+
+	case .Open_Bracket:
+		num_brackets := 1
+
+		for num_brackets > 0 {
+			advance_token(p)
+
+			ct := p.curr_token
+
+			if ct.kind == .Invalid || ct.kind == .EOF {
+				break
+			}
+
+			if ct.kind == .Open_Bracket {
+				num_brackets += 1
+			} else if ct.kind == .Close_Bracket {
+				num_brackets -= 1
+			}
+		}
+
+		advance_token(p)
+		return
+
+	case:
+		if p.spec != .JSON {
+			switch {
+			case allow_token(p, .Infinity):
+				return
+			case allow_token(p, .NaN):
+				return
+			}
+		}
+	}
+
+	err = .Unexpected_Token
+	advance_token(p)
+	return
+}
+
 parse_array :: proc(p: ^Parser, loc := #caller_location) -> (value: Value, err: Error) {
 	err = .None
 	expect_token(p, .Open_Bracket) or_return

--- a/core/encoding/json/unmarshal.odin
+++ b/core/encoding/json/unmarshal.odin
@@ -239,6 +239,103 @@ unmarshal_value :: proc(p: ^Parser, v: any) -> (err: Unmarshal_Error) {
 				assign_int(tag, 1)
 			}
 		} else if v.id != Value {
+			// Check for $data, $name and $tag: They are written if the JSON
+			// was marashalled using write_union_variant_info set to true.
+			if token.kind == .Open_Brace {
+				variant_name: string
+				variant_tag: i64 = -1
+				has_data_parser: bool
+				data_parser: Parser
+
+				check_p := p^
+				check_p.parse_integers = true
+				unmarshal_expect_token(&check_p, .Open_Brace)
+
+				parse_key :: proc(p: ^Parser) -> (key: string, err: Error) {
+					tok := p.curr_token
+					if p.spec != .JSON {
+						if allow_token(p, .Ident) {
+							return tok.text, nil
+						}
+					}
+					if tok_err := expect_token(p, .String); tok_err != nil {
+						err = .Expected_String_For_Object_Key
+						return
+					}
+					return tok.text[1:len(tok.text)-1], nil
+				}
+
+				for check_p.curr_token.kind != .Close_Brace {
+					key := parse_key(&check_p) or_return
+
+					expect_token(&check_p, .Colon) or_return
+
+					if key == "$data" {
+						has_data_parser = true
+						data_parser = check_p
+						skip_value(&check_p) or_return
+					} else if key == "$name" {
+						expect_token(&check_p, .String) or_return
+						variant_name = check_p.prev_token.text[1:len(check_p.prev_token.text)-1]
+					} else if key == "$tag" {
+						expect_token(&check_p, .Integer) or_return
+						if i, i_ok := strconv.parse_i64(check_p.prev_token.text); i_ok {
+							variant_tag = i
+						}
+					} else {
+						skip_value(&check_p) or_return
+					}
+
+					if parse_comma(&check_p) {
+						break
+					}
+				}
+
+				unmarshal_expect_token(&check_p, .Close_Brace)
+
+				if has_data_parser {
+					if variant_name != "" {
+						for variant, i in u.variants {
+							named := variant.variant.(runtime.Type_Info_Named) or_continue
+
+							if named.name != variant_name {
+								continue
+							}
+
+							variant_any := any{v.data, variant.id}
+							if err = unmarshal_value(&data_parser, variant_any); err == nil {
+								p^ = data_parser
+
+								raw_tag := i
+								if !u.no_nil { raw_tag += 1 }
+								tag := any{rawptr(uintptr(v.data) + u.tag_offset), u.tag_type.id}
+								assign_int(tag, raw_tag)
+								return
+							}
+						}
+					}
+
+					if variant_tag != -1 {
+						for variant, i in u.variants {
+							if i64(i) != variant_tag {
+								continue
+							}
+
+							variant_any := any{v.data, variant.id}
+							if err = unmarshal_value(&data_parser, variant_any); err == nil {
+								p^ = data_parser
+
+								raw_tag := i
+								if !u.no_nil { raw_tag += 1 }
+								tag := any{rawptr(uintptr(v.data) + u.tag_offset), u.tag_type.id}
+								assign_int(tag, raw_tag)
+								return
+							}
+						}
+					}
+				}
+			}
+
 			for variant, i in u.variants {
 				variant_any := any{v.data, variant.id}
 				variant_p := p^


### PR DESCRIPTION
Introduces an option to make JSON marshaller write out union variant name and tag. These names and tags are automatically looked for when unmarshalling happens, in a backwards compatible way.

When it is enabled the unions written to JSON look like so:

```
{
	"$data": {
		"b": "Hellope",
	},
	"$name": "B",
	"$tag": 2
}
```

When unmarshalling into a union, it will look for these `$name` and `$tag` fields etc. If found it will use them and try to find a matching union variant.

Test program that shows how it works and how to enable the marshalling option:
```
package main

import "core:fmt"
import "core:encoding/json"
import "core:reflect"

A :: struct {
	a: int,
}

B :: struct {
	b: string,
}

U :: union {
	rawptr,
	A,
	B,
}

main :: proc() {
	um: U = B {
		b = "Hellope",
	}

	bytes, marshal_err := json.marshal(um, opt = {
		write_union_variant_info = true,
		pretty = true,
	})

	if marshal_err != nil {
		fmt.println(marshal_err)
	}

	fmt.println("Marshalled string:")
	fmt.println(string(bytes))

	u: U

	error := json.unmarshal(bytes, &u)

	if error != nil {
		fmt.println(error)
	}

	fmt.println("\nUnmarshalled into:")
	fmt.println(u)
}
```

when run it prints this:
```
Marshalled string:
{
	"$data": {
		"b": "Hellope"
	},
	"$name": "B",
	"$tag": 2
}

Unmarshalled into:
B{b = "Hellope"}
```

The above is similar to the repro in this issue: https://github.com/odin-lang/Odin/issues/3474, but with the desired outcome.

Things to consider:
- Is a best-fit search also wanted? Or perhaps even what we should try to implement before any of this? My motivation for trying this is that I don't trust a JSON marshaller / unmarshaller unless it has this kind of variant info written down.
- Currently it can only write `$name` for variants that have type info `Type_Info_Named`. For basic types like `f32` it would only write the `$tag`. I can use `reflect.write_typeid` in the marshaller to write the "correct" type for something like an f32, but no good way to compare against it in the unmarshaller without doing something similar there, which starts feeling a bit hacky.