### PR TITLE
Suggest `-microarch:native` if `popcnt` instruction is missing.

### DIFF
--- a/src/bug_report.cpp
+++ b/src/bug_report.cpp
@@ -2,12 +2,6 @@
 	Gather and print platform and version info to help with reporting Odin bugs.
 */
 
-#if !defined(GB_COMPILER_MSVC)
-	#if defined(GB_CPU_X86)
-		#include <cpuid.h>
-	#endif
-#endif
-
 #if defined(GB_SYSTEM_LINUX)
 	#include <sys/utsname.h>
 	#include <sys/sysinfo.h>
@@ -153,21 +147,6 @@ gb_internal void report_windows_product_type(DWORD ProductType) {
 	}
 }
 #endif
-
-gb_internal void odin_cpuid(int leaf, int result[]) {
-	#if defined(GB_CPU_ARM) || defined(GB_CPU_RISCV)
-		return;
-
-	#elif defined(GB_CPU_X86)
-	
-		#if defined(GB_COMPILER_MSVC)
-			__cpuid(result, leaf);
-		#else
-			__get_cpuid(leaf, (unsigned int*)&result[0], (unsigned int*)&result[1], (unsigned int*)&result[2], (unsigned int*)&result[3]);
-		#endif
-
-	#endif
-}
 
 gb_internal void report_cpu_info() {
 	gb_printf("\tCPU:     ");

--- a/src/build_cpuid.cpp
+++ b/src/build_cpuid.cpp
@@ -1,0 +1,35 @@
+#if !defined(GB_COMPILER_MSVC)
+	#if defined(GB_CPU_X86)
+		#include <cpuid.h>
+	#endif
+#endif
+
+gb_internal void odin_cpuid(int leaf, int result[]) {
+	#if defined(GB_CPU_ARM) || defined(GB_CPU_RISCV)
+		return;
+
+	#elif defined(GB_CPU_X86)
+	
+		#if defined(GB_COMPILER_MSVC)
+			__cpuid(result, leaf);
+		#else
+			__get_cpuid(leaf, (unsigned int*)&result[0], (unsigned int*)&result[1], (unsigned int*)&result[2], (unsigned int*)&result[3]);
+		#endif
+
+	#endif
+}
+
+gb_internal bool should_use_march_native() {
+	#if !defined(GB_CPU_X86)
+		return false;
+
+	#else
+
+		int cpu[4];
+		odin_cpuid(0x1, &cpu[0]); // Get feature information in ECX + EDX
+
+		bool have_popcnt = cpu[2] && (1 << 23); // bit 23 in ECX = popcnt
+		return !have_popcnt;
+
+	#endif
+}

--- a/src/build_cpuid.cpp
+++ b/src/build_cpuid.cpp
@@ -28,7 +28,7 @@ gb_internal bool should_use_march_native() {
 		int cpu[4];
 		odin_cpuid(0x1, &cpu[0]); // Get feature information in ECX + EDX
 
-		bool have_popcnt = cpu[2] && (1 << 23); // bit 23 in ECX = popcnt
+		bool have_popcnt = cpu[2] & (1 << 23); // bit 23 in ECX = popcnt
 		return !have_popcnt;
 
 	#endif

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -2,6 +2,7 @@
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #endif
+#include "build_cpuid.cpp"
 
 // #if defined(GB_SYSTEM_WINDOWS)
 // #define DEFAULT_TO_THREADED_CHECKER

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3326,10 +3326,10 @@ int main(int arg_count, char const **arg_ptr) {
 	// and that no custom microarch was chosen.
 	if (should_use_march_native() && march == get_default_microarchitecture()) {
 		if (command == "run" || command == "test") {
-			gb_printf_err("Error: Try using '-microarch:native' as Odin defaults to %.*s (close to Nehalem) by default and your CPU seems to be a much older CPU.\n", LIT(march));
+			gb_printf_err("Error: Try using '-microarch:native' as Odin defaults to %.*s (close to Nehalem), and your CPU seems to be older.\n", LIT(march));
 			gb_exit(1);
 		} else if (command == "build") {
-			gb_printf("Suggestion: Try using '-microarch:native' as Odin defaults to %.*s (close to Nehalem) by default and your CPU seems to be a much older CPU.\n", LIT(march));
+			gb_printf("Suggestion: Try using '-microarch:native' as Odin defaults to %.*s (close to Nehalem), and your CPU seems to be older.\n", LIT(march));
 		}
 	}
 	#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3321,6 +3321,19 @@ int main(int arg_count, char const **arg_ptr) {
 		}
 	}
 
+	#if defined(GB_CPU_X86)
+	// We've detected that the CPU doesn't support popcnt, or another reason to use `-microarch:native`,
+	// and that no custom microarch was chosen.
+	if (should_use_march_native() && march == get_default_microarchitecture()) {
+		if (command == "run" || command == "test") {
+			gb_printf_err("Error: Try using '-microarch:native' as Odin defaults to %.*s (close to Nehalem) by default and your CPU seems to be a much older CPU.\n", LIT(march));
+			gb_exit(1);
+		} else if (command == "build") {
+			gb_printf("Suggestion: Try using '-microarch:native' as Odin defaults to %.*s (close to Nehalem) by default and your CPU seems to be a much older CPU.\n", LIT(march));
+		}
+	}
+	#endif
+
 	if (build_context.target_features_string.len != 0) {
 		String_Iterator target_it = {build_context.target_features_string, 0};
 		for (;;) {


### PR DESCRIPTION
Fixes #4453.