### PR TITLE
Fixes #4395 by not assuming simd returns val

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -2060,8 +2060,8 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 		bool ok = check_builtin_simd_operation(c, operand, call, id, type_hint);
 		if (!ok) {
 			operand->type = t_invalid;
+			operand->mode = Addressing_Value;
 		}
-		operand->mode = Addressing_Value;
 		operand->value = {};
 		operand->expr = call;
 		return ok;


### PR DESCRIPTION
Fixes #4395 

## Test Program

```
package bug

import "core:fmt"
import "core:simd"

main :: proc() {
	v := [2] f64 {1, 2};
	mask := #simd [4]bool { true, false, true, false }
	vals := #simd [4]f64 { 0x7f, 0x7f, 0x7f, 0x7f }
	res := simd.masked_compress_store(&v, vals, mask)
	fmt.println(res)
}
```

## How This Fixes It

``simd.masked_compress_store`` is a ``simd`` builtin that does not return a value, but the code assumed that it does always return a value. This fixes it by letting ``check_builtin_simd_operation`` set the type and value in all cases that it was successful and a ``t_invalid`` value otherwise.