### PR TITLE
Add debug info for labels to Odin

### DIFF
--- a/src/llvm_backend_debug.cpp
+++ b/src/llvm_backend_debug.cpp
@@ -1296,7 +1296,7 @@ gb_internal void add_debug_info_for_global_constant_from_entity(lbGenerator *gen
 	}
 }
 
-// TODO(tf2spi) ... *sigh* I hate LLVM so much.
+// TODO(tf2spi) ... *sigh* I'm sad
 // LLVM-C doesn't have an API to emit DILabel yet, so this is not exported in the dll.
 // For POSIX, we can temporarily use the C++ APIs, but we're out of luck for Windows
 // until the DLL gets updated with definitions like LLVMDIBuilderCreateLabel.
@@ -1319,10 +1319,9 @@ extern "C" LLVMMetadataRef _ZN4llvm9DIBuilder11insertLabelEPNS_7DILabelEPKNS_10D
 	LLVMBasicBlockRef Block);
 #endif
 gb_internal void lb_add_debug_label(lbProcedure *p, Ast *label, lbBlock *target) {
-	// TODO(tf2spi): Work with gingerBill to see if we can patch LLVM-C
-	//               to export DILabel functions for the C API on Windows
-	//               or to determine whether it is worthwhile to do this.
-	//               Until then, unimplemented, so just return.
+	// TODO(tf2spi): Not implemented on Windows because LLVM-C does not have
+	//               an official API for DILabel yet, so DLL does not export it.
+	//               When there is one, implement this function for Windows.
 	#ifdef _WIN32
 	if ((volatile int)0 == 0) return;
 	#endif
@@ -1372,6 +1371,7 @@ gb_internal void lb_add_debug_label(lbProcedure *p, Ast *label, lbBlock *target)
 		//               Always preserve the label no matter what when debugging
 		true
 	);
+	GB_ASSERT(llvm_label != nullptr);
 	_ZN4llvm9DIBuilder11insertLabelEPNS_7DILabelEPKNS_10DILocationEPNS_10BasicBlockE(	
 		m->debug_builder,
 		llvm_label,

--- a/src/llvm_backend_debug.cpp
+++ b/src/llvm_backend_debug.cpp
@@ -1296,84 +1296,9 @@ gb_internal void add_debug_info_for_global_constant_from_entity(lbGenerator *gen
 	}
 }
 
