### PR TITLE
Pack MDEI struct to fix issue #4407

### DIFF
--- a/core/sys/windows/dbghelp.odin
+++ b/core/sys/windows/dbghelp.odin
@@ -15,7 +15,7 @@ MINIDUMP_DIRECTORY :: struct {
 	Location:   MINIDUMP_LOCATION_DESCRIPTOR,
 }
 
-MINIDUMP_EXCEPTION_INFORMATION :: struct {
+MINIDUMP_EXCEPTION_INFORMATION :: struct #max_field_align(4) {
 	ThreadId:          DWORD,
 	ExceptionPointers: ^EXCEPTION_POINTERS,
 	ClientPointers:    BOOL,


### PR DESCRIPTION
``MINIDUMP_EXCEPTION_INFORMATION`` is expected to be packed (which is, of course, not documented by ``MSDN``) so this packs it so that it can be used in ``MinidumpWriteDump``.