### PR TITLE
Suggestion when assigning enum to bit_set

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -8475,6 +8475,15 @@ gb_internal ExprKind check_implicit_selector_expr(CheckerContext *c, Operand *o,
 			error(node, "Undeclared name '%.*s' for type '%s'", LIT(name), typ);
 
 			check_did_you_mean_type(name, bt->Enum.fields);
+		} else if (is_type_bit_set(th) && is_type_enum(th->BitSet.elem)) {
+			ERROR_BLOCK();
+
+			gbString typ = type_to_string(th);
+			gbString str = expr_to_string(node);
+			error(node, "Cannot convert enum value to '%s'", typ);
+			error_line("\tSuggestion: Did you mean '{ %s }'?\n", str);
+			gb_string_free(typ);
+			gb_string_free(str);
 		} else {
 			gbString typ = type_to_string(th);
 			gbString str = expr_to_string(node);


### PR DESCRIPTION
This is something I ran into when writing some odin again recently, after not having used the language for >1 year.

Incorrect code:

```
MyEnum :: enum { A, B, C }
bits: bit_set[MyEnum]
bits += .A
```

Old error:
```
C:/dev/tools/Odin/examples/bad_errors.odin(39:14) Error: Invalid type 'bit_set[MyEnum]' for implicit selector expression '.A'
        bits += .A
                 ^
```

New error:
```
C:/dev/tools/Odin/examples/bad_errors.odin(39:14) Error: Cannot convert enum value to 'bit_set[MyEnum]'
        bits += .A
                 ^
        Suggestion: Did you mean '{ .A }'?
```