### PR TITLE
Fix for using `utf8string.at` with last rune index returning wrong rune

### DIFF
--- a/core/unicode/utf8/utf8string/string.odin
+++ b/core/unicode/utf8/utf8string/string.odin
@@ -66,7 +66,7 @@ at :: proc(s: ^String, i: int, loc := #caller_location) -> (r: rune) {
 		return
 
 	case s.rune_count-1:
-		r, s.width = utf8.decode_rune_in_string(s.contents)
+		r, s.width = utf8.decode_last_rune(s.contents)
 		s.rune_pos = i
 		s.byte_pos = _len(s.contents) - s.width
 		return


### PR DESCRIPTION
Before this fix `utf8string.at` returns first rune when you give it last rune index.

The test code below used to write this:
```
s
t
r
 
:
=
 
"
小
猫
咪
s
```

now it writes this:
```
s
t
r
 
:
=
 
"
小
猫
咪
"
```

Note how it now writes `"` instead of `s` on the final line.

```
package utf8_at_bug

import "core:fmt"
import "core:unicode/utf8/utf8string"

main :: proc() {
	us: utf8string.String
	utf8string.init(&us, "str := \"小猫咪\"")
	idx: int
	for idx < utf8string.len(&us) {
		r := utf8string.at(&us, idx)

		fmt.println(r)

		idx += 1
	}
}
```