### PR TITLE
fix relative links in examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,8 +2,8 @@
 
 The `example` directory contains two packages:
 
-A [demo](examples/demo) illustrating the basics of Odin.
+A [demo](demo) illustrating the basics of Odin.
 
-It further contains [all](examples/all), which imports all [core](core) and [vendor](vendor) packages so we can conveniently run `odin check` on everything at once.
+It further contains [all](all), which imports all [core](/core) and [vendor](/vendor) packages so we can conveniently run `odin check` on everything at once.
 
 For additional example code, see the [examples](https://github.com/odin-lang/examples) repository.


### PR DESCRIPTION
This fix adjusts the links for 'demo', 'core', 'all', and 'vendor' so that they navigate to the intended destinations instead of yielding 404s.