### PR TITLE
[core:math/linalg] Add `linalg.clamp_length(vector, max_length) -> clamped_vector`

### DIFF
--- a/core/math/linalg/general.odin
+++ b/core/math/linalg/general.odin
@@ -167,6 +167,18 @@ vector_triple_product :: proc "contextless" (a, b, c: $T/[$N]$E) -> T where IS_N
 length :: proc{vector_length, quaternion_length}
 length2 :: proc{vector_length2, quaternion_length2}
 
+
+@(require_results)
+clamp_length :: proc "contextless" (v: $T/[$N]$E, a: E) -> T where IS_FLOAT(E) {
+	if a <= 0 {
+		return 0
+	}
+	
+	m2 := length2(v)
+	return v if (m2 <= a*a) else (v / sqrt(m2) * a) // returns original when m2 is 0
+}
+
+
 @(require_results)
 projection :: proc "contextless" (x, normal: $T/[$N]$E) -> T where IS_NUMERIC(E) {
 	return dot(x, normal) / dot(normal, normal) * normal


### PR DESCRIPTION
Occasionally vectors need to be clamped to a maximum length while preserving smaller values, for example when processing joystick input from an unreliable source.

```odin
larger         := [2]f32 {1.0, 1.0}
larger_clamped := linalg.clamp_length(larger, 1.0)
// larger_clamped is approximately {0.707, 0.707}

smaller         := [2]f32 {0.2, 0}
smaller_clamped := linalg.clamp_length(smaller, 1.0)
// smaller_clamped == smaller
```

**Divide-by-zero safety:**

- `a` is explicitly checked to be > 0
- `m2` is always 0+ because it's squared. 
- `a*a` is always 0+ because it's squared. 
- if `m2 != 0`, it's not divide-by-zero. 
- if `m2 == 0`, then `m2 <= a*a` which returns the original vector. 