### PR TITLE
Fix parsing of integer w/ 'e' notation

### DIFF
--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -251,7 +251,10 @@ gb_internal void big_int_from_string(BigInt *dst, String const &s, bool *success
 			exp *= 10;
 			exp += v;
 		}
-		big_int_exp_u64(dst, &b, exp, success);
+		BigInt tmp = {};
+		mp_init(&tmp);
+		big_int_exp_u64(&tmp, &b, exp, success);
+		big_int_mul_eq(dst, &tmp);
 	}
 
 	if (is_negative) {


### PR DESCRIPTION
Closes #4485 by making floating point values with 'e' and without a '.' treated as floats rather than ints.