### PR TITLE
fix windows args parser problem from issue #4393

### DIFF
--- a/src/string.cpp
+++ b/src/string.cpp
@@ -411,6 +411,25 @@ gb_internal String concatenate4_strings(gbAllocator a, String const &x, String c
 	return make_string(data, len);
 }
 
+#if defined(GB_SYSTEM_WINDOWS)
+gb_internal String escape_char(gbAllocator a, String s, char cte) {
+	isize buf_len = s.len;
+	u8 *buf = gb_alloc_array(a, u8, buf_len);
+	isize i = 0;
+	for (isize j = 0; j < s.len; j++) {
+		u8 c = s.text[j];
+
+		if (c == cte) {
+			buf[i++] = '\\';
+			buf[i++] = c;
+		} else {
+			buf[i++] = c;
+		}
+	}
+	return make_string(buf, i);
+}
+#endif
+
 gb_internal String string_join_and_quote(gbAllocator a, Array<String> strings) {
 	if (!strings.count) {
 		return make_string(nullptr, 0);
@@ -426,7 +445,11 @@ gb_internal String string_join_and_quote(gbAllocator a, Array<String> strings) {
 		if (i > 0) {
 			s = gb_string_append_fmt(s, " ");
 		}
+#if defined(GB_SYSTEM_WINDOWS)
+		s = gb_string_append_fmt(s, "\"%.*s\" ", LIT(escape_char(a, strings[i], '\\')));
+#else
 		s = gb_string_append_fmt(s, "\"%.*s\" ", LIT(strings[i]));
+#endif
 	}
 
 	return make_string(cast(u8 *) s, gb_string_length(s));

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -415,9 +415,11 @@ gb_internal String concatenate4_strings(gbAllocator a, String const &x, String c
 gb_internal String escape_char(gbAllocator a, String s, char cte) {
 	isize buf_len = s.len;
 	isize cte_count = 0;
-	for (isize j = 0; j < s.len; j++)
-		if (s.text[j] == cte)
+	for (isize j = 0; j < s.len; j++) {
+		if (s.text[j] == cte) {
 			cte_count++;
+		}
+	}
 
 	u8 *buf = gb_alloc_array(a, u8, buf_len+cte_count);
 	isize i = 0;

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -414,7 +414,12 @@ gb_internal String concatenate4_strings(gbAllocator a, String const &x, String c
 #if defined(GB_SYSTEM_WINDOWS)
 gb_internal String escape_char(gbAllocator a, String s, char cte) {
 	isize buf_len = s.len;
-	u8 *buf = gb_alloc_array(a, u8, buf_len);
+	isize cte_count = 0;
+	for (isize j = 0; j < s.len; j++)
+		if (s.text[j] == cte)
+			cte_count++;
+
+	u8 *buf = gb_alloc_array(a, u8, buf_len+cte_count);
 	isize i = 0;
 	for (isize j = 0; j < s.len; j++) {
 		u8 c = s.text[j];


### PR DESCRIPTION
I stumbled upon the same issue as #4393 
this patch should fix windows based parsing by escaping \ with \\

I tried to copy the existing style etc.