### PR TITLE
Fix: `build_odin.sh` always runs demo regardless of argument

### DIFF
--- a/build_odin.sh
+++ b/build_odin.sh
@@ -152,9 +152,7 @@ build_odin() {
 }
 
 run_demo() {
-	if [ $# -eq 0 ] || [ "$1" = "debug" ]; then
-		./odin run examples/demo -vet -strict-style -- Hellope World
-	fi
+	./odin run examples/demo -vet -strict-style -- Hellope World
 }
 
 if [ $# -eq 0 ]; then
@@ -166,14 +164,20 @@ if [ $# -eq 0 ]; then
 elif [ $# -eq 1 ]; then
 	case $1 in
 	report)
-		[ ! -f "./odin" ] && build_odin debug
+		if [ ! -f "./odin" ]; then
+			build_odin debug
+			run_demo
+		fi
 		./odin report
+		;;
+	debug)
+		build_odin debug
+		run_demo
 		;;
 	*)
 		build_odin $1
 		;;
 	esac
-	run_demo
 else
 	error "Too many arguments!"
 fi


### PR DESCRIPTION
In the original code, `run_demo()` checks the argument if it's empty or `debug`:
```sh
# original `build_odin.sh` L:154
run_demo() {
	if [ $# -eq 0 ] || [ "$1" = "debug" ]; then
		./odin run examples/demo -vet -strict-style -- Hellope World
	fi
}
```
However, this `if` block always runs since `run_demo()` is always called without argument at L:162 and L:176, which isn't the intended behavior.
Instead, it should run demo only if the argument pass to `build_odin.sh` or `make` was `debug` or empty.

To fix this issue, I simply removed the `if` block from `run_demo()`, and made it gets called only if the argument that passed to `build_odin.sh` was empty or `debug`.