### PR TITLE
Fix for crash when emitting a comparison between a constant array and a non-constant value.

### DIFF
--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -2555,17 +2555,21 @@ gb_internal lbValue lb_emit_comp(lbProcedure *p, TokenKind op_kind, lbValue left
 
 	if (are_types_identical(a, b)) {
 		// NOTE(bill): No need for a conversion
-	} else if (lb_is_const(left) || lb_is_const_nil(left)) {
+	} else if ((lb_is_const(left) && !is_type_array(left.type)) || lb_is_const_nil(left)) {
+		// NOTE(karl): !is_type_array(left.type) is there to avoid lb_emit_conv
+		// trying to convert a constant array into a non-array. In that case we
+		// want the `else` branch to happen, so it can try to convert the
+		// non-array into an array instead.
+
 		if (lb_is_const_nil(left)) {
 			return lb_emit_comp_against_nil(p, op_kind, right);
 		}
 		left = lb_emit_conv(p, left, right.type);
-	} else if (lb_is_const(right) || lb_is_const_nil(right)) {
+	} else if ((lb_is_const(right) && !is_type_array(right.type)) || lb_is_const_nil(right)) {
 		if (lb_is_const_nil(right)) {
 			return lb_emit_comp_against_nil(p, op_kind, left);
 		}
 		right = lb_emit_conv(p, right, left.type);
-
 	} else {
 		Type *lt = left.type;
 		Type *rt = right.type;


### PR DESCRIPTION
Fixes https://github.com/odin-lang/Odin/issues/2038

Fix for this code:
```odin
package main

import fmt "core:fmt"

main :: proc() {
	a := [3]int{9, 4, 3}
	if a[0] == ([3]int{1, 2, 3}) {
		fmt.println("foo")
	}
}
```

crashing with this error

```
main.main
lb_emit_conv: src -> dst
Not Identical [3]int != int
Not Identical [3]int != int
Not Identical 7f434797a4f0 != 55706d7508f0
Not Identical 7f434797a4f0 != 55706d7508f0
src/llvm_backend_expr.cpp(2197): Panic: Invalid type conversion: '[3]int' to 'int' for procedure 'main.main'
Illegal instruction (core dumped)
```

The issue was that it tried to convert a constant array into a single value, instead of the other way around.