### PR TITLE
bindings, types, and constants for some mach vm apis

### DIFF
--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -54,7 +54,7 @@ foreign mach {
 		offset         : vm_offset_t,
 		copy           : boolean_t,
 		cur_protection,
-		max_protection : vm_prot_t,
+		max_protection : VM_Prot_Flags,
 		inheritance    : vm_inherit_t,
 	) -> Kern_Return ---
 
@@ -62,7 +62,7 @@ foreign mach {
 		target_task   : vm_map_t,
 		size          : ^vm_size_t,
 		offset        : vm_offset_t,
-		permission    : vm_prot_t,
+		permission    : VM_Prot_Flags,
 		object_handle : ^mem_entry_name_port_t,
 		parent_entry  : mem_entry_name_port_t,
 	) -> Kern_Return ---
@@ -399,23 +399,17 @@ VM_FLAGS_OVERWRITE          :: 0x00004000  /* delete any existing mappings first
  *	Protection values, defined as bits within the vm_prot_t type
  */
 
-VM_PROT_NONE    : vm_prot_t : 0x00
+VM_Prot :: enum vm_prot_t {
+    Read,
+    Write,
+    Execute,
+}
 
-VM_PROT_READ    : vm_prot_t : 0x01      /* read permission */
-VM_PROT_WRITE   : vm_prot_t : 0x02      /* write permission */
-VM_PROT_EXECUTE : vm_prot_t : 0x04      /* execute permission */
+VM_Prot_Flags :: distinct bit_set[VM_Prot; vm_prot_t]
 
-/*
- *	The default protection for newly-created virtual memory
- */
-
-VM_PROT_DEFAULT :: VM_PROT_READ | VM_PROT_WRITE
-
-/*
- *	The maximum privileges possible, for parameter checking.
- */
-
-VM_PROT_ALL     :: VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXECUTE
+VM_PROT_NONE    :: VM_Prot_Flags{}
+VM_PROT_DEFAULT :: VM_Prot_Flags{.Read, .Write}
+VM_PROT_ALL     :: VM_Prot_Flags{.Read, .Write, .Execute}
 
 /*
  *	Enumeration of valid values for vm_inherit_t.

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -4,20 +4,15 @@ foreign import mach "system:System.framework"
 
 import "core:c"
 
-// NOTE(tetra): Unclear whether these should be aligned 16 or not.
-// However all other sync primitives are aligned for robustness.
-// I cannot currently align these though.
-// See core/sys/unix/pthread_linux.odin/pthread_t.
-task_t :: distinct u64
-semaphore_t :: distinct u64
-
-kern_return_t :: distinct u64
-thread_act_t :: distinct u64
+kern_return_t :: distinct c.int
 
 mach_port_t :: distinct c.uint
 vm_map_t :: mach_port_t
 mem_entry_name_port_t :: mach_port_t
 ipc_space_t :: mach_port_t
+thread_t :: mach_port_t
+task_t :: mach_port_t
+semaphore_t :: mach_port_t
 
 vm_size_t :: distinct c.uintptr_t
 
@@ -34,14 +29,14 @@ mach_port_name_t :: distinct c.uint
 
 @(default_calling_convention="c")
 foreign mach {
-	mach_task_self :: proc() -> task_t ---
+	mach_task_self :: proc() -> mach_port_t ---
 
 	semaphore_create :: proc(task: task_t, semaphore: ^semaphore_t, policy, value: c.int) -> kern_return_t ---
 	semaphore_destroy :: proc(task: task_t, semaphore: semaphore_t) -> kern_return_t ---
 
 	semaphore_signal :: proc(semaphore: semaphore_t) -> kern_return_t ---
 	semaphore_signal_all :: proc(semaphore: semaphore_t) -> kern_return_t ---
-	semaphore_signal_thread :: proc(semaphore: semaphore_t, thread: thread_act_t) -> kern_return_t ---
+	semaphore_signal_thread :: proc(semaphore: semaphore_t, thread: thread_t) -> kern_return_t ---
 	
 	semaphore_wait :: proc(semaphore: semaphore_t) -> kern_return_t ---
 

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -47,26 +47,26 @@ foreign mach {
 	vm_deallocate :: proc(target_task: vm_map_t, address: vm_address_t, size: vm_size_t) -> Kern_Return ---
 
 	vm_map :: proc(
-		target_task    : vm_map_t,
-		address        : ^vm_address_t,
-		size           : vm_size_t,
-		mask           : vm_address_t,
-		flags          : VM_Flags,
-		object         : mem_entry_name_port_t,
-		offset         : vm_offset_t,
-		copy           : boolean_t,
+		target_task:    vm_map_t,
+		address:        ^vm_address_t,
+		size:           vm_size_t,
+		mask:           vm_address_t,
+		flags:          VM_Flags,
+		object:         mem_entry_name_port_t,
+		offset:         vm_offset_t,
+		copy:           boolean_t,
 		cur_protection,
-		max_protection : VM_Prot_Flags,
-		inheritance    : VM_Inherit,
+		max_protection: VM_Prot_Flags,
+		inheritance:    VM_Inherit,
 	) -> Kern_Return ---
 
 	mach_make_memory_entry :: proc(
-		target_task   : vm_map_t,
-		size          : ^vm_size_t,
-		offset        : vm_offset_t,
-		permission    : VM_Prot_Flags,
-		object_handle : ^mem_entry_name_port_t,
-		parent_entry  : mem_entry_name_port_t,
+		target_task:   vm_map_t,
+		size:          ^vm_size_t,
+		offset:        vm_offset_t,
+		permission:    VM_Prot_Flags,
+		object_handle: ^mem_entry_name_port_t,
+		parent_entry:  mem_entry_name_port_t,
 	) -> Kern_Return ---
 
 	mach_port_deallocate :: proc(
@@ -74,7 +74,7 @@ foreign mach {
 		name: mach_port_name_t,
 	) -> Kern_Return ---
 
-	vm_page_size : vm_size_t
+	vm_page_size: vm_size_t
 }
 
 Kern_Return :: enum kern_return_t {

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -80,115 +80,114 @@ foreign mach {
 Kern_Return :: enum kern_return_t {
 	Success,
 
-	Invalid_Address,
 	/* Specified address is not currently valid.
 	 */
+	Invalid_Address,
 
-	Protection_Failure,
 	/* Specified memory is valid, but does not permit the
 	 * required forms of access.
 	 */
+	Protection_Failure,
 
-	No_Space,
 	/* The address range specified is already in use, or
 	 * no address range of the size specified could be
 	 * found.
 	 */
+	No_Space,
 
-	Invalid_Argument,
 	/* The function requested was not applicable to this
 	 * type of argument, or an argument is invalid
 	 */
+	Invalid_Argument,
 
-	Failure,
 	/* The function could not be performed.  A catch-all.
 	 */
+	Failure,
 
-	Resource_Shortage,
 	/* A system resource could not be allocated to fulfill
 	 * this request.  This failure may not be permanent.
 	 */
+	Resource_Shortage,
 
-	Not_Receiver,
 	/* The task in question does not hold receive rights
 	 * for the port argument.
 	 */
+	Not_Receiver,
 
-	No_Access,
 	/* Bogus access restriction.
 	 */
+	No_Access,
 
-	Memory_Failure,
 	/* During a page fault, the target address refers to a
 	 * memory object that has been destroyed.  This
 	 * failure is permanent.
 	 */
+	Memory_Failure,
 
-	Memory_Error,
 	/* During a page fault, the memory object indicated
 	 * that the data could not be returned.  This failure
 	 * may be temporary; future attempts to access this
 	 * same data may succeed, as defined by the memory
 	 * object.
 	 */
+	Memory_Error,
 
-	Already_In_Set,
 	/* The receive right is already a member of the portset.
 	 */
+	Already_In_Set,
 
-	Not_In_Set,
 	/* The receive right is not a member of a port set.
 	 */
+	Not_In_Set,
 
-	Name_Exists,
 	/* The name already denotes a right in the task.
 	 */
+	Name_Exists,
 
-	Aborted,
 	/* The operation was aborted.  Ipc code will
 	 * catch this and reflect it as a message error.
 	 */
+	Aborted,
 
-	Invalid_Name,
 	/* The name doesn't denote a right in the task.
 	 */
+	Invalid_Name,
 
-	Invalid_Task,
 	/* Target task isn't an active task.
 	 */
+	Invalid_Task,
 
-	Invalid_Right,
 	/* The name denotes a right, but not an appropriate right.
 	 */
+	Invalid_Right,
 
-	Invalid_Value,
 	/* A blatant range error.
 	 */
+	Invalid_Value,
 
-	URefs_Overflow,
 	/* Operation would overflow limit on user-references.
 	 */
+	URefs_Overflow,
 
