### PR TITLE
Add "-build-mode:dynamic" to the "odin help build" output

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2199,6 +2199,7 @@ gb_internal void print_show_help(String const arg0, String const &command) {
 		print_usage_line(3, "-build-mode:test        Builds as an executable that executes tests.");
 		print_usage_line(3, "-build-mode:dll         Builds as a dynamically linked library.");
 		print_usage_line(3, "-build-mode:shared      Builds as a dynamically linked library.");
+		print_usage_line(3, "-build-mode:dynamic     Builds as a dynamically linked library.");
 		print_usage_line(3, "-build-mode:lib         Builds as a statically linked library.");
 		print_usage_line(3, "-build-mode:static      Builds as a statically linked library.");
 		print_usage_line(3, "-build-mode:obj         Builds as an object file.");


### PR DESCRIPTION
To create a dynamic library, Odin accepts `dll`, `shared` and `dynamic` as build modes. They do the same thing are already [in the code](https://github.com/odin-lang/Odin/blob/d4d546a63a3d12ef8e308989562100b95219ac9b/src/main.cpp#L1142)
```odin
...
case BuildFlag_BuildMode: {
    GB_ASSERT(value.kind == ExactValue_String);
    String str = value.value_string;

    if (build_context.command != "build") {
        gb_printf_err("'build-mode' can only be used with the 'build' command\n");
        bad_flags = true;
        break;
    }

    if (str == "dll" || str == "shared" || str == "dynamic") {
        build_context.build_mode = BuildMode_DynamicLibrary;
    } else if (str == "obj" || str == "object") {
        build_context.build_mode = BuildMode_Object;
    } else if (str == "static" || str == "lib") {
        build_context.build_mode = BuildMode_StaticLibrary;
    } else if (str == "exe") {
        build_context.build_mode = BuildMode_Executable;
    } else if (str == "asm" || str == "assembly" || str == "assembler") {
        build_context.build_mode = BuildMode_Assembly;
    } else if (str == "llvm" || str == "llvm-ir") {
        build_context.build_mode = BuildMode_LLVM_IR;
    } else if (str == "test") {
        build_context.build_mode   = BuildMode_Executable;
        build_context.command_kind = Command_test;
    } else {
...
```

But the `help build` subcommand doesn't tell the user about `dynamic` 
```
-build-mode:<mode>
		Sets the build mode.
		Available options:
			-build-mode:exe         Builds as an executable.
			-build-mode:test        Builds as an executable that executes tests.
			-build-mode:dll         Builds as a dynamically linked library.
			-build-mode:shared      Builds as a dynamically linked library.
			-build-mode:lib         Builds as a statically linked library.
			-build-mode:static      Builds as a statically linked library.
			-build-mode:obj         Builds as an object file.
			-build-mode:object      Builds as an object file.
			-build-mode:assembly    Builds as an assembly file.
			-build-mode:assembler   Builds as an assembly file.
			-build-mode:asm         Builds as an assembly file.
			-build-mode:llvm-ir     Builds as an LLVM IR file.
			-build-mode:llvm        Builds as an LLVM IR file.
```
This PR fixes it.