### PR TITLE
Fix math/rand `create` proc

### DIFF
--- a/core/math/rand/rand.odin
+++ b/core/math/rand/rand.odin
@@ -18,7 +18,6 @@ default_random_generator :: runtime.default_random_generator
 
 create :: proc(seed: u64) -> (state: Default_Random_State) {
 	seed := seed
-	runtime.default_random_generator(&state)
 	runtime.default_random_generator_proc(&state, .Reset, ([^]byte)(&seed)[:size_of(seed)])
 	return
 }


### PR DESCRIPTION
The `runtime.default_random_generator(&state)` does nothing and should be removed. It is defined in `base/runtime.random_generator.odin` as 
```
default_random_generator :: proc "contextless" (state: ^Default_Random_State = nil) -> Random_Generator {
	return {
		procedure = default_random_generator_proc,
		data = state,
	}
}
```