### PR TITLE
core:log improvements

### DIFF
--- a/core/log/multi_logger.odin
+++ b/core/log/multi_logger.odin
@@ -1,22 +1,38 @@
 package log
 
+import "base:runtime"
+import "core:slice"
+import "core:mem"
 
 Multi_Logger_Data :: struct {
 	loggers: []Logger,
+	allocator: runtime.Allocator
 }
 
 create_multi_logger :: proc(logs: ..Logger) -> Logger {
-	data := new(Multi_Logger_Data)
-	data.loggers = make([]Logger, len(logs))
-	copy(data.loggers, logs)
-	return Logger{multi_logger_proc, data, Level.Debug, nil}
+	logger, _ := make_multi_logger(..logs, allocator = context.allocator)
+	return logger
 }
 
-destroy_multi_logger :: proc(log: Logger) {
-	data := (^Multi_Logger_Data)(log.data)
-	delete(data.loggers)
-	free(data)
+make_multi_logger :: proc(logs: ..Logger, allocator := context.allocator) -> (res: Logger, err: runtime.Allocator_Error) {
+	logger_size := mem.align_forward_int(size_of(Multi_Logger_Data), align_of(Logger))
+	content_size := len(mem.slice_to_bytes(logs))
+
+	data_bytes := make([]byte, logger_size + content_size, allocator) or_return
+	data := cast(^Multi_Logger_Data)raw_data(data_bytes)
+	data.loggers = slice.reinterpret([]Logger, data_bytes[logger_size:])
+	assert(len(data.loggers) == len(logs))
+	copy(data.loggers, logs)
+	data.allocator = allocator
+
+	return Logger{multi_logger_proc, data, Level.Debug, nil}, nil
 }
+
+delete_multi_logger :: proc(log: Logger) {
+	data := (^Multi_Logger_Data)(log.data)
+	free(data, data.allocator)
+}
+destroy_multi_logger :: delete_multi_logger
 
 multi_logger_proc :: proc(logger_data: rawptr, level: Level, text: string,
                           options: Options, location := #caller_location) {


### PR DESCRIPTION
There were various issues with core:log, namely that it would silently use context.allocator behind your back. The api has been changed to allow the user to provide an interface to the creation of file/console logger and multiloggers.

Furthermore updated the language used to be more consistent with odin's naming scheme. This renames create -> make and  detroy -> delete.

The old names and behaviour have been deprecated and have had their behaviour retained.

Additionally support for os2 has been added.

Documentation was added too.