### PR TITLE
Don't append to buffer if nothing was read

### DIFF
--- a/core/os/os2/process.odin
+++ b/core/os/os2/process.odin
@@ -405,10 +405,10 @@ process_exec :: proc(
 		defer stderr = stderr_b[:]
 
 		buf: [1024]u8 = ---
-		n: int
-
+		
 		stdout_done, stderr_done, has_data: bool
 		for err == nil && (!stdout_done || !stderr_done) {
+			n := 0
 
 			if !stdout_done {
 				has_data, err = pipe_has_data(stdout_r)

--- a/core/os/os2/process.odin
+++ b/core/os/os2/process.odin
@@ -426,6 +426,7 @@ process_exec :: proc(
 			}
 
 			if err == nil && !stderr_done {
+				n = 0
 				has_data, err = pipe_has_data(stderr_r)
 				if has_data {
 					n, err = read(stderr_r, buf[:])

--- a/tests/core/os/os2/process.odin
+++ b/tests/core/os/os2/process.odin
@@ -21,4 +21,5 @@ test_process_exec :: proc(t: ^testing.T) {
 	testing.expect_value(t, state.success, true)
 	testing.expect_value(t, err, nil)
 	testing.expect_value(t, string(stdout), "hellope\n")
+	testing.expect_value(t, string(stderr), "")
 }


### PR DESCRIPTION
The variable `n` wasn't reinitialized during each cycle of stdout/stderr reading in `process_exec`, so if no data was read, the old buffer would get appended again.