### PR TITLE
Fix raymath not applying matrix translations

### DIFF
--- a/vendor/raylib/raymath.odin
+++ b/vendor/raylib/raymath.odin
@@ -153,7 +153,7 @@ Vector2Normalize :: proc "c" (v: Vector2) -> Vector2 {
 // Transforms a Vector2 by a given Matrix
 @(require_results)
 Vector2Transform :: proc "c" (v: Vector2, m: Matrix) -> Vector2 {
-	v4 := Vector4{v.x, v.y, 0, 0}
+	v4 := Vector4{v.x, v.y, 0, 1}
 	return (m * v4).xy
 }
 // Calculate linear interpolation between two vectors
@@ -399,7 +399,7 @@ Vector3RotateByAxisAngle :: proc "c" (v: Vector3, axis: Vector3, angle: f32) -> 
 // Transforms a Vector3 by a given Matrix
 @(require_results)
 Vector3Transform :: proc "c" (v: Vector3, m: Matrix) -> Vector3 {
-	v4 := Vector4{v.x, v.y, v.z, 0}
+	v4 := Vector4{v.x, v.y, v.z, 1}
 	return (m * v4).xyz
 }
 // Calculate linear interpolation between two vectors


### PR DESCRIPTION
Transform matrices use the w vector of the matrix to apply translation, and thus translation only works when the w component of the vector being multiplied is 1. In the original raymath implementation of `Vector2Transform` and `Vector3Transform`, the multiplication is done manually and directly adds the translation components to the result (as if w = 1):
```c
// z = 0 in Vector2Transform
result.x = mat.m0*x + mat.m4*y + mat.m8*z + mat.m12;
result.y = mat.m1*x + mat.m5*y + mat.m9*z + mat.m13;
result.z = mat.m2*x + mat.m6*y + mat.m10*z + mat.m14; // only in Vector3Transform
```
In the Odin binding, these functions are instead implemented via built-in matrix multiplication. However, the given vector is expanded to have a `w` component of 0, resulting in translation not being applied.