### PR TITLE
fix unmarshal unhandled error

### DIFF
--- a/core/encoding/json/unmarshal.odin
+++ b/core/encoding/json/unmarshal.odin
@@ -419,7 +419,10 @@ unmarshal_object :: proc(p: ^Parser, v: any, end_token: Token_Kind) -> (err: Unm
 		}
 	
 		struct_loop: for p.curr_token.kind != end_token {
-			key, _ := parse_object_key(p, p.allocator)
+			key, err := parse_object_key(p, p.allocator)
+			if err != nil {
+				return err
+			}
 			defer delete(key, p.allocator)
 			
 			unmarshal_expect_token(p, .Colon)						

--- a/core/encoding/json/unmarshal.odin
+++ b/core/encoding/json/unmarshal.odin
@@ -419,10 +419,7 @@ unmarshal_object :: proc(p: ^Parser, v: any, end_token: Token_Kind) -> (err: Unm
 		}
 	
 		struct_loop: for p.curr_token.kind != end_token {
-			key, err := parse_object_key(p, p.allocator)
-			if err != nil {
-				return err
-			}
+			key := parse_object_key(p, p.allocator) or_return
 			defer delete(key, p.allocator)
 			
 			unmarshal_expect_token(p, .Colon)						


### PR DESCRIPTION
This PR is a potential fix for unmarshal returning misleading Unsupported_Type_Errors that occur when allocator memory is exceeded during parsing.

See Issue: [Unmarshal unhandled errors](https://github.com/odin-lang/Odin/issues/4514)