### PR TITLE
fix: regex's match_with_preallocated_capture returning num_groups

### DIFF
--- a/core/text/regex/regex.odin
+++ b/core/text/regex/regex.odin
@@ -381,6 +381,7 @@ match_with_preallocated_capture :: proc(
 			capture.pos[n] = {a, b}
 			n += 1
 		}
+		num_groups = n
 	}
 
 	return


### PR DESCRIPTION
regex's `match_with_preallocated_capture` proc never sets and returns `num_groups`