### PR TITLE
SIMD Extract MSbs/LSbs Intrinsics

### DIFF
--- a/base/intrinsics/intrinsics.odin
+++ b/base/intrinsics/intrinsics.odin
@@ -285,6 +285,8 @@ simd_reduce_xor         :: proc(a: #simd[N]T) -> T where type_is_integer(T) || t
 simd_reduce_any         :: proc(a: #simd[N]T) -> T where type_is_boolean(T) ---
 simd_reduce_all         :: proc(a: #simd[N]T) -> T where type_is_boolean(T) ---
 
+simd_extract_msbs       :: proc(a: #simd[N]T) -> bit_set[0..<N] where type_is_integer(T) || type_is_boolean(T) ---
+
 
 simd_gather       :: proc(ptr: #simd[N]rawptr, val: #simd[N]T, mask: #simd[N]U) -> #simd[N]T where type_is_integer(U) || type_is_boolean(U) ---
 simd_scatter      :: proc(ptr: #simd[N]rawptr, val: #simd[N]T, mask: #simd[N]U)              where type_is_integer(U) || type_is_boolean(U) ---

--- a/base/intrinsics/intrinsics.odin
+++ b/base/intrinsics/intrinsics.odin
@@ -285,6 +285,7 @@ simd_reduce_xor         :: proc(a: #simd[N]T) -> T where type_is_integer(T) || t
 simd_reduce_any         :: proc(a: #simd[N]T) -> T where type_is_boolean(T) ---
 simd_reduce_all         :: proc(a: #simd[N]T) -> T where type_is_boolean(T) ---
 
+simd_extract_lsbs       :: proc(a: #simd[N]T) -> bit_set[0..<N] where type_is_integer(T) || type_is_boolean(T) ---
 simd_extract_msbs       :: proc(a: #simd[N]T) -> bit_set[0..<N] where type_is_integer(T) || type_is_boolean(T) ---
 
 

--- a/core/simd/simd.odin
+++ b/core/simd/simd.odin
@@ -135,6 +135,7 @@ reduce_xor         :: intrinsics.simd_reduce_xor
 reduce_any         :: intrinsics.simd_reduce_any
 reduce_all         :: intrinsics.simd_reduce_all
 
+extract_lsbs       :: intrinsics.simd_extract_lsbs
 extract_msbs       :: intrinsics.simd_extract_msbs
 
 // swizzle :: proc(a: #simd[N]T, indices: ..int) -> #simd[len(indices)]T

--- a/core/simd/simd.odin
+++ b/core/simd/simd.odin
@@ -135,6 +135,8 @@ reduce_xor         :: intrinsics.simd_reduce_xor
 reduce_any         :: intrinsics.simd_reduce_any
 reduce_all         :: intrinsics.simd_reduce_all
 
+extract_msbs       :: intrinsics.simd_extract_msbs
+
 // swizzle :: proc(a: #simd[N]T, indices: ..int) -> #simd[len(indices)]T
 swizzle :: builtin.swizzle
 

--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -888,6 +888,7 @@ gb_internal bool check_builtin_simd_operation(CheckerContext *c, Operand *operan
 			return true;
 		}
 
+	case BuiltinProc_simd_extract_lsbs:
 	case BuiltinProc_simd_extract_msbs:
 		{
 			Operand x = {};

--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -888,6 +888,38 @@ gb_internal bool check_builtin_simd_operation(CheckerContext *c, Operand *operan
 			return true;
 		}
 
+	case BuiltinProc_simd_extract_msbs:
+		{
+			Operand x = {};
+			check_expr(c, &x, ce->args[0]); if (x.mode == Addressing_Invalid) return false;
+
+			if (!is_type_simd_vector(x.type)) {
+				gbString xs = type_to_string(x.type);
+				error(x.expr, "'%.*s' expected a simd vector type, got '%s'", LIT(builtin_name), xs);
+				gb_string_free(xs);
+				return false;
+			}
+
+			Type *elem = base_array_type(x.type);
+			if (!is_type_integer_like(elem)) {
+				gbString xs = type_to_string(x.type);
+				error(x.expr, "'%.*s' expected a #simd type with integer or boolean elements, got '%s'", LIT(builtin_name), xs);
+				gb_string_free(xs);
+				return false;
+			}
+
+			i64 num_elems = get_array_type_count(x.type);
+
+			Type *result_type = alloc_type_bit_set();
+			result_type->BitSet.elem = t_int;
+			result_type->BitSet.lower = 0;
+			result_type->BitSet.upper = num_elems - 1;
+
+			operand->mode = Addressing_Value;
+			operand->type = result_type;
+			return true;
+		}
+
 
 	case BuiltinProc_simd_shuffle:
 		{

--- a/src/checker_builtin_procs.hpp
+++ b/src/checker_builtin_procs.hpp
@@ -181,6 +181,7 @@ BuiltinProc__simd_begin,
 	BuiltinProc_simd_reduce_any,
 	BuiltinProc_simd_reduce_all,
 
+	BuiltinProc_simd_extract_lsbs,
 	BuiltinProc_simd_extract_msbs,
 
 	BuiltinProc_simd_shuffle,
@@ -525,6 +526,7 @@ gb_global BuiltinProc builtin_procs[BuiltinProc_COUNT] = {
 	{STR_LIT("simd_reduce_any"),          1, false, Expr_Expr, BuiltinProcPkg_intrinsics},
 	{STR_LIT("simd_reduce_all"),         1, false, Expr_Expr, BuiltinProcPkg_intrinsics},
 
+	{STR_LIT("simd_extract_lsbs"),       1, false, Expr_Expr, BuiltinProcPkg_intrinsics},
 	{STR_LIT("simd_extract_msbs"),       1, false, Expr_Expr, BuiltinProcPkg_intrinsics},
 
 

--- a/src/checker_builtin_procs.hpp
+++ b/src/checker_builtin_procs.hpp
@@ -181,6 +181,8 @@ BuiltinProc__simd_begin,
 	BuiltinProc_simd_reduce_any,
 	BuiltinProc_simd_reduce_all,
 
+	BuiltinProc_simd_extract_msbs,
+
 	BuiltinProc_simd_shuffle,
 	BuiltinProc_simd_select,
 
@@ -522,6 +524,8 @@ gb_global BuiltinProc builtin_procs[BuiltinProc_COUNT] = {
 
 	{STR_LIT("simd_reduce_any"),          1, false, Expr_Expr, BuiltinProcPkg_intrinsics},
 	{STR_LIT("simd_reduce_all"),         1, false, Expr_Expr, BuiltinProcPkg_intrinsics},
+
+	{STR_LIT("simd_extract_msbs"),       1, false, Expr_Expr, BuiltinProcPkg_intrinsics},
 
 
 	{STR_LIT("simd_shuffle"), 2, true,  Expr_Expr, BuiltinProcPkg_intrinsics},

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -1564,6 +1564,30 @@ gb_internal lbValue lb_build_builtin_simd_proc(lbProcedure *p, Ast *expr, TypeAn
 			return res;
 		}
 
+	case BuiltinProc_simd_extract_msbs:
+		{
+			Type *vt = arg0.type;
+			GB_ASSERT(vt->kind == Type_SimdVector);
+
+			i64 elem_bits = 8*type_size_of(elem);
+			i64 num_elems = get_array_type_count(vt);
+
+			LLVMTypeRef word_type = lb_type(m, elem);
+			LLVMValueRef shift_value = llvm_splat_int(num_elems, word_type, elem_bits - 1);
+			LLVMValueRef broadcast_value = LLVMBuildAShr(p->builder, arg0.value, shift_value, "");
+
+			LLVMTypeRef bitvec_type = LLVMVectorType(LLVMInt1TypeInContext(m->ctx), (unsigned)num_elems);
+			LLVMValueRef bitvec_value = LLVMBuildTrunc(p->builder, broadcast_value, bitvec_type, "");
+
+			LLVMTypeRef mask_type = LLVMIntTypeInContext(m->ctx, (unsigned)num_elems);
+			LLVMValueRef mask_value = LLVMBuildBitCast(p->builder, bitvec_value, mask_type, "");
+
+			LLVMTypeRef result_type = lb_type(m, res.type);
+			res.value = LLVMBuildZExtOrBitCast(p->builder, mask_value, result_type, "");
+
+			return res;
+		}
+
 
 	case BuiltinProc_simd_shuffle:
 		{

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -1564,6 +1564,7 @@ gb_internal lbValue lb_build_builtin_simd_proc(lbProcedure *p, Ast *expr, TypeAn
 			return res;
 		}
 
+	case BuiltinProc_simd_extract_lsbs:
 	case BuiltinProc_simd_extract_msbs:
 		{
 			Type *vt = arg0.type;
@@ -1572,9 +1573,12 @@ gb_internal lbValue lb_build_builtin_simd_proc(lbProcedure *p, Ast *expr, TypeAn
 			i64 elem_bits = 8*type_size_of(elem);
 			i64 num_elems = get_array_type_count(vt);
 
-			LLVMTypeRef word_type = lb_type(m, elem);
-			LLVMValueRef shift_value = llvm_splat_int(num_elems, word_type, elem_bits - 1);
-			LLVMValueRef broadcast_value = LLVMBuildAShr(p->builder, arg0.value, shift_value, "");
+			LLVMValueRef broadcast_value = arg0.value;
+			if (builtin_id == BuiltinProc_simd_extract_msbs) {
+				LLVMTypeRef word_type = lb_type(m, elem);
+				LLVMValueRef shift_value = llvm_splat_int(num_elems, word_type, elem_bits - 1);
+				broadcast_value = LLVMBuildAShr(p->builder, broadcast_value, shift_value, "");
+			}
 
 			LLVMTypeRef bitvec_type = LLVMVectorType(LLVMInt1TypeInContext(m->ctx), (unsigned)num_elems);
 			LLVMValueRef bitvec_value = LLVMBuildTrunc(p->builder, broadcast_value, bitvec_type, "");


### PR DESCRIPTION
This PR adds `simd_extract_msbs`/`simd_extract_lsbs` intrinsics, along with corresponding aliases in `core:simd`. These intrinsics extract the most/least significant bit of each element of a `#simd` vector and packs them into a `bit_set`. This behavior is similar to the SSE/AVX `movemask` intrinsic/`movmsk` instruction. This intrinsic is defined similarly to:

```go
simd_extract_lsbs :: proc(a: #simd[N]T) -> bit_set[0..<N] where type_is_integer(T) || type_is_boolean(T)
simd_extract_msbs :: proc(a: #simd[N]T) -> bit_set[0..<N] where type_is_integer(T) || type_is_boolean(T)
```

For example, this code:
```go
v := #simd[8]i32 { -1, -2, +3, +4, -5, +6, +7, -8 }
fmt.println(simd.extract_msbs(v))
fmt.println(simd.extract_lsbs(v))
```
will print:
```
bit_set[0..=7]{0, 1, 4, 7}
bit_set[0..=7]{0, 2, 4, 6}
```
since elements 0, 1, 4, and 7 have their most significant bits set (due to being negative) and elements 0, 2, 4, and 6 have their least significant bits set (due to being odd)

This intrinsic is particularly useful in conjunction with lane-wise comparison masks, in a few particular use cases that I've found so far.

1. Counting matches. This can be useful on its own or in conjunction with `masked_compress_store`, for instance, where `card(extract_msbs(v))` can be used to determine how many elements will be written. Examples:
```go
count_range :: proc (src: []#simd[16]f32, lower, upper: f32) -> (result: int) {
	// Counts the number of values in `src` that are in the range `[lower, upper].`
	for v in src {
		mask := simd.lanes_ge(v, auto_cast lower) & simd.lanes_le(v, auto_cast upper)
		result += card(simd.extract_msbs(mask))
	}
	return
}

filter_range :: proc (dst: ^[dynamic]f32, src: []#simd[16]f32, lower, upper: f32) {
	// Appends to `dst` the values of `src` that are in the range `[lower, upper].`
	for v in src {
		mask := simd.lanes_ge(v, auto_cast lower) & simd.lanes_le(v, auto_cast upper)
		old_len := len(dst)
		non_zero_resize(dst, old_len + card(simd.extract_msbs(mask)))
		#no_bounds_check { simd.masked_compress_store(&dst[old_len], v, mask) }
	}
}
```
This use case *can* also be done via `-simd_reduce_add_ordered(mask)`, though I find using `extract_msbs` to be clearer on intent.

2. Identifying which elements matched, e.g. for searching or looping over them. Examples:
```go
first_range :: proc (src: []#simd[16]f32, lower, upper: f32) -> (at: int, found: bool) {
	// Returns the (flattened) index of the first value in `src` that is in the range `[lower, upper]`.
	for v, i in src {
		matches := simd.extract_msbs(simd.lanes_ge(v, auto_cast lower) & simd.lanes_le(v, auto_cast upper))
		for j in matches {
			at = 16*i + j
			found = true
			return
		}
	}
	return
}

histogram_range :: proc (bins: []int, src: []#simd[16]f32, lower, upper: f32) {
	// Generates histogram bin counts for the values in `src` in the range `[lower, upper)`.
	// bins[0] will be the number of values that fall in the first 1/Nth of the range,
	// bins[1] will be the number of values that fall in the second 1/Nth of the range, etc.
	span := (upper - lower) / f32(len(bins))
	for v in src {
		matches := simd.extract_msbs(simd.lanes_ge(v, auto_cast lower) & simd.lanes_lt(v, auto_cast upper))

		phases := (v - auto_cast lower) / auto_cast span
		indices := cast(#simd[16]i32)phases

		for j in matches {
			// Can't be done in parallel due to potential intersection
			i := int(simd.extract(indices, j))
			bins[i] += 1
		}
	}
	return
}
```

3. In more specific cases, the `bit_set` itself can also be directly useful for doing boolean logic en masse. Condensing the original checks to bit-masks allows the bit-masks themselves to be used in SIMD vectors to do large amounts of boolean logic at once.