### PR TITLE
add more robust (but still quick) hashes in core/mini.odin

### DIFF
--- a/core/hash/mini.odin
+++ b/core/hash/mini.odin
@@ -3,10 +3,10 @@ package hash
 ginger_hash8 :: proc "contextless" (x: u8) -> u8 {
 	h := x * 251
 	h += ~(x << 3)
-	h ~= (x >> 1)
+	h ~=  (x >> 1)
 	h += ~(x << 7)
-	h ~= (x >> 6)
-	h += (x << 2)
+	h ~=  (x >> 6)
+	h +=  (x << 2)
 	return h
 }
 
@@ -15,9 +15,9 @@ ginger_hash16 :: proc "contextless" (x: u16) -> u16 {
 	z := (x << 8) | (x >> 8)
 	h := z
 	h += ~(z << 5)
-	h ~= (z >> 2)
+	h ~=  (z >> 2)
 	h += ~(z << 13)
-	h ~= (z >> 10)
+	h ~=  (z >> 10)
 	h += ~(z << 4)
 	h = (h << 10) | (h >> 10)
 	return h
@@ -47,33 +47,40 @@ sxm_hash_uint_generic :: #force_inline proc "contextless" (x: $T) -> T {
 	shift :: bits >> 1
 	mul :: 0x4ff55ba64bb740e135db2be3690a61d3 % (1 << bits)
 	o := T(x)
-	o = (o ~ o >> shift) * mul
-	o = (o ~ o >> shift) * mul
-	o = (o ~ o >> shift) * mul
-	o = (o ~ o >> shift) * mul
+	o = (o ~ (o >> shift)) * mul
+	o = (o ~ (o >> shift)) * mul
+	o = (o ~ (o >> shift)) * mul
+	o = (o ~ (o >> shift)) * mul
 	return o
 }
 
+// sxm_hash8 computes a hash for an 8-bit unsigned integer.
 sxm_hash8 :: proc "contextless" (x: u8) -> u8 {
 	return sxm_hash_uint_generic(x)
 }
 
+// sxm_hash16 computes a hash for a 16-bit unsigned integer.
 sxm_hash16 :: proc "contextless" (x: u16) -> u16 {
 	return sxm_hash_uint_generic(x)
 }
 
+// sxm_hash32 computes a hash for a 32-bit unsigned integer.
 sxm_hash32 :: proc "contextless" (x: u32) -> u32 {
 	return sxm_hash_uint_generic(x)
 }
 
+// sxm_hash64 computes a hash for a 64-bit unsigned integer.
 sxm_hash64 :: proc "contextless" (x: u64) -> u64 {
 	return sxm_hash_uint_generic(x)
 }
 
+// This function uses a generic hashing mechanism to return a hash value.
 sxm_hash128 :: proc "contextless" (x: u128) -> u128 {
 	return sxm_hash_uint_generic(x)
 }
 
