### PR TITLE
Add trunc to glsl linalg

### DIFF
--- a/core/math/linalg/glsl/linalg_glsl.odin
+++ b/core/math/linalg/glsl/linalg_glsl.odin
@@ -473,6 +473,22 @@ floor :: proc{
 @(require_results) floor_dvec3 :: proc "c" (x: dvec3) -> dvec3 { return {floor(x.x), floor(x.y), floor(x.z)} }
 @(require_results) floor_dvec4 :: proc "c" (x: dvec4) -> dvec4 { return {floor(x.x), floor(x.y), floor(x.z), floor(x.w)} }
 
+trunc :: proc{
+	trunc_f32,
+	trunc_f64,
+	trunc_vec2,
+	trunc_vec3,
+	trunc_vec4,
+	trunc_dvec2,
+	trunc_dvec3,
+	trunc_dvec4,
+}
+@(require_results) trunc_vec2 :: proc "c" (x: vec2) -> vec2 { return {trunc(x.x), trunc(x.y)} }
+@(require_results) trunc_vec3 :: proc "c" (x: vec3) -> vec3 { return {trunc(x.x), trunc(x.y), trunc(x.z)} }
+@(require_results) trunc_vec4 :: proc "c" (x: vec4) -> vec4 { return {trunc(x.x), trunc(x.y), trunc(x.z), trunc(x.w)} }
+@(require_results) trunc_dvec2 :: proc "c" (x: dvec2) -> dvec2 { return {trunc(x.x), trunc(x.y)} }
+@(require_results) trunc_dvec3 :: proc "c" (x: dvec3) -> dvec3 { return {trunc(x.x), trunc(x.y), trunc(x.z)} }
+@(require_results) trunc_dvec4 :: proc "c" (x: dvec4) -> dvec4 { return {trunc(x.x), trunc(x.y), trunc(x.z), trunc(x.w)} }
 
 
 round :: proc{

--- a/core/math/linalg/glsl/linalg_glsl_math.odin
+++ b/core/math/linalg/glsl/linalg_glsl_math.odin
@@ -23,6 +23,7 @@ import "core:math"
 @(require_results) exp2_f32        :: proc "c" (x: f32) -> f32 { return math.pow(f32(2), x) }
 @(require_results) sign_f32        :: proc "c" (x: f32) -> f32 { return math.sign(x) }
 @(require_results) floor_f32       :: proc "c" (x: f32) -> f32 { return math.floor(x) }
+@(require_results) trunc_f32       :: proc "c" (x: f32) -> f32 { return math.trunc(x) }
 @(require_results) round_f32       :: proc "c" (x: f32) -> f32 { return math.round(x) }
 @(require_results) ceil_f32        :: proc "c" (x: f32) -> f32 { return math.ceil(x) }
 @(require_results) mod_f32         :: proc "c" (x, y: f32) -> f32 { return math.mod(x, y) }
@@ -55,6 +56,7 @@ fract_f32 :: proc "c" (x: f32) -> f32 {
 @(require_results) exp2_f64        :: proc "c" (x: f64) -> f64 { return math.pow(f64(2), x) }
 @(require_results) sign_f64        :: proc "c" (x: f64) -> f64 { return math.sign(x) }
 @(require_results) floor_f64       :: proc "c" (x: f64) -> f64 { return math.floor(x) }
+@(require_results) trunc_f64       :: proc "c" (x: f64) -> f64 { return math.trunc(x) }
 @(require_results) round_f64       :: proc "c" (x: f64) -> f64 { return math.round(x) }
 @(require_results) ceil_f64        :: proc "c" (x: f64) -> f64 { return math.ceil(x) }
 @(require_results) mod_f64         :: proc "c" (x, y: f64) -> f64 { return math.mod(x, y) }


### PR DESCRIPTION
Hello, 
I'm using `core:math/linalg/glsl` a lot in my game and I came upon a need for a trunc procedure and was wondering why it was missing. 
So I added it. 

Thank you!