-// NOTE(tf2spi):
-// LLVM-C used to not have an official API to emit DILabel but now they do.
-// That being said, it was a recent addition, so we need to use the C++ APIs
-// on POSIX systems so that older solibs that don't have the C API still work.
-#ifndef _WIN32
-
-typedef LLVMMetadataRef (*LLVMDIBuilderCreateLabelPosixCPP)(
-	LLVMDIBuilderRef Builder,
-	LLVMMetadataRef Scope,
-	// Using String here is not technically proper to do, but it's ABI
-	// compatible for the ABIs and older solib versions that we care about.
-	String Name,
-	LLVMMetadataRef File,
-	unsigned int LineNo,
-	bool AlwaysPreserve);
-typedef LLVMMetadataRef (*LLVMDIBuilderCreateLabelPosixC)(
-	LLVMDIBuilderRef Builder, LLVMMetadataRef Context, const char *Name, size_t NameLen,
-	LLVMMetadataRef File, unsigned LineNo, LLVMBool AlwaysPreserve);
-static inline LLVMMetadataRef LLVMDIBuilderCreateLabelPosix(
-	LLVMDIBuilderRef Builder, LLVMMetadataRef Context, const char *Name, size_t NameLen,
-	LLVMMetadataRef File, unsigned LineNo, LLVMBool AlwaysPreserve) {
-	static LLVMDIBuilderCreateLabelPosixC capi = nullptr;
-	static LLVMDIBuilderCreateLabelPosixCPP cppapi = nullptr;
-	if (capi == nullptr && cppapi == nullptr) {
-		capi = (LLVMDIBuilderCreateLabelPosixC)dlsym(RTLD_NEXT,
-			"LLVMDIBuilderCreateLabel");
-
-		// Mangled name of "llvm::DIBuilder::createLabel(DIScope, StringRef, DIFile, unsigned, bool)"
-		if (capi == nullptr)
-			cppapi = (LLVMDIBuilderCreateLabelPosixCPP)dlsym(RTLD_NEXT,
-				"_ZN4llvm9DIBuilder11createLabelEPNS_7DIScopeENS_9StringRefEPNS_6DIFileEjb");
-	}
-	if (capi != nullptr)
-		return capi(Builder, Context, Name, NameLen, File, LineNo, AlwaysPreserve);
-	if (cppapi != nullptr)
-		return cppapi(Builder, Context, String{(u8 *)Name, (isize)NameLen}, File, LineNo, AlwaysPreserve);
-	return nullptr;
-}
-
-typedef LLVMMetadataRef (*LLVMDIBuilderInsertLabelAtEndPosixCPP)(
-	LLVMDIBuilderRef Builder,
-	LLVMMetadataRef Label,
-	LLVMMetadataRef Location,
-	LLVMBasicBlockRef Block);
-typedef LLVMMetadataRef (*LLVMDIBuilderInsertLabelAtEndPosixC)(
-	LLVMDIBuilderRef Builder,
-	LLVMMetadataRef Label,
-	LLVMMetadataRef Location,
-	LLVMBasicBlockRef Block);
-static inline LLVMMetadataRef LLVMDIBuilderInsertLabelAtEndPosix(
-	LLVMDIBuilderRef Builder, LLVMMetadataRef LabelInfo,
-	LLVMMetadataRef Location, LLVMBasicBlockRef InsertAtEnd) {
-	static LLVMDIBuilderInsertLabelAtEndPosixC capi = nullptr;
-	static LLVMDIBuilderInsertLabelAtEndPosixCPP cppapi = nullptr;
-	if (capi == nullptr && cppapi == nullptr) {
-		capi = (LLVMDIBuilderInsertLabelAtEndPosixC)dlsym(RTLD_NEXT,
-			"LLVMDIBuilderInsertLabelAtEnd");
-
-		// Mangled name of "llvm::DIBuilder::insertLabel(DILabel, DILocation, BasicBlock)"
-		if (capi == nullptr)
-			cppapi = (LLVMDIBuilderInsertLabelAtEndPosixCPP)dlsym(RTLD_NEXT,
-				"_ZN4llvm9DIBuilder11insertLabelEPNS_7DILabelEPKNS_10DILocationEPNS_10BasicBlockE");
-	}
-	if (capi != nullptr)
-		return capi(Builder, LabelInfo, Location, InsertAtEnd);
-	if (cppapi != nullptr)
-		return cppapi(Builder, LabelInfo, Location, InsertAtEnd);
-	return nullptr;
-}
-
-#define LLVMDIBuilderCreateLabel(Builder, Context, Name, NameLen, File, LineNo, AlwaysPreserve) \
-	LLVMDIBuilderCreateLabelPosix(Builder, Context, Name, NameLen, File, LineNo, AlwaysPreserve)
-
-#define LLVMDIBuilderInsertLabelAtEnd(Builder, LabelInfo, Location, InsertAtEnd) \
-	LLVMDIBuilderInsertLabelAtEndPosix(Builder, LabelInfo, Location, InsertAtEnd)
-
-#endif
 gb_internal void lb_add_debug_label(lbProcedure *p, Ast *label, lbBlock *target) {
+// NOTE(tf2spi): LLVM-C DILabel API used only existed for major versions 20+
+#if LLVM_VERSION_MAJOR >= 20
 	if (p == nullptr || p->debug_info == nullptr) {
 		return;
 	}
@@ -1405,7 +1330,6 @@ gb_internal void lb_add_debug_label(lbProcedure *p, Ast *label, lbBlock *target)
 	if (llvm_block == nullptr || llvm_debug_loc == nullptr) {
 		return;
 	}
-
 	LLVMMetadataRef llvm_label = LLVMDIBuilderCreateLabel(
 		m->debug_builder,
 		llvm_scope,
@@ -1425,4 +1349,5 @@ gb_internal void lb_add_debug_label(lbProcedure *p, Ast *label, lbBlock *target)
 		llvm_debug_loc,
 		llvm_block
 	);
+#endif
 }

