### PR TITLE
Add json.unparse: RTTI-less conversion from json.Value to []u8

### DIFF
--- a/core/encoding/json/marshal.odin
+++ b/core/encoding/json/marshal.odin
@@ -176,6 +176,10 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 		return .Unsupported_Type
 
 	case runtime.Type_Info_Pointer:
+		if a.(rawptr) == nil {
+			io.write_string(w, "null") or_return
+			return
+		}
 		return .Unsupported_Type
 
 	case runtime.Type_Info_Multi_Pointer:

--- a/core/encoding/json/unparse.odin
+++ b/core/encoding/json/unparse.odin
@@ -29,8 +29,12 @@ unparse_to_builder :: proc(b: ^strings.Builder, v: Value, opt: ^Marshal_Options)
 }
 
 unparse_to_writer :: proc(w: io.Writer, v: Value, opt: ^Marshal_Options) -> io.Error {
+	if v == nil {
+		return unparse_null_to_writer(w, opt)
+	}
+
 	switch uv in v {
-		case Null: return unparse_null_to_writer(w, uv, opt)
+		case Null: return unparse_null_to_writer(w, opt)
 		case Integer: return unparse_integer_to_writer(w, uv, opt)
 		case Float: return unparse_float_to_writer(w, uv, opt)
 		case Boolean: return unparse_boolean_to_writer(w, uv, opt)
@@ -41,7 +45,7 @@ unparse_to_writer :: proc(w: io.Writer, v: Value, opt: ^Marshal_Options) -> io.E
 	return nil
 }
 
-unparse_null_to_writer :: proc(w: io.Writer, v: Null, opt: ^Marshal_Options) -> io.Error {
+unparse_null_to_writer :: proc(w: io.Writer, opt: ^Marshal_Options) -> io.Error {
 	io.write_string(w, "null") or_return
 	return nil
 }

--- a/core/encoding/json/unparse.odin
+++ b/core/encoding/json/unparse.odin
@@ -1,0 +1,116 @@
+package encoding_json
+
+import "base:runtime"
+import "core:strings"
+import "core:io"
+import "core:slice"
+
+unparse :: proc(v: Value, opt: Marshal_Options = {}, allocator := context.allocator, loc := #caller_location) -> (data: []u8, err: io.Error) {
+	b := strings.builder_make(allocator, loc)
+	defer if err != nil {
+		strings.builder_destroy(&b)
+	}
+	
+	// temp guard in case we are sorting map keys, which will use temp allocations
+	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD(ignore = allocator == context.temp_allocator)
+
+	opt := opt
+	unparse_to_builder(&b, v, &opt) or_return
+	
+	if len(b.buf) != 0 {
+		data = b.buf[:]
+	}
+
+	return data, nil
+}
+
+unparse_to_builder :: proc(b: ^strings.Builder, v: Value, opt: ^Marshal_Options) -> io.Error {
+	return unparse_to_writer(strings.to_writer(b), v, opt)
+}
+
+unparse_to_writer :: proc(w: io.Writer, v: Value, opt: ^Marshal_Options) -> io.Error {
+	switch uv in v {
+		case Null: return unparse_null_to_writer(w, uv, opt)
+		case Integer: return unparse_integer_to_writer(w, uv, opt)
+		case Float: return unparse_float_to_writer(w, uv, opt)
+		case Boolean: return unparse_boolean_to_writer(w, uv, opt)
+		case String: return unparse_string_to_writer(w, uv, opt)
+		case Array: return unparse_array_to_writer(w, uv, opt)
+		case Object: return unparse_object_to_writer(w, uv, opt)
+	}
+	return nil
+}
+
+unparse_null_to_writer :: proc(w: io.Writer, v: Null, opt: ^Marshal_Options) -> io.Error {
+	io.write_string(w, "null") or_return
+	return nil
+}
+
+unparse_integer_to_writer :: proc(w: io.Writer, v: Integer, opt: ^Marshal_Options) -> io.Error {
+	base := 16 if opt.write_uint_as_hex && (opt.spec == .JSON5 || opt.spec == .MJSON) else 10
+	io.write_i64(w, v, base) or_return
+	return nil
+}
+
+unparse_float_to_writer :: proc(w: io.Writer, v: Float, opt: ^Marshal_Options) -> io.Error {
+	io.write_f64(w, v) or_return
+	return nil
+}
+
+unparse_boolean_to_writer :: proc(w: io.Writer, v: Boolean, opt: ^Marshal_Options) -> io.Error {
+	io.write_string(w, v ? "true" : "false") or_return
+	return nil
+}
+
+unparse_string_to_writer :: proc(w: io.Writer, v: String, opt: ^Marshal_Options) -> io.Error {
+	io.write_quoted_string(w, v, '"', nil, true) or_return
+	return nil
+}
+
+unparse_array_to_writer :: proc(w: io.Writer, v: Array, opt: ^Marshal_Options) -> io.Error {
+	opt_write_start(w, opt, '[') or_return
+	for i in 0..<len(v) {
+		opt_write_iteration(w, opt, i == 0) or_return
+		unparse_to_writer(w, v[i], opt) or_return
+	}
+	opt_write_end(w, opt, ']') or_return
+	return nil
+}
+
+unparse_object_to_writer :: proc(w: io.Writer, m: Object, opt: ^Marshal_Options) -> io.Error {
+	if !opt.sort_maps_by_key {
+		opt_write_start(w, opt, '{') or_return
+
+		first_iteration := true
+		for k,v in m {
+			opt_write_iteration(w, opt, first_iteration) or_return
+			opt_write_key(w, opt, k) or_return
+			unparse_to_writer(w, v, opt) or_return
+			first_iteration = false
+		}
+
+		opt_write_end(w, opt, '}') or_return
+	}
+	else {
+		Entry :: struct {
+			key: string,
+			value: Value
+		}
+
+		entries := make([dynamic]Entry, 0, len(m), context.temp_allocator)
+		for k, v in m {
+			append(&entries, Entry{k, v})
+		}
+
+		slice.sort_by(entries[:], proc(i, j: Entry) -> bool { return i.key < j.key })
+		
+		opt_write_start(w, opt, '{') or_return
+		for e, i in entries {
+			opt_write_iteration(w, opt, i == 0) or_return
+			opt_write_key(w, opt, e.key) or_return
+			unparse_to_writer(w, e.value, opt) or_return
+		}
+		opt_write_end(w, opt, '}') or_return
+	}
+	return nil
+}

--- a/core/encoding/json/unparse.odin
+++ b/core/encoding/json/unparse.odin
@@ -34,13 +34,20 @@ unparse_to_writer :: proc(w: io.Writer, v: Value, opt: ^Marshal_Options) -> io.E
 	}
 
 	switch uv in v {
-		case Null: return unparse_null_to_writer(w, opt)
-		case Integer: return unparse_integer_to_writer(w, uv, opt)
-		case Float: return unparse_float_to_writer(w, uv, opt)
-		case Boolean: return unparse_boolean_to_writer(w, uv, opt)
-		case String: return unparse_string_to_writer(w, uv, opt)
-		case Array: return unparse_array_to_writer(w, uv, opt)
-		case Object: return unparse_object_to_writer(w, uv, opt)
+		case Null: 
+			return unparse_null_to_writer(w, opt)
+		case Integer: 
+			return unparse_integer_to_writer(w, uv, opt)
+		case Float: 
+			return unparse_float_to_writer(w, uv, opt)
+		case Boolean: 
+			return unparse_boolean_to_writer(w, uv, opt)
+		case String: 
+			return unparse_string_to_writer(w, uv, opt)
+		case Array: 
+			return unparse_array_to_writer(w, uv, opt)
+		case Object: 
+			return unparse_object_to_writer(w, uv, opt)
 	}
 	return nil
 }
