### PR TITLE
fix cbor.to_json always returning array of tuples for objects

### DIFF
--- a/core/encoding/cbor/cbor.odin
+++ b/core/encoding/cbor/cbor.odin
@@ -563,7 +563,7 @@ to_json :: proc(val: Value, allocator := context.allocator) -> (json.Value, mem.
 					case: return false
 					}
 				}
-				return false
+				return true
 			}
 
 			if keys_all_strings(v) {


### PR DESCRIPTION
to_json uses a small proc to check if all keys of an object are strings. It was always returning false for any input.