### PR TITLE
[checker] Report error when builtin `min`/`max` has only one numeric parameter

### DIFF
--- a/core/encoding/hxa/read.odin
+++ b/core/encoding/hxa/read.odin
@@ -117,7 +117,7 @@ read :: proc(data: []byte, filename := "<input>", print_error := false, allocato
 			layer.name = read_name(r) or_return
 			layer.components = read_value(r, u8) or_return
 			type := read_value(r, Layer_Data_Type) or_return
-			if type > max(type) {
+			if type > max(Layer_Data_Type) {
 				if r.print_error {
 					fmt.eprintf("HxA Error: file '%s' has layer data type %d. Maximum value is %d\n",
 								r.filename, u8(type), u8(max(Layer_Data_Type)))

--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -3170,6 +3170,10 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 			return false;
 		}
 
+		if (ce->args.count <= 1) {
+			error(call, "Too few arguments for 'min', two or more are required");
+			return false;
+		}
 
 		bool all_constant = operand->mode == Addressing_Constant;
 
@@ -3341,6 +3345,11 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 			gbString type_str = type_to_string(original_type);
 			error(call, "Invalid type for 'max', got %s", type_str);
 			gb_string_free(type_str);
+			return false;
+		}
+		
+		if (ce->args.count <= 1) {
+			error(call, "Too few arguments for 'max', two or more are required");
 			return false;
 		}
 


### PR DESCRIPTION
One parameter for `min` or `max` makes only sense when it's a type parameter. But when it's a regular numeric value (constant or variable), it's a no-op. I think in that case it's better to report an error to the user, because there is no practical reason to allow this and it makes it easier to notice a typo.

I ran into this multiple times in cases where I wrote `foo = max(something)` instead of `foo = max(foo, something_else)` to *accumulate* the maximum.