--- a/src/llvm_backend_stmt.cpp
+++ b/src/llvm_backend_stmt.cpp
@@ -2701,10 +2701,14 @@ gb_internal void lb_build_stmt(lbProcedure *p, Ast *node) {
 
 
 	case_ast_node(bs, BlockStmt, node);
+		lbBlock *body = nullptr;
 		lbBlock *done = nullptr;
 		if (bs->label != nullptr) {
+			body = lb_create_block(p, "block.body");
 			done = lb_create_block(p, "block.done");
-			lb_add_debug_label(p, bs->label, p->curr_block);
+			lb_emit_jump(p, body);
+			lb_start_block(p, body);
+			lb_add_debug_label(p, bs->label, body);
 			lbTargetList *tl = lb_push_target_list(p, bs->label, done, nullptr, nullptr);
 			tl->is_block = true;
 		}

--- a/src/llvm_backend_stmt.cpp
+++ b/src/llvm_backend_stmt.cpp
@@ -715,7 +715,7 @@ gb_internal void lb_build_range_interval(lbProcedure *p, AstBinaryExpr *node,
 			continue_block = check;
 		}
 
-		lb_add_debug_label(p, rs->scope, rs->label);
+		lb_add_debug_label(p, rs->label, p->curr_block);
 		lb_push_target_list(p, rs->label, done, continue_block, nullptr);
 
 		lb_build_stmt(p, rs->body);
@@ -849,7 +849,7 @@ gb_internal void lb_build_range_tuple(lbProcedure *p, AstRangeStmt *rs, Scope *s
 		}
 	}
 
-	lb_add_debug_label(p, rs->scope, rs->label);
+	lb_add_debug_label(p, rs->label, p->curr_block);
 	lb_push_target_list(p, rs->label, done, loop, nullptr);
 
 	lb_build_stmt(p, rs->body);
@@ -972,7 +972,7 @@ gb_internal void lb_build_range_stmt_struct_soa(lbProcedure *p, AstRangeStmt *rs
 	}
 
 
-	lb_add_debug_label(p, rs->scope, rs->label);
+	lb_add_debug_label(p, rs->label, p->curr_block);
 	lb_push_target_list(p, rs->label, done, loop, nullptr);
 
 	lb_build_stmt(p, rs->body);
@@ -1170,7 +1170,7 @@ gb_internal void lb_build_range_stmt(lbProcedure *p, AstRangeStmt *rs, Scope *sc
 		if (val1_type) lb_store_range_stmt_val(p, val1, key);
 	}
 
-	lb_add_debug_label(p, rs->scope, rs->label);
+	lb_add_debug_label(p, rs->label, p->curr_block);
 	lb_push_target_list(p, rs->label, done, loop, nullptr);
 
 	lb_build_stmt(p, rs->body);
@@ -1663,7 +1663,6 @@ gb_internal void lb_build_switch_stmt(lbProcedure *p, AstSwitchStmt *ss, Scope *
 		}
 		lb_start_block(p, body);
 
-		lb_add_debug_label(p, ss->scope, ss->label);
 		lb_push_target_list(p, ss->label, done, nullptr, fall);
 		lb_open_scope(p, body->scope);
 		lb_build_stmt_list(p, cc->stmts);
@@ -1682,7 +1681,7 @@ gb_internal void lb_build_switch_stmt(lbProcedure *p, AstSwitchStmt *ss, Scope *
 		}
 		lb_start_block(p, default_block);
 
-		lb_add_debug_label(p, ss->scope, ss->label);
+		lb_add_debug_label(p, ss->label, p->curr_block);
 		lb_push_target_list(p, ss->label, done, nullptr, default_fall);
 		lb_open_scope(p, default_block->scope);
 		lb_build_stmt_list(p, default_stmts);
