### PR TITLE
Fix build for linux aarch64 architectures

### DIFF
--- a/build_odin.sh
+++ b/build_odin.sh
@@ -130,7 +130,7 @@ build_odin() {
 		EXTRAFLAGS="-O3"
 		;;
 	release-native)
-		if [ "$OS_ARCH" = "arm64" ]; then
+		if [ "$OS_ARCH" = "arm64" ] || [ "$OS_ARCH" = "aarch64" ]; then
 			# Use preferred flag for Arm (ie arm64 / aarch64 / etc)
 			EXTRAFLAGS="-O3 -mcpu=native"
 		else


### PR DESCRIPTION
Fixes #4348 

Build failed to compile on Raspberry Pi 4, with

    clang: error: the clang compiler does not support '-march=native'

The build script checks $OS_ARCH for `arm64` to distinghuish between ARM and X64 architecture. However on Raspberry Pi, the `uname -m` command reports `aarch64` rather than `arm64`.

This change updates the EXTRAFLAGS of the `release-native` target to check for both - `arm64` and `aarch64`.