### PR TITLE
`vendor:vulkan` Add support for xlib and xcb

### DIFF
--- a/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
+++ b/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
@@ -929,8 +929,7 @@ when ODIN_OS == .Windows {
 \t}
 }
 
-// We want to use `vendor:x11/xlib` types so we need to match their build constraints.
-when ODIN_OS == .Linux || ODIN_OS == .FreeBSD || ODIN_OS == .OpenBSD {
+when xlib.IS_SUPPORTED {
 \tXlibDisplay  :: xlib.Display
 \tXlibWindow   :: xlib.Window
 \tXlibVisualID :: xlib.VisualID

--- a/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
+++ b/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
@@ -58,7 +58,6 @@ OPAQUE_STRUCTS = """
 wl_surface       :: struct {} // Opaque struct defined by Wayland
 wl_display       :: struct {} // Opaque struct defined by Wayland
 xcb_connection_t :: struct {} // Opaque struct defined by xcb
-XlibDisplay      :: struct {} // Opaque struct defined by Xlib
 IOSurfaceRef     :: struct {} // Opaque struct defined by Apple’s CoreGraphics framework
 """
 
@@ -901,6 +900,10 @@ import "core:c"
 
 import win32 "core:sys/windows"
 _ :: win32
+
+import "vendor:x11/xlib"
+_ :: xlib
+
 when ODIN_OS == .Windows {
 \tHINSTANCE           :: win32.HINSTANCE
 \tHWND                :: win32.HWND
@@ -926,10 +929,19 @@ when ODIN_OS == .Windows {
 \t}
 }
 
+// We want to use `vendor:x11/xlib` types so we need to match their build constraints.
+when ODIN_OS == .Linux || ODIN_OS == .FreeBSD || ODIN_OS == .OpenBSD {
+\tXlibDisplay  :: xlib.Display
+\tXlibWindow   :: xlib.Window
+\tXlibVisualID :: xlib.VisualID
+} else {
+\tXlibDisplay  :: struct {} // Opaque struct defined by Xlib
+\tXlibWindow   :: c.ulong
+\tXlibVisualID :: c.ulong
+}
+
 xcb_visualid_t :: u32
 xcb_window_t   :: u32
-XlibWindow     :: uint
-XlibVisualID   :: uint
 CAMetalLayer   :: struct {}
 
 MTLBuffer_id       :: rawptr

--- a/vendor/vulkan/_gen/vulkan_xcb.h
+++ b/vendor/vulkan/_gen/vulkan_xcb.h
@@ -1,0 +1,56 @@
+#ifndef VULKAN_XCB_H_
+#define VULKAN_XCB_H_ 1
+
+/*
+** Copyright 2015-2024 The Khronos Group Inc.
+**
+** SPDX-License-Identifier: Apache-2.0
+*/
+
+/*
+** This header is generated from the Khronos Vulkan XML API Registry.
+**
+*/
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+// VK_KHR_xcb_surface is a preprocessor guard. Do not pass it to API calls.
+#define VK_KHR_xcb_surface 1
+#define VK_KHR_XCB_SURFACE_SPEC_VERSION   6
+#define VK_KHR_XCB_SURFACE_EXTENSION_NAME "VK_KHR_xcb_surface"
+typedef VkFlags VkXcbSurfaceCreateFlagsKHR;
+typedef struct VkXcbSurfaceCreateInfoKHR {
+    VkStructureType               sType;
+    const void*                   pNext;
+    VkXcbSurfaceCreateFlagsKHR    flags;
+    xcb_connection_t*             connection;
+    xcb_window_t                  window;
+} VkXcbSurfaceCreateInfoKHR;
+
+typedef VkResult (VKAPI_PTR *PFN_vkCreateXcbSurfaceKHR)(VkInstance instance, const VkXcbSurfaceCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface);
+typedef VkBool32 (VKAPI_PTR *PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR)(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex, xcb_connection_t* connection, xcb_visualid_t visual_id);
+
+#ifndef VK_NO_PROTOTYPES
+VKAPI_ATTR VkResult VKAPI_CALL vkCreateXcbSurfaceKHR(
+    VkInstance                                  instance,
+    const VkXcbSurfaceCreateInfoKHR*            pCreateInfo,
+    const VkAllocationCallbacks*                pAllocator,
+    VkSurfaceKHR*                               pSurface);
+
+VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceXcbPresentationSupportKHR(
+    VkPhysicalDevice                            physicalDevice,
+    uint32_t                                    queueFamilyIndex,
+    xcb_connection_t*                           connection,
+    xcb_visualid_t                              visual_id);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/vendor/vulkan/_gen/vulkan_xlib.h
+++ b/vendor/vulkan/_gen/vulkan_xlib.h
@@ -1,0 +1,56 @@
+#ifndef VULKAN_XLIB_H_
+#define VULKAN_XLIB_H_ 1
+
+/*
+** Copyright 2015-2024 The Khronos Group Inc.
+**
+** SPDX-License-Identifier: Apache-2.0
+*/
+
+/*
+** This header is generated from the Khronos Vulkan XML API Registry.
+**
+*/
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+// VK_KHR_xlib_surface is a preprocessor guard. Do not pass it to API calls.
+#define VK_KHR_xlib_surface 1
+#define VK_KHR_XLIB_SURFACE_SPEC_VERSION  6
+#define VK_KHR_XLIB_SURFACE_EXTENSION_NAME "VK_KHR_xlib_surface"
+typedef VkFlags VkXlibSurfaceCreateFlagsKHR;
+typedef struct VkXlibSurfaceCreateInfoKHR {
+    VkStructureType                sType;
+    const void*                    pNext;
+    VkXlibSurfaceCreateFlagsKHR    flags;
+    Display*                       dpy;
+    Window                         window;
+} VkXlibSurfaceCreateInfoKHR;
+
+typedef VkResult (VKAPI_PTR *PFN_vkCreateXlibSurfaceKHR)(VkInstance instance, const VkXlibSurfaceCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface);
+typedef VkBool32 (VKAPI_PTR *PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR)(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex, Display* dpy, VisualID visualID);
+
+#ifndef VK_NO_PROTOTYPES
+VKAPI_ATTR VkResult VKAPI_CALL vkCreateXlibSurfaceKHR(
+    VkInstance                                  instance,
+    const VkXlibSurfaceCreateInfoKHR*           pCreateInfo,
+    const VkAllocationCallbacks*                pAllocator,
+    VkSurfaceKHR*                               pSurface);
+
+VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceXlibPresentationSupportKHR(
+    VkPhysicalDevice                            physicalDevice,
+    uint32_t                                    queueFamilyIndex,
+    Display*                                    dpy,
+    VisualID                                    visualID);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/vendor/vulkan/core.odin
+++ b/vendor/vulkan/core.odin
@@ -1161,6 +1161,12 @@ EXT_METAL_OBJECTS_EXTENSION_NAME                          :: "VK_EXT_metal_objec
 KHR_wayland_surface                                       :: 1
 KHR_WAYLAND_SURFACE_SPEC_VERSION                          :: 6
 KHR_WAYLAND_SURFACE_EXTENSION_NAME                        :: "VK_KHR_wayland_surface"
+KHR_xlib_surface                                          :: 1
+KHR_XLIB_SURFACE_SPEC_VERSION                             :: 6
+KHR_XLIB_SURFACE_EXTENSION_NAME                           :: "VK_KHR_xlib_surface"
+KHR_xcb_surface                                           :: 1
+KHR_XCB_SURFACE_SPEC_VERSION                              :: 6
+KHR_XCB_SURFACE_EXTENSION_NAME                            :: "VK_KHR_xcb_surface"
 
 // Handles types
 Instance       :: distinct Handle

--- a/vendor/vulkan/enums.odin
+++ b/vendor/vulkan/enums.odin
@@ -4585,6 +4585,10 @@ WaylandSurfaceCreateFlagsKHR                         :: distinct bit_set[Wayland
 WaylandSurfaceCreateFlagKHR                          :: enum u32 {}
 Win32SurfaceCreateFlagsKHR                           :: distinct bit_set[Win32SurfaceCreateFlagKHR; Flags]
 Win32SurfaceCreateFlagKHR                            :: enum u32 {}
+XcbSurfaceCreateFlagsKHR                             :: distinct bit_set[XcbSurfaceCreateFlagKHR; Flags]
+XcbSurfaceCreateFlagKHR                              :: enum u32 {}
+XlibSurfaceCreateFlagsKHR                            :: distinct bit_set[XlibSurfaceCreateFlagKHR; Flags]
+XlibSurfaceCreateFlagKHR                             :: enum u32 {}
 AccessFlags2 :: distinct bit_set[AccessFlag2; Flags64]
 AccessFlag2 :: enum Flags64 {
 	INDIRECT_COMMAND_READ                     = 0,

--- a/vendor/vulkan/procedures.odin
+++ b/vendor/vulkan/procedures.odin
@@ -36,6 +36,8 @@ ProcCreateMacOSSurfaceMVK                                            :: #type pr
 ProcCreateMetalSurfaceEXT                                            :: #type proc "system" (instance: Instance, pCreateInfo: ^MetalSurfaceCreateInfoEXT, pAllocator: ^AllocationCallbacks, pSurface: ^SurfaceKHR) -> Result
 ProcCreateWaylandSurfaceKHR                                          :: #type proc "system" (instance: Instance, pCreateInfo: ^WaylandSurfaceCreateInfoKHR, pAllocator: ^AllocationCallbacks, pSurface: ^SurfaceKHR) -> Result
 ProcCreateWin32SurfaceKHR                                            :: #type proc "system" (instance: Instance, pCreateInfo: ^Win32SurfaceCreateInfoKHR, pAllocator: ^AllocationCallbacks, pSurface: ^SurfaceKHR) -> Result
+ProcCreateXcbSurfaceKHR                                              :: #type proc "system" (instance: Instance, pCreateInfo: ^XcbSurfaceCreateInfoKHR, pAllocator: ^AllocationCallbacks, pSurface: ^SurfaceKHR) -> Result
+ProcCreateXlibSurfaceKHR                                             :: #type proc "system" (instance: Instance, pCreateInfo: ^XlibSurfaceCreateInfoKHR, pAllocator: ^AllocationCallbacks, pSurface: ^SurfaceKHR) -> Result
 ProcDebugReportMessageEXT                                            :: #type proc "system" (instance: Instance, flags: DebugReportFlagsEXT, objectType: DebugReportObjectTypeEXT, object: u64, location: int, messageCode: i32, pLayerPrefix: cstring, pMessage: cstring)
 ProcDestroyDebugReportCallbackEXT                                    :: #type proc "system" (instance: Instance, callback: DebugReportCallbackEXT, pAllocator: ^AllocationCallbacks)
 ProcDestroyDebugUtilsMessengerEXT                                    :: #type proc "system" (instance: Instance, messenger: DebugUtilsMessengerEXT, pAllocator: ^AllocationCallbacks)
@@ -113,6 +115,8 @@ ProcGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR            :: #type pr
 ProcGetPhysicalDeviceVideoFormatPropertiesKHR                        :: #type proc "system" (physicalDevice: PhysicalDevice, pVideoFormatInfo: ^PhysicalDeviceVideoFormatInfoKHR, pVideoFormatPropertyCount: ^u32, pVideoFormatProperties: [^]VideoFormatPropertiesKHR) -> Result
 ProcGetPhysicalDeviceWaylandPresentationSupportKHR                   :: #type proc "system" (physicalDevice: PhysicalDevice, queueFamilyIndex: u32, display: ^wl_display) -> b32
 ProcGetPhysicalDeviceWin32PresentationSupportKHR                     :: #type proc "system" (physicalDevice: PhysicalDevice, queueFamilyIndex: u32) -> b32
+ProcGetPhysicalDeviceXcbPresentationSupportKHR                       :: #type proc "system" (physicalDevice: PhysicalDevice, queueFamilyIndex: u32, connection: ^xcb_connection_t, visual_id: xcb_visualid_t) -> b32
+ProcGetPhysicalDeviceXlibPresentationSupportKHR                      :: #type proc "system" (physicalDevice: PhysicalDevice, queueFamilyIndex: u32, dpy: ^XlibDisplay, visualID: XlibVisualID) -> b32
 ProcGetWinrtDisplayNV                                                :: #type proc "system" (physicalDevice: PhysicalDevice, deviceRelativeId: u32, pDisplay: ^DisplayKHR) -> Result
 ProcReleaseDisplayEXT                                                :: #type proc "system" (physicalDevice: PhysicalDevice, display: DisplayKHR) -> Result
 ProcSubmitDebugUtilsMessageEXT                                       :: #type proc "system" (instance: Instance, messageSeverity: DebugUtilsMessageSeverityFlagsEXT, messageTypes: DebugUtilsMessageTypeFlagsEXT, pCallbackData: ^DebugUtilsMessengerCallbackDataEXT)
@@ -730,6 +734,8 @@ CreateMacOSSurfaceMVK:                                            ProcCreateMacO
 CreateMetalSurfaceEXT:                                            ProcCreateMetalSurfaceEXT
 CreateWaylandSurfaceKHR:                                          ProcCreateWaylandSurfaceKHR
 CreateWin32SurfaceKHR:                                            ProcCreateWin32SurfaceKHR
+CreateXcbSurfaceKHR:                                              ProcCreateXcbSurfaceKHR
+CreateXlibSurfaceKHR:                                             ProcCreateXlibSurfaceKHR
 DebugReportMessageEXT:                                            ProcDebugReportMessageEXT
 DestroyDebugReportCallbackEXT:                                    ProcDestroyDebugReportCallbackEXT
 DestroyDebugUtilsMessengerEXT:                                    ProcDestroyDebugUtilsMessengerEXT
@@ -806,6 +812,8 @@ GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR:            ProcGetPhysica
 GetPhysicalDeviceVideoFormatPropertiesKHR:                        ProcGetPhysicalDeviceVideoFormatPropertiesKHR
 GetPhysicalDeviceWaylandPresentationSupportKHR:                   ProcGetPhysicalDeviceWaylandPresentationSupportKHR
 GetPhysicalDeviceWin32PresentationSupportKHR:                     ProcGetPhysicalDeviceWin32PresentationSupportKHR
+GetPhysicalDeviceXcbPresentationSupportKHR:                       ProcGetPhysicalDeviceXcbPresentationSupportKHR
+GetPhysicalDeviceXlibPresentationSupportKHR:                      ProcGetPhysicalDeviceXlibPresentationSupportKHR
 GetWinrtDisplayNV:                                                ProcGetWinrtDisplayNV
 ReleaseDisplayEXT:                                                ProcReleaseDisplayEXT
 SubmitDebugUtilsMessageEXT:                                       ProcSubmitDebugUtilsMessageEXT
@@ -1423,6 +1431,8 @@ load_proc_addresses_custom :: proc(set_proc_address: SetProcAddressType) {
 	set_proc_address(&CreateMetalSurfaceEXT,                                            "vkCreateMetalSurfaceEXT")
 	set_proc_address(&CreateWaylandSurfaceKHR,                                          "vkCreateWaylandSurfaceKHR")
 	set_proc_address(&CreateWin32SurfaceKHR,                                            "vkCreateWin32SurfaceKHR")
+	set_proc_address(&CreateXcbSurfaceKHR,                                              "vkCreateXcbSurfaceKHR")
+	set_proc_address(&CreateXlibSurfaceKHR,                                             "vkCreateXlibSurfaceKHR")
 	set_proc_address(&DebugReportMessageEXT,                                            "vkDebugReportMessageEXT")
 	set_proc_address(&DestroyDebugReportCallbackEXT,                                    "vkDestroyDebugReportCallbackEXT")
 	set_proc_address(&DestroyDebugUtilsMessengerEXT,                                    "vkDestroyDebugUtilsMessengerEXT")
@@ -1499,6 +1509,8 @@ load_proc_addresses_custom :: proc(set_proc_address: SetProcAddressType) {
 	set_proc_address(&GetPhysicalDeviceVideoFormatPropertiesKHR,                        "vkGetPhysicalDeviceVideoFormatPropertiesKHR")
 	set_proc_address(&GetPhysicalDeviceWaylandPresentationSupportKHR,                   "vkGetPhysicalDeviceWaylandPresentationSupportKHR")
 	set_proc_address(&GetPhysicalDeviceWin32PresentationSupportKHR,                     "vkGetPhysicalDeviceWin32PresentationSupportKHR")
+	set_proc_address(&GetPhysicalDeviceXcbPresentationSupportKHR,                       "vkGetPhysicalDeviceXcbPresentationSupportKHR")
+	set_proc_address(&GetPhysicalDeviceXlibPresentationSupportKHR,                      "vkGetPhysicalDeviceXlibPresentationSupportKHR")
 	set_proc_address(&GetWinrtDisplayNV,                                                "vkGetWinrtDisplayNV")
 	set_proc_address(&ReleaseDisplayEXT,                                                "vkReleaseDisplayEXT")
 	set_proc_address(&SubmitDebugUtilsMessageEXT,                                       "vkSubmitDebugUtilsMessageEXT")
@@ -3879,6 +3891,8 @@ load_proc_addresses_instance :: proc(instance: Instance) {
 	CreateMetalSurfaceEXT                                            = auto_cast GetInstanceProcAddr(instance, "vkCreateMetalSurfaceEXT")
 	CreateWaylandSurfaceKHR                                          = auto_cast GetInstanceProcAddr(instance, "vkCreateWaylandSurfaceKHR")
 	CreateWin32SurfaceKHR                                            = auto_cast GetInstanceProcAddr(instance, "vkCreateWin32SurfaceKHR")
+	CreateXcbSurfaceKHR                                              = auto_cast GetInstanceProcAddr(instance, "vkCreateXcbSurfaceKHR")
+	CreateXlibSurfaceKHR                                             = auto_cast GetInstanceProcAddr(instance, "vkCreateXlibSurfaceKHR")
 	DebugReportMessageEXT                                            = auto_cast GetInstanceProcAddr(instance, "vkDebugReportMessageEXT")
 	DestroyDebugReportCallbackEXT                                    = auto_cast GetInstanceProcAddr(instance, "vkDestroyDebugReportCallbackEXT")
 	DestroyDebugUtilsMessengerEXT                                    = auto_cast GetInstanceProcAddr(instance, "vkDestroyDebugUtilsMessengerEXT")
@@ -3955,6 +3969,8 @@ load_proc_addresses_instance :: proc(instance: Instance) {
 	GetPhysicalDeviceVideoFormatPropertiesKHR                        = auto_cast GetInstanceProcAddr(instance, "vkGetPhysicalDeviceVideoFormatPropertiesKHR")
 	GetPhysicalDeviceWaylandPresentationSupportKHR                   = auto_cast GetInstanceProcAddr(instance, "vkGetPhysicalDeviceWaylandPresentationSupportKHR")
 	GetPhysicalDeviceWin32PresentationSupportKHR                     = auto_cast GetInstanceProcAddr(instance, "vkGetPhysicalDeviceWin32PresentationSupportKHR")
+	GetPhysicalDeviceXcbPresentationSupportKHR                       = auto_cast GetInstanceProcAddr(instance, "vkGetPhysicalDeviceXcbPresentationSupportKHR")
+	GetPhysicalDeviceXlibPresentationSupportKHR                      = auto_cast GetInstanceProcAddr(instance, "vkGetPhysicalDeviceXlibPresentationSupportKHR")
 	GetWinrtDisplayNV                                                = auto_cast GetInstanceProcAddr(instance, "vkGetWinrtDisplayNV")
 	ReleaseDisplayEXT                                                = auto_cast GetInstanceProcAddr(instance, "vkReleaseDisplayEXT")
 	SubmitDebugUtilsMessageEXT                                       = auto_cast GetInstanceProcAddr(instance, "vkSubmitDebugUtilsMessageEXT")

--- a/vendor/vulkan/structs.odin
+++ b/vendor/vulkan/structs.odin
@@ -36,8 +36,7 @@ when ODIN_OS == .Windows {
 	}
 }
 
-// We want to use `vendor:x11/xlib` types so we need to match their build constraints.
-when ODIN_OS == .Linux || ODIN_OS == .FreeBSD || ODIN_OS == .OpenBSD {
+when xlib.IS_SUPPORTED {
 	XlibDisplay  :: xlib.Display
 	XlibWindow   :: xlib.Window
 	XlibVisualID :: xlib.VisualID

--- a/vendor/vulkan/structs.odin
+++ b/vendor/vulkan/structs.odin
@@ -7,6 +7,10 @@ import "core:c"
 
 import win32 "core:sys/windows"
 _ :: win32
+
+import "vendor:x11/xlib"
+_ :: xlib
+
 when ODIN_OS == .Windows {
 	HINSTANCE           :: win32.HINSTANCE
 	HWND                :: win32.HWND
@@ -32,10 +36,19 @@ when ODIN_OS == .Windows {
 	}
 }
 
+// We want to use `vendor:x11/xlib` types so we need to match their build constraints.
+when ODIN_OS == .Linux || ODIN_OS == .FreeBSD || ODIN_OS == .OpenBSD {
+	XlibDisplay  :: xlib.Display
+	XlibWindow   :: xlib.Window
+	XlibVisualID :: xlib.VisualID
+} else {
+	XlibDisplay  :: struct {} // Opaque struct defined by Xlib
+	XlibWindow   :: c.ulong
+	XlibVisualID :: c.ulong
+}
+
 xcb_visualid_t :: u32
 xcb_window_t   :: u32
-XlibWindow     :: uint
-XlibVisualID   :: uint
 CAMetalLayer   :: struct {}
 
 MTLBuffer_id       :: rawptr
@@ -9776,7 +9789,6 @@ VideoEncodeH265ReferenceInfo :: struct {
 wl_surface       :: struct {} // Opaque struct defined by Wayland
 wl_display       :: struct {} // Opaque struct defined by Wayland
 xcb_connection_t :: struct {} // Opaque struct defined by xcb
-XlibDisplay      :: struct {} // Opaque struct defined by Xlib
 IOSurfaceRef     :: struct {} // Opaque struct defined by Apple’s CoreGraphics framework
 // Aliases
 PhysicalDeviceVariablePointerFeatures                       :: PhysicalDeviceVariablePointersFeatures

--- a/vendor/vulkan/structs.odin
+++ b/vendor/vulkan/structs.odin
@@ -32,7 +32,11 @@ when ODIN_OS == .Windows {
 	}
 }
 
-CAMetalLayer :: struct {}
+xcb_visualid_t :: u32
+xcb_window_t   :: u32
+XlibWindow     :: uint
+XlibVisualID   :: uint
+CAMetalLayer   :: struct {}
 
 MTLBuffer_id       :: rawptr
 MTLTexture_id      :: rawptr
@@ -8910,6 +8914,22 @@ WaylandSurfaceCreateInfoKHR :: struct {
 	surface: ^wl_surface,
 }
 
+XlibSurfaceCreateInfoKHR :: struct {
+	sType:  StructureType,
+	pNext:  rawptr,
+	flags:  XlibSurfaceCreateFlagsKHR,
+	dpy:    ^XlibDisplay,
+	window: XlibWindow,
+}
+
+XcbSurfaceCreateInfoKHR :: struct {
+	sType:      StructureType,
+	pNext:      rawptr,
+	flags:      XcbSurfaceCreateFlagsKHR,
+	connection: ^xcb_connection_t,
+	window:     xcb_window_t,
+}
+
 VideoAV1ColorConfigFlags :: struct {
 	bitfield: u32,
 }
@@ -9753,9 +9773,11 @@ VideoEncodeH265ReferenceInfo :: struct {
 
 // Opaque structs
 
-wl_surface   :: struct {} // Opaque struct defined by Wayland
-wl_display   :: struct {} // Opaque struct defined by Wayland
-IOSurfaceRef :: struct {} // Opaque struct defined by Apple’s CoreGraphics framework
+wl_surface       :: struct {} // Opaque struct defined by Wayland
+wl_display       :: struct {} // Opaque struct defined by Wayland
+xcb_connection_t :: struct {} // Opaque struct defined by xcb
+XlibDisplay      :: struct {} // Opaque struct defined by Xlib
+IOSurfaceRef     :: struct {} // Opaque struct defined by Apple’s CoreGraphics framework
 // Aliases
 PhysicalDeviceVariablePointerFeatures                       :: PhysicalDeviceVariablePointersFeatures
 PhysicalDeviceShaderDrawParameterFeatures                   :: PhysicalDeviceShaderDrawParametersFeatures

--- a/vendor/x11/xlib/xlib.odin
+++ b/vendor/x11/xlib/xlib.odin
@@ -1,0 +1,4 @@
+package xlib
+
+// Value, specifying whether `vendor:x11/xlib` is available on the current platform.
+IS_SUPPORTED :: ODIN_OS == .Linux || ODIN_OS == .FreeBSD || ODIN_OS == .OpenBSD


### PR DESCRIPTION
We need forward declarations for the WSI types, but xlib doesn't use any prefixes.
To make it clear and consistent with the other WSI types, I've added the `Xlib` prefix:

`Display` => `XlibDisplay`
`Window` => `XlibWindow`
`VisualID` => `XlibVisualID`

However, one could argue keeping the names consistent with xlib would be better, so let me know your thoughts on that.