### PR TITLE
Misc fixes

### DIFF
--- a/src/gb/gb.h
+++ b/src/gb/gb.h
@@ -2541,7 +2541,11 @@ gb_inline void const *gb_pointer_add_const(void const *ptr, isize bytes)       {
 gb_inline void const *gb_pointer_sub_const(void const *ptr, isize bytes)       { return cast(void const *)(cast(u8 const *)ptr - bytes); }
 gb_inline isize       gb_pointer_diff     (void const *begin, void const *end) { return cast(isize)(cast(u8 const *)end - cast(u8 const *)begin); }
 
-gb_inline void gb_zero_size(void *ptr, isize size) { memset(ptr, 0, size); }
+gb_inline void gb_zero_size(void *ptr, isize size) {
+	if (size != 0) {
+		memset(ptr, 0, size);
+	}
+}
 
 
 #if defined(_MSC_VER) && !defined(__clang__)

--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -1647,7 +1647,7 @@ gb_internal lbValue lb_emit_conv(lbProcedure *p, lbValue value, Type *t) {
 			lb_emit_store(p, a1, id);
 			return lb_addr_load(p, res);
 		} else if (dst->kind == Type_Basic) {
-			if (src->Basic.kind == Basic_string && dst->Basic.kind == Basic_cstring) {
+			if (src->kind == Type_Basic && src->Basic.kind == Basic_string && dst->Basic.kind == Basic_cstring) {
 				String str = lb_get_const_string(m, value);
 				lbValue res = {};
 				res.type = t;

--- a/src/llvm_backend_stmt.cpp
+++ b/src/llvm_backend_stmt.cpp
@@ -2018,14 +2018,7 @@ gb_internal void lb_build_return_stmt_internal(lbProcedure *p, lbValue res) {
 gb_internal void lb_build_return_stmt(lbProcedure *p, Slice<Ast *> const &return_results) {
 	lb_ensure_abi_function_type(p->module, p);
 
-	lbValue res = {};
-
-	TypeTuple *tuple  = &p->type->Proc.results->Tuple;
 	isize return_count = p->type->Proc.result_count;
-	isize res_count = return_results.count;
-
-	lbFunctionType *ft = lb_get_function_type(p->module, p->type);
-	bool return_by_pointer = ft->ret.kind == lbArg_Indirect;
 
 	if (return_count == 0) {
 		// No return values
@@ -2038,7 +2031,17 @@ gb_internal void lb_build_return_stmt(lbProcedure *p, Slice<Ast *> const &return
 			LLVMBuildRetVoid(p->builder);
 		}
 		return;
-	} else if (return_count == 1) {
+	}
+
+	lbValue res = {};
+
+	TypeTuple *tuple = &p->type->Proc.results->Tuple;
+	isize res_count = return_results.count;
+
+	lbFunctionType *ft = lb_get_function_type(p->module, p->type);
+	bool return_by_pointer = ft->ret.kind == lbArg_Indirect;
+
+	if (return_count == 1) {
 		Entity *e = tuple->variables[0];
 		if (res_count == 0) {
 			rw_mutex_shared_lock(&p->module->values_mutex);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -4262,8 +4262,6 @@ gb_internal bool allow_field_separator(AstFile *f) {
 gb_internal Ast *parse_struct_field_list(AstFile *f, isize *name_count_) {
 	Token start_token = f->curr_token;
 
-	auto decls = array_make<Ast *>(ast_allocator(f));
-
 	isize total_name_count = 0;
 
 	Ast *params = parse_field_list(f, &total_name_count, FieldFlag_Struct, Token_CloseBrace, false, false);

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -156,6 +156,7 @@ gb_internal isize string_index_byte(String const &s, u8 x) {
 
 gb_internal gb_inline bool str_eq(String const &a, String const &b) {
 	if (a.len != b.len) return false;
+	if (a.len == 0) return true;
 	return memcmp(a.text, b.text, a.len) == 0;
 }
 gb_internal gb_inline bool str_ne(String const &a, String const &b) { return !str_eq(a, b);                }

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -109,7 +109,7 @@ gb_internal isize utf8_decode(u8 const *str, isize str_len, Rune *codepoint_out)
 		u8 b1, b2, b3;
 		Utf8AcceptRange accept;
 		if (x >= 0xf0) {
-			Rune mask = (cast(Rune)x << 31) >> 31;
+			Rune mask = -cast(Rune)(x & 1);
 			codepoint = (cast(Rune)s0 & (~mask)) | (GB_RUNE_INVALID & mask);
 			width = 1;
 			goto end;

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -1,10 +1,15 @@
-#pragma warning(push)
-#pragma warning(disable: 4245)
+#if defined(GB_SYSTEM_WINDOWS)
+	#pragma warning(push)
+	#pragma warning(disable: 4245)
+#endif
 
 extern "C" {
 #include "utf8proc/utf8proc.c"
 }
-#pragma warning(pop)
+
+#if defined(GB_SYSTEM_WINDOWS)
+	#pragma warning(pop)
+#endif
 
 
 gb_internal bool rune_is_letter(Rune r) {


### PR DESCRIPTION
Misc fixes found from trying out Odin on Linux.

See commits for details on each change:

* 771d308d6 Fix invalid union access
* e67692b06 Avoid member access through nullptr in debug
* 4f800a7fd Avoid undefined arithmetic shifting
* c1496ab6c Fix passing nullptr to args marked as non-null
* bb308b3ff Add missing guards around push/pop pragmas
* b59647084 Plug a memory leak

The last commit was found by enabling warnings via `-Wall` (*) however that's uncovered a lot of unused variables so they'll come in in a following PR.

All tests I could find continue to pass locally.

(*) Note that `-Wall` doesn't mean every warning - that's `-Weverything` - and I had to disable a few more harmless ones too.