### PR TITLE
path/filepath: fix leak when glob is recursed

### DIFF
--- a/core/path/filepath/match.odin
+++ b/core/path/filepath/match.odin
@@ -243,6 +243,7 @@ glob :: proc(pattern: string, allocator := context.allocator) -> (matches: []str
 
 	m: []string
 	m, err = glob(dir)
+	defer for s in m { delete(s) }; if m != nil { delete(m) }
 	if err != .None {
 		return
 	}


### PR DESCRIPTION
path/filepath: fix leak when glob is recursed such as when pattern is "/folder/*/*/*.txt"

I was seeing leaks when running tests, of glob, this fixed it
not sure if the typical way to do this or not