### PR TITLE
Pass allocator to implicitly (de)allocating procs in `core:log`

### DIFF
--- a/core/log/file_console_logger.odin
+++ b/core/log/file_console_logger.odin
@@ -37,30 +37,30 @@ File_Console_Logger_Data :: struct {
 	ident: string,
 }
 
-create_file_logger :: proc(h: os.Handle, lowest := Level.Debug, opt := Default_File_Logger_Opts, ident := "") -> Logger {
-	data := new(File_Console_Logger_Data)
+create_file_logger :: proc(h: os.Handle, lowest := Level.Debug, opt := Default_File_Logger_Opts, ident := "", allocator := context.allocator) -> Logger {
+	data := new(File_Console_Logger_Data, allocator)
 	data.file_handle = h
 	data.ident = ident
 	return Logger{file_console_logger_proc, data, lowest, opt}
 }
 
-destroy_file_logger :: proc(log: Logger) {
+destroy_file_logger :: proc(log: Logger, allocator := context.allocator) {
 	data := cast(^File_Console_Logger_Data)log.data
 	if data.file_handle != os.INVALID_HANDLE {
 		os.close(data.file_handle)
 	}
-	free(data)
+	free(data, allocator)
 }
 
-create_console_logger :: proc(lowest := Level.Debug, opt := Default_Console_Logger_Opts, ident := "") -> Logger {
-	data := new(File_Console_Logger_Data)
+create_console_logger :: proc(lowest := Level.Debug, opt := Default_Console_Logger_Opts, ident := "", allocator := context.allocator) -> Logger {
+	data := new(File_Console_Logger_Data, allocator)
 	data.file_handle = os.INVALID_HANDLE
 	data.ident = ident
 	return Logger{file_console_logger_proc, data, lowest, opt}
 }
 
-destroy_console_logger :: proc(log: Logger) {
-	free(log.data)
+destroy_console_logger :: proc(log: Logger, allocator := context.allocator) {
+	free(log.data, allocator)
 }
 
 file_console_logger_proc :: proc(logger_data: rawptr, level: Level, text: string, options: Options, location := #caller_location) {

--- a/core/log/multi_logger.odin
+++ b/core/log/multi_logger.odin
@@ -5,17 +5,17 @@ Multi_Logger_Data :: struct {
 	loggers: []Logger,
 }
 
-create_multi_logger :: proc(logs: ..Logger) -> Logger {
-	data := new(Multi_Logger_Data)
-	data.loggers = make([]Logger, len(logs))
+create_multi_logger :: proc(logs: ..Logger, allocator := context.allocator) -> Logger {
+	data := new(Multi_Logger_Data, allocator)
+	data.loggers = make([]Logger, len(logs), allocator)
 	copy(data.loggers, logs)
 	return Logger{multi_logger_proc, data, Level.Debug, nil}
 }
 
-destroy_multi_logger :: proc(log: Logger) {
+destroy_multi_logger :: proc(log: Logger, allocator := context.allocator) {
 	data := (^Multi_Logger_Data)(log.data)
-	delete(data.loggers)
-	free(data)
+	delete(data.loggers, allocator)
+	free(data, allocator)
 }
 
 multi_logger_proc :: proc(logger_data: rawptr, level: Level, text: string,


### PR DESCRIPTION
Not much to say here, `log.create_*` and `log.destroy_*` did some implicit allocations, without passing an allocator, not very interesting to work with.

#4463 will probably alter this again