### PR TITLE
[core:encoding/json] Enumerated arrays as objects, bit sets as arrays, fix map sorting, fix bit set endian

### DIFF
--- a/core/encoding/json/marshal.odin
+++ b/core/encoding/json/marshal.odin
@@ -45,25 +45,23 @@ Marshal_Options :: struct {
 	// If spec is MJSON and this is true, then use '=' as delimiter between
 	// keys and values, otherwise ':' is used.
 	mjson_keys_use_equal_sign: bool,
-	
+
 	// When outputting a map, sort the output by key.
 	//
 	// NOTE: This will temp allocate and sort a list for each map.
-	// TODO: handle non sortable keys!!!
 	sort_maps_by_key: bool,
 
 	// Output enum value's name instead of its underlying value.
 	//
 	// NOTE: If a name isn't found it'll use the underlying value.
 	use_enum_names: bool,
-	
+
 	// Store enumerated arrays as a map instead of a regular array with implicit index.
 	// Set 'enumerated_array_map_use_names' to use the enum name string as a key.
 	enumerated_array_as_map: bool,
 	// when 'enumerated_array_as_map' is true, use the enum value name is used as a key instead of the enum integer value.
 	enumerated_array_map_use_names: bool,
-	
-	
+
 	// Store bit sets as a list of values instead of the raw underlying integer value.
 	// Set 'bit_set_array_use_names' to use the enum names instead of the value.
 	bit_set_as_array: bool,

--- a/core/encoding/json/unmarshal.odin
+++ b/core/encoding/json/unmarshal.odin
@@ -119,7 +119,23 @@ assign_int :: proc(val: any, i: $T) -> bool {
 	case:
 		ti := type_info_of(v.id)
 		if _, ok := ti.variant.(runtime.Type_Info_Bit_Set); ok {
-			do_byte_swap := reflect.bit_set_is_big_endian(v)
+			is_bit_set_different_endian_to_platform :: proc(ti: ^runtime.Type_Info) -> bool {
+				if ti == nil {
+					return false
+				}
+				t := runtime.type_info_base(ti)
+				#partial switch info in t.variant {
+				case runtime.Type_Info_Integer:
+					switch info.endianness {
+					case .Platform: return false
+					case .Little:   return ODIN_ENDIAN != .Little
+					case .Big:      return ODIN_ENDIAN != .Big
+					}
+				}
+				return false
+			}
+			
+			do_byte_swap := is_bit_set_different_endian_to_platform(ti)
 			switch ti.size * 8 {
 			case 0: // no-op.
 			case 8:


### PR DESCRIPTION
This PR has a whole bunch of changes to `core:encoding/json` which I wanted for a long time, as well as a number of bugfixes I found along the way.

Changes:
- option to store enumerated arrays as maps where keys are either enum values or names
- option to store bit sets as arrays of either integers or enum names
- fix map sorting, previously it would return unsupported type when a map isn't sortable. This caused issues in big nested datastructures. Now it sorts the map if possible, otherwise it writes it unsorted. Also currently only maps with string keys are considered sortable, it might be a good idea to add support for all ordered types. But I didn't see a good way to implement that.
- fix bit set endianness, it now swaps if endian is different than the platform

The reason why I need enumerated arrays and bitsets in a more readable form is to better handle changes in the underlying data structures. Currently it's unusable for e.g. game assets when enums can change over time, since enumerated arrays and bitsets will be out of order etc. And since the index in enumerated arrays and values in bitsets are implicit, it's difficult to procedurally upgrade assets from old format to a new one. Now it should be way more flexible since it's possible to always explicitly use the enum field name or value.