### PR TITLE
Implicit broadcasting for SIMD arrays

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -3672,6 +3672,13 @@ gb_internal bool check_binary_array_expr(CheckerContext *c, Token op, Operand *x
 			}
 		}
 	}
+	if (is_type_simd_vector(x->type) && !is_type_simd_vector(y->type)) {
+		if (check_is_assignable_to(c, y, x->type)) {
+			if (check_binary_op(c, x, op)) {
+				return true;
+			}
+		}
+	}
 	return false;
 }
 
@@ -4548,6 +4555,19 @@ gb_internal void convert_to_typed(CheckerContext *c, Operand *operand, Type *tar
 					}
 				}
 			}
+			operand->mode = Addressing_Invalid;
+			convert_untyped_error(c, operand, target_type);
+			return;
+		}
+
+		break;
+	}
+	
+	case Type_SimdVector: {
+		Type *elem = base_array_type(t);
+		if (check_is_assignable_to(c, operand, elem)) {
+			operand->mode = Addressing_Value;
+		} else {
 			operand->mode = Addressing_Invalid;
 			convert_untyped_error(c, operand, target_type);
 			return;


### PR DESCRIPTION
This covers broadcasting from untyped numbers when converting to a `#simd` vector, as well as when performing binary operations. This mirrors the way this logic works with regular fixed arrays (except untyped strings won't be converted). SIMD intrinsics, which have special logic for handling their inputs, have not been adjusted.

A simple example of usage (which worked for fixed arrays, but would have been erroneous with `#simd`):
```odin
package test
import "core:fmt"
main :: proc () {
	a : #simd[4]u32 = 2
	b : u32 = 3
	fmt.println(b * a + 1) // <7, 7, 7, 7>
}
```