### PR TITLE
Fix missing registers in User_Regs on AMD64

### DIFF
--- a/core/sys/linux/types.odin
+++ b/core/sys/linux/types.odin
@@ -1136,6 +1136,12 @@ when ODIN_ARCH == .arm32 {
 		eflags:           uint,
 		rsp:              uint,
 		ss:               uint,
+		fs_base:          uint,
+		gs_base:          uint,
+		ds:               uint,
+		es:               uint,
+		fs:               uint,
+		gs:               uint,
 	}
 	// All floating point state
 	_Arch_User_FP_Regs :: struct {


### PR DESCRIPTION
This PR fixes the OOB stack corruption when calling `ptrace_getregs`, due to `User_Regs` structure not containing segment registers as well as gs and fs register hidden bases.

This PR seems to be fixing #4306, but I'm not entirely sure this fix is correct, because the I copied the definition of the struct from glibc, and not the actual kernel's source code. It's also not clear to me how after the fix segment registers and their bases are all 0.