### PR TITLE
Fix for casing error in box2d/wasm.Makefile

### DIFF
--- a/vendor/box2d/wasm.Makefile
+++ b/vendor/box2d/wasm.Makefile
@@ -10,7 +10,7 @@ SRCS      = $(wildcard box2d-$(VERSION)/src/*.c)
 OBJS_SIMD = $(SRCS:.c=_simd.o)
 OBJS      = $(SRCS:.c=.o)
 SYSROOT   = $(shell odin root)/vendor/libc
-CFLAGS    = -Ibox2d-$(VERSION)/include -Ibox2d-$(VERSION)/Extern/simde --target=wasm32 -D__EMSCRIPTEN__ -DNDEBUG -O3 --sysroot=$(SYSROOT)
+CFLAGS    = -Ibox2d-$(VERSION)/include -Ibox2d-$(VERSION)/extern/simde --target=wasm32 -D__EMSCRIPTEN__ -DNDEBUG -O3 --sysroot=$(SYSROOT)
 
 all: lib/box2d_wasm.o lib/box2d_wasm_simd.o clean
 


### PR DESCRIPTION
This prevented me from building box2d lib on Linux, since `extern` is with lower case.

However, this build script still didn't work for me. It broke on both WSL and Ubuntu with error:
`box2d-3.0.0/src/aabb.o: file not recognized: file format not recognized`. I'll make a separate issue about that.