### PR TITLE
sys/info & odin report: rework macos version retrieval

### DIFF
--- a/core/sys/darwin/Foundation/NSObjectProtocol.odin
+++ b/core/sys/darwin/Foundation/NSObjectProtocol.odin
@@ -1,0 +1,5 @@
+package objc_Foundation
+
+@(objc_class="NSObjectProtocol")
+ObjectProtocol :: struct {using _: Object}
+// TODO: implement NSObjectProtocol

--- a/core/sys/darwin/Foundation/NSProcessInfo.odin
+++ b/core/sys/darwin/Foundation/NSProcessInfo.odin
@@ -1,0 +1,203 @@
+package objc_Foundation
+
+import "base:intrinsics"
+
+import "core:c"
+
+@(objc_class="NSProcessInfo")
+ProcessInfo :: struct {using _: Object}
+
+// Getting the Process Information Agent
+
+@(objc_type=ProcessInfo, objc_name="processInfo", objc_is_class_method=true)
+ProcessInfo_processInfo :: proc "c" () -> ^ProcessInfo {
+	return msgSend(^ProcessInfo, ProcessInfo, "processInfo")
+}
+
+// Accessing Process Information
+
+@(objc_type=ProcessInfo, objc_name="arguments")
+ProcessInfo_arguments :: proc "c" (self: ^ProcessInfo) -> ^Array {
+	return msgSend(^Array, self, "arguments")
+}
+
+@(objc_type=ProcessInfo, objc_name="environment")
+ProcessInfo_environment :: proc "c" (self: ^ProcessInfo) -> ^Dictionary {
+	return msgSend(^Dictionary, self, "environment")
+}
+
+@(objc_type=ProcessInfo, objc_name="globallyUniqueString")
+ProcessInfo_globallyUniqueString :: proc "c" (self: ^ProcessInfo) -> ^String {
+	return msgSend(^String, self, "globallyUniqueString")
+}
+
+@(objc_type=ProcessInfo, objc_name="isMacCatalystApp")
+ProcessInfo_isMacCatalystApp :: proc "c" (self: ^ProcessInfo) -> bool {
+	return msgSend(bool, self, "isMacCatalystApp")
+}
+
+@(objc_type=ProcessInfo, objc_name="isiOSAppOnMac")
+ProcessInfo_isiOSAppOnMac :: proc "c" (self: ^ProcessInfo) -> bool {
+	return msgSend(bool, self, "isiOSAppOnMac")
+}
+
+@(objc_type=ProcessInfo, objc_name="processIdentifier")
+ProcessInfo_processIdentifier :: proc "c" (self: ^ProcessInfo) -> c.int {
+	return msgSend(c.int, self, "processIdentifier")
+}
+
+@(objc_type=ProcessInfo, objc_name="processName")
+ProcessInfo_processName :: proc "c" (self: ^ProcessInfo) -> ^String {
+	return msgSend(^String, self, "processName")
+}
+
+// Accessing User Information 
+
+@(objc_type=ProcessInfo, objc_name="userName")
+ProcessInfo_userName :: proc "c" (self: ^ProcessInfo) -> ^String {
+	return msgSend(^String, self, "userName")
+}
+
+@(objc_type=ProcessInfo, objc_name="fullUserName")
+ProcessInfo_fullUserName :: proc "c" (self: ^ProcessInfo) -> ^String {
+	return msgSend(^String, self, "fullUserName")
+}
+
+// Sudden Application Termination
+
+@(objc_type=ProcessInfo, objc_name="disableSuddenTermination")
+ProcessInfo_disableSuddenTermination :: proc "c" (self: ^ProcessInfo) {
+	msgSend(nil, self, "disableSuddenTermination")
+}
+
+@(objc_type=ProcessInfo, objc_name="enableSuddenTermination")
+ProcessInfo_enableSuddenTermination :: proc "c" (self: ^ProcessInfo) {
+	msgSend(nil, self, "enableSuddenTermination")
+}
+
+// Controlling Automatic Termination
+
+@(objc_type=ProcessInfo, objc_name="disableAutomaticTermination")
+ProcessInfo_disableAutomaticTermination :: proc "c" (self: ^ProcessInfo, reason: ^String) {
+	msgSend(nil, self, "disableAutomaticTermination:", reason)
+}
+
+@(objc_type=ProcessInfo, objc_name="enableAutomaticTermination")
+ProcessInfo_enableAutomaticTermination :: proc "c" (self: ^ProcessInfo, reason: ^String) {
+	msgSend(nil, self, "enableAutomaticTermination:", reason)
+}
+
+@(objc_type=ProcessInfo, objc_name="automaticTerminationSupportEnabled")
+ProcessInfo_automaticTerminationSupportEnabled :: proc "c" (self: ^ProcessInfo) -> bool {
+	return msgSend(bool, self, "automaticTerminationSupportEnabled")
+}
+
+@(objc_type=ProcessInfo, objc_name="setAutomaticTerminationSupportEnabled")
+ProcessInfo_setAutomaticTerminationSupportEnabled :: proc "c" (self: ^ProcessInfo, automaticTerminationSupportEnabled: bool) {
+	msgSend(nil, self, "setAutomaticTerminationSupportEnabled:", automaticTerminationSupportEnabled)
+}
+
+// Getting Host Information
+
+@(objc_type=ProcessInfo, objc_name="hostName")
+ProcessInfo_hostName :: proc "c" (self: ^ProcessInfo) -> ^String {
+	return msgSend(^String, self, "hostName")
+}
+
+@(objc_type=ProcessInfo, objc_name="operatingSystemVersionString")
+ProcessInfo_operatingSystemVersionString :: proc "c" (self: ^ProcessInfo) -> ^String {
+	return msgSend(^String, self, "operatingSystemVersionString")
+}
+
+@(objc_type=ProcessInfo, objc_name="operatingSystemVersion")
+ProcessInfo_operatingSystemVersion :: proc "c" (self: ^ProcessInfo) -> OperatingSystemVersion {
+	return msgSend(OperatingSystemVersion, self, "operatingSystemVersion")
+}
+
+@(objc_type=ProcessInfo, objc_name="isOperatingSystemAtLeastVersion")
+ProcessInfo_isOperatingSystemAtLeastVersion :: proc "c" (self: ^ProcessInfo, version: OperatingSystemVersion) -> bool {
+	return msgSend(bool, self, "isOperatingSystemAtLeastVersion:", version)
+}
+
+// Getting Computer Information
+
+@(objc_type=ProcessInfo, objc_name="processorCount")
+ProcessInfo_processorCount :: proc "c" (self: ^ProcessInfo) -> UInteger {
+	return msgSend(UInteger, self, "processorCount")
+}
+
+@(objc_type=ProcessInfo, objc_name="activeProcessorCount")
+ProcessInfo_activeProcessorCount :: proc "c" (self: ^ProcessInfo) -> UInteger {
+	return msgSend(UInteger, self, "activeProcessorCount")
+}
+
+@(objc_type=ProcessInfo, objc_name="physicalMemory")
+ProcessInfo_physicalMemory :: proc "c" (self: ^ProcessInfo) -> c.ulonglong {
+	return msgSend(c.ulonglong, self, "physicalMemory")
+}
+
+@(objc_type=ProcessInfo, objc_name="systemUptime")
+ProcessInfo_systemUptime :: proc "c" (self: ^ProcessInfo) -> TimeInterval {
+	return msgSend(TimeInterval, self, "systemUptime")
+}
+
+// Managing Activities
+
+@(private)
+log2 :: intrinsics.constant_log2
+
+ActivityOptionsBits :: enum u64 {
+	IdleDisplaySleepDisabled             = log2(1099511627776),  // Require the screen to stay powered on.
+	IdleSystemSleepDisabled              = log2(1048576),        // Prevent idle sleep.
+	SuddenTerminationDisabled            = log2(16384),          // Prevent sudden termination.
+	AutomaticTerminationDisabled         = log2(32768),          // Prevent automatic termination.
+	AnimationTrackingEnabled             = log2(35184372088832), // Track activity with an animation signpost interval.
+	TrackingEnabled                      = log2(70368744177664), // Track activity with a signpost interval.
+	UserInitiated                        = log2(16777215),       // Performing a user-requested action.
+	UserInitiatedAllowingIdleSystemSleep = log2(15728639),       // Performing a user-requested action, but the system can sleep on idle.
+	Background                           = log2(255),            // Initiated some kind of work, but not as the direct result of a user request.
+	LatencyCritical                      = log2(1095216660480),  // Requires the highest amount of timer and I/O precision available.
+	UserInteractive                      = log2(1095233437695),  // Responding to user interaction.
+}
+ActivityOptions :: bit_set[ActivityOptionsBits; u64]
+
+@(objc_type=ProcessInfo, objc_name="beginActivityWithOptions")
+ProcessInfo_beginActivityWithOptions :: proc "c" (self: ^ProcessInfo, options: ActivityOptions, reason: ^String) -> ^ObjectProtocol {
+	return msgSend(^ObjectProtocol, self, "beginActivityWithOptions:reason:", options, reason)
+}
+
+@(objc_type=ProcessInfo, objc_name="endActivity")
+ProcessInfo_endActivity :: proc "c" (self: ^ProcessInfo, activity: ^ObjectProtocol) {
+	msgSend(nil, self, "endActivity:", activity)
+}
+
+@(objc_type=ProcessInfo, objc_name="performActivityWithOptions")
+ProcessInfo_performActivityWithOptions :: proc "c" (self: ^ProcessInfo, options: ActivityOptions, reason: ^String, block: proc "c" ()) {
+	msgSend(nil, self, "performActivityWithOptions:reason:usingBlock:", options, reason, block)
+}
+
+@(objc_type=ProcessInfo, objc_name="performExpiringActivityWithReason")
+ProcessInfo_performExpiringActivityWithReason :: proc "c" (self: ^ProcessInfo, reason: ^String, block: proc "c" (expired: bool)) {
+	msgSend(nil, self, "performExpiringActivityWithReason:usingBlock:", reason, block)
+}
+
+// Getting the Thermal State
+
+ProcessInfoThermalState :: enum c.long {
+	Nominal,
+	Fair,
+	Serious,
+	Critical,
+}
+
+@(objc_type=ProcessInfo, objc_name="thermalState")
+ProcessInfo_thermalState :: proc "c" (self: ^ProcessInfo) -> ProcessInfoThermalState {
+	return msgSend(ProcessInfoThermalState, self, "thermalState")
+}
+
+// Determining Whether Low Power Mode is Enabled
+
+@(objc_type=ProcessInfo, objc_name="isLowPowerModeEnabled")
+ProcessInfo_isLowPowerModeEnabled :: proc "c" (self: ^ProcessInfo) -> bool {
+	return msgSend(bool, self, "isLowPowerModeEnabled")
+}

--- a/core/sys/darwin/Foundation/NSTypes.odin
+++ b/core/sys/darwin/Foundation/NSTypes.odin
@@ -20,7 +20,7 @@ BOOL :: bool // TODO(bill): should this be `distinct`?
 YES  :: true
 NO   :: false
 
-OperatingSystemVersion :: struct #packed {
+OperatingSystemVersion :: struct #align(8) {
 	majorVersion: Integer,
 	minorVersion: Integer,
 	patchVersion: Integer,

--- a/core/sys/info/doc.odin
+++ b/core/sys/info/doc.odin
@@ -4,7 +4,7 @@ Made available under Odin's BSD-3 license.
 
 List of contributors:
 	Jeroen van Rijn: Initial implementation.
