### PR TITLE
move GetCommPorts, add missing comm functions, add communication events

### DIFF
--- a/core/sys/windows/kernel32.odin
+++ b/core/sys/windows/kernel32.odin
@@ -21,6 +21,16 @@ COMMON_LVB_REVERSE_VIDEO   :: WORD(0x4000)
 COMMON_LVB_UNDERSCORE      :: WORD(0x8000)
 COMMON_LVB_SBCSDBCS        :: WORD(0x0300)
 
+EV_BREAK :: DWORD(0x0040)
+EV_CTS :: DWORD(0x0008)
+EV_DSR :: DWORD(0x0010)
+EV_ERR :: DWORD(0x0080)
+EV_RING :: DWORD(0x0100)
+EV_RLSD :: DWORD(0x0020)
+EV_RXCHAR :: DWORD(0x0001)
+EV_RXFLAG :: DWORD(0x0002)
+EV_TXEMPTY :: DWORD(0x0004)
+
 @(default_calling_convention="system")
 foreign kernel32 {
 	OutputDebugStringA :: proc(lpOutputString: LPCSTR) --- // The only A thing that is allowed
@@ -109,6 +119,9 @@ foreign kernel32 {
 	ClearCommError :: proc(hFile: HANDLE, lpErrors: ^Com_Error, lpStat: ^COMSTAT) -> BOOL ---
 	GetCommState :: proc(handle: HANDLE, dcb: ^DCB) -> BOOL ---
 	SetCommState :: proc(handle: HANDLE, dcb: ^DCB) -> BOOL ---
+	SetCommMask :: proc(handle: HANDLE, dwEvtMap: DWORD) -> BOOL ---
+	GetCommMask :: proc(handle: HANDLE, lpEvtMask: LPDWORD) -> BOOL ---
+	WaitCommEvent ::proc(handle: HANDLE, lpEvtMask: LPDWORD, lpOverlapped: LPOVERLAPPED) -> BOOL ---
 	GetCommandLineW :: proc() -> LPCWSTR ---
 	GetTempPathW :: proc(nBufferLength: DWORD, lpBuffer: LPCWSTR) -> DWORD ---
 	GetCurrentProcess :: proc() -> HANDLE ---
@@ -1067,7 +1080,11 @@ foreign one_core {
 		PageProtection: ULONG,
 		PreferredNode: ULONG,
 	) -> PVOID ---
-	GetCommPorts :: proc(lpPortNumbers: PULONG, uPortNumbersCount: ULONG, puPortNumbersFound: PULONG) -> ULONG ---
+	GetCommPorts :: proc(
+		lpPortNumbers: PULONG,
+		uPortNumbersCount: ULONG,
+		puPortNumbersFound: PULONG,
+	) -> ULONG ---
 }
 
 

--- a/core/sys/windows/kernel32.odin
+++ b/core/sys/windows/kernel32.odin
@@ -109,7 +109,6 @@ foreign kernel32 {
 	ClearCommError :: proc(hFile: HANDLE, lpErrors: ^Com_Error, lpStat: ^COMSTAT) -> BOOL ---
 	GetCommState :: proc(handle: HANDLE, dcb: ^DCB) -> BOOL ---
 	SetCommState :: proc(handle: HANDLE, dcb: ^DCB) -> BOOL ---
-	GetCommPorts :: proc(lpPortNumbers: PULONG, uPortNumbersCount: ULONG, puPortNumbersFound: PULONG) -> ULONG ---
 	GetCommandLineW :: proc() -> LPCWSTR ---
 	GetTempPathW :: proc(nBufferLength: DWORD, lpBuffer: LPCWSTR) -> DWORD ---
 	GetCurrentProcess :: proc() -> HANDLE ---
@@ -1068,6 +1067,7 @@ foreign one_core {
 		PageProtection: ULONG,
 		PreferredNode: ULONG,
 	) -> PVOID ---
+	GetCommPorts :: proc(lpPortNumbers: PULONG, uPortNumbersCount: ULONG, puPortNumbersFound: PULONG) -> ULONG ---
 }
 
 

--- a/core/sys/windows/kernel32.odin
+++ b/core/sys/windows/kernel32.odin
@@ -20,16 +20,15 @@ COMMON_LVB_GRID_RVERTICAL  :: WORD(0x1000)
 COMMON_LVB_REVERSE_VIDEO   :: WORD(0x4000)
 COMMON_LVB_UNDERSCORE      :: WORD(0x8000)
 COMMON_LVB_SBCSDBCS        :: WORD(0x0300)
-
-EV_BREAK :: DWORD(0x0040)
-EV_CTS :: DWORD(0x0008)
-EV_DSR :: DWORD(0x0010)
-EV_ERR :: DWORD(0x0080)
-EV_RING :: DWORD(0x0100)
-EV_RLSD :: DWORD(0x0020)
-EV_RXCHAR :: DWORD(0x0001)
-EV_RXFLAG :: DWORD(0x0002)
-EV_TXEMPTY :: DWORD(0x0004)
+EV_BREAK                   :: DWORD(0x0040)
+EV_CTS                     :: DWORD(0x0008)
+EV_DSR                     :: DWORD(0x0010)
+EV_ERR                     :: DWORD(0x0080)
+EV_RING                    :: DWORD(0x0100)
+EV_RLSD                    :: DWORD(0x0020)
+EV_RXCHAR                  :: DWORD(0x0001)
+EV_RXFLAG                  :: DWORD(0x0002)
+EV_TXEMPTY                 :: DWORD(0x0004)
 
 @(default_calling_convention="system")
 foreign kernel32 {
@@ -121,7 +120,7 @@ foreign kernel32 {
 	SetCommState :: proc(handle: HANDLE, dcb: ^DCB) -> BOOL ---
 	SetCommMask :: proc(handle: HANDLE, dwEvtMap: DWORD) -> BOOL ---
 	GetCommMask :: proc(handle: HANDLE, lpEvtMask: LPDWORD) -> BOOL ---
-	WaitCommEvent ::proc(handle: HANDLE, lpEvtMask: LPDWORD, lpOverlapped: LPOVERLAPPED) -> BOOL ---
+	WaitCommEvent :: proc(handle: HANDLE, lpEvtMask: LPDWORD, lpOverlapped: LPOVERLAPPED) -> BOOL ---
 	GetCommandLineW :: proc() -> LPCWSTR ---
 	GetTempPathW :: proc(nBufferLength: DWORD, lpBuffer: LPCWSTR) -> DWORD ---
 	GetCurrentProcess :: proc() -> HANDLE ---


### PR DESCRIPTION
Calling `GetCommPorts` from `core:sys/windows` resulted in `unresolved external symbol GetCommPorts referenced in function` because it's provided by `OneCore.lib` and not `Kernel32.lib`.

I'm not really familiar with low level programming and couldn't really find a good overview over `OneCore.lib` (available in >=Win10 afaik), so I'm not sure if there are other functions that should be moved.

I also added the missing `SetCommMask`, `GetCommMask`, `WaitCommEvent`, as well as [communication function constants](https://learn.microsoft.com/en-us/windows/win32/devio/communications-events)

[Docs](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getcommports#requirements)
