### PR TITLE
Added Unlinking Section to Posix Socket Binding Documentation

### DIFF
--- a/core/sys/posix/sys_socket.odin
+++ b/core/sys/posix/sys_socket.odin
@@ -48,6 +48,12 @@ foreign libc {
 		addr.sun_family = .UNIX
 		copy(addr.sun_path[:], "/somepath\x00")
 
+		/*
+			unlink the socket before binding in case
+			of previous runs not cleaning up the socket
+		*/
+		posix.unlink("/somepath")
+
 		if posix.bind(sfd, (^posix.sockaddr)(&addr), size_of(addr)) != .OK {
 			/* Handle error */
 		}


### PR DESCRIPTION
Adds documentation surrounding needing a socket to be unlinked before use. In the current state, the documentation provides no indication of `bind` requiring any requisite system state and as-is, would cause the example snippet to fail on the second run with the code `ENOTSUP`.