### PR TITLE
math/linalg add matrix_mul_vector_differ & update matrix_mul_vector

### DIFF
--- a/core/math/linalg/general.odin
+++ b/core/math/linalg/general.odin
@@ -212,7 +212,13 @@ matrix_mul_differ :: proc "contextless" (a: $A/matrix[$I, $J]$E, b: $B/matrix[J,
 
 
 @(require_results)
-matrix_mul_vector :: proc "contextless" (a: $A/matrix[$I, $J]$E, b: $B/[J]E) -> (c: B)
+matrix_mul_vector :: proc "contextless" (a: $A/matrix[$I, I]$E, b: $B/[I]E) -> (c: B)
+	where !IS_ARRAY(E), IS_NUMERIC(E) #no_bounds_check {
+	return a * b
+}
+
+@(require_results)
+matrix_mul_vector_differ :: proc "contextless" (a: $A/matrix[$I, $J]$E, b: $B/[J]E) -> (c: matrix[I, 1]E)
 	where !IS_ARRAY(E), IS_NUMERIC(E) #no_bounds_check {
 	return a * b
 }
@@ -252,6 +258,7 @@ mul :: proc{
 	matrix_mul,
 	matrix_mul_differ,
 	matrix_mul_vector,
+	matrix_mul_vector_differ,
 	quaternion64_mul_vector3,
 	quaternion128_mul_vector3,
 	quaternion256_mul_vector3,


### PR DESCRIPTION
Currently passing a `maritx[I, J]T` & `[J]T` to matrix_mul_vector (as the inputs want) results in a type error.
`Error: Cannot assign value 'a * b' of type 'matrix[2, 1]int' to '[3]int' in return statement`

Add matrix_mul_vector_differ that returns the expect resulting matrix `maritx[I, 1]T` 
Update matrix_mul_vector to take only take a `maritx[I, I]T`
This change shouldn't effect any current use of matrix_mul_vector

Suggested fix for https://github.com/odin-lang/Odin/issues/4433