### PR TITLE
compiler: remove viral `#force(_no)_inline`

### DIFF
--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -1136,10 +1136,6 @@ gb_internal lbValue lb_emit_call(lbProcedure *p, lbValue value, Array<lbValue> c
 			}
 		}
 
-		if (inlining == ProcInlining_none) {
-			inlining = p->inlining;
-		}
-
 		Type *rt = reduce_tuple_to_single_type(results);
 		Type *original_rt = rt;
 		if (split_returns) {


### PR DESCRIPTION
If a procedure was marked `#force_no_inline`, any procedure calls within it would also implicitly be. This is not expected for multiple reasons:

1. `#force(_no)_inline` on a call expr works differently than on a procedure literal.
2. Adding the attribute on it and every called proc blows up the amount of work for the inliner pass and may increase the time it takes.
3. Putting `#force_no_inline` on a procedure to keep executable size down (like we do for some map procedures), benchmark it, or find it in asm/ir has the added effect of slowing those procedures down significantly and not representing truth.