### PR TITLE
Fix for vendor:libc using wrong types for log and sin procs.

### DIFF
--- a/vendor/libc/include/math.h
+++ b/vendor/libc/include/math.h
@@ -17,5 +17,5 @@ double fabs(double x);
 int abs(int);
 double ldexp(double, int);
 double exp(double);
-float log(float);
-float sin(float);
+double log(double);
+double sin(double);

--- a/vendor/libc/math.odin
+++ b/vendor/libc/math.odin
@@ -90,11 +90,11 @@ exp :: proc "c" (x: f64) -> f64 {
 }
 
 @(require, linkage="strong", link_name="log")
-log :: proc "c" (x: f32) -> f32 {
+log :: proc "c" (x: f64) -> f64 {
 	return math.ln(x)
 }
 
 @(require, linkage="strong", link_name="sin")
-sin :: proc "c" (x: f32) -> f32 {
+sin :: proc "c" (x: f64) -> f64 {
 	return math.sin(x)
 }


### PR DESCRIPTION
These two libc procs are supposed to be double precision.

Note: I haven't recompiled the WASM lib binaries that use `vendor:libc`. I tried to do it for box2D, but the build script in `vendor/box2d` doesn't work for me on WSL or Ubuntu.