### PR TITLE
runtime: map_cell_index_static produced wrong results when the number of elements per cell was a power of 2

### DIFF
--- a/base/runtime/dynamic_map_internal.odin
+++ b/base/runtime/dynamic_map_internal.odin
@@ -158,6 +158,11 @@ map_cell_index_static :: #force_inline proc "contextless" (cells: [^]Map_Cell($T
 	} else when (N & (N - 1)) == 0 && N <= 8*size_of(uintptr) {
 		// Likely case, N is a power of two because T is a power of two.
 
+		// Unique case, no need to index data here since only one element.
+		when N == 1 {
+			return &cells[index].data[0]
+		}
+
 		// Compute the integer log 2 of N, this is the shift amount to index the
 		// correct cell. Odin's intrinsics.count_leading_zeros does not produce a
 		// constant, hence this approach. We only need to check up to N = 64.
@@ -167,12 +172,7 @@ map_cell_index_static :: #force_inline proc "contextless" (cells: [^]Map_Cell($T
 		         4 when N == 16 else
 		         5 when N == 32 else 6
 		#assert(SHIFT <= MAP_CACHE_LINE_LOG2)
-		// Unique case, no need to index data here since only one element.
-		when N == 1 {
-			return &cells[index >> SHIFT].data[0]
-		} else {
-			return &cells[index >> SHIFT].data[index & (N - 1)]
-		}
+		return &cells[index >> SHIFT].data[index & (N - 1)]
 	} else {
 		// Least likely (and worst case), we pay for a division operation but we
 		// assume the compiler does not actually generate a division. N will be in the

--- a/base/runtime/dynamic_map_internal.odin
+++ b/base/runtime/dynamic_map_internal.odin
@@ -161,11 +161,11 @@ map_cell_index_static :: #force_inline proc "contextless" (cells: [^]Map_Cell($T
 		// Compute the integer log 2 of N, this is the shift amount to index the
 		// correct cell. Odin's intrinsics.count_leading_zeros does not produce a
 		// constant, hence this approach. We only need to check up to N = 64.
-		SHIFT :: 1 when N < 2  else
-		         2 when N < 4  else
-		         3 when N < 8  else
-		         4 when N < 16 else
-		         5 when N < 32 else 6
+		SHIFT :: 1 when N == 2  else
+		         2 when N == 4  else
+		         3 when N == 8  else
+		         4 when N == 16 else
+		         5 when N == 32 else 6
 		#assert(SHIFT <= MAP_CACHE_LINE_LOG2)
 		// Unique case, no need to index data here since only one element.
 		when N == 1 {

--- a/tests/core/runtime/test_core_runtime.odin
+++ b/tests/core/runtime/test_core_runtime.odin
@@ -72,6 +72,7 @@ test_map_get :: proc(t: ^testing.T) {
 		2 = {20, 200, 2000},
 		3 = {30, 300, 3000},
 	}
+	defer delete(m)
 
 	k1, v1, ok1 := runtime.map_get(m, 1)
 	testing.expect_value(t, k1, 1)

--- a/tests/core/runtime/test_core_runtime.odin
+++ b/tests/core/runtime/test_core_runtime.odin
@@ -64,3 +64,27 @@ test_init_cap_map_dynarray :: proc(t: ^testing.T) {
         testing.expect(t, cap(d2) == 0)
         testing.expect(t, d2.allocator.procedure == ally.procedure)
 }
+
+@(test)
+test_map_get :: proc(t: ^testing.T) {
+	m := map[int][3]int{
+		1 = {10, 100, 1000},
+		2 = {20, 200, 2000},
+		3 = {30, 300, 3000},
+	}
+
+	k1, v1, ok1 := runtime.map_get(m, 1)
+	testing.expect_value(t, k1, 1)
+	testing.expect_value(t, v1, [3]int{10, 100, 1000})
+	testing.expect_value(t, ok1, true)
+
+	k2, v2, ok2 := runtime.map_get(m, 2)
+	testing.expect_value(t, k2, 2)
+	testing.expect_value(t, v2, [3]int{20, 200, 2000})
+	testing.expect_value(t, ok2, true)
+
+	k3, v3, ok3 := runtime.map_get(m, 3)
+	testing.expect_value(t, k3, 3)
+	testing.expect_value(t, v3, [3]int{30, 300, 3000})
+	testing.expect_value(t, ok3, true)
+}

--- a/tests/core/runtime/test_core_runtime.odin
+++ b/tests/core/runtime/test_core_runtime.odin
@@ -109,6 +109,37 @@ test_map_get :: proc(t: ^testing.T) {
 		check(t, m)
 	}
 
+
+	// small keys; 3 values per cell
+	{
+		val :: struct #packed {
+			a, b: int,
+			c:    i32,
+		}
+		m := map[int]val{
+			1 = val{10, 100, 1000},
+			2 = val{20, 200, 2000},
+			3 = val{30, 300, 3000},
+		}
+		defer delete(m)
+		check(t, m)
+	}
+
+	// 3 keys per cell; small values
+	{
+		key :: struct #packed {
+			a, b: int,
+			c:    i32,
+		}
+		m := map[key]int{
+			key{10, 100, 1000} = 1,
+			key{20, 200, 2000} = 2,
+			key{30, 300, 3000} = 3,
+		}
+		defer delete(m)
+		check(t, m)
+	}
+
 	// small keys; value bigger than a chacheline
 	{
 		m := map[int][9]int{


### PR DESCRIPTION
```odin
package main

import "base:runtime"
import "core:fmt"

main :: proc() {
	m := map[int][3]int{
		1 = {10, 20, 30},
		2 = {40, 50, 60},
		3 = {70, 80, 90},
	}

	fmt.println(runtime.map_get(m, 1))
	fmt.println(runtime.map_get(m, 2))
	fmt.println(runtime.map_get(m, 3))
}
```

prints 
```
0 [0, 0, 0] false
0 [0, 0, 0] false
0 [0, 0, 0] false
```

instead of 
```
1 [10, 20, 30] true
2 [40, 50, 60] true
3 [70, 80, 90] true 
```