### PR TITLE
`vendor:miniaudio`: Use bit sets for flags

### DIFF
--- a/vendor/miniaudio/device_io_types.odin
+++ b/vendor/miniaudio/device_io_types.odin
@@ -357,8 +357,6 @@ data_format_flag :: enum c.int {
 
 data_format_flags :: bit_set[data_format_flag; u32]
 
-DATA_FORMAT_FLAG_EXCLUSIVE_MODE :: data_format_flags{.EXCLUSIVE_MODE}
-
 MAX_DEVICE_NAME_LENGTH :: 255
 
 device_info :: struct {

--- a/vendor/miniaudio/device_io_types.odin
+++ b/vendor/miniaudio/device_io_types.odin
@@ -351,8 +351,13 @@ device_id :: struct #raw_union {
 	nullbackend: c.int,                 /* The null backend uses an integer for device IDs. */
 }
 
+data_format_flag :: enum c.int {
+	EXCLUSIVE_MODE = 1, /* If set, this is supported in exclusive mode. Otherwise not natively supported by exclusive mode. */
+}
 
-DATA_FORMAT_FLAG_EXCLUSIVE_MODE :: 1 << 1    /* If set, this is supported in exclusive mode. Otherwise not natively supported by exclusive mode. */
+data_format_flags :: bit_set[data_format_flag; u32]
+
+DATA_FORMAT_FLAG_EXCLUSIVE_MODE :: data_format_flags{.EXCLUSIVE_MODE}
 
 MAX_DEVICE_NAME_LENGTH :: 255
 
@@ -364,10 +369,10 @@ device_info :: struct {
 
 	nativeDataFormatCount: u32,
 	nativeDataFormats: [/*len(format_count) * standard_sample_rate.rate_count * MAX_CHANNELS*/ 64]struct { /* Not sure how big to make this. There can be *many* permutations for virtual devices which can support anything. */
-		format:     format, /* Sample format. If set to ma_format_unknown, all sample formats are supported. */
-		channels:   u32,    /* If set to 0, all channels are supported. */
-		sampleRate: u32,    /* If set to 0, all sample rates are supported. */
-		flags:      u32,    /* A combination of MA_DATA_FORMAT_FLAG_* flags. */
+		format:     format,            /* Sample format. If set to ma_format_unknown, all sample formats are supported. */
+		channels:   u32,               /* If set to 0, all channels are supported. */
+		sampleRate: u32,               /* If set to 0, all sample rates are supported. */
+		flags:      data_format_flags, /* A combination of MA_DATA_FORMAT_FLAG_* flags. */
 	},  
 }
 

--- a/vendor/miniaudio/resource_manager.odin
+++ b/vendor/miniaudio/resource_manager.odin
@@ -10,13 +10,15 @@ Resource Manager
 
 ************************************************************************************************************************************************************/
 
-resource_manager_data_source_flags :: enum c.int {
-	STREAM         = 0x00000001,   /* When set, does not load the entire data source in memory. Disk I/O will happen on job threads. */
-	DECODE         = 0x00000002,   /* Decode data before storing in memory. When set, decoding is done at the resource manager level rather than the mixing thread. Results in faster mixing, but higher memory usage. */
-	ASYNC          = 0x00000004,   /* When set, the resource manager will load the data source asynchronously. */
-	WAIT_INIT      = 0x00000008,   /* When set, waits for initialization of the underlying data source before returning from ma_resource_manager_data_source_init(). */
-	UNKNOWN_LENGTH = 0x00000010,   /* Gives the resource manager a hint that the length of the data source is unknown and calling `ma_data_source_get_length_in_pcm_frames()` should be avoided. */
+resource_manager_data_source_flag :: enum c.int {
+	STREAM         = 0,   /* When set, does not load the entire data source in memory. Disk I/O will happen on job threads. */
+	DECODE         = 1,   /* Decode data before storing in memory. When set, decoding is done at the resource manager level rather than the mixing thread. Results in faster mixing, but higher memory usage. */
+	ASYNC          = 2,   /* When set, the resource manager will load the data source asynchronously. */
+	WAIT_INIT      = 3,   /* When set, waits for initialization of the underlying data source before returning from ma_resource_manager_data_source_init(). */
+	UNKNOWN_LENGTH = 4,   /* Gives the resource manager a hint that the length of the data source is unknown and calling `ma_data_source_get_length_in_pcm_frames()` should be avoided. */
 }
+
+resource_manager_data_source_flags :: bit_set[resource_manager_data_source_flag; u32]
 
 /*
 Pipeline notifications used by the resource manager. Made up of both an async notification and a fence, both of which are optional.
@@ -58,13 +60,15 @@ resource_manager_job_queue_next                   :: job_queue_next
 /* Maximum job thread count will be restricted to this, but this may be removed later and replaced with a heap allocation thereby removing any limitation. */
 RESOURCE_MANAGER_MAX_JOB_THREAD_COUNT :: 64
 
-resource_manager_flags :: enum c.int {
+resource_manager_flag :: enum c.int {
 	/* Indicates ma_resource_manager_next_job() should not block. Only valid when the job thread count is 0. */
 	NON_BLOCKING = 0x00000001,
 
 	/* Disables any kind of multithreading. Implicitly enables MA_RESOURCE_MANAGER_FLAG_NON_BLOCKING. */
 	NO_THREADING = 0x00000002,
 }
+
+resource_manager_flags :: bit_set[resource_manager_flag; u32]
 
 resource_manager_data_source_config :: struct {
 	pFilePath:                   cstring,
@@ -126,7 +130,7 @@ resource_manager_data_buffer :: struct {
 	ds:                     data_source_base,                      /* Base data source. A data buffer is a data source. */
 	pResourceManager:       ^resource_manager,                     /* A pointer to the resource manager that owns this buffer. */
 	pNode:                  ^resource_manager_data_buffer_node,    /* The data node. This is reference counted and is what supplies the data. */
-	flags:                  u32,                                   /* The flags that were passed used to initialize the buffer. */
+	flags:                  resource_manager_flags,                /* The flags that were passed used to initialize the buffer. */
 	executionCounter:       u32, /*atomic*/                        /* For allocating execution orders for jobs. */
 	executionPointer:       u32, /*atomic*/                        /* For managing the order of execution for asynchronous jobs relating to this object. Incremented as jobs complete processing. */
 	seekTargetInPCMFrames:  u64,                                   /* Only updated by the public API. Never written nor read from the job thread. */

--- a/vendor/miniaudio/resource_manager.odin
+++ b/vendor/miniaudio/resource_manager.odin
@@ -62,10 +62,10 @@ RESOURCE_MANAGER_MAX_JOB_THREAD_COUNT :: 64
 
 resource_manager_flag :: enum c.int {
 	/* Indicates ma_resource_manager_next_job() should not block. Only valid when the job thread count is 0. */
-	NON_BLOCKING = 0x00000001,
+	NON_BLOCKING = 0,
 
 	/* Disables any kind of multithreading. Implicitly enables MA_RESOURCE_MANAGER_FLAG_NON_BLOCKING. */
-	NO_THREADING = 0x00000002,
+	NO_THREADING = 1,
 }
 
 resource_manager_flags :: bit_set[resource_manager_flag; u32]

--- a/vendor/miniaudio/utilities.odin
+++ b/vendor/miniaudio/utilities.odin
@@ -119,7 +119,13 @@ offset_pcm_frames_const_ptr_f32 :: #force_inline proc "c" (p: [^]f32, offsetInFr
 
 data_source :: struct {}
 
-DATA_SOURCE_SELF_MANAGED_RANGE_AND_LOOP_POINT :: 0x00000001
+data_source_flag :: enum c.int {
+	SELF_MANAGED_RANGE_AND_LOOP_POINT = 0,
+}
+
+data_source_flags :: bit_set[data_source_flag; u32]
+
+DATA_SOURCE_SELF_MANAGED_RANGE_AND_LOOP_POINT :: data_source_flags{.SELF_MANAGED_RANGE_AND_LOOP_POINT}
 
 data_source_vtable :: struct {
 	onRead:          proc "c" (pDataSource: ^data_source, pFramesOut: rawptr, frameCount: u64, pFramesRead: ^u64) -> result,
@@ -128,7 +134,7 @@ data_source_vtable :: struct {
 	onGetCursor:     proc "c" (pDataSource: ^data_source, pCursor: ^u64) -> result,
 	onGetLength:     proc "c" (pDataSource: ^data_source, pLength: ^u64) -> result,
 	onSetLooping:    proc "c" (pDataSource: ^data_source, isLooping: b32) -> result,
-	flags:           u32,
+	flags:           data_source_flags,
 } 
 
 data_source_get_next_proc :: proc "c" (pDataSource: ^data_source) -> ^data_source

--- a/vendor/miniaudio/utilities.odin
+++ b/vendor/miniaudio/utilities.odin
@@ -125,7 +125,6 @@ data_source_flag :: enum c.int {
 
 data_source_flags :: bit_set[data_source_flag; u32]
 
-DATA_SOURCE_SELF_MANAGED_RANGE_AND_LOOP_POINT :: data_source_flags{.SELF_MANAGED_RANGE_AND_LOOP_POINT}
 
 data_source_vtable :: struct {
 	onRead:          proc "c" (pDataSource: ^data_source, pFramesOut: rawptr, frameCount: u64, pFramesRead: ^u64) -> result,

--- a/vendor/miniaudio/vfs.odin
+++ b/vendor/miniaudio/vfs.odin
@@ -16,10 +16,12 @@ appropriate for a given situation.
 vfs :: struct {}
 vfs_file :: distinct handle
 
-open_mode_flags :: enum c.int {
-	READ  = 0x00000001,
-	WRITE = 0x00000002,
+open_mode_flag :: enum c.int {
+	READ  = 0,
+	WRITE = 1,
 }
+
+open_mode_flags :: bit_set[open_mode_flag; u32]
 
 seek_origin :: enum c.int {
 	start,
@@ -32,8 +34,8 @@ file_info :: struct {
 }
 
 vfs_callbacks :: struct {
-	onOpen:  proc "c" (pVFS: ^vfs, pFilePath: cstring,      openMode: u32, pFile: ^vfs_file) -> result,
-	onOpenW: proc "c" (pVFS: ^vfs, pFilePath: [^]c.wchar_t, openMode: u32, pFile: ^vfs_file) -> result,
+	onOpen:  proc "c" (pVFS: ^vfs, pFilePath: cstring,      openMode: open_mode_flags, pFile: ^vfs_file) -> result,
+	onOpenW: proc "c" (pVFS: ^vfs, pFilePath: [^]c.wchar_t, openMode: open_mode_flags, pFile: ^vfs_file) -> result,
 	onClose: proc "c" (pVFS: ^vfs, file: vfs_file) -> result,
 	onRead:  proc "c" (pVFS: ^vfs, file: vfs_file, pDst: rawptr, sizeInBytes: c.size_t, pBytesRead: ^c.size_t) -> result,
 	onWrite: proc "c" (pVFS: ^vfs, file: vfs_file, pSrc: rawptr, sizeInBytes: c.size_t, pBytesWritten: ^c.size_t) -> result,
@@ -54,8 +56,8 @@ ma_tell_proc :: proc "c" (pUserData: rawptr, pCursor: ^i64) -> result
 
 @(default_calling_convention="c", link_prefix="ma_")
 foreign lib {
-	vfs_open               :: proc(pVFS: ^vfs, pFilePath: cstring,      openMode: u32, pFile: ^vfs_file) -> result ---
-	vfs_open_w             :: proc(pVFS: ^vfs, pFilePath: [^]c.wchar_t, openMode: u32, pFile: ^vfs_file) -> result ---
+	vfs_open               :: proc(pVFS: ^vfs, pFilePath: cstring,      openMode: open_mode_flags, pFile: ^vfs_file) -> result ---
+	vfs_open_w             :: proc(pVFS: ^vfs, pFilePath: [^]c.wchar_t, openMode: open_mode_flags, pFile: ^vfs_file) -> result ---
 	vfs_close              :: proc(pVFS: ^vfs, file: vfs_file) -> result ---
 	vfs_read               :: proc(pVFS: ^vfs, file: vfs_file, pDst: rawptr, sizeInBytes: c.size_t, pBytesRead: ^c.size_t) -> result ---
 	vfs_write              :: proc(pVFS: ^vfs, file: vfs_file, pSrc: rawptr, sizeInBytes: c.size_t, pBytesWritten: ^c.size_t) -> result ---


### PR DESCRIPTION
This is a breaking change, existing code will need to switch to using the bit_sets.
- Replaces the raw `u32` enum flags with `bit_set` versions to make using miniaudio a bit more ergonomic.
- Added missing `MA_NODE_OUTPUT_BUS_FLAG_*` flags