### PR TITLE
Mark procs as "contextless" in winerror.odin

### DIFF
--- a/core/sys/windows/winerror.odin
+++ b/core/sys/windows/winerror.odin
@@ -251,26 +251,26 @@ SEVERITY :: enum DWORD {
 // Generic test for success on any status value (non-negative numbers indicate success).
 SUCCEEDED :: #force_inline proc "contextless" (#any_int result: int) -> bool { return result >= S_OK }
 // and the inverse
-FAILED :: #force_inline proc(#any_int result: int) -> bool { return result < S_OK }
+FAILED :: #force_inline proc "contextless" (#any_int result: int) -> bool { return result < S_OK }
 
 // Generic test for error on any status value.
-IS_ERROR :: #force_inline proc(#any_int status: int) -> bool { return u32(status) >> 31 == u32(SEVERITY.ERROR) }
+IS_ERROR :: #force_inline proc "contextless" (#any_int status: int) -> bool { return u32(status) >> 31 == u32(SEVERITY.ERROR) }
 
 // Return the code
-HRESULT_CODE :: #force_inline proc(#any_int hr: int) -> int { return int(u32(hr) & 0xFFFF) }
+HRESULT_CODE :: #force_inline proc "contextless" (#any_int hr: int) -> int { return int(u32(hr) & 0xFFFF) }
 
 //  Return the facility
-HRESULT_FACILITY :: #force_inline proc(#any_int hr: int) -> FACILITY { return FACILITY((u32(hr) >> 16) & 0x1FFF) }
+HRESULT_FACILITY :: #force_inline proc "contextless" (#any_int hr: int) -> FACILITY { return FACILITY((u32(hr) >> 16) & 0x1FFF) }
 
 //  Return the severity
-HRESULT_SEVERITY :: #force_inline proc(#any_int hr: int) -> SEVERITY { return SEVERITY((u32(hr) >> 31) & 0x1) }
+HRESULT_SEVERITY :: #force_inline proc "contextless" (#any_int hr: int) -> SEVERITY { return SEVERITY((u32(hr) >> 31) & 0x1) }
 
 // Create an HRESULT value from component pieces
-MAKE_HRESULT :: #force_inline proc(#any_int sev: int, #any_int fac: int, #any_int code: int) -> HRESULT {
+MAKE_HRESULT :: #force_inline proc "contextless" (#any_int sev: int, #any_int fac: int, #any_int code: int) -> HRESULT {
 	return HRESULT((uint(sev)<<31) | (uint(fac)<<16) | (uint(code)))
 }
 
-DECODE_HRESULT :: #force_inline proc(#any_int hr: int) -> (SEVERITY, FACILITY, int) {
+DECODE_HRESULT :: #force_inline proc "contextless" (#any_int hr: int) -> (SEVERITY, FACILITY, int) {
 	return HRESULT_SEVERITY(hr), HRESULT_FACILITY(hr), HRESULT_CODE(hr)
 }
 


### PR DESCRIPTION
So that they can be called from places like the windproc and stuff.