-	Invalid_Capability,
 	/* The supplied (port) capability is improper.
 	 */
+	Invalid_Capability,
 
-	Right_Exists,
 	/* The task already has send or receive rights
 	 * for the port under another name.
 	 */
+	Right_Exists,
 
-	Invalid_Host,
 	/* Target host isn't actually a host.
 	 */
+	Invalid_Host,
 
-	Memory_Present,
 	/* An attempt was made to supply "precious" data
 	 * for memory that is already present in a
 	 * memory object.
 	 */
+	Memory_Present,
 
-	Memory_Data_Moved,
 	/* A page was requested of a memory manager via
 	 * memory_object_data_request for an object using
 	 * a MEMORY_OBJECT_COPY_CALL strategy, with the
@@ -203,154 +202,155 @@ Kern_Return :: enum kern_return_t {
 	 * kernel to restart the fault). It will not be
 	 * seen by users.
 	 */
+	Memory_Data_Moved,
 
-	Memory_Restart_Copy,
 	/* A strategic copy was attempted of an object
 	 * upon which a quicker copy is now possible.
 	 * The caller should retry the copy using
 	 * vm_object_copy_quickly. This error code
 	 * is seen only by the kernel.
 	 */
+	Memory_Restart_Copy,
 
-	Invalid_Processor_Set,
 	/* An argument applied to assert processor set privilege
 	 * was not a processor set control port.
 	 */
+	Invalid_Processor_Set,
 
-	Policy_Limit,
 	/* The specified scheduling attributes exceed the thread's
 	 * limits.
 	 */
+	Policy_Limit,
 
-	Invalid_Policy,
 	/* The specified scheduling policy is not currently
 	 * enabled for the processor set.
 	 */
+	Invalid_Policy,
 
-	Invalid_Object,
 	/* The external memory manager failed to initialize the
 	 * memory object.
 	 */
+	Invalid_Object,
 
-	Already_Waiting,
 	/* A thread is attempting to wait for an event for which
 	 * there is already a waiting thread.
 	 */
+	Already_Waiting,
 
-	Default_Set,
 	/* An attempt was made to destroy the default processor
 	 * set.
 	 */
+	Default_Set,
 
-	Exception_Protected,
 	/* An attempt was made to fetch an exception port that is
 	 * protected, or to abort a thread while processing a
 	 * protected exception.
 	 */
+	Exception_Protected,
 
-	Invalid_Ledger,
 	/* A ledger was required but not supplied.
 	 */
+	Invalid_Ledger,
 
-	Invalid_Memory_Control,
 	/* The port was not a memory cache control port.
 	 */
+	Invalid_Memory_Control,
 
-	Invalid_Security,
 	/* An argument supplied to assert security privilege
 	 * was not a host security port.
 	 */
+	Invalid_Security,
 
-	Not_Depressed,
 	/* thread_depress_abort was called on a thread which
 	 * was not currently depressed.
 	 */
+	Not_Depressed,
 
-	Terminated,
 	/* Object has been terminated and is no longer available
 	 */
+	Terminated,
 
-	Lock_Set_Destroyed,
 	/* Lock set has been destroyed and is no longer available.
 	 */
+	Lock_Set_Destroyed,
 
-	Lock_Unstable,
 	/* The thread holding the lock terminated before releasing
 	 * the lock
 	 */
+	Lock_Unstable,
 
-	Lock_Owned,
 	/* The lock is already owned by another thread
 	 */
+	Lock_Owned,
 
-	Lock_Owned_Self,
 	/* The lock is already owned by the calling thread
 	 */
+	Lock_Owned_Self,
 
-	Semaphore_Destroyed,
 	/* Semaphore has been destroyed and is no longer available.
 	 */
+	Semaphore_Destroyed,
 
-	Rpc_Server_Terminated,
 	/* Return from RPC indicating the target server was
 	 * terminated before it successfully replied
 	 */
+	Rpc_Server_Terminated,
 
-	RPC_Terminate_Orphan,
 	/* Terminate an orphaned activation.
 	 */
+	RPC_Terminate_Orphan,
 
-	RPC_Continue_Orphan,
 	/* Allow an orphaned activation to continue executing.
 	 */
+	RPC_Continue_Orphan,
 
-	Not_Supported,
 	/* Empty thread activation (No thread linked to it)
 	 */
+	Not_Supported,
 
-	Node_Down,
 	/* Remote node down or inaccessible.
 	 */
+	Node_Down,
 
-	Not_Waiting,
 	/* A signalled thread was not actually waiting. */
+	Not_Waiting,
 
-	Operation_Timed_Out,
 	/* Some thread-oriented operation (semaphore_wait) timed out
 	 */
+	Operation_Timed_Out,
 
-	Codesign_Error,
 	/* During a page fault, indicates that the page was rejected
 	 * as a result of a signature check.
 	 */
+	Codesign_Error,
 
-	Policy_Static,
 	/* The requested property cannot be changed at this time.
 	 */
+	Policy_Static,
 
-	Insufficient_Buffer_Size,
 	/* The provided buffer is of insufficient size for the requested data.
 	 */
+	Insufficient_Buffer_Size,
 
-	Denied,
 	/* Denied by security policy
 	 */
+	Denied,
 
-	Missing_KC,
 	/* The KC on which the function is operating is missing
 	 */
+	Missing_KC,
 
-	Invalid_KC,
 	/* The KC on which the function is operating is invalid
 	 */
+	Invalid_KC,
 
-	Not_Found,
 	/* A search or query operation did not return a result
 	 */
+	Not_Found,
 
-	Return_Max               = 0x100,
 	/* Maximum return value allowable
 	 */
+	Return_Max               = 0x100,
 }
 
 /*

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -46,7 +46,7 @@ foreign mach {
 
 	vm_deallocate :: proc(target_task: vm_map_t, address: vm_address_t, size: vm_size_t) -> Kern_Return ---
 
-	vm_map :: proc (
+	vm_map :: proc(
 		target_task    : vm_map_t,
 		address        : ^vm_address_t,
 		size           : vm_size_t,
@@ -60,7 +60,7 @@ foreign mach {
 		inheritance    : VM_Inherit,
 	) -> Kern_Return ---
 
-	mach_make_memory_entry :: proc (
+	mach_make_memory_entry :: proc(
 		target_task   : vm_map_t,
 		size          : ^vm_size_t,
 		offset        : vm_offset_t,
@@ -69,7 +69,7 @@ foreign mach {
 		parent_entry  : mem_entry_name_port_t,
 	) -> Kern_Return ---
 
-	mach_port_deallocate :: proc (
+	mach_port_deallocate :: proc(
 		task: ipc_space_t,
 		name: mach_port_name_t,
 	) -> Kern_Return ---

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -57,7 +57,7 @@ foreign mach {
 		copy           : boolean_t,
 		cur_protection : vm_prot_t,
 		max_protection : vm_prot_t,
-		inheritance    : vm_inherit_t
+		inheritance    : vm_inherit_t,
 	) -> kern_return_t ---
 
 	mach_make_memory_entry :: proc (

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -390,3 +390,16 @@ VM_PROT_DEFAULT :: VM_PROT_READ | VM_PROT_WRITE
  */
 
 VM_PROT_ALL     :: VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXECUTE
