### PR TITLE
add `math.pow2` overloads

### DIFF
--- a/core/math/math.odin
+++ b/core/math/math.odin
@@ -205,8 +205,21 @@ pow10_f64 :: proc "contextless" (n: f64) -> f64 {
 	return 0
 }
 
+@(require_results) pow2_f16le :: proc "contextless" (x: f16le) -> f16le { return #force_inline f16le(pow2_f16(f16(x))) }
+@(require_results) pow2_f16be :: proc "contextless" (x: f16be) -> f16be { return #force_inline f16be(pow2_f16(f16(x))) }
+@(require_results) pow2_f32le :: proc "contextless" (x: f32le) -> f32le { return #force_inline f32le(pow2_f32(f32(x))) }
+@(require_results) pow2_f32be :: proc "contextless" (x: f32be) -> f32be { return #force_inline f32be(pow2_f32(f32(x))) }
+@(require_results) pow2_f64le :: proc "contextless" (x: f64le) -> f64le { return #force_inline f64le(pow2_f64(f64(x))) }
+@(require_results) pow2_f64be :: proc "contextless" (x: f64be) -> f64be { return #force_inline f64be(pow2_f64(f64(x))) }
+pow2 :: proc{
+	pow2_f16, pow2_f16le, pow2_f16be,
+	pow2_f32, pow2_f32le, pow2_f32be,
+	pow2_f64, pow2_f64le, pow2_f64be,
+}
+
 @(require_results)
-pow2_f64 :: proc "contextless" (#any_int exp: int) -> (res: f64) {
+pow2_f64 :: proc "contextless" (n: f64) -> (res: f64) {
+	exp := i64(n)
 	switch {
 	case exp >= -1022 && exp <= 1023: // Normal
 		return transmute(f64)(u64(exp + F64_BIAS) << F64_SHIFT)
@@ -225,7 +238,8 @@ pow2_f64 :: proc "contextless" (#any_int exp: int) -> (res: f64) {
 }
 
 @(require_results)
-pow2_f32 :: proc "contextless" (#any_int exp: int) -> (res: f32) {
+pow2_f32 :: proc "contextless" (n: f32) -> (res: f32) {
+	exp := i32(n)
 	switch {
 	case exp >= -126 && exp <= 127:  // Normal
 		return transmute(f32)(u32(exp + F32_BIAS) << F32_SHIFT)
@@ -241,7 +255,8 @@ pow2_f32 :: proc "contextless" (#any_int exp: int) -> (res: f32) {
 }
 
 @(require_results)
-pow2_f16 :: proc "contextless" (#any_int exp: int) -> (res: f16) {
+pow2_f16 :: proc "contextless" (n: f16) -> (res: f16) {
+	exp := i16(n)
 	switch {
 	case exp >= -14 && exp <= 15:    // Normal
 		return transmute(f16)(u16(exp + F16_BIAS) << F16_SHIFT)

--- a/tests/internal/test_pow.odin
+++ b/tests/internal/test_pow.odin
@@ -9,37 +9,37 @@ pow_test :: proc(t: ^testing.T) {
 	for exp in -2000..=2000 {
 		{
 			v1 := math.pow(2, f64(exp))
-			v2 := math.pow2_f64(exp)
+			v2 := math.pow2(f64(exp))
 			_v1 := transmute(u64)v1
 			_v2 := transmute(u64)v2
 			if exp == -1075 && ODIN_OS == .Windows {
 				// LLVM on Windows returns 0h00000000_00000001 for pow(2, -1075),
 				// unlike macOS and Linux where it returns 0h00000000_00000000
-				// pow2_f64 returns the same float on all platforms because it isn't this stupid
+				// pow2 returns the same float on all platforms because it isn't this stupid
 				_v1 = 0h00000000_00000000
 			}
-			testing.expectf(t,  _v1 == _v2, "Expected math.pow2_f64(%d) == math.pow(2, %d) (= %16x), got %16x", exp, exp, _v1, _v2)
+			testing.expectf(t,  _v1 == _v2, "Expected math.pow2(%d) == math.pow(2, %d) (= %16x), got %16x", exp, exp, _v1, _v2)
 		}
 		{
 			v1 := math.pow(2, f32(exp))
-			v2 := math.pow2_f32(exp)
+			v2 := math.pow2(f32(exp))
 			_v1 := transmute(u32)v1
 			_v2 := transmute(u32)v2
-			testing.expectf(t,  _v1 == _v2, "Expected math.pow2_f32(%d) == math.pow(2, %d) (= %08x), got %08x", exp, exp, _v1, _v2)
+			testing.expectf(t,  _v1 == _v2, "Expected math.pow2(%d) == math.pow(2, %d) (= %08x), got %08x", exp, exp, _v1, _v2)
 		}
 		{
 			v1 := math.pow(2, f16(exp))
-			v2 := math.pow2_f16(exp)
+			v2 := math.pow2(f16(exp))
 			_v2 := transmute(u16)v2
 			_v1 := transmute(u16)v1
 
 			when ODIN_OS == .Darwin && ODIN_ARCH == .arm64 {
 				if exp == -25 {
-					log.info("skipping known test failure on darwin+arm64, Expected math.pow2_f16(-25) == math.pow(2, -25) (= 0000), got 0001")
+					log.info("skipping known test failure on darwin+arm64, Expected math.pow2(-25) == math.pow(2, -25) (= 0000), got 0001")
 					_v2 = 0
 				}
 			}
-			testing.expectf(t,  _v1 == _v2, "Expected math.pow2_f16(%d) == math.pow(2, %d) (= %04x), got %04x", exp, exp, _v1, _v2)
+			testing.expectf(t,  _v1 == _v2, "Expected math.pow2(%d) == math.pow(2, %d) (= %04x), got %04x", exp, exp, _v1, _v2)
 		}
 	}
 }


### PR DESCRIPTION
add overloads for `math.pow2_f{16, 32, 64}` in the vein of the `math.pow`/`math.pow10`s overloads

`odin test tests\internal`, which includes `test_pow.odin`, ran successfully on my `x86_64-win11` device. Given the nature of the changes I don't expect differing behavior on other targets.