### PR TITLE
docs: improved `slice.reinterpret` docstring

### DIFF
--- a/core/slice/slice.odin
+++ b/core/slice/slice.odin
@@ -48,22 +48,41 @@ to_type :: proc(buf: []u8, $T: typeid) -> (T, bool) #optional_ok {
 }
 
 /*
-	Turn a slice of one type, into a slice of another type.
+Turn a slice of one type, into a slice of another type.
 
-	Only converts the type and length of the slice itself.
-	The length is rounded down to the nearest whole number of items.
+Only converts the type and length of the slice itself.
+The length is rounded down to the nearest whole number of items.
 
-	```
-	large_items := []i64{1, 2, 3, 4}
-	small_items := slice.reinterpret([]i32, large_items)
-	assert(len(small_items) == 8)
-	```
-	```
-	small_items := []byte{1, 0, 0, 0, 0, 0, 0, 0,
-						  2, 0, 0, 0}
-	large_items := slice.reinterpret([]i64, small_items)
-	assert(len(large_items) == 1) // only enough bytes to make 1 x i64; two would need at least 8 bytes.
-	```
+Example:
+
+	import "core:fmt"
+	import "core:slice"
+
+	i64s_as_i32s :: proc() {
+		large_items := []i64{1, 2, 3, 4}
+		small_items := slice.reinterpret([]i32, large_items)
+		assert(len(small_items) == 8)
+		fmt.println(large_items, "->", small_items)
+	}
+
+	bytes_as_i64s :: proc() {
+		small_items := [12]byte{}
+		small_items[0] = 1
+		small_items[8] = 2
+		large_items := slice.reinterpret([]i64, small_items[:])
+		assert(len(large_items) == 1) // only enough bytes to make 1 x i64; two would need at least 8 bytes.
+		fmt.println(small_items, "->", large_items)
+	}
+
+	reinterpret_example :: proc() {
+		i64s_as_i32s()
+		bytes_as_i64s()
+	}
+
+Output:
+	[1, 2, 3, 4] -> [1, 0, 2, 0, 3, 0, 4, 0]
+	[1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0] -> [1]
+
 */
 @(require_results)
 reinterpret :: proc "contextless" ($T: typeid/[]$U, s: []$V) -> []U {


### PR DESCRIPTION
I've noticed that the documentation for the procedure `slice.reinterpret` is malformed at pkg.odin-lang.org because it was using the ``` notation instead of `Example` and `Output`.
While I was at it, for the second example docstring, I ended up changing it a bit to avoid having a formatting incompatible with `ols` by  initializing an array and setting two values.

## Docs before:
![reinterpret_before](https://github.com/user-attachments/assets/860ae340-269d-43b6-9417-fddcb9a66982)

## Docs now:
![image](https://github.com/user-attachments/assets/2cd49173-eec9-49d8-bb56-0a2b6be0f32c)