+
+
+// NOTE(beau): vm_inherit_t constants and type, ported directly
+vm_inherit_t           :: c.uint
+
+/*
+ *	Enumeration of valid values for vm_inherit_t.
+ */
+
+VM_INHERIT_SHARE       : vm_inherit_t : 0      /* share with child */
+VM_INHERIT_COPY        : vm_inherit_t : 1      /* copy into child */
+VM_INHERIT_NONE        : vm_inherit_t : 2      /* absent from child */
+VM_INHERIT_DONATE_COPY : vm_inherit_t : 3      /* copy and delete */

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -26,6 +26,44 @@ foreign mach {
 	semaphore_signal_thread :: proc(semaphore: semaphore_t, thread: thread_act_t) -> kern_return_t ---
 	
 	semaphore_wait :: proc(semaphore: semaphore_t) -> kern_return_t ---
+
+    vm_allocate :: proc (
+        target_task : vm_map_t,
+        address     : ^vm_address_t,
+        size        : vm_size_t,
+        flags       : vm_flags_t,
+    ) -> kern_return_t ---
+
+    vm_deallocate :: proc(
+        target_task: vm_map_t,
+        address    : vm_address_t,
+        size       : vm_size_t
+    ) -> kern_return_t---
+
+    vm_map :: proc (
+        target_task    : vm_map_t,
+        address        : ^vm_address_t,
+        size           : vm_size_t,
+        mask           : vm_address_t,
+        flags          : vm_flags_t,
+        object         : mem_entry_name_port_t,
+        offset         : vm_offset_t,
+        copy           : boolean_t,
+        cur_protection : vm_prot_t,
+        max_protection : vm_prot_t,
+        inheritance    : vm_inherit_t
+    ) -> kern_return_t ---
+
+    mach_make_memory_entry :: proc (
+        target_task   : vm_map_t,
+        size          : ^vm_size_t,
+        offset        : vm_offset_t,
+        permission    : vm_prot_t,
+        object_handle : ^mem_entry_name_port_t,
+        parent_entry  : mem_entry_name_port_t,
+    ) -> kern_return_t ---
+
+    vm_page_size : vm_size_t
 }
 
 // NOTE(beau): types for stuff in the mach APIS, recreated from the typedefs as

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -55,7 +55,7 @@ foreign mach {
 		copy           : boolean_t,
 		cur_protection,
 		max_protection : VM_Prot_Flags,
-		inheritance    : vm_inherit_t,
+		inheritance    : VM_Inherit,
 	) -> Kern_Return ---
 
 	mach_make_memory_entry :: proc (
@@ -415,7 +415,12 @@ VM_PROT_ALL     :: VM_Prot_Flags{.Read, .Write, .Execute}
  *	Enumeration of valid values for vm_inherit_t.
  */
 
-VM_INHERIT_SHARE       : vm_inherit_t : 0      /* share with child */
-VM_INHERIT_COPY        : vm_inherit_t : 1      /* copy into child */
-VM_INHERIT_NONE        : vm_inherit_t : 2      /* absent from child */
-VM_INHERIT_DONATE_COPY : vm_inherit_t : 3      /* copy and delete */
+VM_Inherit :: enum vm_inherit_t {
+    Share,
+    Copy,
+    None,
+    Donate_Copy,
+}
+
+VM_INHERIT_DEFAULT    :: VM_Inherit.Copy
+VM_INHERIT_LAST_VALID :: VM_Inherit.None

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -365,3 +365,28 @@ VM_FLAGS_RESILIENT_MEDIA    : vm_flags_t : 0x00000040
 VM_FLAGS_PERMANENT          : vm_flags_t : 0x00000080
 VM_FLAGS_TPRO               : vm_flags_t : 0x00001000
 VM_FLAGS_OVERWRITE          : vm_flags_t : 0x00004000  /* delete any existing mappings first */
+
+// NOTE(beau): vm_prot_t types and constants, ported directly
+vm_prot_t :: c.int
+
+/*
+ *	Protection values, defined as bits within the vm_prot_t type
+ */
+
+VM_PROT_NONE    : vm_prot_t : 0x00
+
+VM_PROT_READ    : vm_prot_t : 0x01      /* read permission */
+VM_PROT_WRITE   : vm_prot_t : 0x02      /* write permission */
+VM_PROT_EXECUTE : vm_prot_t : 0x04      /* execute permission */
+
+/*
+ *	The default protection for newly-created virtual memory
+ */
+
+VM_PROT_DEFAULT :: VM_PROT_READ | VM_PROT_WRITE
+
+/*
+ *	The maximum privileges possible, for parameter checking.
+ */
+
+VM_PROT_ALL     :: VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXECUTE

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -15,12 +15,12 @@ kern_return_t :: distinct u64
 thread_act_t :: distinct u64
 
 mach_port_t :: distinct c.uint
-vm_map_t :: distinct mach_port_t
-mem_entry_name_port_t :: distinct mach_port_t
+vm_map_t :: mach_port_t
+mem_entry_name_port_t :: mach_port_t
 
 vm_size_t :: distinct c.uintptr_t
 
-vm_address_t :: distinct vm_offset_t
+vm_address_t :: vm_offset_t
 vm_offset_t :: distinct c.uintptr_t
 
 boolean_t :: distinct c.int

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -42,34 +42,34 @@ foreign mach {
 	
 	semaphore_wait :: proc(semaphore: semaphore_t) -> kern_return_t ---
 
-    vm_allocate :: proc (target_task : vm_map_t, address: ^vm_address_t, size: vm_size_t, flags: vm_flags_t,) -> kern_return_t ---
+	vm_allocate :: proc (target_task : vm_map_t, address: ^vm_address_t, size: vm_size_t, flags: vm_flags_t,) -> kern_return_t ---
 
-    vm_deallocate :: proc(target_task: vm_map_t, address: vm_address_t, size: vm_size_t) -> kern_return_t---
+	vm_deallocate :: proc(target_task: vm_map_t, address: vm_address_t, size: vm_size_t) -> kern_return_t---
 
-    vm_map :: proc (
-        target_task    : vm_map_t,
-        address        : ^vm_address_t,
-        size           : vm_size_t,
-        mask           : vm_address_t,
-        flags          : vm_flags_t,
-        object         : mem_entry_name_port_t,
-        offset         : vm_offset_t,
-        copy           : boolean_t,
-        cur_protection : vm_prot_t,
-        max_protection : vm_prot_t,
-        inheritance    : vm_inherit_t
-    ) -> kern_return_t ---
+	vm_map :: proc (
+		target_task    : vm_map_t,
+		address        : ^vm_address_t,
+		size           : vm_size_t,
+		mask           : vm_address_t,
+		flags          : vm_flags_t,
+		object         : mem_entry_name_port_t,
+		offset         : vm_offset_t,
+		copy           : boolean_t,
+		cur_protection : vm_prot_t,
+		max_protection : vm_prot_t,
+		inheritance    : vm_inherit_t
+	) -> kern_return_t ---
 
-    mach_make_memory_entry :: proc (
-        target_task   : vm_map_t,
-        size          : ^vm_size_t,
-        offset        : vm_offset_t,
-        permission    : vm_prot_t,
-        object_handle : ^mem_entry_name_port_t,
-        parent_entry  : mem_entry_name_port_t,
-    ) -> kern_return_t ---
+	mach_make_memory_entry :: proc (
+		target_task   : vm_map_t,
+		size          : ^vm_size_t,
+		offset        : vm_offset_t,
+		permission    : vm_prot_t,
+		object_handle : ^mem_entry_name_port_t,
+		parent_entry  : mem_entry_name_port_t,
+	) -> kern_return_t ---
 
-    vm_page_size : vm_size_t
+	vm_page_size : vm_size_t
 }
 
 KERN_SUCCESS                  : kern_return_t : 0

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -14,6 +14,21 @@ semaphore_t :: distinct u64
 kern_return_t :: distinct u64
 thread_act_t :: distinct u64
 
+mach_port_t :: c.uint
+vm_map_t :: mach_port_t
+mem_entry_name_port_t :: mach_port_t
+
+vm_size_t :: c.uintptr_t
+
+vm_address_t :: vm_offset_t
+vm_offset_t :: c.uintptr_t
+
+boolean_t :: c.int
+
+vm_prot_t :: c.int
+
+vm_inherit_t           :: c.uint
+
 @(default_calling_convention="c")
 foreign mach {
 	mach_task_self :: proc() -> task_t ---
@@ -65,22 +80,6 @@ foreign mach {
 
     vm_page_size : vm_size_t
 }
-
-// NOTE(beau): types for stuff in the mach APIS, recreated from the typedefs as
-// faithfully as possible
-mach_port_t            :: c.uint
-vm_map_t               :: mach_port_t
-mem_entry_name_port_t  :: mach_port_t
-
-vm_size_t              :: c.uintptr_t
-
-vm_address_t           :: vm_offset_t
-vm_offset_t            :: c.uintptr_t
-
-boolean_t              :: c.int
-
-// REVIEW(beau): its actually defined as an int
-// kern_return_t          :: c.int
 
 // NOTE(beau): kern_return_t constants - ported directly
 KERN_SUCCESS                  : kern_return_t : 0
@@ -404,9 +403,6 @@ VM_FLAGS_PERMANENT          : vm_flags_t : 0x00000080
 VM_FLAGS_TPRO               : vm_flags_t : 0x00001000
 VM_FLAGS_OVERWRITE          : vm_flags_t : 0x00004000  /* delete any existing mappings first */
 
-// NOTE(beau): vm_prot_t types and constants, ported directly
-vm_prot_t :: c.int
-
 /*
  *	Protection values, defined as bits within the vm_prot_t type
  */
@@ -428,10 +424,6 @@ VM_PROT_DEFAULT :: VM_PROT_READ | VM_PROT_WRITE
  */
 
 VM_PROT_ALL     :: VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXECUTE
-
-
-// NOTE(beau): vm_inherit_t constants and type, ported directly
-vm_inherit_t           :: c.uint
 
 /*
  *	Enumeration of valid values for vm_inherit_t.

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -316,3 +316,52 @@ KERN_NOT_FOUND                : kern_return_t : 56
  */
 
 KERN_RETURN_MAX               : kern_return_t : 0x100
+
+// NOTE(beau): VM_FLAGS constants - ported directly
+/* Maximum return value allowable
+ */
+/*
+ * VM allocation flags:
+ *
+ * VM_FLAGS_FIXED
+ *      (really the absence of VM_FLAGS_ANYWHERE)
+ *	Allocate new VM region at the specified virtual address, if possible.
+ *
+ * VM_FLAGS_ANYWHERE
+ *	Allocate new VM region anywhere it would fit in the address space.
+ *
+ * VM_FLAGS_PURGABLE
+ *	Create a purgable VM object for that new VM region.
+ *
+ * VM_FLAGS_4GB_CHUNK
+ *	The new VM region will be chunked up into 4GB sized pieces.
+ *
+ * VM_FLAGS_NO_PMAP_CHECK
+ *	(for DEBUG kernel config only, ignored for other configs)
+ *	Do not check that there is no stale pmap mapping for the new VM region.
+ *	This is useful for kernel memory allocations at bootstrap when building
+ *	the initial kernel address space while some memory is already in use.
+ *
+ * VM_FLAGS_OVERWRITE
+ *	The new VM region can replace existing VM regions if necessary
+ *	(to be used in combination with VM_FLAGS_FIXED).
+ *
+ * VM_FLAGS_NO_CACHE
+ *	Pages brought in to this VM region are placed on the speculative
+ *	queue instead of the active queue.  In other words, they are not
+ *	cached so that they will be stolen first if memory runs low.
+ */
+
+vm_flags_t :: distinct c.int // NOTE(beau): not in the apple sdk
+
+VM_FLAGS_FIXED              : vm_flags_t : 0x00000000
+VM_FLAGS_ANYWHERE           : vm_flags_t : 0x00000001
+VM_FLAGS_PURGABLE           : vm_flags_t : 0x00000002
+VM_FLAGS_4GB_CHUNK          : vm_flags_t : 0x00000004
+VM_FLAGS_RANDOM_ADDR        : vm_flags_t : 0x00000008
+VM_FLAGS_NO_CACHE           : vm_flags_t : 0x00000010
+VM_FLAGS_RESILIENT_CODESIGN : vm_flags_t : 0x00000020
+VM_FLAGS_RESILIENT_MEDIA    : vm_flags_t : 0x00000040
+VM_FLAGS_PERMANENT          : vm_flags_t : 0x00000080
+VM_FLAGS_TPRO               : vm_flags_t : 0x00001000
+VM_FLAGS_OVERWRITE          : vm_flags_t : 0x00004000  /* delete any existing mappings first */

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -27,3 +27,17 @@ foreign mach {
 	
 	semaphore_wait :: proc(semaphore: semaphore_t) -> kern_return_t ---
 }
+
+// NOTE(beau): types for stuff in the mach APIS, recreated from the typedefs as
+// faithfully as possible
+mach_port_t            :: c.uint
+vm_map_t               :: mach_port_t
+mem_entry_name_port_t  :: mach_port_t
+
+vm_size_t              :: c.uintptr_t
+
+vm_address_t           :: vm_offset_t
+vm_offset_t            :: c.uintptr_t
+
+boolean_t              :: c.int
+

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -17,6 +17,7 @@ thread_act_t :: distinct u64
 mach_port_t :: distinct c.uint
 vm_map_t :: mach_port_t
 mem_entry_name_port_t :: mach_port_t
+ipc_space_t :: mach_port_t
 
 vm_size_t :: distinct c.uintptr_t
 
@@ -28,6 +29,8 @@ boolean_t :: distinct c.int
 vm_prot_t :: distinct c.int
 
 vm_inherit_t :: distinct c.uint
+
+mach_port_name_t :: distinct c.uint
 
 @(default_calling_convention="c")
 foreign mach {
@@ -67,6 +70,11 @@ foreign mach {
 		permission    : vm_prot_t,
 		object_handle : ^mem_entry_name_port_t,
 		parent_entry  : mem_entry_name_port_t,
+	) -> kern_return_t ---
+
+	mach_port_deallocate :: proc (
+		task: ipc_space_t,
+		name: mach_port_name_t,
 	) -> kern_return_t ---
 
 	vm_page_size : vm_size_t

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -39,7 +39,7 @@ foreign mach {
 	semaphore_signal :: proc(semaphore: semaphore_t) -> Kern_Return ---
 	semaphore_signal_all :: proc(semaphore: semaphore_t) -> Kern_Return ---
 	semaphore_signal_thread :: proc(semaphore: semaphore_t, thread: thread_t) -> Kern_Return ---
-	
+
 	semaphore_wait :: proc(semaphore: semaphore_t) -> Kern_Return ---
 
 	vm_allocate :: proc (target_task : vm_map_t, address: ^vm_address_t, size: vm_size_t, flags: VM_Flags) -> Kern_Return ---
@@ -488,9 +488,9 @@ VM_FLAGS_SUPERPAGE_NONE :: VM_Flags{} /* no superpages, if all bits are 0 */
  */
 
 VM_Prot :: enum vm_prot_t {
-    Read,
-    Write,
-    Execute,
+	Read,
+	Write,
+	Execute,
 }
 
 VM_Prot_Flags :: distinct bit_set[VM_Prot; vm_prot_t]
@@ -504,10 +504,10 @@ VM_PROT_ALL     :: VM_Prot_Flags{.Read, .Write, .Execute}
  */
 
 VM_Inherit :: enum vm_inherit_t {
-    Share,
-    Copy,
-    None,
-    Donate_Copy,
+	Share,
+	Copy,
+	None,
+	Donate_Copy,
 }
 
 VM_INHERIT_DEFAULT    :: VM_Inherit.Copy

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -41,3 +41,278 @@ vm_offset_t            :: c.uintptr_t
 
 boolean_t              :: c.int
 
+// REVIEW(beau): its actually defined as an int
+// kern_return_t          :: c.int
+
+// NOTE(beau): kern_return_t constants - ported directly
+KERN_SUCCESS                  : kern_return_t : 0
+
+KERN_INVALID_ADDRESS          : kern_return_t : 1
+/* Specified address is not currently valid.
+ */
+
+KERN_PROTECTION_FAILURE       : kern_return_t : 2
+/* Specified memory is valid, but does not permit the
+ * required forms of access.
+ */
+
+KERN_NO_SPACE                 : kern_return_t : 3
+/* The address range specified is already in use, or
+ * no address range of the size specified could be
+ * found.
+ */
+
+KERN_INVALID_ARGUMENT         : kern_return_t : 4
+/* The function requested was not applicable to this
+ * type of argument, or an argument is invalid
+ */
+
+KERN_FAILURE                  : kern_return_t : 5
+/* The function could not be performed.  A catch-all.
+ */
+
+KERN_RESOURCE_SHORTAGE        : kern_return_t : 6
+/* A system resource could not be allocated to fulfill
+ * this request.  This failure may not be permanent.
+ */
+
+KERN_NOT_RECEIVER             : kern_return_t : 7
+/* The task in question does not hold receive rights
+ * for the port argument.
+ */
+
+KERN_NO_ACCESS                : kern_return_t : 8
+/* Bogus access restriction.
+ */
+
+KERN_MEMORY_FAILURE           : kern_return_t : 9
+/* During a page fault, the target address refers to a
+ * memory object that has been destroyed.  This
+ * failure is permanent.
+ */
+
+KERN_MEMORY_ERROR             : kern_return_t : 10
+/* During a page fault, the memory object indicated
+ * that the data could not be returned.  This failure
+ * may be temporary; future attempts to access this
+ * same data may succeed, as defined by the memory
+ * object.
+ */
+
+KERN_ALREADY_IN_SET           : kern_return_t : 11
+/* The receive right is already a member of the portset.
+ */
+
+KERN_NOT_IN_SET               : kern_return_t : 12
+/* The receive right is not a member of a port set.
+ */
+
+KERN_NAME_EXISTS              : kern_return_t : 13
+/* The name already denotes a right in the task.
+ */
+
+KERN_ABORTED                  : kern_return_t : 14
+/* The operation was aborted.  Ipc code will
+ * catch this and reflect it as a message error.
+ */
+
+KERN_INVALID_NAME             : kern_return_t : 15
+/* The name doesn't denote a right in the task.
+ */
+
+KERN_INVALID_TASK             : kern_return_t : 16
+/* Target task isn't an active task.
+ */
+
+KERN_INVALID_RIGHT            : kern_return_t : 17
+/* The name denotes a right, but not an appropriate right.
+ */
+
+KERN_INVALID_VALUE            : kern_return_t : 18
+/* A blatant range error.
+ */
+
+KERN_UREFS_OVERFLOW           : kern_return_t : 19
+/* Operation would overflow limit on user-references.
+ */
+
+KERN_INVALID_CAPABILITY       : kern_return_t : 20
+/* The supplied (port) capability is improper.
+ */
+
+KERN_RIGHT_EXISTS             : kern_return_t : 21
+/* The task already has send or receive rights
+ * for the port under another name.
+ */
+
+KERN_INVALID_HOST             : kern_return_t : 22
+/* Target host isn't actually a host.
+ */
+
+KERN_MEMORY_PRESENT           : kern_return_t : 23
+/* An attempt was made to supply "precious" data
+ * for memory that is already present in a
+ * memory object.
+ */
+
+KERN_MEMORY_DATA_MOVED        : kern_return_t : 24
+/* A page was requested of a memory manager via
+ * memory_object_data_request for an object using
+ * a MEMORY_OBJECT_COPY_CALL strategy, with the
+ * VM_PROT_WANTS_COPY flag being used to specify
+ * that the page desired is for a copy of the
+ * object, and the memory manager has detected
+ * the page was pushed into a copy of the object
+ * while the kernel was walking the shadow chain
+ * from the copy to the object. This error code
+ * is delivered via memory_object_data_error
+ * and is handled by the kernel (it forces the
+ * kernel to restart the fault). It will not be
+ * seen by users.
+ */
+
+KERN_MEMORY_RESTART_COPY      : kern_return_t : 25
+/* A strategic copy was attempted of an object
+ * upon which a quicker copy is now possible.
+ * The caller should retry the copy using
+ * vm_object_copy_quickly. This error code
+ * is seen only by the kernel.
+ */
+
+KERN_INVALID_PROCESSOR_SET    : kern_return_t : 26
+/* An argument applied to assert processor set privilege
+ * was not a processor set control port.
+ */
+
+KERN_POLICY_LIMIT             : kern_return_t : 27
+/* The specified scheduling attributes exceed the thread's
+ * limits.
+ */
+
+KERN_INVALID_POLICY           : kern_return_t : 28
+/* The specified scheduling policy is not currently
+ * enabled for the processor set.
+ */
+
+KERN_INVALID_OBJECT           : kern_return_t : 29
+/* The external memory manager failed to initialize the
+ * memory object.
+ */
+
+KERN_ALREADY_WAITING          : kern_return_t : 30
+/* A thread is attempting to wait for an event for which
+ * there is already a waiting thread.
+ */
+
+KERN_DEFAULT_SET              : kern_return_t : 31
+/* An attempt was made to destroy the default processor
+ * set.
+ */
+
+KERN_EXCEPTION_PROTECTED      : kern_return_t : 32
+/* An attempt was made to fetch an exception port that is
+ * protected, or to abort a thread while processing a
+ * protected exception.
+ */
+
+KERN_INVALID_LEDGER           : kern_return_t : 33
+/* A ledger was required but not supplied.
+ */
+
+KERN_INVALID_MEMORY_CONTROL   : kern_return_t : 34
+/* The port was not a memory cache control port.
+ */
+
+KERN_INVALID_SECURITY         : kern_return_t : 35
+/* An argument supplied to assert security privilege
+ * was not a host security port.
+ */
+
+KERN_NOT_DEPRESSED            : kern_return_t : 36
+/* thread_depress_abort was called on a thread which
+ * was not currently depressed.
+ */
+
+KERN_TERMINATED               : kern_return_t : 37
+/* Object has been terminated and is no longer available
+ */
+
+KERN_LOCK_SET_DESTROYED       : kern_return_t : 38
+/* Lock set has been destroyed and is no longer available.
+ */
+
+KERN_LOCK_UNSTABLE            : kern_return_t : 39
+/* The thread holding the lock terminated before releasing
+ * the lock
+ */
+
+KERN_LOCK_OWNED               : kern_return_t : 40
+/* The lock is already owned by another thread
+ */
+
+KERN_LOCK_OWNED_SELF          : kern_return_t : 41
+/* The lock is already owned by the calling thread
+ */
+
+KERN_SEMAPHORE_DESTROYED      : kern_return_t : 42
+/* Semaphore has been destroyed and is no longer available.
+ */
+
+KERN_RPC_SERVER_TERMINATED    : kern_return_t : 43
+/* Return from RPC indicating the target server was
+ * terminated before it successfully replied
+ */
+
+KERN_RPC_TERMINATE_ORPHAN     : kern_return_t : 44
+/* Terminate an orphaned activation.
+ */
+
+KERN_RPC_CONTINUE_ORPHAN      : kern_return_t : 45
+/* Allow an orphaned activation to continue executing.
+ */
+
+KERN_NOT_SUPPORTED            : kern_return_t : 46
+/* Empty thread activation (No thread linked to it)
+ */
+
+KERN_NODE_DOWN                : kern_return_t : 47
+/* Remote node down or inaccessible.
+ */
+
+KERN_NOT_WAITING              : kern_return_t : 48
+/* A signalled thread was not actually waiting. */
+
+KERN_OPERATION_TIMED_OUT      : kern_return_t : 49
+/* Some thread-oriented operation (semaphore_wait) timed out
+ */
+
+KERN_CODESIGN_ERROR           : kern_return_t : 50
+/* During a page fault, indicates that the page was rejected
+ * as a result of a signature check.
+ */
+
+KERN_POLICY_STATIC            : kern_return_t : 51
+/* The requested property cannot be changed at this time.
+ */
+
+KERN_INSUFFICIENT_BUFFER_SIZE : kern_return_t : 52
+/* The provided buffer is of insufficient size for the requested data.
+ */
+
+KERN_DENIED                   : kern_return_t : 53
+/* Denied by security policy
+ */
+
+KERN_MISSING_KC               : kern_return_t : 54
+/* The KC on which the function is operating is missing
+ */
+
+KERN_INVALID_KC               : kern_return_t : 55
+/* The KC on which the function is operating is invalid
+ */
+
+KERN_NOT_FOUND                : kern_return_t : 56
+/* A search or query operation did not return a result
+ */
+
+KERN_RETURN_MAX               : kern_return_t : 0x100

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -42,18 +42,9 @@ foreign mach {
 	
 	semaphore_wait :: proc(semaphore: semaphore_t) -> kern_return_t ---
 
-    vm_allocate :: proc (
-        target_task : vm_map_t,
-        address     : ^vm_address_t,
-        size        : vm_size_t,
-        flags       : vm_flags_t,
-    ) -> kern_return_t ---
+    vm_allocate :: proc (target_task : vm_map_t, address: ^vm_address_t, size: vm_size_t, flags: vm_flags_t,) -> kern_return_t ---
 
-    vm_deallocate :: proc(
-        target_task: vm_map_t,
-        address    : vm_address_t,
-        size       : vm_size_t
-    ) -> kern_return_t---
+    vm_deallocate :: proc(target_task: vm_map_t, address: vm_address_t, size: vm_size_t) -> kern_return_t---
 
     vm_map :: proc (
         target_task    : vm_map_t,

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -348,10 +348,10 @@ Kern_Return :: enum kern_return_t {
 	 */
 
 	Return_Max               = 0x100,
+	/* Maximum return value allowable
+	 */
 }
 
-/* Maximum return value allowable
- */
 /*
  * VM allocation flags:
  *

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -55,7 +55,7 @@ foreign mach {
 		object         : mem_entry_name_port_t,
 		offset         : vm_offset_t,
 		copy           : boolean_t,
-		cur_protection : vm_prot_t,
+		cur_protection,
 		max_protection : vm_prot_t,
 		inheritance    : vm_inherit_t,
 	) -> kern_return_t ---

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -42,7 +42,7 @@ foreign mach {
 	
 	semaphore_wait :: proc(semaphore: semaphore_t) -> kern_return_t ---
 
-	vm_allocate :: proc (target_task : vm_map_t, address: ^vm_address_t, size: vm_size_t, flags: vm_flags_t,) -> kern_return_t ---
+	vm_allocate :: proc (target_task : vm_map_t, address: ^vm_address_t, size: vm_size_t, flags: c.int,) -> kern_return_t ---
 
 	vm_deallocate :: proc(target_task: vm_map_t, address: vm_address_t, size: vm_size_t) -> kern_return_t---
 
@@ -51,7 +51,7 @@ foreign mach {
 		address        : ^vm_address_t,
 		size           : vm_size_t,
 		mask           : vm_address_t,
-		flags          : vm_flags_t,
+		flags          : c.int,
 		object         : mem_entry_name_port_t,
 		offset         : vm_offset_t,
 		copy           : boolean_t,
@@ -378,19 +378,17 @@ KERN_RETURN_MAX               : kern_return_t : 0x100
  *	cached so that they will be stolen first if memory runs low.
  */
 
-vm_flags_t :: distinct c.int // NOTE(beau): not in the apple sdk
-
-VM_FLAGS_FIXED              : vm_flags_t : 0x00000000
-VM_FLAGS_ANYWHERE           : vm_flags_t : 0x00000001
-VM_FLAGS_PURGABLE           : vm_flags_t : 0x00000002
-VM_FLAGS_4GB_CHUNK          : vm_flags_t : 0x00000004
-VM_FLAGS_RANDOM_ADDR        : vm_flags_t : 0x00000008
-VM_FLAGS_NO_CACHE           : vm_flags_t : 0x00000010
-VM_FLAGS_RESILIENT_CODESIGN : vm_flags_t : 0x00000020
-VM_FLAGS_RESILIENT_MEDIA    : vm_flags_t : 0x00000040
-VM_FLAGS_PERMANENT          : vm_flags_t : 0x00000080
-VM_FLAGS_TPRO               : vm_flags_t : 0x00001000
-VM_FLAGS_OVERWRITE          : vm_flags_t : 0x00004000  /* delete any existing mappings first */
+VM_FLAGS_FIXED              :: 0x00000000
+VM_FLAGS_ANYWHERE           :: 0x00000001
+VM_FLAGS_PURGABLE           :: 0x00000002
+VM_FLAGS_4GB_CHUNK          :: 0x00000004
+VM_FLAGS_RANDOM_ADDR        :: 0x00000008
+VM_FLAGS_NO_CACHE           :: 0x00000010
+VM_FLAGS_RESILIENT_CODESIGN :: 0x00000020
+VM_FLAGS_RESILIENT_MEDIA    :: 0x00000040
+VM_FLAGS_PERMANENT          :: 0x00000080
+VM_FLAGS_TPRO               :: 0x00001000
+VM_FLAGS_OVERWRITE          :: 0x00004000  /* delete any existing mappings first */
 
 /*
  *	Protection values, defined as bits within the vm_prot_t type

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -14,20 +14,20 @@ semaphore_t :: distinct u64
 kern_return_t :: distinct u64
 thread_act_t :: distinct u64
 
-mach_port_t :: c.uint
-vm_map_t :: mach_port_t
-mem_entry_name_port_t :: mach_port_t
+mach_port_t :: distinct c.uint
+vm_map_t :: distinct mach_port_t
+mem_entry_name_port_t :: distinct mach_port_t
 
-vm_size_t :: c.uintptr_t
+vm_size_t :: distinct c.uintptr_t
 
-vm_address_t :: vm_offset_t
-vm_offset_t :: c.uintptr_t
+vm_address_t :: distinct vm_offset_t
+vm_offset_t :: distinct c.uintptr_t
 
-boolean_t :: c.int
+boolean_t :: distinct c.int
 
-vm_prot_t :: c.int
+vm_prot_t :: distinct c.int
 
-vm_inherit_t           :: c.uint
+vm_inherit_t :: distinct c.uint
 
 @(default_calling_convention="c")
 foreign mach {

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -72,7 +72,6 @@ foreign mach {
     vm_page_size : vm_size_t
 }
 
-// NOTE(beau): kern_return_t constants - ported directly
 KERN_SUCCESS                  : kern_return_t : 0
 
 KERN_INVALID_ADDRESS          : kern_return_t : 1
@@ -345,7 +344,6 @@ KERN_NOT_FOUND                : kern_return_t : 56
 
 KERN_RETURN_MAX               : kern_return_t : 0x100
 
-// NOTE(beau): VM_FLAGS constants - ported directly
 /* Maximum return value allowable
  */
 /*

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -19,7 +19,8 @@ vm_size_t :: distinct c.uintptr_t
 vm_address_t :: vm_offset_t
 vm_offset_t :: distinct c.uintptr_t
 
-boolean_t :: distinct c.int
+// NOTE(beau): typedefed to int in the original headers
+boolean_t :: b32
 
 vm_prot_t :: distinct c.int
 

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -29,11 +29,13 @@ vm_inherit_t :: distinct c.uint
 
 mach_port_name_t :: distinct c.uint
 
+sync_policy_t :: distinct c.int
+
 @(default_calling_convention="c")
 foreign mach {
 	mach_task_self :: proc() -> mach_port_t ---
 
-	semaphore_create :: proc(task: task_t, semaphore: ^semaphore_t, policy, value: c.int) -> Kern_Return ---
+	semaphore_create :: proc(task: task_t, semaphore: ^semaphore_t, policy: Sync_Policy, value: c.int) -> Kern_Return ---
 	semaphore_destroy :: proc(task: task_t, semaphore: semaphore_t) -> Kern_Return ---
 
 	semaphore_signal :: proc(semaphore: semaphore_t) -> Kern_Return ---
@@ -512,3 +514,12 @@ VM_Inherit :: enum vm_inherit_t {
 
 VM_INHERIT_DEFAULT    :: VM_Inherit.Copy
 VM_INHERIT_LAST_VALID :: VM_Inherit.None
+
+Sync_Policy :: enum sync_policy_t {
+	Fifo,
+	Fixed_Priority,
+	Reversed,
+	Order_Mask,
+}
+
+SYNC_POLICY_LIFO :: Sync_Policy.Fifo | Sync_Policy.Reversed

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -31,18 +31,18 @@ mach_port_name_t :: distinct c.uint
 foreign mach {
 	mach_task_self :: proc() -> mach_port_t ---
 
-	semaphore_create :: proc(task: task_t, semaphore: ^semaphore_t, policy, value: c.int) -> kern_return_t ---
-	semaphore_destroy :: proc(task: task_t, semaphore: semaphore_t) -> kern_return_t ---
+	semaphore_create :: proc(task: task_t, semaphore: ^semaphore_t, policy, value: c.int) -> Kern_Return ---
+	semaphore_destroy :: proc(task: task_t, semaphore: semaphore_t) -> Kern_Return ---
 
-	semaphore_signal :: proc(semaphore: semaphore_t) -> kern_return_t ---
-	semaphore_signal_all :: proc(semaphore: semaphore_t) -> kern_return_t ---
-	semaphore_signal_thread :: proc(semaphore: semaphore_t, thread: thread_t) -> kern_return_t ---
+	semaphore_signal :: proc(semaphore: semaphore_t) -> Kern_Return ---
+	semaphore_signal_all :: proc(semaphore: semaphore_t) -> Kern_Return ---
+	semaphore_signal_thread :: proc(semaphore: semaphore_t, thread: thread_t) -> Kern_Return ---
 	
-	semaphore_wait :: proc(semaphore: semaphore_t) -> kern_return_t ---
+	semaphore_wait :: proc(semaphore: semaphore_t) -> Kern_Return ---
 
-	vm_allocate :: proc (target_task : vm_map_t, address: ^vm_address_t, size: vm_size_t, flags: c.int,) -> kern_return_t ---
+	vm_allocate :: proc (target_task : vm_map_t, address: ^vm_address_t, size: vm_size_t, flags: c.int,) -> Kern_Return ---
 
-	vm_deallocate :: proc(target_task: vm_map_t, address: vm_address_t, size: vm_size_t) -> kern_return_t---
+	vm_deallocate :: proc(target_task: vm_map_t, address: vm_address_t, size: vm_size_t) -> Kern_Return ---
 
 	vm_map :: proc (
 		target_task    : vm_map_t,
@@ -56,7 +56,7 @@ foreign mach {
 		cur_protection,
 		max_protection : vm_prot_t,
 		inheritance    : vm_inherit_t,
-	) -> kern_return_t ---
+	) -> Kern_Return ---
 
 	mach_make_memory_entry :: proc (
 		target_task   : vm_map_t,
@@ -65,287 +65,289 @@ foreign mach {
 		permission    : vm_prot_t,
 		object_handle : ^mem_entry_name_port_t,
 		parent_entry  : mem_entry_name_port_t,
-	) -> kern_return_t ---
+	) -> Kern_Return ---
 
 	mach_port_deallocate :: proc (
 		task: ipc_space_t,
 		name: mach_port_name_t,
-	) -> kern_return_t ---
+	) -> Kern_Return ---
 
 	vm_page_size : vm_size_t
 }
 
-KERN_SUCCESS                  : kern_return_t : 0
+Kern_Return :: enum kern_return_t {
+	Success,
 
-KERN_INVALID_ADDRESS          : kern_return_t : 1
-/* Specified address is not currently valid.
- */
+	Invalid_Address,
+	/* Specified address is not currently valid.
+	 */
 
-KERN_PROTECTION_FAILURE       : kern_return_t : 2
-/* Specified memory is valid, but does not permit the
- * required forms of access.
- */
+	Protection_Failure,
+	/* Specified memory is valid, but does not permit the
+	 * required forms of access.
+	 */
 
-KERN_NO_SPACE                 : kern_return_t : 3
-/* The address range specified is already in use, or
- * no address range of the size specified could be
- * found.
- */
+	No_Space,
+	/* The address range specified is already in use, or
+	 * no address range of the size specified could be
+	 * found.
+	 */
 
-KERN_INVALID_ARGUMENT         : kern_return_t : 4
-/* The function requested was not applicable to this
- * type of argument, or an argument is invalid
- */
+	Invalid_Argument,
+	/* The function requested was not applicable to this
+	 * type of argument, or an argument is invalid
+	 */
 
-KERN_FAILURE                  : kern_return_t : 5
-/* The function could not be performed.  A catch-all.
- */
+	Failure,
+	/* The function could not be performed.  A catch-all.
+	 */
 
-KERN_RESOURCE_SHORTAGE        : kern_return_t : 6
-/* A system resource could not be allocated to fulfill
- * this request.  This failure may not be permanent.
- */
+	Resource_Shortage,
+	/* A system resource could not be allocated to fulfill
+	 * this request.  This failure may not be permanent.
+	 */
 
-KERN_NOT_RECEIVER             : kern_return_t : 7
-/* The task in question does not hold receive rights
- * for the port argument.
- */
+	Not_Receiver,
+	/* The task in question does not hold receive rights
+	 * for the port argument.
+	 */
 
-KERN_NO_ACCESS                : kern_return_t : 8
-/* Bogus access restriction.
- */
+	No_Access,
+	/* Bogus access restriction.
+	 */
 
-KERN_MEMORY_FAILURE           : kern_return_t : 9
-/* During a page fault, the target address refers to a
- * memory object that has been destroyed.  This
- * failure is permanent.
- */
+	Memory_Failure,
+	/* During a page fault, the target address refers to a
+	 * memory object that has been destroyed.  This
+	 * failure is permanent.
+	 */
 
-KERN_MEMORY_ERROR             : kern_return_t : 10
-/* During a page fault, the memory object indicated
- * that the data could not be returned.  This failure
- * may be temporary; future attempts to access this
- * same data may succeed, as defined by the memory
- * object.
- */
+	Memory_Error,
+	/* During a page fault, the memory object indicated
+	 * that the data could not be returned.  This failure
+	 * may be temporary; future attempts to access this
+	 * same data may succeed, as defined by the memory
+	 * object.
+	 */
 
-KERN_ALREADY_IN_SET           : kern_return_t : 11
-/* The receive right is already a member of the portset.
- */
+	Already_In_Set,
+	/* The receive right is already a member of the portset.
+	 */
 
-KERN_NOT_IN_SET               : kern_return_t : 12
-/* The receive right is not a member of a port set.
- */
+	Not_In_Set,
+	/* The receive right is not a member of a port set.
+	 */
 
-KERN_NAME_EXISTS              : kern_return_t : 13
-/* The name already denotes a right in the task.
- */
+	Name_Exists,
+	/* The name already denotes a right in the task.
+	 */
 
-KERN_ABORTED                  : kern_return_t : 14
-/* The operation was aborted.  Ipc code will
- * catch this and reflect it as a message error.
- */
+	Aborted,
+	/* The operation was aborted.  Ipc code will
+	 * catch this and reflect it as a message error.
+	 */
 
-KERN_INVALID_NAME             : kern_return_t : 15
-/* The name doesn't denote a right in the task.
- */
+	Invalid_Name,
+	/* The name doesn't denote a right in the task.
+	 */
 
-KERN_INVALID_TASK             : kern_return_t : 16
-/* Target task isn't an active task.
- */
+	Invalid_Task,
+	/* Target task isn't an active task.
+	 */
 
-KERN_INVALID_RIGHT            : kern_return_t : 17
-/* The name denotes a right, but not an appropriate right.
- */
+	Invalid_Right,
+	/* The name denotes a right, but not an appropriate right.
+	 */
 
-KERN_INVALID_VALUE            : kern_return_t : 18
-/* A blatant range error.
- */
+	Invalid_Value,
+	/* A blatant range error.
+	 */
 
-KERN_UREFS_OVERFLOW           : kern_return_t : 19
-/* Operation would overflow limit on user-references.
- */
+	URefs_Overflow,
+	/* Operation would overflow limit on user-references.
+	 */
 
-KERN_INVALID_CAPABILITY       : kern_return_t : 20
-/* The supplied (port) capability is improper.
- */
+	Invalid_Capability,
+	/* The supplied (port) capability is improper.
+	 */
 
-KERN_RIGHT_EXISTS             : kern_return_t : 21
-/* The task already has send or receive rights
- * for the port under another name.
- */
+	Right_Exists,
+	/* The task already has send or receive rights
+	 * for the port under another name.
+	 */
 
-KERN_INVALID_HOST             : kern_return_t : 22
-/* Target host isn't actually a host.
- */
+	Invalid_Host,
+	/* Target host isn't actually a host.
+	 */
 
-KERN_MEMORY_PRESENT           : kern_return_t : 23
-/* An attempt was made to supply "precious" data
- * for memory that is already present in a
- * memory object.
- */
+	Memory_Present,
+	/* An attempt was made to supply "precious" data
+	 * for memory that is already present in a
+	 * memory object.
+	 */
 
-KERN_MEMORY_DATA_MOVED        : kern_return_t : 24
-/* A page was requested of a memory manager via
- * memory_object_data_request for an object using
- * a MEMORY_OBJECT_COPY_CALL strategy, with the
- * VM_PROT_WANTS_COPY flag being used to specify
- * that the page desired is for a copy of the
- * object, and the memory manager has detected
- * the page was pushed into a copy of the object
- * while the kernel was walking the shadow chain
- * from the copy to the object. This error code
- * is delivered via memory_object_data_error
- * and is handled by the kernel (it forces the
- * kernel to restart the fault). It will not be
- * seen by users.
- */
+	Memory_Data_Moved,
+	/* A page was requested of a memory manager via
+	 * memory_object_data_request for an object using
+	 * a MEMORY_OBJECT_COPY_CALL strategy, with the
+	 * VM_PROT_WANTS_COPY flag being used to specify
+	 * that the page desired is for a copy of the
+	 * object, and the memory manager has detected
+	 * the page was pushed into a copy of the object
+	 * while the kernel was walking the shadow chain
+	 * from the copy to the object. This error code
+	 * is delivered via memory_object_data_error
+	 * and is handled by the kernel (it forces the
+	 * kernel to restart the fault). It will not be
+	 * seen by users.
+	 */
 
-KERN_MEMORY_RESTART_COPY      : kern_return_t : 25
-/* A strategic copy was attempted of an object
- * upon which a quicker copy is now possible.
- * The caller should retry the copy using
- * vm_object_copy_quickly. This error code
- * is seen only by the kernel.
- */
+	Memory_Restart_Copy,
+	/* A strategic copy was attempted of an object
+	 * upon which a quicker copy is now possible.
+	 * The caller should retry the copy using
+	 * vm_object_copy_quickly. This error code
+	 * is seen only by the kernel.
+	 */
 
-KERN_INVALID_PROCESSOR_SET    : kern_return_t : 26
-/* An argument applied to assert processor set privilege
- * was not a processor set control port.
- */
+	Invalid_Processor_Set,
+	/* An argument applied to assert processor set privilege
+	 * was not a processor set control port.
+	 */
 
-KERN_POLICY_LIMIT             : kern_return_t : 27
-/* The specified scheduling attributes exceed the thread's
- * limits.
- */
+	Policy_Limit,
+	/* The specified scheduling attributes exceed the thread's
+	 * limits.
+	 */
 
-KERN_INVALID_POLICY           : kern_return_t : 28
-/* The specified scheduling policy is not currently
- * enabled for the processor set.
- */
+	Invalid_Policy,
+	/* The specified scheduling policy is not currently
+	 * enabled for the processor set.
+	 */
 
-KERN_INVALID_OBJECT           : kern_return_t : 29
-/* The external memory manager failed to initialize the
- * memory object.
- */
+	Invalid_Object,
+	/* The external memory manager failed to initialize the
+	 * memory object.
+	 */
 
-KERN_ALREADY_WAITING          : kern_return_t : 30
-/* A thread is attempting to wait for an event for which
- * there is already a waiting thread.
- */
+	Already_Waiting,
+	/* A thread is attempting to wait for an event for which
+	 * there is already a waiting thread.
+	 */
 
-KERN_DEFAULT_SET              : kern_return_t : 31
-/* An attempt was made to destroy the default processor
- * set.
- */
+	Default_Set,
+	/* An attempt was made to destroy the default processor
+	 * set.
+	 */
 
-KERN_EXCEPTION_PROTECTED      : kern_return_t : 32
-/* An attempt was made to fetch an exception port that is
- * protected, or to abort a thread while processing a
- * protected exception.
- */
+	Exception_Protected,
+	/* An attempt was made to fetch an exception port that is
+	 * protected, or to abort a thread while processing a
+	 * protected exception.
+	 */
 
-KERN_INVALID_LEDGER           : kern_return_t : 33
-/* A ledger was required but not supplied.
- */
+	Invalid_Ledger,
+	/* A ledger was required but not supplied.
+	 */
 
-KERN_INVALID_MEMORY_CONTROL   : kern_return_t : 34
-/* The port was not a memory cache control port.
- */
+	Invalid_Memory_Control,
+	/* The port was not a memory cache control port.
+	 */
 
-KERN_INVALID_SECURITY         : kern_return_t : 35
-/* An argument supplied to assert security privilege
- * was not a host security port.
- */
+	Invalid_Security,
+	/* An argument supplied to assert security privilege
+	 * was not a host security port.
+	 */
 
-KERN_NOT_DEPRESSED            : kern_return_t : 36
-/* thread_depress_abort was called on a thread which
- * was not currently depressed.
- */
+	Not_Depressed,
+	/* thread_depress_abort was called on a thread which
+	 * was not currently depressed.
+	 */
 
-KERN_TERMINATED               : kern_return_t : 37
-/* Object has been terminated and is no longer available
- */
+	Terminated,
+	/* Object has been terminated and is no longer available
+	 */
 
-KERN_LOCK_SET_DESTROYED       : kern_return_t : 38
-/* Lock set has been destroyed and is no longer available.
- */
+	Lock_Set_Destroyed,
+	/* Lock set has been destroyed and is no longer available.
+	 */
 
-KERN_LOCK_UNSTABLE            : kern_return_t : 39
-/* The thread holding the lock terminated before releasing
- * the lock
- */
+	Lock_Unstable,
+	/* The thread holding the lock terminated before releasing
+	 * the lock
+	 */
 
-KERN_LOCK_OWNED               : kern_return_t : 40
-/* The lock is already owned by another thread
- */
+	Lock_Owned,
+	/* The lock is already owned by another thread
+	 */
 
-KERN_LOCK_OWNED_SELF          : kern_return_t : 41
-/* The lock is already owned by the calling thread
- */
+	Lock_Owned_Self,
+	/* The lock is already owned by the calling thread
+	 */
 
-KERN_SEMAPHORE_DESTROYED      : kern_return_t : 42
-/* Semaphore has been destroyed and is no longer available.
- */
+	Semaphore_Destroyed,
+	/* Semaphore has been destroyed and is no longer available.
+	 */
 
-KERN_RPC_SERVER_TERMINATED    : kern_return_t : 43
-/* Return from RPC indicating the target server was
- * terminated before it successfully replied
- */
+	Rpc_Server_Terminated,
+	/* Return from RPC indicating the target server was
+	 * terminated before it successfully replied
+	 */
 
-KERN_RPC_TERMINATE_ORPHAN     : kern_return_t : 44
-/* Terminate an orphaned activation.
- */
+	RPC_Terminate_Orphan,
+	/* Terminate an orphaned activation.
+	 */
 
-KERN_RPC_CONTINUE_ORPHAN      : kern_return_t : 45
-/* Allow an orphaned activation to continue executing.
- */
+	RPC_Continue_Orphan,
+	/* Allow an orphaned activation to continue executing.
+	 */
 
-KERN_NOT_SUPPORTED            : kern_return_t : 46
-/* Empty thread activation (No thread linked to it)
- */
+	Not_Supported,
+	/* Empty thread activation (No thread linked to it)
+	 */
 
-KERN_NODE_DOWN                : kern_return_t : 47
-/* Remote node down or inaccessible.
- */
+	Node_Down,
+	/* Remote node down or inaccessible.
+	 */
 
-KERN_NOT_WAITING              : kern_return_t : 48
-/* A signalled thread was not actually waiting. */
+	Not_Waiting,
+	/* A signalled thread was not actually waiting. */
 
-KERN_OPERATION_TIMED_OUT      : kern_return_t : 49
-/* Some thread-oriented operation (semaphore_wait) timed out
- */
+	Operation_Timed_Out,
+	/* Some thread-oriented operation (semaphore_wait) timed out
+	 */
 
-KERN_CODESIGN_ERROR           : kern_return_t : 50
-/* During a page fault, indicates that the page was rejected
- * as a result of a signature check.
- */
+	Codesign_Error,
+	/* During a page fault, indicates that the page was rejected
+	 * as a result of a signature check.
+	 */
 
-KERN_POLICY_STATIC            : kern_return_t : 51
-/* The requested property cannot be changed at this time.
- */
+	Policy_Static,
+	/* The requested property cannot be changed at this time.
+	 */
 
-KERN_INSUFFICIENT_BUFFER_SIZE : kern_return_t : 52
-/* The provided buffer is of insufficient size for the requested data.
- */
+	Insufficient_Buffer_Size,
+	/* The provided buffer is of insufficient size for the requested data.
+	 */
 
-KERN_DENIED                   : kern_return_t : 53
-/* Denied by security policy
- */
+	Denied,
+	/* Denied by security policy
+	 */
 
-KERN_MISSING_KC               : kern_return_t : 54
-/* The KC on which the function is operating is missing
- */
+	Missing_KC,
+	/* The KC on which the function is operating is missing
+	 */
 
-KERN_INVALID_KC               : kern_return_t : 55
-/* The KC on which the function is operating is invalid
- */
+	Invalid_KC,
+	/* The KC on which the function is operating is invalid
+	 */
 
-KERN_NOT_FOUND                : kern_return_t : 56
-/* A search or query operation did not return a result
- */
+	Not_Found,
+	/* A search or query operation did not return a result
+	 */
 
-KERN_RETURN_MAX               : kern_return_t : 0x100
+	Return_Max               = 0x100,
+}
 
 /* Maximum return value allowable
  */

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -1,6 +1,6 @@
 package darwin
 
-foreign import pthread "system:System.framework"
+foreign import mach "system:System.framework"
 
 import "core:c"
 
@@ -15,7 +15,7 @@ kern_return_t :: distinct u64
 thread_act_t :: distinct u64
 
 @(default_calling_convention="c")
-foreign pthread {
+foreign mach {
 	mach_task_self :: proc() -> task_t ---
 
 	semaphore_create :: proc(task: task_t, semaphore: ^semaphore_t, policy, value: c.int) -> kern_return_t ---


### PR DESCRIPTION
From my own bindings, cleaned up a bit to resemble what I see here.

I added:

- `vm_allocate()`
- `vm_deallocate()`
- `vm_map()`
- `mach_make_memory_entry()`
- `vm_page_size` (constant)
- types for each of the functions

I've reproduced the signatures, types/typedefs, and constants as exactly as
possible from the headers. I also kept doc comments from the original headers
(but they can go of course).

To that end, I wanted to ask about some of the types and procedure already in
`mach_darwin.odin`, as they don't match the original C api exactly. There is
a note about aligning the types to 16 bytes so I wanted to check if there was
a reason for the changes (e.g. in case I need to do something similar for the
type aliases I've given).

type aliases:
| type          | `mach_darwin.odin` | c api       |
|---------------|--------------------|-------------|
|`task_t`       |`u64`               |`mach_port_t`|
|`semaphore_t`  |`u64`               |`mach_port_t`|
|`kern_return_t`|`u64`               |`int`        |
|`thread_act_t` |`u64`               |`mach_port_t`|

procedures:
| procedure                 | `mach_darwin.odin`                                              | c api                                                               |
|---------------------------|-----------------------------------------------------------------|---------------------------------------------------------------------|
|`mach_task_self()`         |`proc() -> task_t`                                               |`proc() -> mach_port_t`                                              |
|`semaphore_signal_thread()`|`proc(semaphore: semaphore_t, thread: thread_t) -> kern_return_t`|`proc(semaphore: semaphore_t, thread: thread_t) -> kern_return_t`|

Note that `mach_port_t` is normally an `unsigned int`

Additionally, `semaphore_signal_thread()` takes a `thread_t`, not
a `thread_act_t` (though they're both typedef-ed to `mach_port_t`)

Also regarding aligning the types, the note referenced another note that said
that aligning a single-field struct didn't work at the time of writing. This
information was committed in 2019, so perhaps the issue is resolved now?

I made a vm-backed ring that maps multiple virtual pages onto the same physical
page to prove that the bindings are working. (I didn't want to clutter here so
I made a gist).
https://gist.github.com/beaumccartney/60cc84799dbdc1e4890ab1ec0a128fcb


I've made a thin wrapper to do make the api usable with more "odin-y" types,
it's included in the gist I linked above. Is a wrapper like mine worth
including?

- enums and bitsets
- `[^]byte` to reference a c pointer that represents the base of a region of
  memory

I didn't wrap `VM_FLAGS_*` in anything cause you can pack more information than
just toggling stuff ("superpage" stuff - its a bit weird)