@@ -73,9 +80,9 @@ unparse_string_to_writer :: proc(w: io.Writer, v: String, opt: ^Marshal_Options)
 
 unparse_array_to_writer :: proc(w: io.Writer, v: Array, opt: ^Marshal_Options) -> io.Error {
 	opt_write_start(w, opt, '[') or_return
-	for i in 0..<len(v) {
+	for e, i in v {
 		opt_write_iteration(w, opt, i == 0) or_return
-		unparse_to_writer(w, v[i], opt) or_return
+		unparse_to_writer(w, e, opt) or_return
 	}
 	opt_write_end(w, opt, ']') or_return
 	return nil
@@ -94,11 +101,10 @@ unparse_object_to_writer :: proc(w: io.Writer, m: Object, opt: ^Marshal_Options)
 		}
 
 		opt_write_end(w, opt, '}') or_return
-	}
-	else {
+	} else {
 		Entry :: struct {
 			key: string,
-			value: Value
+			value: Value,
 		}
 
 		entries := make([dynamic]Entry, 0, len(m), context.temp_allocator)

--- a/tests/core/encoding/json/test_core_json.odin
+++ b/tests/core/encoding/json/test_core_json.odin
@@ -498,12 +498,20 @@ unparse_json_schema :: proc(t: ^testing.T) {
 			"tags" = json.Object{
 				"type" = "array",
 				"items" = json.Object{"type" = "string"}
+			},
+			"also" = json.Object{
+				"integer" = 42,
+				"float" = 3.1415,
+				"bool" = false,
+				"null" = nil,
+				"array" = json.Array{42, 3.1415, false, nil, "string"}
 			}
 		}
 	}
 
 	// having fun cleaning up json literals
 	defer {
+		delete(json_schema.(json.Object)["properties"].(json.Object)["also"].(json.Object)["array"].(json.Array))
 		delete(json_schema.(json.Object)["properties"].(json.Object)["tags"].(json.Object)["items"].(json.Object))
 		for k, &v in json_schema.(json.Object)["properties"].(json.Object) {
 			delete(v.(json.Object))
@@ -513,7 +521,7 @@ unparse_json_schema :: proc(t: ^testing.T) {
 	}
 
 	is_error :: proc(t: ^testing.T, E: $Error_Type, fn: string) -> bool {
-		testing.expectf(t, E == nil, "%s failed with error:", fn, E)
+		testing.expectf(t, E == nil, "%s failed with error: %v", fn, E)
 		return E != nil
 	}
 

--- a/tests/core/encoding/json/test_core_json.odin
+++ b/tests/core/encoding/json/test_core_json.odin
@@ -497,16 +497,16 @@ unparse_json_schema :: proc(t: ^testing.T) {
 			"is_valid" = json.Object{"type" = "boolean"},
 			"tags" = json.Object{
 				"type" = "array",
-				"items" = json.Object{"type" = "string"}
+				"items" = json.Object{"type" = "string"},
 			},
 			"also" = json.Object{
 				"integer" = 42,
 				"float" = 3.1415,
 				"bool" = false,
 				"null" = nil,
-				"array" = json.Array{42, 3.1415, false, nil, "string"}
-			}
-		}
+				"array" = json.Array{42, 3.1415, false, nil, "string"},
+			},
+		},
 	}
 
 	// having fun cleaning up json literals


### PR DESCRIPTION
This is a follow up PR to the smalltalk we had in Discord/General/Beginners.

### Introduction
While trying out odin's encoding/json module I've found out that the only way to convert json.Value to []u8/string was to use json.marshal (docs lack that information).
Which feels very unnatural and misleading to me as a C/C++ developer. So I did implement json.unparse. It probably has a tiny bit of performance boost due to it being RTTI-less.

Added test case for json.unparse, tested it on my windows 11.

Named it json.unparse for consistency with json.parse, but naming suggestions are wellcome.

### Bonus
Fixed an Unsupported_Type error in json.marshal on (rawptr)nil values.

### P.S. 
json.marshal uses Raw_Map routines when converting json.Object, but it requires runtime.Type_Info for accessing Map_Info hence I used simple k/v for-loop over map. Let me know if traversing Raw_Map buckets is preferred for some reason. I might implement it that way instead.