### PR TITLE
vendor:raylib: add options to link with raylib/raygui from system

### DIFF
--- a/vendor/raylib/raygui.odin
+++ b/vendor/raylib/raygui.odin
@@ -3,8 +3,11 @@ package raylib
 import "core:c"
 
 RAYGUI_SHARED :: #config(RAYGUI_SHARED, false)
+RAYGUI_SYSTEM :: #config(RAYGUI_SYSTEM, false)
 
-when ODIN_OS == .Windows {
+when RAYGUI_SYSTEM {
+	foreign import lib "system:raygui"
+} else when ODIN_OS == .Windows {
 	foreign import lib {
 		"windows/rayguidll.lib" when RAYGUI_SHARED else "windows/raygui.lib",
 	}

--- a/vendor/raylib/raylib.odin
+++ b/vendor/raylib/raylib.odin
@@ -100,8 +100,11 @@ MAX_TEXT_BUFFER_LENGTH :: #config(RAYLIB_MAX_TEXT_BUFFER_LENGTH, 1024)
 #assert(size_of(rune) == size_of(c.int))
 
 RAYLIB_SHARED :: #config(RAYLIB_SHARED, false)
+RAYLIB_SYSTEM :: #config(RAYLIB_SYSTEM, false)
 
-when ODIN_OS == .Windows {
+when RAYLIB_SYSTEM {
+	foreign import lib "system:raylib"
+} else when ODIN_OS == .Windows {
 	@(extra_linker_flags="/NODEFAULTLIB:" + ("msvcrt" when RAYLIB_SHARED else "libcmt"))
 	foreign import lib {
 		"windows/raylibdll.lib" when RAYLIB_SHARED else "windows/raylib.lib" ,

--- a/vendor/raylib/rlgl/rlgl.odin
+++ b/vendor/raylib/rlgl/rlgl.odin
@@ -113,13 +113,16 @@ import rl "../."
 VERSION :: "5.0"
 
 RAYLIB_SHARED :: #config(RAYLIB_SHARED, false)
+RAYLIB_SYSTEM :: #config(RAYLIB_SYSTEM, false)
 
 // Note: We pull in the full raylib library. If you want a truly stand-alone rlgl, then:
 // - Compile a separate rlgl library and use that in the foreign import blocks below.
 // - Remove the `import rl "../."` line
 // - Copy the code from raylib.odin for any types we alias from that package (see PixelFormat etc)
 
-when ODIN_OS == .Windows {
+when RAYLIB_SYSTEM {
+	foreign import lib "system:raylib"
+} else when ODIN_OS == .Windows {
 	@(extra_linker_flags="/NODEFAULTLIB:" + ("msvcrt" when RAYLIB_SHARED else "libcmt"))
 	foreign import lib {
 		"../windows/raylibdll.lib" when RAYLIB_SHARED else "../windows/raylib.lib" ,


### PR DESCRIPTION
Odin ships the libraries for raylib and raygui and links to them when using their bindings from vendor. But this does not play well with Nix, presumably because the libraries are not compiled for Nix.
To use `vendor:raylib` in Nix, you have to also compile the libraries for Nix and link with it. 
This added an option to link the libraries from system instead of the libraries shipped into the compiler.
May fix <https://github.com/NixOS/nixpkgs/issues/338972>.