### PR TITLE
Fix dynamic array not zeroing when growing

### DIFF
--- a/base/runtime/core_builtin.odin
+++ b/base/runtime/core_builtin.odin
@@ -826,10 +826,12 @@ _resize_dynamic_array :: #force_inline proc(a: ^Raw_Dynamic_Array, size_of_elem,
 		return nil
 	}
 
+	if should_zero && a.len < length {
+		num_reused := min(a.cap, length) - a.len
+		intrinsics.mem_zero(([^]byte)(a.data)[a.len*size_of_elem:], num_reused*size_of_elem)
+	}
+
 	if length <= a.cap {
-		if should_zero && a.len < length {
-			intrinsics.mem_zero(([^]byte)(a.data)[a.len*size_of_elem:], (length-a.len)*size_of_elem)
-		}
 		a.len = max(length, 0)
 		return nil
 	}


### PR DESCRIPTION
When a dynamic array has unused capacity and is resized to a size greater than its capacity, the unused part of its capacity wasn't being zeroed.

Sample reproducing the issue:
```odin
package main
import "core:fmt"
main :: proc() {
	a := [dynamic]int { 1, 2, 3 }
	assert(cap(a) == 3)
	clear(&a)
	resize(&a, 4)
	fmt.println(a) // [1, 2, 3, 0] before changes, [0, 0, 0, 0] after
}
```
