### PR TITLE
Fix typo, its supposed to be #config

### DIFF
--- a/vendor/lua/5.2/lua.odin
+++ b/vendor/lua/5.2/lua.odin
@@ -7,7 +7,7 @@ import c "core:c/libc"
 
 #assert(size_of(c.int) == size_of(b32))
 
-LUA_SHARED :: config(LUA_SHARED, false)
+LUA_SHARED :: #config(LUA_SHARED, false)
 
 when LUA_SHARED {
 	when ODIN_OS == .Windows {


### PR DESCRIPTION
Otherwise compile errors out when importing the file with the error:

```odin
vendor/lua/5.2/lua.odin(10:15) Error: Undeclared name: config 
        LUA_SHARED :: config(LUA_SHARED, false) 
```