### PR TITLE
Fixed crash in arena_free_all() for bootstrapped growing arenas.

### DIFF
--- a/core/mem/virtual/arena.odin
+++ b/core/mem/virtual/arena.odin
@@ -204,8 +204,9 @@ arena_free_all :: proc(arena: ^Arena, loc := #caller_location) {
 		}
 		// Zero the first block's memory
 		if arena.curr_block != nil {
-			mem.zero(arena.curr_block.base, int(arena.curr_block.used))
+			curr_block_used := int(arena.curr_block.used)
 			arena.curr_block.used = 0
+			mem.zero(arena.curr_block.base, curr_block_used)
 		}
 		arena.total_used = 0
 	case .Static, .Buffer:


### PR DESCRIPTION
When trying to set arena.curr_block.used = 0 after mem.zero() caused a crash because if the arena is bootstrapped its memory will be zeroed out after mem.zero() thus making arena.cur_block point to zero.