### PR TITLE
Fix: Added newline after 'root' command output

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3181,7 +3181,7 @@ int main(int arg_count, char const **arg_ptr) {
 			return 0;
 		}
 	} else if (command == "root") {
-		gb_printf("%.*s", LIT(odin_root_dir()));
+		gb_printf("%.*s\n", LIT(odin_root_dir()));
 		return 0;
 	} else if (command == "clear-cache") {
 		return try_clear_cache() ? 0 : 1;


### PR DESCRIPTION
When executing the `odin root` command, it displayed the root directory's location but without a newline at the end. As a result, the terminal prompt was stuck right next to the output, which caused a cluttered appearance. This change adds a newline after the root directory output to properly separate it from the terminal prompt, improving ux.

Before:
![before](https://github.com/user-attachments/assets/60a54d10-1ad6-492a-813d-98c3352e7f82)
After:
![after](https://github.com/user-attachments/assets/5fb4316d-d736-4be8-8223-d49b7df07470)