### PR TITLE
[vendor:raylib/rlgl] Add `EnableColorBlend()` binding

### DIFF
--- a/vendor/raylib/rlgl/rlgl.odin
+++ b/vendor/raylib/rlgl/rlgl.odin
@@ -438,6 +438,7 @@ foreign lib {
 	BlitFramebuffer	 :: proc(srcX, srcY, srcWidth, srcHeight, dstX, dstY, dstWidth, dstHeight, bufferMask: c.int) --- // Blit active framebuffer to main framebuffer
 
 	// General render state
+	EnableColorBlend       :: proc() ---                           // Enable color blending
 	DisableColorBlend      :: proc() ---                           // Disable color blending
 	EnableDepthTest        :: proc() ---                           // Enable depth test
 	DisableDepthTest       :: proc() ---                           // Disable depth test


### PR DESCRIPTION
Was rewriting a C rlgl gizmo library in odin and noticed that `rlEnableColorBlend()` has no bindings, while it's counterpart `rlDisableColorBlend()` does.

RAYLIB/RLGL API for reference:
https://github.com/raysan5/raylib/blob/59417636ca956d64800e7e26d4f4ec331cf1b412/src/rlgl.h#L672