### PR TITLE
Fix crash when proc return type is undeclared parapoly variable

### DIFF
--- a/src/checker.hpp
+++ b/src/checker.hpp
@@ -521,6 +521,7 @@ struct CheckerContext {
 	bool       in_enum_type;
 	bool       collect_delayed_decls;
 	bool       allow_polymorphic_types;
+	bool       disallow_polymorphic_return_types; // NOTE(zen3ger): no poly type decl in return types
 	bool       no_polymorphic_errors;
 	bool       hide_polymorphic_errors;
 	bool       in_polymorphic_specialization;


### PR DESCRIPTION
Disallow the declaration of new parapoly variables in return types, when the procedure's parapoly scope is itself. This happens if e.g.: `foo :: proc() -> $T`.

Close #3949 
Close #4294 
Close #4563