### PR TITLE
Fix unused variables error without -vet flags enabled.

### DIFF
--- a/src/check_stmt.cpp
+++ b/src/check_stmt.cpp
@@ -1583,8 +1583,9 @@ gb_internal void check_block_stmt_for_errors(CheckerContext *ctx, Ast *body)  {
 			}
 		}
 
+		bool	detect_unused_decls = (build_context.vet_flags & VetFlag_UnusedVariables) || (build_context.vet_flags & VetFlag_Unused);
 		if (stmt_count == 1) {
-			if (the_stmt->kind == Ast_ValueDecl) {
+			if (detect_unused_decls && the_stmt->kind == Ast_ValueDecl) {
 				for (Ast *name : the_stmt->ValueDecl.names) {
 					if (name->kind != Ast_Ident) {
 						continue;


### PR DESCRIPTION
Fix for #4581.
It only adds a couple of lines.
A store for checking vet flags using the global `build_context.vet_flags` and a compare before starting the loop to check for errors.