-	Laytan: ARM and RISC-V CPU feature detection.
+	Laytan: ARM and RISC-V CPU feature detection, iOS/macOS platform overhaul.
 */
 
 /*

--- a/core/sys/info/platform_darwin.odin
+++ b/core/sys/info/platform_darwin.odin
@@ -1,598 +1,101 @@
 package sysinfo
 
-import sys "core:sys/unix"
-import "core:strconv"
-import "core:strings"
-import "base:runtime"
+import    "core:strconv"
+import    "core:strings"
+import    "core:sys/unix"
+import NS "core:sys/darwin/Foundation"
 
 @(private)
 version_string_buf: [1024]u8
 
 @(init, private)
-init_os_version :: proc () {
-	os_version.platform = .MacOS
+init_platform :: proc() {
+	ws :: strings.write_string
+	wi :: strings.write_int
 
-	// Start building display version
 	b := strings.builder_from_bytes(version_string_buf[:])
 
-	mib := []i32{sys.CTL_KERN, sys.KERN_OSVERSION}
-	build_buf: [12]u8
+	version: NS.OperatingSystemVersion
+	{
+		NS.scoped_autoreleasepool() 
 
-	ok := sys.sysctl(mib, &build_buf)
-	if !ok {
-		strings.write_string(&b, "macOS Unknown")
-		os_version.as_string = strings.to_string(b)
-		return
+		info    := NS.ProcessInfo.processInfo()
+		version  = info->operatingSystemVersion()
+		mem     := info->physicalMemory()
+
+		ram.total_ram = int(mem)
 	}
 
-	build := string(cstring(&build_buf[0]))
+	macos_version = {int(version.majorVersion), int(version.minorVersion), int(version.patchVersion)}
 
-	// Do we have an exact match?
-	match: Darwin_Match
-	rel, exact := macos_release_map[build]
-
-	if exact {
-		match = .Exact
+	when ODIN_PLATFORM_SUBTARGET == .iOS {
+		os_version.platform = .iOS
+		ws(&b, "iOS")
 	} else {
+		os_version.platform = .MacOS
+		switch version.majorVersion {
+		case 15: ws(&b, "macOS Sequoia")
+		case 14: ws(&b, "macOS Sonoma")
+		case 13: ws(&b, "macOS Ventura")
+		case 12: ws(&b, "macOS Monterey")
+		case 11: ws(&b, "macOS Big Sur")
+		case 10:
+			switch version.minorVersion {
+			case 15: ws(&b, "macOS Catalina")
+			case 14: ws(&b, "macOS Mojave")
+			case 13: ws(&b, "macOS High Sierra")
+			case 12: ws(&b, "macOS Sierra")
+			case 11: ws(&b, "OS X El Capitan")
+			case 10: ws(&b, "OS X Yosemite")
+			case:
+				// `ProcessInfo.operatingSystemVersion` is 10.10 and up.
+				unreachable()
+			}
+		case:
+			// New version not yet added here.
+			assert(version.majorVersion > 15)
+			ws(&b, "macOS Unknown")
+		}
+	}
+
+	ws(&b, " ")
+	wi(&b, int(version.majorVersion))
+	ws(&b, ".")
+	wi(&b, int(version.minorVersion))
+	ws(&b, ".")
+	wi(&b, int(version.patchVersion))
+
+	{
+		build_buf: [12]u8
+		mib := []i32{unix.CTL_KERN, unix.KERN_OSVERSION}
+		ok := unix.sysctl(mib, &build_buf)
+		build := string(cstring(raw_data(build_buf[:]))) if ok else "Unknown"
+
+		ws(&b, " (build ")
+
+		build_start := len(b.buf)
+		ws(&b, build)
+		os_version.version = string(b.buf[build_start:][:len(build)])
+	}
+
+	{
 		// Match on XNU kernel version
-		mib = []i32{sys.CTL_KERN, sys.KERN_OSRELEASE}
 		version_bits: [12]u8 // enough for 999.999.999\x00
-		have_kernel_version := sys.sysctl(mib, &version_bits)
+		mib := []i32{unix.CTL_KERN, unix.KERN_OSRELEASE}
+		ok := unix.sysctl(mib, &version_bits)
+		kernel := string(cstring(raw_data(version_bits[:]))) if ok else "Unknown"
 
-		major_ok, minor_ok, patch_ok: bool
+		major, _, tail  := strings.partition(kernel, ".")
+		minor, _, patch := strings.partition(tail, ".")
 
-		tmp := runtime.default_temp_allocator_temp_begin()
+		os_version.major, _ = strconv.parse_int(major, 10)
+		os_version.minor, _ = strconv.parse_int(minor, 10)
+		os_version.patch, _ = strconv.parse_int(patch, 10)
 
-		triplet := strings.split(string(cstring(&version_bits[0])), ".", context.temp_allocator)
-		if len(triplet) != 3 {
-			have_kernel_version = false
-		} else {
-			rel.darwin.x, major_ok = strconv.parse_int(triplet[0])
-			rel.darwin.y, minor_ok = strconv.parse_int(triplet[1])
-			rel.darwin.z, patch_ok = strconv.parse_int(triplet[2])
-
-			if !(major_ok && minor_ok && patch_ok) {
-				have_kernel_version = false
-			}
-		}
-
-		runtime.default_temp_allocator_temp_end(tmp)
-
-		if !have_kernel_version {
-			// We don't know the kernel version, but we do know the build
-			strings.write_string(&b, "macOS Unknown (build ")
-			l := strings.builder_len(b)
-			strings.write_string(&b, build)
-			os_version.version = strings.to_string(b)[l:]
-			strings.write_rune(&b, ')')
-			os_version.as_string = strings.to_string(b)
-			return
-		}
-		rel, match = map_darwin_kernel_version_to_macos_release(build, rel.darwin)
+		ws(&b, ", kernel ")
+		ws(&b, kernel)
+		ws(&b, ")")
 	}
 
-	os_version.major = rel.darwin.x
-	os_version.minor = rel.darwin.y
-	os_version.patch = rel.darwin.z
-
-	macos_version = transmute(Version)rel.release.version
-
-	strings.write_string(&b, rel.os_name)
-	if match == .Exact || match == .Nearest {
-		strings.write_rune(&b, ' ')
-		strings.write_string(&b, rel.release.name)
-		strings.write_rune(&b, ' ')
-		strings.write_int(&b, rel.release.version.x)
-		if rel.release.version.y > 0 || rel.release.version.z > 0 {
-			strings.write_rune(&b, '.')
-			strings.write_int(&b, rel.release.version.y)
-		}
-		if rel.release.version.z > 0 {
-			strings.write_rune(&b, '.')
-			strings.write_int(&b, rel.release.version.z)
-		}
-		if match == .Nearest {
-			strings.write_rune(&b, '?')
-		}
-	} else {
-		strings.write_string(&b, " Unknown")
-	}
-
-	strings.write_string(&b, " (build ")
-	l := strings.builder_len(b)
-	strings.write_string(&b, build)
-	os_version.version = strings.to_string(b)[l:]
-
-	strings.write_string(&b, ", kernel ")
-	strings.write_int(&b, rel.darwin.x)
-	strings.write_rune(&b, '.')
-	strings.write_int(&b, rel.darwin.y)
-	strings.write_rune(&b, '.')
-	strings.write_int(&b, rel.darwin.z)
-	strings.write_rune(&b, ')')
-
-	os_version.as_string = strings.to_string(b)
-}
-
-@(init, private)
-init_ram :: proc() {
-	// Retrieve RAM info using `sysctl`
-
-	mib := []i32{sys.CTL_HW, sys.HW_MEMSIZE}
-	mem_size: u64
-	if sys.sysctl(mib, &mem_size) {
-		ram.total_ram = int(mem_size)
-	}
-}
-
-@(private)
-Darwin_To_Release :: struct {
-	darwin:      [3]int, // Darwin kernel triplet
-	os_name:     string, // OS X, MacOS
-	release:     struct {
-		name:    string, // Monterey, Mojave, etc.
-		version: [3]int, // 12.4, etc.
-	},
-}
-
-// Important: Order from lowest to highest kernel version
-@(private)
-macos_release_map: map[string]Darwin_To_Release = {
-	// MacOS Tiger
-	"8A428"      = {{8, 0, 0},   "macOS", {"Tiger",         {10,  4, 0}}},
-	"8A432"      = {{8, 0, 0},   "macOS", {"Tiger",         {10,  4, 0}}},
-	"8B15"       = {{8, 1, 0},   "macOS", {"Tiger",         {10,  4, 1}}},
-	"8B17"       = {{8, 1, 0},   "macOS", {"Tiger",         {10,  4, 1}}},
-	"8C46"       = {{8, 2, 0},   "macOS", {"Tiger",         {10,  4, 2}}},
-	"8C47"       = {{8, 2, 0},   "macOS", {"Tiger",         {10,  4, 2}}},
-	"8E102"      = {{8, 2, 0},   "macOS", {"Tiger",         {10,  4, 2}}},
-	"8E45"       = {{8, 2, 0},   "macOS", {"Tiger",         {10,  4, 2}}},
-	"8E90"       = {{8, 2, 0},   "macOS", {"Tiger",         {10,  4, 2}}},
-	"8F46"       = {{8, 3, 0},   "macOS", {"Tiger",         {10,  4, 3}}},
-	"8G32"       = {{8, 4, 0},   "macOS", {"Tiger",         {10,  4, 4}}},
-	"8G1165"     = {{8, 4, 0},   "macOS", {"Tiger",         {10,  4, 4}}},
-	"8H14"       = {{8, 5, 0},   "macOS", {"Tiger",         {10,  4, 5}}},
-	"8G1454"     = {{8, 5, 0},   "macOS", {"Tiger",         {10,  4, 5}}},
-	"8I127"      = {{8, 6, 0},   "macOS", {"Tiger",         {10,  4, 6}}},
-	"8I1119"     = {{8, 6, 0},   "macOS", {"Tiger",         {10,  4, 6}}},
-	"8J135"      = {{8, 7, 0},   "macOS", {"Tiger",         {10,  4, 7}}},
-	"8J2135a"    = {{8, 7, 0},   "macOS", {"Tiger",         {10,  4, 7}}},
-	"8K1079"     = {{8, 7, 0},   "macOS", {"Tiger",         {10,  4, 7}}},
-	"8N5107"     = {{8, 7, 0},   "macOS", {"Tiger",         {10,  4, 7}}},
-	"8L127"      = {{8, 8, 0},   "macOS", {"Tiger",         {10,  4, 8}}},
-	"8L2127"     = {{8, 8, 0},   "macOS", {"Tiger",         {10,  4, 8}}},
-	"8P135"      = {{8, 9, 0},   "macOS", {"Tiger",         {10,  4, 9}}},
-	"8P2137"     = {{8, 9, 0},   "macOS", {"Tiger",         {10,  4, 9}}},
-	"8R218"      = {{8, 10, 0},  "macOS", {"Tiger",         {10,  4, 10}}},
-	"8R2218"     = {{8, 10, 0},  "macOS", {"Tiger",         {10,  4, 10}}},
-	"8R2232"     = {{8, 10, 0},  "macOS", {"Tiger",         {10,  4, 10}}},
-	"8S165"      = {{8, 11, 0},  "macOS", {"Tiger",         {10,  4, 11}}},
-	"8S2167"     = {{8, 11, 0},  "macOS", {"Tiger",         {10,  4, 11}}},
-
-	// MacOS Leopard
-	"9A581"      = {{9, 0, 0},   "macOS", {"Leopard",       {10,  5, 0}}},
-	"9B18"       = {{9, 1, 0},   "macOS", {"Leopard",       {10,  5, 1}}},
-	"9B2117"     = {{9, 1, 1},   "macOS", {"Leopard",       {10,  5, 1}}},
-	"9C31"       = {{9, 2, 0},   "macOS", {"Leopard",       {10,  5, 2}}},
-	"9C7010"     = {{9, 2, 0},   "macOS", {"Leopard",       {10,  5, 2}}},
-	"9D34"       = {{9, 3, 0},   "macOS", {"Leopard",       {10,  5, 3}}},
-	"9E17"       = {{9, 4, 0},   "macOS", {"Leopard",       {10,  5, 4}}},
-	"9F33"       = {{9, 5, 0},   "macOS", {"Leopard",       {10,  5, 5}}},
-	"9G55"       = {{9, 6, 0},   "macOS", {"Leopard",       {10,  5, 6}}},
-	"9G66"       = {{9, 6, 0},   "macOS", {"Leopard",       {10,  5, 6}}},
-	"9G71"       = {{9, 6, 0},   "macOS", {"Leopard",       {10,  5, 6}}},
-	"9J61"       = {{9, 7, 0},   "macOS", {"Leopard",       {10,  5, 7}}},
-	"9L30"       = {{9, 8, 0},   "macOS", {"Leopard",       {10,  5, 8}}},
-	"9L34"       = {{9, 8, 0},   "macOS", {"Leopard",       {10,  5, 8}}},
-
-	// MacOS Snow Leopard
-	"10A432"     = {{10, 0, 0},  "macOS", {"Snow Leopard",  {10,  6, 0}}},
-	"10A433"     = {{10, 0, 0},  "macOS", {"Snow Leopard",  {10,  6, 0}}},
-	"10B504"     = {{10, 1, 0},  "macOS", {"Snow Leopard",  {10,  6, 1}}},
-	"10C540"     = {{10, 2, 0},  "macOS", {"Snow Leopard",  {10,  6, 2}}},
-	"10D573"     = {{10, 3, 0},  "macOS", {"Snow Leopard",  {10,  6, 3}}},
-	"10D575"     = {{10, 3, 0},  "macOS", {"Snow Leopard",  {10,  6, 3}}},
-	"10D578"     = {{10, 3, 0},  "macOS", {"Snow Leopard",  {10,  6, 3}}},
-	"10F569"     = {{10, 4, 0},  "macOS", {"Snow Leopard",  {10,  6, 4}}},
-	"10H574"     = {{10, 5, 0},  "macOS", {"Snow Leopard",  {10,  6, 5}}},
-	"10J567"     = {{10, 6, 0},  "macOS", {"Snow Leopard",  {10,  6, 6}}},
-	"10J869"     = {{10, 7, 0},  "macOS", {"Snow Leopard",  {10,  6, 7}}},
-	"10J3250"    = {{10, 7, 0},  "macOS", {"Snow Leopard",  {10,  6, 7}}},
-	"10J4138"    = {{10, 7, 0},  "macOS", {"Snow Leopard",  {10,  6, 7}}},
-	"10K540"     = {{10, 8, 0},  "macOS", {"Snow Leopard",  {10,  6, 8}}},
-	"10K549"     = {{10, 8, 0},  "macOS", {"Snow Leopard",  {10,  6, 8}}},
-
-	// MacOS Lion
-	"11A511"     = {{11, 0, 0},  "macOS", {"Lion",          {10,  7, 0}}},
-	"11A511s"    = {{11, 0, 0},  "macOS", {"Lion",          {10,  7, 0}}},
-	"11A2061"    = {{11, 0, 2},  "macOS", {"Lion",          {10,  7, 0}}},
-	"11A2063"    = {{11, 0, 2},  "macOS", {"Lion",          {10,  7, 0}}},
-	"11B26"      = {{11, 1, 0},  "macOS", {"Lion",          {10,  7, 1}}},
-	"11B2118"    = {{11, 1, 0},  "macOS", {"Lion",          {10,  7, 1}}},
-	"11C74"      = {{11, 2, 0},  "macOS", {"Lion",          {10,  7, 2}}},
-	"11D50"      = {{11, 3, 0},  "macOS", {"Lion",          {10,  7, 3}}},
-	"11E53"      = {{11, 4, 0},  "macOS", {"Lion",          {10,  7, 4}}},
-	"11G56"      = {{11, 4, 2},  "macOS", {"Lion",          {10,  7, 5}}},
-	"11G63"      = {{11, 4, 2},  "macOS", {"Lion",          {10,  7, 5}}},
-
-	// MacOS Mountain Lion
-	"12A269"     = {{12, 0, 0},  "macOS", {"Mountain Lion", {10,  8, 0}}},
-	"12B19"      = {{12, 1, 0},  "macOS", {"Mountain Lion", {10,  8, 1}}},
-	"12C54"      = {{12, 2, 0},  "macOS", {"Mountain Lion", {10,  8, 2}}},
-	"12C60"      = {{12, 2, 0},  "macOS", {"Mountain Lion", {10,  8, 2}}},
-	"12C2034"    = {{12, 2, 0},  "macOS", {"Mountain Lion", {10,  8, 2}}},
-	"12C3104"    = {{12, 2, 0},  "macOS", {"Mountain Lion", {10,  8, 2}}},
-	"12D78"      = {{12, 3, 0},  "macOS", {"Mountain Lion", {10,  8, 3}}},
-	"12E55"      = {{12, 4, 0},  "macOS", {"Mountain Lion", {10,  8, 4}}},
-	"12E3067"    = {{12, 4, 0},  "macOS", {"Mountain Lion", {10,  8, 4}}},
-	"12E4022"    = {{12, 4, 0},  "macOS", {"Mountain Lion", {10,  8, 4}}},
-	"12F37"      = {{12, 5, 0},  "macOS", {"Mountain Lion", {10,  8, 5}}},
-	"12F45"      = {{12, 5, 0},  "macOS", {"Mountain Lion", {10,  8, 5}}},
-	"12F2501"    = {{12, 5, 0},  "macOS", {"Mountain Lion", {10,  8, 5}}},
-	"12F2518"    = {{12, 5, 0},  "macOS", {"Mountain Lion", {10,  8, 5}}},
-	"12F2542"    = {{12, 5, 0},  "macOS", {"Mountain Lion", {10,  8, 5}}},
-	"12F2560"    = {{12, 5, 0},  "macOS", {"Mountain Lion", {10,  8, 5}}},
-
-	// MacOS Mavericks
-	"13A603"     = {{13, 0, 0},  "macOS", {"Mavericks",     {10,  9, 0}}},
-	"13B42"      = {{13, 0, 0},  "macOS", {"Mavericks",     {10,  9, 1}}},
-	"13C64"      = {{13, 1, 0},  "macOS", {"Mavericks",     {10,  9, 2}}},
-	"13C1021"    = {{13, 1, 0},  "macOS", {"Mavericks",     {10,  9, 2}}},
-	"13D65"      = {{13, 2, 0},  "macOS", {"Mavericks",     {10,  9, 3}}},
-	"13E28"      = {{13, 3, 0},  "macOS", {"Mavericks",     {10,  9, 4}}},
-	"13F34"      = {{13, 4, 0},  "macOS", {"Mavericks",     {10,  9, 5}}},
-	"13F1066"    = {{13, 4, 0},  "macOS", {"Mavericks",     {10,  9, 5}}},
-	"13F1077"    = {{13, 4, 0},  "macOS", {"Mavericks",     {10,  9, 5}}},
-	"13F1096"    = {{13, 4, 0},  "macOS", {"Mavericks",     {10,  9, 5}}},
-	"13F1112"    = {{13, 4, 0},  "macOS", {"Mavericks",     {10,  9, 5}}},
-	"13F1134"    = {{13, 4, 0},  "macOS", {"Mavericks",     {10,  9, 5}}},
-	"13F1507"    = {{13, 4, 0},  "macOS", {"Mavericks",     {10,  9, 5}}},
-	"13F1603"    = {{13, 4, 0},  "macOS", {"Mavericks",     {10,  9, 5}}},
-	"13F1712"    = {{13, 4, 0},  "macOS", {"Mavericks",     {10,  9, 5}}},
-	"13F1808"    = {{13, 4, 0},  "macOS", {"Mavericks",     {10,  9, 5}}},
-	"13F1911"    = {{13, 4, 0},  "macOS", {"Mavericks",     {10,  9, 5}}},
-
-	// MacOS Yosemite
-	"14A389"     = {{14, 0, 0},  "macOS", {"Yosemite",      {10, 10, 0}}},
-	"14B25"      = {{14, 0, 0},  "macOS", {"Yosemite",      {10, 10, 1}}},
-	"14C109"     = {{14, 1, 0},  "macOS", {"Yosemite",      {10, 10, 2}}},
-	"14C1510"    = {{14, 1, 0},  "macOS", {"Yosemite",      {10, 10, 2}}},
-	"14C2043"    = {{14, 1, 0},  "macOS", {"Yosemite",      {10, 10, 2}}},
-	"14C1514"    = {{14, 1, 0},  "macOS", {"Yosemite",      {10, 10, 2}}},
-	"14C2513"    = {{14, 1, 0},  "macOS", {"Yosemite",      {10, 10, 2}}},
-	"14D131"     = {{14, 3, 0},  "macOS", {"Yosemite",      {10, 10, 3}}},
-	"14D136"     = {{14, 3, 0},  "macOS", {"Yosemite",      {10, 10, 3}}},
-	"14E46"      = {{14, 4, 0},  "macOS", {"Yosemite",      {10, 10, 4}}},
-	"14F27"      = {{14, 5, 0},  "macOS", {"Yosemite",      {10, 10, 5}}},
-	"14F1021"    = {{14, 5, 0},  "macOS", {"Yosemite",      {10, 10, 5}}},
-	"14F1505"    = {{14, 5, 0},  "macOS", {"Yosemite",      {10, 10, 5}}},
-	"14F1509"    = {{14, 5, 0},  "macOS", {"Yosemite",      {10, 10, 5}}},
-	"14F1605"    = {{14, 5, 0},  "macOS", {"Yosemite",      {10, 10, 5}}},
-	"14F1713"    = {{14, 5, 0},  "macOS", {"Yosemite",      {10, 10, 5}}},
-	"14F1808"    = {{14, 5, 0},  "macOS", {"Yosemite",      {10, 10, 5}}},
-	"14F1909"    = {{14, 5, 0},  "macOS", {"Yosemite",      {10, 10, 5}}},
-	"14F1912"    = {{14, 5, 0},  "macOS", {"Yosemite",      {10, 10, 5}}},
-	"14F2009"    = {{14, 5, 0},  "macOS", {"Yosemite",      {10, 10, 5}}},
-	"14F2109"    = {{14, 5, 0},  "macOS", {"Yosemite",      {10, 10, 5}}},
-	"14F2315"    = {{14, 5, 0},  "macOS", {"Yosemite",      {10, 10, 5}}},
-	"14F2411"    = {{14, 5, 0},  "macOS", {"Yosemite",      {10, 10, 5}}},
-	"14F2511"    = {{14, 5, 0},  "macOS", {"Yosemite",      {10, 10, 5}}},
-
-	// MacOS El Capitan
-	"15A284"     = {{15, 0, 0}, "macOS", {"El Capitan",     {10, 11, 0}}},
-	"15B42"      = {{15, 0, 0}, "macOS", {"El Capitan",     {10, 11, 1}}},
-	"15C50"      = {{15, 2, 0}, "macOS", {"El Capitan",     {10, 11, 2}}},
-	"15D21"      = {{15, 3, 0}, "macOS", {"El Capitan",     {10, 11, 3}}},
-	"15E65"      = {{15, 4, 0}, "macOS", {"El Capitan",     {10, 11, 4}}},
-	"15F34"      = {{15, 5, 0}, "macOS", {"El Capitan",     {10, 11, 5}}},
-	"15G31"      = {{15, 6, 0}, "macOS", {"El Capitan",     {10, 11, 6}}},
-	"15G1004"    = {{15, 6, 0}, "macOS", {"El Capitan",     {10, 11, 6}}},
-	"15G1011"    = {{15, 6, 0}, "macOS", {"El Capitan",     {10, 11, 6}}},
-	"15G1108"    = {{15, 6, 0}, "macOS", {"El Capitan",     {10, 11, 6}}},
-	"15G1212"    = {{15, 6, 0}, "macOS", {"El Capitan",     {10, 11, 6}}},
-	"15G1217"    = {{15, 6, 0}, "macOS", {"El Capitan",     {10, 11, 6}}},
-	"15G1421"    = {{15, 6, 0}, "macOS", {"El Capitan",     {10, 11, 6}}},
-	"15G1510"    = {{15, 6, 0}, "macOS", {"El Capitan",     {10, 11, 6}}},
-	"15G1611"    = {{15, 6, 0}, "macOS", {"El Capitan",     {10, 11, 6}}},
-	"15G17023"   = {{15, 6, 0}, "macOS", {"El Capitan",     {10, 11, 6}}},
-	"15G18013"   = {{15, 6, 0}, "macOS", {"El Capitan",     {10, 11, 6}}},
-	"15G19009"   = {{15, 6, 0}, "macOS", {"El Capitan",     {10, 11, 6}}},
-	"15G20015"   = {{15, 6, 0}, "macOS", {"El Capitan",     {10, 11, 6}}},
-	"15G21013"   = {{15, 6, 0}, "macOS", {"El Capitan",     {10, 11, 6}}},
-	"15G22010"   = {{15, 6, 0}, "macOS", {"El Capitan",     {10, 11, 6}}},
-
-	// MacOS Sierra
-	"16A323"     = {{16, 0, 0}, "macOS", {"Sierra",         {10, 12, 0}}},
-	"16B2555"    = {{16, 1, 0}, "macOS", {"Sierra",         {10, 12, 1}}},
-	"16B2657"    = {{16, 1, 0}, "macOS", {"Sierra",         {10, 12, 1}}},
-	"16C67"      = {{16, 3, 0}, "macOS", {"Sierra",         {10, 12, 2}}},
-	"16C68"      = {{16, 3, 0}, "macOS", {"Sierra",         {10, 12, 2}}},
-	"16D32"      = {{16, 4, 0}, "macOS", {"Sierra",         {10, 12, 3}}},
-	"16E195"     = {{16, 5, 0}, "macOS", {"Sierra",         {10, 12, 4}}},
-	"16F73"      = {{16, 6, 0}, "macOS", {"Sierra",         {10, 12, 5}}},
-	"16F2073"    = {{16, 6, 0}, "macOS", {"Sierra",         {10, 12, 5}}},
-	"16G29"      = {{16, 7, 0}, "macOS", {"Sierra",         {10, 12, 6}}},
-	"16G1036"    = {{16, 7, 0}, "macOS", {"Sierra",         {10, 12, 6}}},
-	"16G1114"    = {{16, 7, 0}, "macOS", {"Sierra",         {10, 12, 6}}},
-	"16G1212"    = {{16, 7, 0}, "macOS", {"Sierra",         {10, 12, 6}}},
-	"16G1314"    = {{16, 7, 0}, "macOS", {"Sierra",         {10, 12, 6}}},
-	"16G1408"    = {{16, 7, 0}, "macOS", {"Sierra",         {10, 12, 6}}},
-	"16G1510"    = {{16, 7, 0}, "macOS", {"Sierra",         {10, 12, 6}}},
-	"16G1618"    = {{16, 7, 0}, "macOS", {"Sierra",         {10, 12, 6}}},
-	"16G1710"    = {{16, 7, 0}, "macOS", {"Sierra",         {10, 12, 6}}},
-	"16G1815"    = {{16, 7, 0}, "macOS", {"Sierra",         {10, 12, 6}}},
-	"16G1917"    = {{16, 7, 0}, "macOS", {"Sierra",         {10, 12, 6}}},
-	"16G1918"    = {{16, 7, 0}, "macOS", {"Sierra",         {10, 12, 6}}},
-	"16G2016"    = {{16, 7, 0}, "macOS", {"Sierra",         {10, 12, 6}}},
-	"16G2127"    = {{16, 7, 0}, "macOS", {"Sierra",         {10, 12, 6}}},
-	"16G2128"    = {{16, 7, 0}, "macOS", {"Sierra",         {10, 12, 6}}},
-	"16G2136"    = {{16, 7, 0}, "macOS", {"Sierra",         {10, 12, 6}}},
-
-	// MacOS High Sierra
-	"17A365"     = {{17, 0, 0}, "macOS", {"High Sierra",    {10, 13, 0}}},
-	"17A405"     = {{17, 0, 0}, "macOS", {"High Sierra",    {10, 13, 0}}},
-	"17B48"      = {{17, 2, 0}, "macOS", {"High Sierra",    {10, 13, 1}}},
-	"17B1002"    = {{17, 2, 0}, "macOS", {"High Sierra",    {10, 13, 1}}},
-	"17B1003"    = {{17, 2, 0}, "macOS", {"High Sierra",    {10, 13, 1}}},
-	"17C88"      = {{17, 3, 0}, "macOS", {"High Sierra",    {10, 13, 2}}},
-	"17C89"      = {{17, 3, 0}, "macOS", {"High Sierra",    {10, 13, 2}}},
-	"17C205"     = {{17, 3, 0}, "macOS", {"High Sierra",    {10, 13, 2}}},
-	"17C2205"    = {{17, 3, 0}, "macOS", {"High Sierra",    {10, 13, 2}}},
-	"17D47"      = {{17, 4, 0}, "macOS", {"High Sierra",    {10, 13, 3}}},
-	"17D2047"    = {{17, 4, 0}, "macOS", {"High Sierra",    {10, 13, 3}}},
-	"17D102"     = {{17, 4, 0}, "macOS", {"High Sierra",    {10, 13, 3}}},
-	"17D2102"    = {{17, 4, 0}, "macOS", {"High Sierra",    {10, 13, 3}}},
-	"17E199"     = {{17, 5, 0}, "macOS", {"High Sierra",    {10, 13, 4}}},
-	"17E202"     = {{17, 5, 0}, "macOS", {"High Sierra",    {10, 13, 4}}},
-	"17F77"      = {{17, 6, 0}, "macOS", {"High Sierra",    {10, 13, 5}}},
-	"17G65"      = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G2208"    = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G2307"    = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G3025"    = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G4015"    = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G5019"    = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G6029"    = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G6030"    = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G7024"    = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G8029"    = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G8030"    = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G8037"    = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G9016"    = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G10021"   = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G11023"   = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G12034"   = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G13033"   = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G13035"   = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G14019"   = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G14033"   = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-	"17G14042"   = {{17, 7, 0}, "macOS", {"High Sierra",    {10, 13, 6}}},
-
-	// MacOS Mojave
-	"18A391"     = {{18, 0, 0}, "macOS", {"Mojave",         {10, 14, 0}}},
-	"18B75"      = {{18, 2, 0}, "macOS", {"Mojave",         {10, 14, 1}}},
-	"18B2107"    = {{18, 2, 0}, "macOS", {"Mojave",         {10, 14, 1}}},
-	"18B3094"    = {{18, 2, 0}, "macOS", {"Mojave",         {10, 14, 1}}},
-	"18C54"      = {{18, 2, 0}, "macOS", {"Mojave",         {10, 14, 2}}},
-	"18D42"      = {{18, 2, 0}, "macOS", {"Mojave",         {10, 14, 3}}},
-	"18D43"      = {{18, 2, 0}, "macOS", {"Mojave",         {10, 14, 3}}},
-	"18D109"     = {{18, 2, 0}, "macOS", {"Mojave",         {10, 14, 3}}},
-	"18E226"     = {{18, 5, 0}, "macOS", {"Mojave",         {10, 14, 4}}},
-	"18E227"     = {{18, 5, 0}, "macOS", {"Mojave",         {10, 14, 4}}},
-	"18F132"     = {{18, 6, 0}, "macOS", {"Mojave",         {10, 14, 5}}},
-	"18G84"      = {{18, 7, 0}, "macOS", {"Mojave",         {10, 14, 6}}},
-	"18G87"      = {{18, 7, 0}, "macOS", {"Mojave",         {10, 14, 6}}},
-	"18G95"      = {{18, 7, 0}, "macOS", {"Mojave",         {10, 14, 6}}},
-	"18G103"     = {{18, 7, 0}, "macOS", {"Mojave",         {10, 14, 6}}},
-	"18G1012"    = {{18, 7, 0}, "macOS", {"Mojave",         {10, 14, 6}}},
-	"18G2022"    = {{18, 7, 0}, "macOS", {"Mojave",         {10, 14, 6}}},
-	"18G3020"    = {{18, 7, 0}, "macOS", {"Mojave",         {10, 14, 6}}},
-	"18G4032"    = {{18, 7, 0}, "macOS", {"Mojave",         {10, 14, 6}}},
-	"18G5033"    = {{18, 7, 0}, "macOS", {"Mojave",         {10, 14, 6}}},
-	"18G6020"    = {{18, 7, 0}, "macOS", {"Mojave",         {10, 14, 6}}},
-	"18G6032"    = {{18, 7, 0}, "macOS", {"Mojave",         {10, 14, 6}}},
-	"18G6042"    = {{18, 7, 0}, "macOS", {"Mojave",         {10, 14, 6}}},
-	"18G7016"    = {{18, 7, 0}, "macOS", {"Mojave",         {10, 14, 6}}},
-	"18G8012"    = {{18, 7, 0}, "macOS", {"Mojave",         {10, 14, 6}}},
-	"18G8022"    = {{18, 7, 0}, "macOS", {"Mojave",         {10, 14, 6}}},
-	"18G9028"    = {{18, 7, 0}, "macOS", {"Mojave",         {10, 14, 6}}},
-	"18G9216"    = {{18, 7, 0}, "macOS", {"Mojave",         {10, 14, 6}}},
-	"18G9323"    = {{18, 7, 0}, "macOS", {"Mojave",         {10, 14, 6}}},
-
-	// MacOS Catalina
-	"19A583"     = {{19, 0, 0}, "macOS", {"Catalina",       {10, 15, 0}}},
-	"19A602"     = {{19, 0, 0}, "macOS", {"Catalina",       {10, 15, 0}}},
-	"19A603"     = {{19, 0, 0}, "macOS", {"Catalina",       {10, 15, 0}}},
-	"19B88"      = {{19, 0, 0}, "macOS", {"Catalina",       {10, 15, 1}}},
-	"19C57"      = {{19, 2, 0}, "macOS", {"Catalina",       {10, 15, 2}}},
-	"19C58"      = {{19, 2, 0}, "macOS", {"Catalina",       {10, 15, 2}}},
-	"19D76"      = {{19, 3, 0}, "macOS", {"Catalina",       {10, 15, 3}}},
-	"19E266"     = {{19, 4, 0}, "macOS", {"Catalina",       {10, 15, 4}}},
-	"19E287"     = {{19, 4, 0}, "macOS", {"Catalina",       {10, 15, 4}}},
-	"19F96"      = {{19, 5, 0}, "macOS", {"Catalina",       {10, 15, 5}}},
-	"19F101"     = {{19, 5, 0}, "macOS", {"Catalina",       {10, 15, 5}}},
-	"19G73"      = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 6}}},
-	"19G2021"    = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 6}}},
-	"19H2"       = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 7}}},
-	"19H4"       = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 7}}},
-	"19H15"      = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 7}}},
-	"19H114"     = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 7}}},
-	"19H512"     = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 7}}},
-	"19H524"     = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 7}}},
-	"19H1030"    = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 7}}},
-	"19H1217"    = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 7}}},
-	"19H1323"    = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 7}}},
-	"19H1417"    = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 7}}},
-	"19H1419"    = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 7}}},
-	"19H1519"    = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 7}}},
-	"19H1615"    = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 7}}},
-	"19H1713"    = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 7}}},
-	"19H1715"    = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 7}}},
-	"19H1824"    = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 7}}},
-	"19H1922"    = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 7}}},
-	"19H2026"    = {{19, 6, 0}, "macOS", {"Catalina",       {10, 15, 7}}},
-
-	// MacOS Big Sur
-	"20A2411"    = {{20, 1, 0}, "macOS", {"Big Sur",        {11, 0, 0}}},
-	"20B29"      = {{20, 1, 0}, "macOS", {"Big Sur",        {11, 0, 1}}},
-	"20B50"      = {{20, 1, 0}, "macOS", {"Big Sur",        {11, 0, 1}}},
-	"20C69"      = {{20, 2, 0}, "macOS", {"Big Sur",        {11, 1, 0}}},
-	"20D64"      = {{20, 3, 0}, "macOS", {"Big Sur",        {11, 2, 0}}},
-	"20D74"      = {{20, 3, 0}, "macOS", {"Big Sur",        {11, 2, 1}}},
-	"20D75"      = {{20, 3, 0}, "macOS", {"Big Sur",        {11, 2, 1}}},
-	"20D80"      = {{20, 3, 0}, "macOS", {"Big Sur",        {11, 2, 2}}},
-	"20D91"      = {{20, 3, 0}, "macOS", {"Big Sur",        {11, 2, 3}}},
-	"20E232"     = {{20, 4, 0}, "macOS", {"Big Sur",        {11, 3, 0}}},
-	"20E241"     = {{20, 4, 0}, "macOS", {"Big Sur",        {11, 3, 1}}},
-	"20F71"      = {{20, 5, 0}, "macOS", {"Big Sur",        {11, 4, 0}}},
-	"20G71"      = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 5, 0}}},
-	"20G80"      = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 5, 1}}},
-	"20G95"      = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 5, 2}}},
-	"20G165"     = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 6, 0}}},
-	"20G224"     = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 6, 1}}},
-	"20G314"     = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 6, 2}}},
-	"20G415"     = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 6, 3}}},
-	"20G417"     = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 6, 4}}},
-	"20G527"     = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 6, 5}}},
-	"20G624"     = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 6, 6}}},
-	"20G630"     = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 6, 7}}},
-	"20G730"     = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 6, 8}}},
-	"20G817"     = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 7, 0}}},
-	"20G918"     = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 7, 1}}},
-	"20G1020"    = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 7, 2}}},
-	"20G1116"    = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 7, 3}}},
-	"20G1120"    = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 7, 4}}},
-	"20G1225"    = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 7, 5}}},
-	"20G1231"    = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 7, 6}}},
-	"20G1345"    = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 7, 7}}},
-	"20G1351"    = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 7, 8}}},
-	"20G1426"    = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 7, 9}}},
-	"20G1427"    = {{20, 6, 0}, "macOS", {"Big Sur",        {11, 7, 10}}},
-
-	// MacOS Monterey
-	"21A344"     = {{21, 0, 1}, "macOS", {"Monterey",       {12, 0, 0}}},
-	"21A559"     = {{21, 1, 0}, "macOS", {"Monterey",       {12, 0, 1}}},
-	"21C52"      = {{21, 2, 0}, "macOS", {"Monterey",       {12, 1, 0}}},
-	"21D49"      = {{21, 3, 0}, "macOS", {"Monterey",       {12, 2, 0}}},
-	"21D62"      = {{21, 3, 0}, "macOS", {"Monterey",       {12, 2, 1}}},
-	"21E230"     = {{21, 4, 0}, "macOS", {"Monterey",       {12, 3, 0}}},
-	"21E258"     = {{21, 4, 0}, "macOS", {"Monterey",       {12, 3, 1}}},
-	"21F79"      = {{21, 5, 0}, "macOS", {"Monterey",       {12, 4, 0}}},
-	"21F2081"    = {{21, 5, 0}, "macOS", {"Monterey",       {12, 4, 0}}},
-	"21F2092"    = {{21, 5, 0}, "macOS", {"Monterey",       {12, 4, 0}}},
-	"21G72"      = {{21, 6, 0}, "macOS", {"Monterey",       {12, 5, 0}}},
-	"21G83"      = {{21, 6, 0}, "macOS", {"Monterey",       {12, 5, 1}}},
-	"21G115"     = {{21, 6, 0}, "macOS", {"Monterey",       {12, 6, 0}}},
-	"21G217"     = {{21, 6, 0}, "macOS", {"Monterey",       {12, 6, 1}}},
-	"21G320"     = {{21, 6, 0}, "macOS", {"Monterey",       {12, 6, 2}}},
-	"21G419"     = {{21, 6, 0}, "macOS", {"Monterey",       {12, 6, 3}}},
-	"21G526"     = {{21, 6, 0}, "macOS", {"Monterey",       {12, 6, 4}}},
-	"21G531"     = {{21, 6, 0}, "macOS", {"Monterey",       {12, 6, 5}}},
-	"21G646"     = {{21, 6, 0}, "macOS", {"Monterey",       {12, 6, 6}}},
-	"21G651"     = {{21, 6, 0}, "macOS", {"Monterey",       {12, 6, 7}}},
-	"21G725"     = {{21, 6, 0}, "macOS", {"Monterey",       {12, 6, 8}}},
-	"21G726"     = {{21, 6, 0}, "macOS", {"Monterey",       {12, 6, 9}}},
-	"21G816"     = {{21, 6, 0}, "macOS", {"Monterey",       {12, 7, 0}}},
-	"21G920"     = {{21, 6, 0}, "macOS", {"Monterey",       {12, 7, 1}}},
-	"21G1974"    = {{21, 6, 0}, "macOS", {"Monterey",       {12, 7, 2}}},
-	"21H1015"    = {{21, 6, 0}, "macOS", {"Monterey",       {12, 7, 3}}},
-	"21H1123"    = {{21, 6, 0}, "macOS", {"Monterey",       {12, 7, 4}}},
-	"21H1222"    = {{21, 6, 0}, "macOS", {"Monterey",       {12, 7, 5}}},
-	"21H1320"    = {{21, 6, 0}, "macOS", {"Monterey",       {12, 7, 6}}},
-
-	// MacOS Ventura 
-	"22A380"     = {{22, 1, 0}, "macOS", {"Ventura",        {13, 0, 0}}},
-	"22A400"     = {{22, 1, 0}, "macOS", {"Ventura",        {13, 0, 1}}},
-	"22C65"	     = {{22, 2, 0}, "macOS", {"Ventura",        {13, 1, 0}}},
-	"22D49"	     = {{22, 3, 0}, "macOS", {"Ventura",        {13, 2, 0}}},
-	"22D68"	     = {{22, 3, 0}, "macOS", {"Ventura",        {13, 2, 1}}},
-	"22E252"     = {{22, 4, 0}, "macOS", {"Ventura",        {13, 3, 0}}},
-	"22E261"     = {{22, 4, 0}, "macOS", {"Ventura",        {13, 3, 1}}},
-	"22F66"	     = {{22, 5, 0}, "macOS", {"Ventura",        {13, 4, 0}}},
-	"22F82"	     = {{22, 5, 0}, "macOS", {"Ventura",        {13, 4, 1}}},
-	"22E772610a" = {{22, 5, 0}, "macOS", {"Ventura",        {13, 4, 1}}},
-	"22F770820d" = {{22, 5, 0}, "macOS", {"Ventura",        {13, 4, 1}}},
-	"22G74"	     = {{22, 6, 0}, "macOS", {"Ventura",        {13, 5, 0}}},
-	"22G90"	     = {{22, 6, 0}, "macOS", {"Ventura",        {13, 5, 1}}},
-	"22G91"	     = {{22, 6, 0}, "macOS", {"Ventura",        {13, 5, 2}}},
-	"22G120"     = {{22, 6, 0}, "macOS", {"Ventura",        {13, 6, 0}}},
-	"22G313"     = {{22, 6, 0}, "macOS", {"Ventura",        {13, 6, 1}}},
-	"22G320"     = {{22, 6, 0}, "macOS", {"Ventura",        {13, 6, 2}}},
-	"22G436"     = {{22, 6, 0}, "macOS", {"Ventura",        {13, 6, 3}}},
-	"22G513"     = {{22, 6, 0}, "macOS", {"Ventura",        {13, 6, 4}}},
-	"22G621"     = {{22, 6, 0}, "macOS", {"Ventura",        {13, 6, 5}}},
-	"22G630"     = {{22, 6, 0}, "macOS", {"Ventura",        {13, 6, 6}}},
-	"22G720"     = {{22, 6, 0}, "macOS", {"Ventura",        {13, 6, 7}}},
-	"22G820"     = {{22, 6, 0}, "macOS", {"Ventura",        {13, 6, 8}}},
-	"22G830"     = {{22, 6, 0}, "macOS", {"Ventura",        {13, 6, 9}}},
-	"22H123"     = {{22, 6, 0}, "macOS", {"Ventura",        {13, 7, 0}}},
-	"22H221"     = {{22, 6, 0}, "macOS", {"Ventura",        {13, 7, 1}}},
-
-	// MacOS Sonoma 
-	"23A344"     = {{23, 0, 0}, "macOS", {"Sonoma",         {14, 0, 0}}},
-	"23B74"      = {{23, 1, 0}, "macOS", {"Sonoma",         {14, 1, 0}}},
-	"23B81"      = {{23, 1, 0}, "macOS", {"Sonoma",         {14, 1, 1}}},
-	"23B2082"    = {{23, 1, 0}, "macOS", {"Sonoma",         {14, 1, 1}}},
-	"23B92"      = {{23, 1, 0}, "macOS", {"Sonoma",         {14, 1, 2}}},
-	"23B2091"    = {{23, 1, 0}, "macOS", {"Sonoma",         {14, 1, 2}}},
-	"23C64"      = {{23, 2, 0}, "macOS", {"Sonoma",         {14, 2, 0}}},
-	"23C71"      = {{23, 2, 0}, "macOS", {"Sonoma",         {14, 2, 1}}},
-	"23D56"      = {{23, 3, 0}, "macOS", {"Sonoma",         {14, 3, 0}}},
-	"23D60"      = {{23, 3, 0}, "macOS", {"Sonoma",         {14, 3, 1}}},
-	"23E214"     = {{23, 4, 0}, "macOS", {"Sonoma",         {14, 4, 0}}},
-	"23E224"     = {{23, 4, 0}, "macOS", {"Sonoma",         {14, 4, 1}}},
-	"23F79"      = {{23, 5, 0}, "macOS", {"Sonoma",         {14, 5, 0}}},
-	"23G80"      = {{23, 6, 0}, "macOS", {"Sonoma",         {14, 6, 0}}},
-	"23G93"      = {{23, 6, 0}, "macOS", {"Sonoma",         {14, 6, 1}}},
-	"23H124"     = {{23, 6, 0}, "macOS", {"Sonoma",         {14, 7, 0}}},
-	"23H222"     = {{23, 6, 0}, "macOS", {"Sonoma",         {14, 7, 1}}},
-
-	// MacOS Sequoia
-	"24A335"     = {{24, 0, 0}, "macOS", {"Sequoia",        {15, 0, 0}}},
-	"24A348"     = {{24, 0, 0}, "macOS", {"Sequoia",        {15, 0, 1}}},
-	"24B83"      = {{24, 1, 0}, "macOS", {"Sequoia",        {15, 1, 0}}},
-	"24B91"      = {{24, 1, 0}, "macOS", {"Sequoia",        {15, 1, 1}}},
-	"24B2091"    = {{24, 1, 0}, "macOS", {"Sequoia",        {15, 1, 1}}},
-}
-
-@(private)
-Darwin_Match :: enum {
-	Unknown,
-	Exact,
-	Nearest,
-}
-
-@(private)
-map_darwin_kernel_version_to_macos_release :: proc(build: string, darwin: [3]int) -> (res: Darwin_To_Release, match: Darwin_Match) {
-	// Find exact release match if possible.
-	if v, v_ok := macos_release_map[build]; v_ok {
-		return v, .Exact
-	}
-
-	nearest: Darwin_To_Release
-	for _, v in macos_release_map {
-		// Try an exact match on XNU version first.
-		if darwin == v.darwin {
-			return v, .Exact
-		}
-
-		// Major kernel version needs to match exactly,
-		// otherwise the release is considered .Unknown
-		if darwin.x == v.darwin.x {
-			if nearest == {} {
-				nearest = v
-			}
-			if darwin.y >= v.darwin.y && v.darwin != nearest.darwin {
-				nearest = v
-				if darwin.z >= v.darwin.z && v.darwin != nearest.darwin {
-					nearest = v
-				}
-			}
-		}
-	}
-
-	if nearest == {} {
-		return {darwin, "macOS", {"Unknown", {}}}, .Unknown
-	} else {
-		return nearest, .Nearest
-	}
+	os_version.as_string = string(b.buf[:])
 }

--- a/src/bug_report.cpp
+++ b/src/bug_report.cpp
@@ -526,404 +526,46 @@ gb_internal void report_os_info() {
 		gb_printf(", %s %s\n", info->sysname, info->release);
 
 	#elif defined(GB_SYSTEM_OSX)
-		struct Darwin_To_Release {
-			const char* build;    // 21G83
-			int   darwin[3];      // Darwin kernel triplet
-			const char* os_name;  // OS X, MacOS
-			struct {
-				const char* name; // Monterey, Mojave, etc.
-				int version[3];   // 12.4, etc.
-			} release;
+		gbString sw_vers = gb_string_make(heap_allocator(), "");
+		if (!system_exec_command_line_app_output("sw_vers --productVersion", &sw_vers)) {
+			gb_printf("macOS Unknown\n");
+			return;
+		}
+
+		uint32_t major, minor, patch;
+
+		if (sscanf(cast(const char *)sw_vers, "%u.%u.%u", &major, &minor, &patch) != 3) {
+			gb_printf("macOS Unknown\n");
+			return;
+		}
+
+		switch (major) {
+		case 15: gb_printf("macOS Sequoia"); break;
+		case 14: gb_printf("macOS Sonoma"); break;
+		case 13: gb_printf("macOS Ventura"); break;
+		case 12: gb_printf("macOS Monterey"); break;
+		case 11: gb_printf("macOS Big Sur"); break;
+		case 10:
+			{
+				switch (minor) {
+				case 15: gb_printf("macOS Catalina"); break;
+				case 14: gb_printf("macOS Mojave"); break;
+				case 13: gb_printf("macOS High Sierra"); break;
+				case 12: gb_printf("macOS Sierra"); break;
+				case 11: gb_printf("OS X El Capitan"); break;
+				case 10: gb_printf("OS X Yosemite"); break;
+				default: gb_printf("macOS Unknown");
+				};
+				break;
+			}
+		default:
+			gb_printf("macOS Unknown");
 		};
 
-		Darwin_To_Release macos_release_map[] = {
-			{"8A428",    { 8,  0,  0}, "macOS", {"Tiger",         {10,  4,  0}}},
-			{"8A432",    { 8,  0,  0}, "macOS", {"Tiger",         {10,  4,  0}}},
-			{"8B15",     { 8,  1,  0}, "macOS", {"Tiger",         {10,  4,  1}}},
-			{"8B17",     { 8,  1,  0}, "macOS", {"Tiger",         {10,  4,  1}}},
-			{"8C46",     { 8,  2,  0}, "macOS", {"Tiger",         {10,  4,  2}}},
-			{"8C47",     { 8,  2,  0}, "macOS", {"Tiger",         {10,  4,  2}}},
-			{"8E102",    { 8,  2,  0}, "macOS", {"Tiger",         {10,  4,  2}}},
-			{"8E45",     { 8,  2,  0}, "macOS", {"Tiger",         {10,  4,  2}}},
-			{"8E90",     { 8,  2,  0}, "macOS", {"Tiger",         {10,  4,  2}}},
-			{"8F46",     { 8,  3,  0}, "macOS", {"Tiger",         {10,  4,  3}}},
-			{"8G32",     { 8,  4,  0}, "macOS", {"Tiger",         {10,  4,  4}}},
-			{"8G1165",   { 8,  4,  0}, "macOS", {"Tiger",         {10,  4,  4}}},
-			{"8H14",     { 8,  5,  0}, "macOS", {"Tiger",         {10,  4,  5}}},
-			{"8G1454",   { 8,  5,  0}, "macOS", {"Tiger",         {10,  4,  5}}},
-			{"8I127",    { 8,  6,  0}, "macOS", {"Tiger",         {10,  4,  6}}},
-			{"8I1119",   { 8,  6,  0}, "macOS", {"Tiger",         {10,  4,  6}}},
-			{"8J135",    { 8,  7,  0}, "macOS", {"Tiger",         {10,  4,  7}}},
-			{"8J2135a",  { 8,  7,  0}, "macOS", {"Tiger",         {10,  4,  7}}},
-			{"8K1079",   { 8,  7,  0}, "macOS", {"Tiger",         {10,  4,  7}}},
-			{"8N5107",   { 8,  7,  0}, "macOS", {"Tiger",         {10,  4,  7}}},
-			{"8L127",    { 8,  8,  0}, "macOS", {"Tiger",         {10,  4,  8}}},
-			{"8L2127",   { 8,  8,  0}, "macOS", {"Tiger",         {10,  4,  8}}},
-			{"8P135",    { 8,  9,  0}, "macOS", {"Tiger",         {10,  4,  9}}},
-			{"8P2137",   { 8,  9,  0}, "macOS", {"Tiger",         {10,  4,  9}}},
-			{"8R218",    { 8, 10,  0}, "macOS", {"Tiger",         {10,  4, 10}}},
-			{"8R2218",   { 8, 10,  0}, "macOS", {"Tiger",         {10,  4, 10}}},
-			{"8R2232",   { 8, 10,  0}, "macOS", {"Tiger",         {10,  4, 10}}},
-			{"8S165",    { 8, 11,  0}, "macOS", {"Tiger",         {10,  4, 11}}},
-			{"8S2167",   { 8, 11,  0}, "macOS", {"Tiger",         {10,  4, 11}}},
-			{"9A581",    { 9,  0,  0}, "macOS", {"Leopard",       {10,  5,  0}}},
-			{"9B18",     { 9,  1,  0}, "macOS", {"Leopard",       {10,  5,  1}}},
-			{"9B2117",   { 9,  1,  1}, "macOS", {"Leopard",       {10,  5,  1}}},
-			{"9C31",     { 9,  2,  0}, "macOS", {"Leopard",       {10,  5,  2}}},
-			{"9C7010",   { 9,  2,  0}, "macOS", {"Leopard",       {10,  5,  2}}},
-			{"9D34",     { 9,  3,  0}, "macOS", {"Leopard",       {10,  5,  3}}},
-			{"9E17",     { 9,  4,  0}, "macOS", {"Leopard",       {10,  5,  4}}},
-			{"9F33",     { 9,  5,  0}, "macOS", {"Leopard",       {10,  5,  5}}},
-			{"9G55",     { 9,  6,  0}, "macOS", {"Leopard",       {10,  5,  6}}},
-			{"9G66",     { 9,  6,  0}, "macOS", {"Leopard",       {10,  5,  6}}},
-			{"9G71",     { 9,  6,  0}, "macOS", {"Leopard",       {10,  5,  6}}},
-			{"9J61",     { 9,  7,  0}, "macOS", {"Leopard",       {10,  5,  7}}},
-			{"9L30",     { 9,  8,  0}, "macOS", {"Leopard",       {10,  5,  8}}},
-			{"9L34",     { 9,  8,  0}, "macOS", {"Leopard",       {10,  5,  8}}},
-			{"10A432",   {10,  0,  0}, "macOS", {"Snow Leopard",  {10,  6,  0}}},
-			{"10A433",   {10,  0,  0}, "macOS", {"Snow Leopard",  {10,  6,  0}}},
-			{"10B504",   {10,  1,  0}, "macOS", {"Snow Leopard",  {10,  6,  1}}},
-			{"10C540",   {10,  2,  0}, "macOS", {"Snow Leopard",  {10,  6,  2}}},
-			{"10D573",   {10,  3,  0}, "macOS", {"Snow Leopard",  {10,  6,  3}}},
-			{"10D575",   {10,  3,  0}, "macOS", {"Snow Leopard",  {10,  6,  3}}},
-			{"10D578",   {10,  3,  0}, "macOS", {"Snow Leopard",  {10,  6,  3}}},
-			{"10F569",   {10,  4,  0}, "macOS", {"Snow Leopard",  {10,  6,  4}}},
-			{"10H574",   {10,  5,  0}, "macOS", {"Snow Leopard",  {10,  6,  5}}},
-			{"10J567",   {10,  6,  0}, "macOS", {"Snow Leopard",  {10,  6,  6}}},
-			{"10J869",   {10,  7,  0}, "macOS", {"Snow Leopard",  {10,  6,  7}}},
-			{"10J3250",  {10,  7,  0}, "macOS", {"Snow Leopard",  {10,  6,  7}}},
-			{"10J4138",  {10,  7,  0}, "macOS", {"Snow Leopard",  {10,  6,  7}}},
-			{"10K540",   {10,  8,  0}, "macOS", {"Snow Leopard",  {10,  6,  8}}},
-			{"10K549",   {10,  8,  0}, "macOS", {"Snow Leopard",  {10,  6,  8}}},
-			{"11A511",   {11,  0,  0}, "macOS", {"Lion",          {10,  7,  0}}},
-			{"11A511s",  {11,  0,  0}, "macOS", {"Lion",          {10,  7,  0}}},
-			{"11A2061",  {11,  0,  2}, "macOS", {"Lion",          {10,  7,  0}}},
-			{"11A2063",  {11,  0,  2}, "macOS", {"Lion",          {10,  7,  0}}},
-			{"11B26",    {11,  1,  0}, "macOS", {"Lion",          {10,  7,  1}}},
-			{"11B2118",  {11,  1,  0}, "macOS", {"Lion",          {10,  7,  1}}},
-			{"11C74",    {11,  2,  0}, "macOS", {"Lion",          {10,  7,  2}}},
-			{"11D50",    {11,  3,  0}, "macOS", {"Lion",          {10,  7,  3}}},
-			{"11E53",    {11,  4,  0}, "macOS", {"Lion",          {10,  7,  4}}},
-			{"11G56",    {11,  4,  2}, "macOS", {"Lion",          {10,  7,  5}}},
-			{"11G63",    {11,  4,  2}, "macOS", {"Lion",          {10,  7,  5}}},
-			{"12A269",   {12,  0,  0}, "macOS", {"Mountain Lion", {10,  8,  0}}},
-			{"12B19",    {12,  1,  0}, "macOS", {"Mountain Lion", {10,  8,  1}}},
-			{"12C54",    {12,  2,  0}, "macOS", {"Mountain Lion", {10,  8,  2}}},
-			{"12C60",    {12,  2,  0}, "macOS", {"Mountain Lion", {10,  8,  2}}},
-			{"12C2034",  {12,  2,  0}, "macOS", {"Mountain Lion", {10,  8,  2}}},
-			{"12C3104",  {12,  2,  0}, "macOS", {"Mountain Lion", {10,  8,  2}}},
-			{"12D78",    {12,  3,  0}, "macOS", {"Mountain Lion", {10,  8,  3}}},
-			{"12E55",    {12,  4,  0}, "macOS", {"Mountain Lion", {10,  8,  4}}},
-			{"12E3067",  {12,  4,  0}, "macOS", {"Mountain Lion", {10,  8,  4}}},
-			{"12E4022",  {12,  4,  0}, "macOS", {"Mountain Lion", {10,  8,  4}}},
-			{"12F37",    {12,  5,  0}, "macOS", {"Mountain Lion", {10,  8,  5}}},
-			{"12F45",    {12,  5,  0}, "macOS", {"Mountain Lion", {10,  8,  5}}},
-			{"12F2501",  {12,  5,  0}, "macOS", {"Mountain Lion", {10,  8,  5}}},
-			{"12F2518",  {12,  5,  0}, "macOS", {"Mountain Lion", {10,  8,  5}}},
-			{"12F2542",  {12,  5,  0}, "macOS", {"Mountain Lion", {10,  8,  5}}},
-			{"12F2560",  {12,  5,  0}, "macOS", {"Mountain Lion", {10,  8,  5}}},
-			{"13A603",   {13,  0,  0}, "macOS", {"Mavericks",     {10,  9,  0}}},
-			{"13B42",    {13,  0,  0}, "macOS", {"Mavericks",     {10,  9,  1}}},
-			{"13C64",    {13,  1,  0}, "macOS", {"Mavericks",     {10,  9,  2}}},
-			{"13C1021",  {13,  1,  0}, "macOS", {"Mavericks",     {10,  9,  2}}},
-			{"13D65",    {13,  2,  0}, "macOS", {"Mavericks",     {10,  9,  3}}},
-			{"13E28",    {13,  3,  0}, "macOS", {"Mavericks",     {10,  9,  4}}},
-			{"13F34",    {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
-			{"13F1066",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
-			{"13F1077",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
-			{"13F1096",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
-			{"13F1112",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
-			{"13F1134",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
-			{"13F1507",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
-			{"13F1603",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
-			{"13F1712",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
-			{"13F1808",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
-			{"13F1911",  {13,  4,  0}, "macOS", {"Mavericks",     {10,  9,  5}}},
-			{"14A389",   {14,  0,  0}, "macOS", {"Yosemite",      {10, 10,  0}}},
-			{"14B25",    {14,  0,  0}, "macOS", {"Yosemite",      {10, 10,  1}}},
-			{"14C109",   {14,  1,  0}, "macOS", {"Yosemite",      {10, 10,  2}}},
-			{"14C1510",  {14,  1,  0}, "macOS", {"Yosemite",      {10, 10,  2}}},
-			{"14C2043",  {14,  1,  0}, "macOS", {"Yosemite",      {10, 10,  2}}},
-			{"14C1514",  {14,  1,  0}, "macOS", {"Yosemite",      {10, 10,  2}}},
-			{"14C2513",  {14,  1,  0}, "macOS", {"Yosemite",      {10, 10,  2}}},
-			{"14D131",   {14,  3,  0}, "macOS", {"Yosemite",      {10, 10,  3}}},
-			{"14D136",   {14,  3,  0}, "macOS", {"Yosemite",      {10, 10,  3}}},
-			{"14E46",    {14,  4,  0}, "macOS", {"Yosemite",      {10, 10,  4}}},
-			{"14F27",    {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
-			{"14F1021",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
-			{"14F1505",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
-			{"14F1509",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
-			{"14F1605",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
-			{"14F1713",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
-			{"14F1808",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
-			{"14F1909",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
-			{"14F1912",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
-			{"14F2009",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
-			{"14F2109",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
-			{"14F2315",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
-			{"14F2411",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
-			{"14F2511",  {14,  5,  0}, "macOS", {"Yosemite",      {10, 10,  5}}},
-			{"15A284",   {15,  0,  0}, "macOS", {"El Capitan",    {10, 11,  0}}},
-			{"15B42",    {15,  0,  0}, "macOS", {"El Capitan",    {10, 11,  1}}},
-			{"15C50",    {15,  2,  0}, "macOS", {"El Capitan",    {10, 11,  2}}},
-			{"15D21",    {15,  3,  0}, "macOS", {"El Capitan",    {10, 11,  3}}},
-			{"15E65",    {15,  4,  0}, "macOS", {"El Capitan",    {10, 11,  4}}},
-			{"15F34",    {15,  5,  0}, "macOS", {"El Capitan",    {10, 11,  5}}},
-			{"15G31",    {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
-			{"15G1004",  {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
-			{"15G1011",  {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
-			{"15G1108",  {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
-			{"15G1212",  {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
-			{"15G1217",  {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
-			{"15G1421",  {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
-			{"15G1510",  {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
-			{"15G1611",  {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
-			{"15G17023", {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
-			{"15G18013", {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
-			{"15G19009", {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
-			{"15G20015", {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
-			{"15G21013", {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
-			{"15G22010", {15,  6,  0}, "macOS", {"El Capitan",    {10, 11,  6}}},
-			{"16A323",   {16,  0,  0}, "macOS", {"Sierra",        {10, 12,  0}}},
-			{"16B2555",  {16,  1,  0}, "macOS", {"Sierra",        {10, 12,  1}}},
-			{"16B2657",  {16,  1,  0}, "macOS", {"Sierra",        {10, 12,  1}}},
-			{"16C67",    {16,  3,  0}, "macOS", {"Sierra",        {10, 12,  2}}},
-			{"16C68",    {16,  3,  0}, "macOS", {"Sierra",        {10, 12,  2}}},
-			{"16D32",    {16,  4,  0}, "macOS", {"Sierra",        {10, 12,  3}}},
-			{"16E195",   {16,  5,  0}, "macOS", {"Sierra",        {10, 12,  4}}},
-			{"16F73",    {16,  6,  0}, "macOS", {"Sierra",        {10, 12,  5}}},
-			{"16F2073",  {16,  6,  0}, "macOS", {"Sierra",        {10, 12,  5}}},
-			{"16G29",    {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
-			{"16G1036",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
-			{"16G1114",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
-			{"16G1212",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
-			{"16G1314",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
-			{"16G1408",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
-			{"16G1510",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
-			{"16G1618",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
-			{"16G1710",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
-			{"16G1815",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
-			{"16G1917",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
-			{"16G1918",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
-			{"16G2016",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
-			{"16G2127",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
-			{"16G2128",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
-			{"16G2136",  {16,  7,  0}, "macOS", {"Sierra",        {10, 12,  6}}},
-			{"17A365",   {17,  0,  0}, "macOS", {"High Sierra",   {10, 13,  0}}},
-			{"17A405",   {17,  0,  0}, "macOS", {"High Sierra",   {10, 13,  0}}},
-			{"17B48",    {17,  2,  0}, "macOS", {"High Sierra",   {10, 13,  1}}},
-			{"17B1002",  {17,  2,  0}, "macOS", {"High Sierra",   {10, 13,  1}}},
-			{"17B1003",  {17,  2,  0}, "macOS", {"High Sierra",   {10, 13,  1}}},
-			{"17C88",    {17,  3,  0}, "macOS", {"High Sierra",   {10, 13,  2}}},
-			{"17C89",    {17,  3,  0}, "macOS", {"High Sierra",   {10, 13,  2}}},
-			{"17C205",   {17,  3,  0}, "macOS", {"High Sierra",   {10, 13,  2}}},
-			{"17C2205",  {17,  3,  0}, "macOS", {"High Sierra",   {10, 13,  2}}},
-			{"17D47",    {17,  4,  0}, "macOS", {"High Sierra",   {10, 13,  3}}},
-			{"17D2047",  {17,  4,  0}, "macOS", {"High Sierra",   {10, 13,  3}}},
-			{"17D102",   {17,  4,  0}, "macOS", {"High Sierra",   {10, 13,  3}}},
-			{"17D2102",  {17,  4,  0}, "macOS", {"High Sierra",   {10, 13,  3}}},
-			{"17E199",   {17,  5,  0}, "macOS", {"High Sierra",   {10, 13,  4}}},
-			{"17E202",   {17,  5,  0}, "macOS", {"High Sierra",   {10, 13,  4}}},
-			{"17F77",    {17,  6,  0}, "macOS", {"High Sierra",   {10, 13,  5}}},
-			{"17G65",    {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G2208",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G2307",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G3025",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G4015",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G5019",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G6029",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G6030",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G7024",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G8029",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G8030",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G8037",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G9016",  {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G10021", {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G11023", {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G12034", {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G13033", {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G13035", {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G14019", {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G14033", {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"17G14042", {17,  7,  0}, "macOS", {"High Sierra",   {10, 13,  6}}},
-			{"18A391",   {18,  0,  0}, "macOS", {"Mojave",        {10, 14,  0}}},
-			{"18B75",    {18,  2,  0}, "macOS", {"Mojave",        {10, 14,  1}}},
-			{"18B2107",  {18,  2,  0}, "macOS", {"Mojave",        {10, 14,  1}}},
-			{"18B3094",  {18,  2,  0}, "macOS", {"Mojave",        {10, 14,  1}}},
-			{"18C54",    {18,  2,  0}, "macOS", {"Mojave",        {10, 14,  2}}},
-			{"18D42",    {18,  2,  0}, "macOS", {"Mojave",        {10, 14,  3}}},
-			{"18D43",    {18,  2,  0}, "macOS", {"Mojave",        {10, 14,  3}}},
-			{"18D109",   {18,  2,  0}, "macOS", {"Mojave",        {10, 14,  3}}},
-			{"18E226",   {18,  5,  0}, "macOS", {"Mojave",        {10, 14,  4}}},
-			{"18E227",   {18,  5,  0}, "macOS", {"Mojave",        {10, 14,  4}}},
-			{"18F132",   {18,  6,  0}, "macOS", {"Mojave",        {10, 14,  5}}},
-			{"18G84",    {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
-			{"18G87",    {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
-			{"18G95",    {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
-			{"18G103",   {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
-			{"18G1012",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
-			{"18G2022",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
-			{"18G3020",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
-			{"18G4032",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
-			{"18G5033",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
-			{"18G6020",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
-			{"18G6032",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
-			{"18G6042",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
-			{"18G7016",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
-			{"18G8012",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
-			{"18G8022",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
-			{"18G9028",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
-			{"18G9216",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
-			{"18G9323",  {18,  7,  0}, "macOS", {"Mojave",        {10, 14,  6}}},
-			{"19A583",   {19,  0,  0}, "macOS", {"Catalina",      {10, 15,  0}}},
-			{"19A602",   {19,  0,  0}, "macOS", {"Catalina",      {10, 15,  0}}},
-			{"19A603",   {19,  0,  0}, "macOS", {"Catalina",      {10, 15,  0}}},
-			{"19B88",    {19,  0,  0}, "macOS", {"Catalina",      {10, 15,  1}}},
-			{"19C57",    {19,  2,  0}, "macOS", {"Catalina",      {10, 15,  2}}},
-			{"19C58",    {19,  2,  0}, "macOS", {"Catalina",      {10, 15,  2}}},
-			{"19D76",    {19,  3,  0}, "macOS", {"Catalina",      {10, 15,  3}}},
-			{"19E266",   {19,  4,  0}, "macOS", {"Catalina",      {10, 15,  4}}},
-			{"19E287",   {19,  4,  0}, "macOS", {"Catalina",      {10, 15,  4}}},
-			{"19F96",    {19,  5,  0}, "macOS", {"Catalina",      {10, 15,  5}}},
-			{"19F101",   {19,  5,  0}, "macOS", {"Catalina",      {10, 15,  5}}},
-			{"19G73",    {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  6}}},
-			{"19G2021",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  6}}},
-			{"19H2",     {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
-			{"19H4",     {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
-			{"19H15",    {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
-			{"19H114",   {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
-			{"19H512",   {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
-			{"19H524",   {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
-			{"19H1030",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
-			{"19H1217",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
-			{"19H1323",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
-			{"19H1417",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
-			{"19H1419",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
-			{"19H1519",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
-			{"19H1615",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
-			{"19H1713",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
-			{"19H1715",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
-			{"19H1824",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
-			{"19H1922",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
-			{"19H2026",  {19,  6,  0}, "macOS", {"Catalina",      {10, 15,  7}}},
-			{"20A2411",  {20,  1,  0}, "macOS", {"Big Sur",       {11,  0,  0}}},
-			{"20B29",    {20,  1,  0}, "macOS", {"Big Sur",       {11,  0,  1}}},
-			{"20B50",    {20,  1,  0}, "macOS", {"Big Sur",       {11,  0,  1}}},
-			{"20C69",    {20,  2,  0}, "macOS", {"Big Sur",       {11,  1,  0}}},
-			{"20D64",    {20,  3,  0}, "macOS", {"Big Sur",       {11,  2,  0}}},
-			{"20D74",    {20,  3,  0}, "macOS", {"Big Sur",       {11,  2,  1}}},
-			{"20D75",    {20,  3,  0}, "macOS", {"Big Sur",       {11,  2,  1}}},
-			{"20D80",    {20,  3,  0}, "macOS", {"Big Sur",       {11,  2,  2}}},
-			{"20D91",    {20,  3,  0}, "macOS", {"Big Sur",       {11,  2,  3}}},
-			{"20E232",   {20,  4,  0}, "macOS", {"Big Sur",       {11,  3,  0}}},
-			{"20E241",   {20,  4,  0}, "macOS", {"Big Sur",       {11,  3,  1}}},
-			{"20F71",    {20,  5,  0}, "macOS", {"Big Sur",       {11,  4,  0}}},
-			{"20G71",    {20,  6,  0}, "macOS", {"Big Sur",       {11,  5,  0}}},
-			{"20G80",    {20,  6,  0}, "macOS", {"Big Sur",       {11,  5,  1}}},
-			{"20G95",    {20,  6,  0}, "macOS", {"Big Sur",       {11,  5,  2}}},
-			{"20G165",   {20,  6,  0}, "macOS", {"Big Sur",       {11,  6,  0}}},
-			{"20G224",   {20,  6,  0}, "macOS", {"Big Sur",       {11,  6,  1}}},
-			{"20G314",   {20,  6,  0}, "macOS", {"Big Sur",       {11,  6,  2}}},
-			{"20G415",   {20,  6,  0}, "macOS", {"Big Sur",       {11,  6,  3}}},
-			{"20G417",   {20,  6,  0}, "macOS", {"Big Sur",       {11,  6,  4}}},
-			{"20G527",   {20,  6,  0}, "macOS", {"Big Sur",       {11,  6,  5}}},
-			{"20G624",   {20,  6,  0}, "macOS", {"Big Sur",       {11,  6,  6}}},
-			{"20G630",   {20,  6,  0}, "macOS", {"Big Sur",       {11,  6,  7}}},
-			{"20G730",   {20,  6,  0}, "macOS", {"Big Sur",       {11,  6,  8}}},
-			{"20G817",   {20,  6,  0}, "macOS", {"Big Sur",       {11, 7,   0}}},
-			{"20G918",   {20,  6,  0}, "macOS", {"Big Sur",       {11, 7,   1}}},
-			{"20G1020",  {20,  6,  0}, "macOS", {"Big Sur",       {11, 7,   2}}},
-			{"20G1116",  {20,  6,  0}, "macOS", {"Big Sur",       {11, 7,   3}}},
-			{"20G1120",  {20,  6,  0}, "macOS", {"Big Sur",       {11, 7,   4}}},
-			{"20G1225",  {20,  6,  0}, "macOS", {"Big Sur",       {11, 7,   5}}},
-			{"20G1231",  {20,  6,  0}, "macOS", {"Big Sur",       {11, 7,   6}}},
-			{"20G1345",  {20,  6,  0}, "macOS", {"Big Sur",       {11, 7,   7}}},
-			{"20G1351",  {20,  6,  0}, "macOS", {"Big Sur",       {11, 7,   8}}},
-			{"20G1426",  {20,  6,  0}, "macOS", {"Big Sur",       {11, 7,   9}}},
-			{"20G1427",  {20,  6,  0}, "macOS", {"Big Sur",       {11, 7,  10}}},
-			{"21A344",   {21,  0,  1}, "macOS", {"Monterey",      {12,  0,  0}}},
-			{"21A559",   {21,  1,  0}, "macOS", {"Monterey",      {12,  0,  1}}},
-			{"21C52",    {21,  2,  0}, "macOS", {"Monterey",      {12,  1,  0}}},
-			{"21D49",    {21,  3,  0}, "macOS", {"Monterey",      {12,  2,  0}}},
-			{"21D62",    {21,  3,  0}, "macOS", {"Monterey",      {12,  2,  1}}},
-			{"21E230",   {21,  4,  0}, "macOS", {"Monterey",      {12,  3,  0}}},
-			{"21E258",   {21,  4,  0}, "macOS", {"Monterey",      {12,  3,  1}}},
-			{"21F79",    {21,  5,  0}, "macOS", {"Monterey",      {12,  4,  0}}},
-			{"21F2081",  {21,  5,  0}, "macOS", {"Monterey",      {12,  4,  0}}},
-			{"21F2092",  {21,  5,  0}, "macOS", {"Monterey",      {12,  4,  0}}},
-			{"21G72",    {21,  6,  0}, "macOS", {"Monterey",      {12,  5,  0}}},
-			{"21G83",    {21,  6,  0}, "macOS", {"Monterey",      {12,  5,  1}}},
-			{"21G115",   {21,  6,  0}, "macOS", {"Monterey",      {12,  6,  0}}},
-			{"21G217",   {21,  6,  0}, "macOS", {"Monterey",      {12,  6,  1}}},
-			{"21G320",   {21,  6,  0}, "macOS", {"Monterey",      {12,  6,  2}}},
-			{"21G419",   {21,  6,  0}, "macOS", {"Monterey",      {12,  6,  3}}},
-			{"21G526",   {21,  6,  0}, "macOS", {"Monterey",      {12,  6,  4}}},
-			{"21G531",   {21,  6,  0}, "macOS", {"Monterey",      {12,  6,  5}}},
-			{"21G646",   {21,  6,  0}, "macOS", {"Monterey",      {12,  6,  6}}},
-			{"21G651",   {21,  6,  0}, "macOS", {"Monterey",      {12,  6,  7}}},
-			{"21G725",   {21,  6,  0}, "macOS", {"Monterey",      {12,  6,  8}}},
-			{"21G726",   {21,  6,  0}, "macOS", {"Monterey",      {12,  6,  9}}},
-			{"21G816",   {21,  6,  0}, "macOS", {"Monterey",      {12,  7,  0}}},
-			{"21G920",   {21,  6,  0}, "macOS", {"Monterey",      {12,  7,  1}}},
-			{"21G1974",  {21,  6,  0}, "macOS", {"Monterey",      {12,  7,  2}}},
-			{"21H1015",  {21,  6,  0}, "macOS", {"Monterey",      {12,  7,  3}}},
-			{"21H1123",  {21,  6,  0}, "macOS", {"Monterey",      {12,  7,  4}}},
-			{"21H1222",  {21,  6,  0}, "macOS", {"Monterey",      {12,  7,  5}}},
-			{"21H1320",  {21,  6,  0}, "macOS", {"Monterey",      {12,  7,  6}}},
-			{"22A380",   {13,  0,  0}, "macOS", {"Ventura",       {22,  1,  0}}},
-			{"22A400",   {13,  0,  1}, "macOS", {"Ventura",       {22,  1,  0}}},
-			{"22C65",    {13,  1,  0}, "macOS", {"Ventura",       {22,  2,  0}}},
-			{"22D49",    {13,  2,  0}, "macOS", {"Ventura",       {22,  3,  0}}},
-			{"22D68",    {13,  2,  1}, "macOS", {"Ventura",       {22,  3,  0}}},
-			{"22E252",   {13,  3,  0}, "macOS", {"Ventura",       {22,  4,  0}}},
-			{"22E261",   {13,  3,  1}, "macOS", {"Ventura",       {22,  4,  0}}},
-			{"22F66",    {13,  4,  0}, "macOS", {"Ventura",       {22,  5,  0}}},
-			{"22F82",    {13,  4,  1}, "macOS", {"Ventura",       {22,  5,  0}}},
-			{"22E772610a", {13, 4, 1}, "macOS", {"Ventura",       {22,  5,  0}}},
-			{"22F770820d", {13, 4, 1}, "macOS", {"Ventura",       {22,  5,  0}}},
-			{"22G74",    {13,  5,  0}, "macOS", {"Ventura",       {22,  6,  0}}},
-			{"22G90",    {13,  5,  1}, "macOS", {"Ventura",       {22,  6,  0}}},
-			{"22G91",    {13,  5,  2}, "macOS", {"Ventura",       {22,  6,  0}}},
-			{"22G120",   {13,  6,  0}, "macOS", {"Ventura",       {22,  6,  0}}},
-			{"22G313",   {13,  6,  1}, "macOS", {"Ventura",       {22,  6,  0}}},
-			{"22G320",   {13,  6,  2}, "macOS", {"Ventura",       {22,  6,  0}}},
-			{"22G436",   {22,  6,  0}, "macOS", {"Ventura",       {13,  6,  3}}},
-			{"22G513",   {22,  6,  0}, "macOS", {"Ventura",       {13,  6,  4}}},
-			{"22G621",   {22,  6,  0}, "macOS", {"Ventura",       {13,  6,  5}}},
-			{"22G630",   {22,  6,  0}, "macOS", {"Ventura",       {13,  6,  6}}},
-			{"22G720",   {22,  6,  0}, "macOS", {"Ventura",       {13,  6,  7}}},
-			{"22G820",   {22,  6,  0}, "macOS", {"Ventura",       {13,  6,  8}}},
-			{"22G830",   {22,  6,  0}, "macOS", {"Ventura",       {13,  6,  9}}},
-			{"22H123",   {22,  6,  0}, "macOS", {"Ventura",       {13,  7,  0}}},
-			{"22H221",   {22,  6,  0}, "macOS", {"Ventura",       {13,  7,  1}}},
-			{"23A344",   {23,  0,  0}, "macOS", {"Sonoma",        {14,  0,  0}}},
-			{"23B74",    {23,  1,  0}, "macOS", {"Sonoma",        {14,  1,  0}}},
-			{"23B81",    {23,  1,  0}, "macOS", {"Sonoma",        {14,  1,  1}}},
-			{"23B2082",  {23,  1,  0}, "macOS", {"Sonoma",        {14,  1,  1}}},
-			{"23B92",    {23,  1,  0}, "macOS", {"Sonoma",        {14,  1,  2}}},
-			{"23B2091",  {23,  1,  0}, "macOS", {"Sonoma",        {14,  1,  2}}},
-			{"23C64",    {23,  2,  0}, "macOS", {"Sonoma",        {14,  2,  0}}},
-			{"23C71",    {23,  2,  0}, "macOS", {"Sonoma",        {14,  2,  1}}},
-			{"23D56",    {23,  3,  0}, "macOS", {"Sonoma",        {14,  3,  0}}},
-			{"23D60",    {23,  3,  0}, "macOS", {"Sonoma",        {14,  3,  1}}},
-			{"23E214",   {23,  4,  0}, "macOS", {"Sonoma",        {14,  4,  0}}},
-			{"23E224",   {23,  4,  0}, "macOS", {"Sonoma",        {14,  4,  1}}},
-			{"23F79",    {23,  5,  0}, "macOS", {"Sonoma",        {14,  5,  0}}},
-			{"23G80",    {23,  6,  0}, "macOS", {"Sonoma",        {14,  6,  0}}},
-			{"23G93",    {23,  6,  0}, "macOS", {"Sonoma",        {14,  6,  1}}},
-			{"23H124",   {23,  6,  0}, "macOS", {"Sonoma",        {14,  7,  0}}},
-			{"23H222",   {23,  6,  0}, "macOS", {"Sonoma",        {14,  7,  1}}},
-			{"24A335",   {24,  0,  0}, "macOS", {"Sequoia",       {15,  0,  0}}},
-			{"24A348",   {24,  0,  0}, "macOS", {"Sequoia",       {15,  0,  1}}},
-			{"24B83",    {24,  1,  0}, "macOS", {"Sequoia",       {15,  1,  0}}},
-			{"24B91",    {24,  1,  0}, "macOS", {"Sequoia",       {15,  1,  1}}},
-			{"24B2091",  {24,  1,  0}, "macOS", {"Sequoia",       {15,  1,  1}}},
-		};
-
+		gb_printf(" %d.%d.%d (build ", major, minor, patch);
 
 		b32 build_found  = 1;
 		b32 darwin_found = 1;
-		uint32_t major, minor, patch;
 
 		#define MACOS_VERSION_BUFFER_SIZE 100
 		char build_buffer[MACOS_VERSION_BUFFER_SIZE];
@@ -939,81 +581,25 @@ gb_internal void report_os_info() {
 
 		int darwin_mibs[] = { CTL_KERN, KERN_OSRELEASE };
 		if (sysctl(darwin_mibs, 2, darwin_buffer, &darwin_buffer_size, NULL, 0) == -1) {
-			gb_printf("macOS Unknown\n");
-			return;
+			darwin_found = 0;
 		} else {
 			if (sscanf(darwin_buffer, "%u.%u.%u", &major, &minor, &patch) != 3) {
 				darwin_found = 0;
 			}
 		}
 
-		// Scan table for match on BUILD
-		int macos_release_count = sizeof(macos_release_map) / sizeof(macos_release_map[0]);
-		Darwin_To_Release build_match = {};
-		Darwin_To_Release kernel_match = {};
-	
-		for (int build = 0; build < macos_release_count; build++) {
-			Darwin_To_Release rel = macos_release_map[build];
-			
-			// Do we have an exact match on the BUILD?
-			if (gb_strcmp(rel.build, (const char *)build_buffer) == 0) {
-				build_match = rel;
-				break;
-			}
-			
-			// Do we have an exact Darwin match?
-			if (rel.darwin[0] == major && rel.darwin[1] == minor && rel.darwin[2] == patch) {
-				kernel_match = rel;
-			}
-	
-			// Major kernel version needs to match exactly,
-			if (rel.darwin[0] == major) {
-				// No major version match yet.
-				if (!kernel_match.os_name) {
-					kernel_match = rel;
-				}
-				if (minor >= rel.darwin[1]) {
-					kernel_match = rel;
-					if (patch >= rel.darwin[2]) {
-						kernel_match = rel;
-					}
-				}
-			}
-		}
-	
-		Darwin_To_Release match = {};
-		if(!build_match.build) {
-			match = kernel_match;
+		if (build_found) {
+			gb_printf("%s, kernel ", build_buffer);
 		} else {
-			match = build_match;
+			gb_printf("Unknown, kernel ");
 		}
 
-		if (match.os_name) {
-			gb_printf("%s %s %d", match.os_name, match.release.name, match.release.version[0]);
-			if (match.release.version[1] > 0 || match.release.version[2] > 0) {
-				gb_printf(".%d", match.release.version[1]);
-			}
-			if (match.release.version[2] > 0) {
-				gb_printf(".%d", match.release.version[2]);
-			}
-			if (build_found) {
-				gb_printf(" (build: %s, kernel: %d.%d.%d)\n", build_buffer, match.darwin[0], match.darwin[1], match.darwin[2]);
-			} else {
-				gb_printf(" (build: %s?, kernel: %d.%d.%d)\n", match.build, match.darwin[0], match.darwin[1], match.darwin[2]);				
-			}
-			return;
+		if (darwin_found) {
+			gb_printf("%s)\n", darwin_buffer);
+		} else {
+			gb_printf("Unknown)\n");
 		}
 
-		if (build_found && darwin_found) {
-			gb_printf("macOS Unknown (build: %s, kernel: %d.%d.%d)\n", build_buffer, major, minor, patch);
-			return;
-		} else if (build_found) {
-			gb_printf("macOS Unknown (build: %s)\n", build_buffer);
-			return;
-		} else if (darwin_found) {
-			gb_printf("macOS Unknown (kernel: %d.%d.%d)\n", major, minor, patch);
-			return;
-		}
 	#elif defined(GB_SYSTEM_OPENBSD) || defined(GB_SYSTEM_NETBSD)
 		struct utsname un;
 		


### PR DESCRIPTION
- adds NSProcessInfo bindings
- reworks sys/info macos version retrieval to use NSProcessInfo.operatingSystemVersion
- reworks `odin report` to use `sw_vers --productVersion` (didn't want to introduce objc into compiler and shelling out is no problem)

Ultimately reducing the maintenance burden keeping the tables up-to-date every release and also makes it (probably) work on iOS once we flesh it out. This also means you don't need an updated compiler to have updated versions reported.