### PR TITLE
Fix #4390 by assigning invalid entity type

### DIFF
--- a/src/check_decl.cpp
+++ b/src/check_decl.cpp
@@ -88,11 +88,12 @@ gb_internal Type *check_init_variable(CheckerContext *ctx, Entity *e, Operand *o
 			e->type = t_invalid;
 			return nullptr;
 		} else if (is_type_polymorphic(t)) {
-			Entity *e = entity_of_node(operand->expr);
-			if (e == nullptr) {
+			Entity *e2 = entity_of_node(operand->expr);
+			if (e2 == nullptr) {
+				e->type = t_invalid;
 				return nullptr;
 			}
-			if (e->state.load() != EntityState_Resolved) {
+			if (e2->state.load() != EntityState_Resolved) {
 				gbString str = type_to_string(t);
 				defer (gb_string_free(str));
 				error(e->token, "Invalid use of a polymorphic type '%s' in %.*s", str, LIT(context_name));


### PR DESCRIPTION
Fixes #4390 

## Test Program

```
package oh_no;

main :: proc() {
    numbers := make_numbers();
}

make_numbers :: proc() -> []u8 {
    list := make([dynamic]u8, cap = 2, allocator = context.allocator)
    return list[:];
}
```

## How This Fixes It

When trying to infer the type of an entity (``e->type == nullptr``), not all cases assigned a type to the entity and so it kept its ``nullptr`` type even though it was an initialized local variable. This assigns an invalid type to the entity when the operand expression lacks a type like it did in this case because the function call was invalid.