### PR TITLE
Implement unreachable in terms of panic

### DIFF
--- a/base/builtin/builtin.odin
+++ b/base/builtin/builtin.odin
@@ -126,5 +126,3 @@ clamp :: proc(value, minimum, maximum: T) -> T ---
 
 soa_zip :: proc(slices: ...) -> #soa[]Struct ---
 soa_unzip :: proc(value: $S/#soa[]$E) -> (slices: ...) ---
-
-unreachable :: proc() -> ! ---

--- a/base/runtime/core_builtin.odin
+++ b/base/runtime/core_builtin.odin
@@ -949,6 +949,11 @@ unimplemented :: proc(message := "", loc := #caller_location) -> ! {
 	p("not yet implemented", message, loc)
 }
 
+@builtin
+unreachable :: proc(loc := #caller_location) -> ! {
+	panic("reached unreachable code", loc)
+}
+
 
 @builtin
 @(disabled=ODIN_DISABLE_ASSERT)
@@ -974,4 +979,9 @@ panic_contextless :: proc "contextless" (message: string, loc := #caller_locatio
 @builtin
 unimplemented_contextless :: proc "contextless" (message := "", loc := #caller_location) -> ! {
 	default_assertion_contextless_failure_proc("not yet implemented", message, loc)
+}
+
+@builtin
+unreachable_contextless :: proc "contextless" (loc := #caller_location) -> ! {
+	default_assertion_contextless_failure_proc("panic", "reached unreachable code", loc)
 }

--- a/core/math/math.odin
+++ b/core/math/math.odin
@@ -221,7 +221,7 @@ pow2_f64 :: proc "contextless" (#any_int exp: int) -> (res: f64) {
 	case exp > 1023:                  // Overflow, +Inf
 		return 0h7ff00000_00000000
 	}
-	unreachable()
+	unreachable_contextless()
 }
 
 @(require_results)
@@ -237,7 +237,7 @@ pow2_f32 :: proc "contextless" (#any_int exp: int) -> (res: f32) {
 	case exp > 127:                  // Overflow, +Inf
 		return 0h7f80_0000
 	}
-	unreachable()
+	unreachable_contextless()
 }
 
 @(require_results)
@@ -255,7 +255,7 @@ pow2_f16 :: proc "contextless" (#any_int exp: int) -> (res: f16) {
 	case exp > 15:                   // Overflow, +Inf
 		return 0h7c00
 	}
-	unreachable()
+	unreachable_contextless()
 }
 
 @(require_results)

--- a/core/sync/primitives_atomic.odin
+++ b/core/sync/primitives_atomic.odin
@@ -67,7 +67,7 @@ atomic_mutex_unlock :: proc "contextless" (m: ^Atomic_Mutex) {
 
 	switch atomic_exchange_explicit(&m.state, .Unlocked, .Release) {
 	case .Unlocked:
-		unreachable()
+		unreachable_contextless()
 	case .Locked:
 		// Okay
 	case .Waiting:

--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -4203,7 +4203,6 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 		operand->mode = Addressing_NoValue;
 		break;
 
-	case BuiltinProc_unreachable:
 	case BuiltinProc_trap:
 	case BuiltinProc_debug_trap:
 		operand->mode = Addressing_NoValue;

--- a/src/checker_builtin_procs.hpp
+++ b/src/checker_builtin_procs.hpp
@@ -35,8 +35,6 @@ enum BuiltinProcId {
 	BuiltinProc_soa_zip,
 	BuiltinProc_soa_unzip,
 
-	BuiltinProc_unreachable,
-
 	BuiltinProc_raw_data,
 
 	BuiltinProc_DIRECTIVE, // NOTE(bill): This is used for specialized hash-prefixed procedures
@@ -373,8 +371,6 @@ gb_global BuiltinProc builtin_procs[BuiltinProc_COUNT] = {
 
 	{STR_LIT("soa_zip"),          1, true,  Expr_Expr, BuiltinProcPkg_builtin},
 	{STR_LIT("soa_unzip"),        1, false, Expr_Expr, BuiltinProcPkg_builtin},
-
-	{STR_LIT("unreachable"),      0, false, Expr_Expr, BuiltinProcPkg_builtin, /*diverging*/true},
 
 	{STR_LIT("raw_data"),         1, false, Expr_Expr, BuiltinProcPkg_builtin},
 

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -2203,10 +2203,6 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 			return lb_emit_matrix_flatten(p, m, tv.type);
 		}
 
-	case BuiltinProc_unreachable:
-		lb_emit_unreachable(p);
-		return {};
-
 	case BuiltinProc_raw_data:
 		{
 			lbValue x = lb_build_expr(p, ce->args[0]);


### PR DESCRIPTION
I have the following program:

```
package unreachable

main :: proc() {
    unreachable()
}
```

Which crashes silently on windows or crashes with "Illegal instruction (core dumped)" on linux. This is because (in my understanding), llvm emits a `ud2` instruction on unreachable code, which acts like a trap. See `lb_emit_unreachable` in `src/llvm_backend_utility.cpp`. It works when running in the debugger, but running the program normally and seeing it crash silently is not a good thing.

This PR enables unreachable to report the location of the crash and removes the changes from #3659 

## Context

```
        Odin:    dev-2024-09:791b05b14
        OS:      Windows 10 Professional (version: 22H2), build 19045.4894
        CPU:     AMD Ryzen 7 5800X 8-Core Processor
        RAM:     32711 MiB
        Backend: LLVM 18.1.8
```