### PR TITLE
[runtime] `make(map[K]V)` should not allocate any capacity

### DIFF
--- a/base/runtime/core_builtin.odin
+++ b/base/runtime/core_builtin.odin
@@ -388,7 +388,7 @@ _make_dynamic_array_len_cap :: proc(array: ^Raw_Dynamic_Array, size_of_elem, ali
 //
 // Note: Prefer using the procedure group `make`.
 @(builtin, require_results)
-make_map :: proc($T: typeid/map[$K]$E, allocator := context.allocator) -> (m: T) {
+make_map :: proc($T: typeid/map[$K]$E, allocator := context.allocator, loc := #caller_location) -> (m: T) {
 	m.allocator = allocator
 	return m
 }
@@ -399,7 +399,7 @@ make_map :: proc($T: typeid/map[$K]$E, allocator := context.allocator) -> (m: T)
 //
 // Note: Prefer using the procedure group `make`.
 @(builtin, require_results)
-make_map_cap :: proc($T: typeid/map[$K]$E, #any_int capacity: int = 1<<MAP_MIN_LOG2_CAPACITY, allocator := context.allocator, loc := #caller_location) -> (m: T, err: Allocator_Error) #optional_allocator_error {
+make_map_cap :: proc($T: typeid/map[$K]$E, #any_int capacity: int, allocator := context.allocator, loc := #caller_location) -> (m: T, err: Allocator_Error) #optional_allocator_error {
 	make_map_expr_error_loc(loc, capacity)
 	context.allocator = allocator
 

--- a/tests/core/runtime/test_core_runtime.odin
+++ b/tests/core/runtime/test_core_runtime.odin
@@ -40,3 +40,27 @@ test_temp_allocator_returns_correct_size :: proc(t: ^testing.T) {
 	testing.expect(t, err == nil)
 	testing.expect(t, len(bytes) == 10)
 }
+
+@(test)
+test_init_cap_map_dynarray :: proc(t: ^testing.T) {
+        m1 := make(map[int]string)
+        defer delete(m1)
+        testing.expect(t, cap(m1) == 0)
+        testing.expect(t, m1.allocator.procedure == context.allocator.procedure)
+
+        ally := context.temp_allocator
+        m2 := make(map[int]string, ally)
+        defer delete(m2)
+        testing.expect(t, cap(m2) == 0)
+        testing.expect(t, m2.allocator.procedure == ally.procedure)
+
+        d1 := make([dynamic]string)
+        defer delete(d1)
+        testing.expect(t, cap(d1) == 0)
+        testing.expect(t, d1.allocator.procedure == context.allocator.procedure)
+
+        d2 := make([dynamic]string, ally)
+        defer delete(d2)
+        testing.expect(t, cap(d2) == 0)
+        testing.expect(t, d2.allocator.procedure == ally.procedure)
+}


### PR DESCRIPTION
`make(map[K]V)` was resolving to `make_map_cap()` which allocates initial capacity when it wasn't intended to. It now calls `make_map()` which doesn't allocate any capacity.

Both `make(map[K]V)` and `make(map[K]V, allocator)` will NOT allocate initial capacity now.