### PR TITLE
Fix bindings for uniform 1iv, 2iv, 3iv, 4iv in webgl

### DIFF
--- a/core/sys/wasm/js/odin.js
+++ b/core/sys/wasm/js/odin.js
@@ -800,6 +800,23 @@ class WebGLInterface {
 			Uniform3i: (location, v0, v1, v2)     => { this.ctx.uniform3i(this.uniforms[location], v0, v1, v2);     },
 			Uniform4i: (location, v0, v1, v2, v3) => { this.ctx.uniform4i(this.uniforms[location], v0, v1, v2, v3); },
 
+			Uniform1iv: (location, count, addr) => {
+				let array = this.mem.loadI32Array(addr, count);
+				this.ctx.uniform1iv(this.uniforms[location], array);
+			},
+			Uniform2iv: (location, count, addr) => {
+				let array = this.mem.loadI32Array(addr, count);
+				this.ctx.uniform2iv(this.uniforms[location], array);
+			},
+			Uniform3iv: (location, count, addr) => {
+				let array = this.mem.loadI32Array(addr, count);
+				this.ctx.uniform3iv(this.uniforms[location], array);
+			},
+			Uniform4iv: (location, count, addr) => {
+				let array = this.mem.loadI32Array(addr, count);
+				this.ctx.uniform4iv(this.uniforms[location], array);
+			},
+
 			UniformMatrix2fv: (location, addr) => {
 				let array = this.mem.loadF32Array(addr, 2*2);
 				this.ctx.uniformMatrix2fv(this.uniforms[location], false, array);

--- a/vendor/wasm/WebGL/webgl.odin
+++ b/vendor/wasm/WebGL/webgl.odin
@@ -158,6 +158,11 @@ foreign webgl {
 	Uniform3i :: proc(location: i32, v0, v1, v2: i32) ---
 	Uniform4i :: proc(location: i32, v0, v1, v2, v3: i32) ---
 	
+	Uniform1iv :: proc(location: i32, count: i32, value: rawptr) ---
+	Uniform2iv :: proc(location: i32, count: i32, value: rawptr) ---
+	Uniform3iv :: proc(location: i32, count: i32, value: rawptr) ---
+	Uniform4iv :: proc(location: i32, count: i32, value: rawptr) ---
+	
 	UseProgram      :: proc(program: Program) ---
 	ValidateProgram :: proc(program: Program) ---
 		
@@ -174,10 +179,6 @@ Uniform1fv :: proc "contextless" (location: i32, v: f32)       { Uniform1f(locat
 Uniform2fv :: proc "contextless" (location: i32, v: glm.vec2)  { Uniform2f(location, v.x, v.y) }
 Uniform3fv :: proc "contextless" (location: i32, v: glm.vec3)  { Uniform3f(location, v.x, v.y, v.z) }
 Uniform4fv :: proc "contextless" (location: i32, v: glm.vec4)  { Uniform4f(location, v.x, v.y, v.z, v.w) }
-Uniform1iv :: proc "contextless" (location: i32, v: i32)       { Uniform1i(location, v) }
-Uniform2iv :: proc "contextless" (location: i32, v: glm.ivec2) { Uniform2i(location, v.x, v.y) }
-Uniform3iv :: proc "contextless" (location: i32, v: glm.ivec3) { Uniform3i(location, v.x, v.y, v.z) }
-Uniform4iv :: proc "contextless" (location: i32, v: glm.ivec4) { Uniform4i(location, v.x, v.y, v.z, v.w) }
 
 VertexAttrib1fv :: proc "contextless" (index: i32, v: f32)     { VertexAttrib1f(index, v) }
 VertexAttrib2fv :: proc "contextless" (index: i32, v: glm.vec2){ VertexAttrib2f(index, v.x, v.y) }


### PR DESCRIPTION
This PR addresses issues with the bindings for `uniform1iv`, `uniform2iv`, `uniform3iv`, and `uniform4iv` in WebGL. The implementation has been updated to align with the official WebGL API as documented on [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/uniform).