### PR TITLE
Add static GLFW bindings for Linux

### DIFF
--- a/vendor/glfw/bindings/bindings.odin
+++ b/vendor/glfw/bindings/bindings.odin
@@ -41,9 +41,13 @@ when ODIN_OS == .Windows {
 	when GLFW_SHARED {
 		foreign import glfw "system:glfw"
 	} else {
-		foreign import glfw { 
-			"../lib/libglfw3.a",
+		@(private)
+		LIBGLFW3 :: "../lib/libglfw3.a"
+		when !#exists(LIBGLFW3) {
+			#panic("Could not find the static glfw library, add it at \"" + ODIN_ROOT + "vendor/glfw/lib/\"`")
 		}
+
+		foreign import glfw { LIBGLFW3 }
 	}
 }
 

--- a/vendor/glfw/bindings/bindings.odin
+++ b/vendor/glfw/bindings/bindings.odin
@@ -3,7 +3,7 @@ package glfw_bindings
 import "core:c"
 import vk "vendor:vulkan"
 
-GLFW_SHARED :: #config(GLFW_SHARED, false)
+GLFW_SHARED :: #config(GLFW_SHARED, ODIN_OS != .Windows && ODIN_OS != .Darwin)
 
 when ODIN_OS == .Windows {
 	when GLFW_SHARED {
@@ -38,7 +38,13 @@ when ODIN_OS == .Windows {
 		}
 	}
 } else {
-	foreign import glfw "system:glfw"
+	when GLFW_SHARED {
+		foreign import glfw "system:glfw"
+	} else {
+		foreign import glfw { 
+			"../lib/libglfw3.a",
+		}
+	}
 }
 
 #assert(size_of(c.int) == size_of(b32))


### PR DESCRIPTION
I static link GLFW for my game but I can't do that with the current bindings for linux. 
I kept the default as true for shared linking for linux to not break anyone else. 