### PR TITLE
add which to shell.nix to build with --pure

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -3,6 +3,7 @@ pkgs.mkShell {
   name = "odin";
   nativeBuildInputs = with pkgs; [
     git
+    which
     clang_17
     llvmPackages_17.llvm
     llvmPackages_17.bintools


### PR DESCRIPTION
There might be another issue to look into here, namely that `llvmPackages_17.llvm` provides `llvm-config` but not `llvm-config-17`. Since my distribution provides llvm 14 and `llvm-config-14`, that's always picked by `build_odin.sh` over the one in `shell.nix` unless it's entered with `--pure`