+// sxm_hash_uint is a collection of hashing procedures for various unsigned integer types.
+// It provides a unified interface for hashing different sizes of unsigned integers.
 sxm_hash_uint :: proc {
 	sxm_hash8,
 	sxm_hash16,
@@ -82,6 +89,9 @@ sxm_hash_uint :: proc {
 	sxm_hash128,
 }
 
+// sxm_hash_slice_u8 computes a hash for a slice of bytes.
+// It initializes the hash with a seed value and iteratively hashes each byte in the slice.
+// The final hash value is returned as a 64-bit unsigned integer.
 sxm_hash_slice_u8 :: proc "contextless" (data: []byte) -> u64 {
 	h := sxm_hash_uint(u64(1))
 	for b in data {
@@ -90,6 +100,9 @@ sxm_hash_slice_u8 :: proc "contextless" (data: []byte) -> u64 {
 	return h
 }
 
+// sxm_hash_string computes a hash for a given string.
+// It converts the string to a byte slice and then calls the byte slice hashing function.
+// The resulting hash value is returned as a 64-bit unsigned integer.
 sxm_hash_string :: proc "contextless" (data: string) -> u64 {
-	return sxm_hash_slice_u8(transmute([]u8)data)
+	return sxm_hash_slice_u8(transmute([]byte)data)
 }

--- a/core/hash/mini.odin
+++ b/core/hash/mini.odin
@@ -3,10 +3,10 @@ package hash
 ginger_hash8 :: proc "contextless" (x: u8) -> u8 {
 	h := x * 251
 	h += ~(x << 3)
-	h ~=  (x >> 1)
+	h ~= (x >> 1)
 	h += ~(x << 7)
-	h ~=  (x >> 6)
-	h +=  (x << 2)
+	h ~= (x >> 6)
+	h += (x << 2)
 	return h
 }
 
@@ -15,9 +15,9 @@ ginger_hash16 :: proc "contextless" (x: u16) -> u16 {
 	z := (x << 8) | (x >> 8)
 	h := z
 	h += ~(z << 5)
-	h ~=  (z >> 2)
+	h ~= (z >> 2)
 	h += ~(z << 13)
-	h ~=  (z >> 10)
+	h ~= (z >> 10)
 	h += ~(z << 4)
 	h = (h << 10) | (h >> 10)
 	return h
@@ -31,10 +31,65 @@ ginger8 :: proc "contextless" (data: []byte) -> u8 {
 	}
 	return h
 }
+
 ginger16 :: proc "contextless" (data: []byte) -> u16 {
 	h := ginger_hash16(0)
 	for b in data {
 		h ~= ginger_hash16(u16(b))
 	}
 	return h
+}
+
+
+@(private)
+sxm_hash_uint_generic :: #force_inline proc "contextless" (x: $T) -> T {
+	bits :: size_of(x) << 3
+	shift :: bits >> 1
+	mul :: 0x4ff55ba64bb740e135db2be3690a61d3 % (1 << bits)
+	o := T(x)
+	o = (o ~ o >> shift) * mul
+	o = (o ~ o >> shift) * mul
+	o = (o ~ o >> shift) * mul
+	o = (o ~ o >> shift) * mul
+	return o
+}
+
+sxm_hash8 :: proc "contextless" (x: u8) -> u8 {
+	return sxm_hash_uint_generic(x)
+}
+
+sxm_hash16 :: proc "contextless" (x: u16) -> u16 {
+	return sxm_hash_uint_generic(x)
+}
+
+sxm_hash32 :: proc "contextless" (x: u32) -> u32 {
+	return sxm_hash_uint_generic(x)
+}
+
+sxm_hash64 :: proc "contextless" (x: u64) -> u64 {
+	return sxm_hash_uint_generic(x)
+}
+
+sxm_hash128 :: proc "contextless" (x: u128) -> u128 {
+	return sxm_hash_uint_generic(x)
+}
+
+sxm_hash_uint :: proc {
+	sxm_hash8,
+	sxm_hash16,
+	sxm_hash32,
+	sxm_hash64,
+	sxm_hash128,
+}
+
+sxm_hash_slice_u8 :: proc "contextless" (data: []byte) -> u64 {
+	h := sxm_hash_uint(u64(1))
+	for b in data {
+		h ~= sxm_hash_uint(u64(b) ~ h)
+	}
+	return h
+}
+
+sxm_hash_string :: proc "contextless" (data: string) -> u64 {
+	return sxm_hash_slice_u8(transmute([]u8)data)
 }

--- a/core/hash/mini.odin
+++ b/core/hash/mini.odin
@@ -74,7 +74,7 @@ sxm_hash64 :: proc "contextless" (x: u64) -> u64 {
 	return sxm_hash_generic(x)
 }
 
-// This function uses a generic hashing mechanism to return a hash value.
+// sxm_hash128 computes a hash for a 128-bit unsigned integer.
 sxm_hash128 :: proc "contextless" (x: u128) -> u128 {
 	return sxm_hash_generic(x)
 }

--- a/core/hash/mini.odin
+++ b/core/hash/mini.odin
@@ -42,7 +42,7 @@ ginger16 :: proc "contextless" (data: []byte) -> u16 {
 
 
 @(private)
-sxm_hash_uint_generic :: #force_inline proc "contextless" (x: $T) -> T {
+sxm_hash_generic :: #force_inline proc "contextless" (x: $T) -> T {
 	bits :: size_of(x) << 3
 	shift :: bits >> 1
 	mul :: 0x4ff55ba64bb740e135db2be3690a61d3 % (1 << bits)
@@ -56,32 +56,32 @@ sxm_hash_uint_generic :: #force_inline proc "contextless" (x: $T) -> T {
 
 // sxm_hash8 computes a hash for an 8-bit unsigned integer.
 sxm_hash8 :: proc "contextless" (x: u8) -> u8 {
-	return sxm_hash_uint_generic(x)
+	return sxm_hash_generic(x)
 }
 
 // sxm_hash16 computes a hash for a 16-bit unsigned integer.
 sxm_hash16 :: proc "contextless" (x: u16) -> u16 {
-	return sxm_hash_uint_generic(x)
+	return sxm_hash_generic(x)
 }
 
 // sxm_hash32 computes a hash for a 32-bit unsigned integer.
 sxm_hash32 :: proc "contextless" (x: u32) -> u32 {
-	return sxm_hash_uint_generic(x)
+	return sxm_hash_generic(x)
 }
 
 // sxm_hash64 computes a hash for a 64-bit unsigned integer.
 sxm_hash64 :: proc "contextless" (x: u64) -> u64 {
-	return sxm_hash_uint_generic(x)
+	return sxm_hash_generic(x)
 }
 
 // This function uses a generic hashing mechanism to return a hash value.
 sxm_hash128 :: proc "contextless" (x: u128) -> u128 {
-	return sxm_hash_uint_generic(x)
+	return sxm_hash_generic(x)
 }
 
-// sxm_hash_uint is a collection of hashing procedures for various unsigned integer types.
+// sxm_hash is a collection of hashing procedures for various unsigned integer types.
 // It provides a unified interface for hashing different sizes of unsigned integers.
-sxm_hash_uint :: proc {
+sxm_hash :: proc {
 	sxm_hash8,
 	sxm_hash16,
 	sxm_hash32,
@@ -93,9 +93,9 @@ sxm_hash_uint :: proc {
 // It initializes the hash with a seed value and iteratively hashes each byte in the slice.
 // The final hash value is returned as a 64-bit unsigned integer.
 sxm_hash_slice_u8 :: proc "contextless" (data: []byte) -> u64 {
-	h := sxm_hash_uint(u64(1))
+	h := sxm_hash(u64(1))
 	for b in data {
-		h ~= sxm_hash_uint(u64(b) ~ h)
+		h ~= sxm_hash(u64(b) ~ h)
 	}
 	return h
 }


### PR DESCRIPTION
This PR provides new hash functions for Odin, significantly more robust than core.hash.ginger* functions.

<details><summary>Old tests & original post content: open for details</summary>
<p>
fix bias in hashes, add other widths, break permutation invariance in ginger8/ginger16

currently the bias in core::hash.ginger_hash16 is closer to 100% than it is to 0%, some bits are not avalanched at all:
```odin
TESTING STD HASH16
0.25 0.50 0.69 0.01 0.01 0.14 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 
0.04 0.24 0.50 0.69 0.00 0.47 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 
0.50 0.03 0.23 0.49 0.68 0.03 1.00 1.00 1.00 1.00 1.00 1.00 0.00 0.50 0.75 0.88 
0.00 0.50 0.03 0.23 0.49 0.68 1.00 1.00 1.00 1.00 1.00 1.00 0.00 0.50 0.75 0.88 
1.00 0.00 0.50 0.03 0.23 0.49 1.00 1.00 1.00 1.00 1.00 1.00 1.00 0.50 0.75 0.88 
1.00 1.00 0.00 0.50 0.00 0.24 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 0.75 0.88 
0.97 0.98 0.99 0.00 0.50 0.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 0.00 
0.94 0.97 0.98 0.99 0.00 0.50 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 
0.82 0.89 0.94 0.97 0.00 0.50 1.00 1.00 1.00 1.00 1.00 1.00 0.00 0.12 0.47 0.00 
0.69 0.81 0.89 0.94 0.96 0.00 1.00 1.00 1.00 1.00 1.00 1.00 0.00 0.00 0.38 0.66 
0.51 0.69 0.81 0.89 0.93 0.96 1.00 1.00 1.00 1.00 1.00 1.00 0.00 0.12 0.38 0.66 
0.25 0.50 0.69 0.81 0.88 0.93 1.00 1.00 1.00 1.00 1.00 1.00 0.00 0.25 0.38 0.66 
0.01 0.25 0.50 0.69 0.81 0.89 1.00 1.00 1.00 1.00 1.00 1.00 1.00 0.25 0.56 0.11 
0.01 0.01 0.26 0.51 0.69 0.81 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 0.56 0.77 
0.68 0.01 0.01 0.26 0.51 0.69 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 0.00 
0.50 0.69 0.01 0.01 0.26 0.48 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 
```

instead of risking very bad performance or hash collisions, these hashes can be replaced with a high quality one which has very low bias, optimised for avalanching all the bits.
```odin
TESTING NEW HASH16
0.01 0.01 0.00 0.01 0.01 0.01 0.00 0.01 0.00 0.01 0.00 0.00 0.01 0.00 0.01 0.00 
0.00 0.01 0.00 0.01 0.00 0.01 0.00 0.00 0.01 0.01 0.00 0.00 0.00 0.00 0.00 0.00 
0.00 0.00 0.00 0.01 0.00 0.00 0.00 0.01 0.00 0.00 0.00 0.01 0.00 0.00 0.00 0.00 
0.01 0.00 0.01 0.00 0.00 0.00 0.00 0.00 0.01 0.00 0.01 0.00 0.00 0.00 0.00 0.00 
0.02 0.00 0.00 0.01 0.00 0.01 0.00 0.01 0.00 0.01 0.01 0.01 0.01 0.00 0.00 0.01 
0.00 0.01 0.00 0.00 0.00 0.00 0.01 0.01 0.00 0.00 0.01 0.00 0.00 0.00 0.00 0.00 
0.00 0.01 0.00 0.00 0.01 0.00 0.00 0.00 0.00 0.00 0.01 0.01 0.01 0.01 0.00 0.00 
0.00 0.00 0.01 0.00 0.00 0.00 0.00 0.01 0.00 0.00 0.01 0.01 0.00 0.00 0.00 0.00 
0.01 0.00 0.01 0.01 0.01 0.00 0.01 0.01 0.00 0.01 0.01 0.00 0.00 0.00 0.01 0.01 
0.01 0.00 0.01 0.00 0.01 0.00 0.00 0.01 0.00 0.01 0.00 0.00 0.01 0.01 0.01 0.00 
0.01 0.01 0.00 0.00 0.00 0.01 0.01 0.00 0.01 0.00 0.00 0.00 0.01 0.01 0.00 0.00 
0.01 0.01 0.00 0.00 0.00 0.01 0.00 0.01 0.00 0.00 0.00 0.01 0.00 0.00 0.01 0.00 
0.00 0.00 0.00 0.00 0.00 0.00 0.01 0.00 0.00 0.01 0.00 0.01 0.01 0.00 0.01 0.00 
0.00 0.00 0.00 0.01 0.00 0.00 0.00 0.01 0.00 0.00 0.00 0.01 0.01 0.00 0.00 0.01 
0.00 0.01 0.01 0.00 0.01 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.01 0.00 
0.00 0.00 0.01 0.01 0.00 0.00 0.00 0.00 0.01 0.00 0.00 0.00 0.01 0.00 0.00 0.00 
```

For details on how bias is quantified read here:
https://www.gkbrk.com/wiki/avalanche-diagram/

EDIT: this PR is no longer replacing, instead it is adding.
</p>
</details> 

testing 

```
TESTING STD HASH16
average bias: 0.72411919 - max bias: 1


TESTING NEW HASH16
average bias: 0.0042052269 - max bias: 0.01965332


TESTING NEW HASH32
average bias: 0.0038142502 - max bias: 0.017822266


TESTING NEW HASH64
average bias: 0.0034942478 - max bias: 0.018737793


TESTING NEW HASH128
average bias: 0.0032566916 - max bias: 0.02142334


-----------------------

TESTING STD HASH16 FOR COLLISIONS
score: 1672.67 (higher == better)


TESTING NEW HASH16 FOR COLLISIONS
score: 9492.73 (higher == better)
```


<details><summary>test of goodness is provided here - open for code</summary>
<p>


```odin
package main
import "core:fmt"
import "core:hash"

// COPY HASHES FROM THIS PR HERE.

test :: proc($T: typeid, hash : $p) {
	bits :: size_of(T)<<3
	bias: [bits][bits]f32
	N :: 1<<16
	for i_ in 0 ..< N {
		i := T(i_)
		h := hash(i)
		for b in 0 ..< bits {
			v := hash(i ~ (1 << T(b)))
			cmp := h ~ v
			for j in 0 ..< bits {
				bias[b][j] += f32((cmp >> T(j)) & 1) * 2 - 1
			}
		}
	}
	avg: f32
	hiv: f32
	for i in 0 ..< bits {
		for j in 0 ..< bits {
			v := bias[i][j] / N
			if v<0 {v=-v}
			avg += v
			hiv = max(hiv, v)
		}
	}
	fmt.println("average bias:",avg/(bits*bits),"- max bias:", hiv)
}

test_collision :: proc(hash : $p) {
	tbl : [1<<13]bool
	last_hit := 0
	score:f64 = 0
	N :: 65536
	for i in 0..<N {
		idx := hash(u16(i))%len(tbl)
		if tbl[idx] {
			last_hit = i
			for i in 0..<len(tbl) {tbl[i]=false}
		} else {
			score += f64((i-last_hit)*(i-last_hit))
		}
		tbl[idx]=true
	}
	fmt.printf("score: %.2f (higher == better)\n", score/65536)
}

main :: proc() {
	fmt.println("TESTING STD HASH16")
	test(u16, hash.ginger_hash16)
	fmt.println("\n\nTESTING NEW HASH16")
	test(u16, sxm_hash16)
	fmt.println("\n\nTESTING NEW HASH32")
	test(u32, sxm_hash32)
	fmt.println("\n\nTESTING NEW HASH64")
	test(u64, sxm_hash64)
	fmt.println("\n\nTESTING NEW HASH128")
	test(u128, sxm_hash128)

	fmt.println("\n\n-----------------------\n\nTESTING STD HASH16 FOR COLLISIONS")
	test_collision(hash.ginger_hash16)
	fmt.println("\n\nTESTING NEW HASH16 FOR COLLISIONS")
	test_collision(sxm_hash16)
}

```

</p>
</details> 