### PR TITLE
Fix math binomial proc giving wrong result

### DIFF
--- a/core/math/math.odin
+++ b/core/math/math.odin
@@ -1271,7 +1271,7 @@ binomial :: proc "contextless" (n, k: int) -> int {
 	}
 
 	b := n
-	for i in 2..<k {
+	for i in 2..=k {
 		b = (b * (n+1-i))/i
 	}
 	return b


### PR DESCRIPTION
Fixes binomial function by making loop inclusive. 

was - 
```
for i in 2 ..< k {
	b = (b * (n + 1 - i)) / i
}
```
now - 
```
for i in 2 ..= k {
	b = (b * (n + 1 - i)) / i
}
```