### PR TITLE
add default -I and -L paths for OpenBSD

### DIFF
--- a/build_odin.sh
+++ b/build_odin.sh
@@ -110,8 +110,8 @@ Linux)
 	LDFLAGS="$LDFLAGS -Wl,-rpath=\$ORIGIN"
 	;;
 OpenBSD)
-	CXXFLAGS="$CXXFLAGS $($LLVM_CONFIG --cxxflags --ldflags)"
-	LDFLAGS="$LDFLAGS -liconv"
+	CXXFLAGS="$CXXFLAGS -I/usr/local/include $($LLVM_CONFIG --cxxflags --ldflags)"
+	LDFLAGS="$LDFLAGS -L/usr/local/lib -liconv"
 	LDFLAGS="$LDFLAGS $($LLVM_CONFIG --libs core native --system-libs)"
 	;;
 Haiku)


### PR DESCRIPTION
These can be added manually via environment variables when building, but it's probably sensible to have them as default on OpenBSD.