@@ -1741,6 +1740,7 @@ gb_internal lbAddr lb_store_range_stmt_val(lbProcedure *p, Ast *stmt_val, lbValu
 gb_internal void lb_type_case_body(lbProcedure *p, Ast *label, Ast *clause, lbBlock *body, lbBlock *done) {
 	ast_node(cc, CaseClause, clause);
 
+	// NOTE(tf2spi): Debug info for label not generated here on purpose
 	lb_push_target_list(p, label, done, nullptr, nullptr);
 	lb_build_stmt_list(p, cc->stmts);
 	lb_close_scope(p, lbDeferExit_Default, body, clause);
@@ -2312,7 +2312,7 @@ gb_internal void lb_build_if_stmt(lbProcedure *p, Ast *node) {
 		else_ = lb_create_block(p, "if.else");
 	}
 	if (is->label != nullptr) {
-		lb_add_debug_label(p, is->scope, is->label);
+		lb_add_debug_label(p, is->label, p->curr_block);
 		lbTargetList *tl = lb_push_target_list(p, is->label, done, nullptr, nullptr);
 		tl->is_block = true;
 	}
@@ -2403,7 +2403,7 @@ gb_internal void lb_build_for_stmt(lbProcedure *p, Ast *node) {
 		post = lb_create_block(p, "for.post");
 	}
 
-	lb_add_debug_label(p, fs->scope, fs->label);
+	lb_add_debug_label(p, fs->label, p->curr_block);
 	lb_push_target_list(p, fs->label, done, post, nullptr);
 
 	if (fs->init != nullptr) {
@@ -2704,7 +2704,7 @@ gb_internal void lb_build_stmt(lbProcedure *p, Ast *node) {
 		lbBlock *done = nullptr;
 		if (bs->label != nullptr) {
 			done = lb_create_block(p, "block.done");
-			lb_add_debug_label(p, bs->scope, bs->label);
+			lb_add_debug_label(p, bs->label, p->curr_block);
 			lbTargetList *tl = lb_push_target_list(p, bs->label, done, nullptr, nullptr);
 			tl->is_block = true;
 		}

--- a/src/llvm_backend_stmt.cpp
+++ b/src/llvm_backend_stmt.cpp
@@ -2403,16 +2403,17 @@ gb_internal void lb_build_for_stmt(lbProcedure *p, Ast *node) {
 		post = lb_create_block(p, "for.post");
 	}
 
-	lb_add_debug_label(p, fs->label, p->curr_block);
 	lb_push_target_list(p, fs->label, done, post, nullptr);
 
+	lbBlock *init = lb_create_block(p, "for.init");
+	lb_emit_jump(p, init);
+	lb_start_block(p, init);
 	if (fs->init != nullptr) {
-	#if 1
-		lbBlock *init = lb_create_block(p, "for.init");
-		lb_emit_jump(p, init);
-		lb_start_block(p, init);
-	#endif
 		lb_build_stmt(p, fs->init);
+	}
+	if (fs->label != nullptr && p->debug_info != nullptr) {
+		LLVMSetCurrentDebugLocation2(p->builder, lb_debug_location_from_ast(p, fs->label));
+		lb_add_debug_label(p, fs->label, init);
 	}
 
 	lb_emit_jump(p, loop);
@@ -2426,7 +2427,6 @@ gb_internal void lb_build_for_stmt(lbProcedure *p, Ast *node) {
 		lb_build_cond(p, fs->cond, body, done);
 		lb_start_block(p, body);
 	}
-
 
 	lb_build_stmt(p, fs->body);
 

--- a/src/llvm_backend_stmt.cpp
+++ b/src/llvm_backend_stmt.cpp
@@ -136,7 +136,6 @@ gb_internal lbBranchBlocks lb_lookup_branch_blocks(lbProcedure *p, Ast *ident) {
 	return empty;
 }
 
-
 gb_internal lbTargetList *lb_push_target_list(lbProcedure *p, Ast *label, lbBlock *break_, lbBlock *continue_, lbBlock *fallthrough_) {
 	lbTargetList *tl = gb_alloc_item(permanent_allocator(), lbTargetList);
 	tl->prev = p->target_list;
@@ -716,6 +715,7 @@ gb_internal void lb_build_range_interval(lbProcedure *p, AstBinaryExpr *node,
 			continue_block = check;
 		}
 
+		lb_add_debug_label(p, rs->scope, rs->label);
 		lb_push_target_list(p, rs->label, done, continue_block, nullptr);
 
 		lb_build_stmt(p, rs->body);
@@ -849,6 +849,7 @@ gb_internal void lb_build_range_tuple(lbProcedure *p, AstRangeStmt *rs, Scope *s
 		}
 	}
 
+	lb_add_debug_label(p, rs->scope, rs->label);
 	lb_push_target_list(p, rs->label, done, loop, nullptr);
 
 	lb_build_stmt(p, rs->body);
@@ -971,6 +972,7 @@ gb_internal void lb_build_range_stmt_struct_soa(lbProcedure *p, AstRangeStmt *rs
 	}
 
 
+	lb_add_debug_label(p, rs->scope, rs->label);
 	lb_push_target_list(p, rs->label, done, loop, nullptr);
 
 	lb_build_stmt(p, rs->body);
@@ -1168,6 +1170,7 @@ gb_internal void lb_build_range_stmt(lbProcedure *p, AstRangeStmt *rs, Scope *sc
 		if (val1_type) lb_store_range_stmt_val(p, val1, key);
 	}
 
+	lb_add_debug_label(p, rs->scope, rs->label);
 	lb_push_target_list(p, rs->label, done, loop, nullptr);
 
 	lb_build_stmt(p, rs->body);
@@ -1660,6 +1663,7 @@ gb_internal void lb_build_switch_stmt(lbProcedure *p, AstSwitchStmt *ss, Scope *
 		}
 		lb_start_block(p, body);
 
+		lb_add_debug_label(p, ss->scope, ss->label);
 		lb_push_target_list(p, ss->label, done, nullptr, fall);
 		lb_open_scope(p, body->scope);
 		lb_build_stmt_list(p, cc->stmts);
@@ -1678,6 +1682,7 @@ gb_internal void lb_build_switch_stmt(lbProcedure *p, AstSwitchStmt *ss, Scope *
 		}
 		lb_start_block(p, default_block);
 
+		lb_add_debug_label(p, ss->scope, ss->label);
 		lb_push_target_list(p, ss->label, done, nullptr, default_fall);
 		lb_open_scope(p, default_block->scope);
 		lb_build_stmt_list(p, default_stmts);
@@ -2307,6 +2312,7 @@ gb_internal void lb_build_if_stmt(lbProcedure *p, Ast *node) {
 		else_ = lb_create_block(p, "if.else");
 	}
 	if (is->label != nullptr) {
+		lb_add_debug_label(p, is->scope, is->label);
 		lbTargetList *tl = lb_push_target_list(p, is->label, done, nullptr, nullptr);
 		tl->is_block = true;
 	}
@@ -2397,6 +2403,7 @@ gb_internal void lb_build_for_stmt(lbProcedure *p, Ast *node) {
 		post = lb_create_block(p, "for.post");
 	}
 
+	lb_add_debug_label(p, fs->scope, fs->label);
 	lb_push_target_list(p, fs->label, done, post, nullptr);
 
 	if (fs->init != nullptr) {
@@ -2697,6 +2704,7 @@ gb_internal void lb_build_stmt(lbProcedure *p, Ast *node) {
 		lbBlock *done = nullptr;
 		if (bs->label != nullptr) {
 			done = lb_create_block(p, "block.done");
+			lb_add_debug_label(p, bs->scope, bs->label);
 			lbTargetList *tl = lb_push_target_list(p, bs->label, done, nullptr, nullptr);
 			tl->is_block = true;
 		}


### PR DESCRIPTION
This is a PR that adds debug info for labels in the ``Odin`` compiler, so now labels attached to statements in general like ``if``, ``block``, ``for``, etc., have debug info.

```
package labels
import "core:fmt"
main :: proc() {
        myloop: for i in 0..<5 {
                fmt.println("We have debug labels now!")
        }

        myswitch: switch true {
                case:
                        fmt.println("Debug labels on switches but not in cases")
        }
        myif: if true {
                fmt.println("Debug labels on if statements")
        }
        // etc...
}
```

This is useful because debuggers can discern the location of code given a function and label and do actions to it like putting breakpoints on it. It's less finnicky than line breakpoints when it comes to source code changes.
```
# This works on gdb and puts a breakpoint on the 'myif' label in the code above
b labels.main:myif
```