### PR TITLE
Minor adjustments in documentation-only files for better LSP support 

### DIFF
--- a/base/builtin/builtin.odin
+++ b/base/builtin/builtin.odin
@@ -1,6 +1,8 @@
 // This is purely for documentation
 package builtin
 
+import "base:runtime"
+
 nil   :: nil
 false :: 0!=0
 true  :: 0==0

--- a/base/intrinsics/intrinsics.odin
+++ b/base/intrinsics/intrinsics.odin
@@ -2,6 +2,7 @@
 #+build ignore
 package intrinsics
 
+import "base:runtime"
 // Package-Related
 is_package_imported :: proc(package_name: string) -> bool ---
 

--- a/base/intrinsics/intrinsics.odin
+++ b/base/intrinsics/intrinsics.odin
@@ -3,6 +3,7 @@
 package intrinsics
 
 import "base:runtime"
+
 // Package-Related
 is_package_imported :: proc(package_name: string) -> bool ---
 

--- a/base/intrinsics/intrinsics.odin
+++ b/base/intrinsics/intrinsics.odin
@@ -220,7 +220,7 @@ type_map_cell_info :: proc($T: typeid)           -> ^runtime.Map_Cell_Info ---
 type_convert_variants_to_pointers :: proc($T: typeid) -> typeid where type_is_union(T) ---
 type_merge :: proc($U, $V: typeid) -> typeid where type_is_union(U), type_is_union(V) ---
 
-type_has_shared_fields :: proc($U, $V: typeid) -> bool typeid where type_is_struct(U), type_is_struct(V) ---
+type_has_shared_fields :: proc($U, $V: typeid) -> bool where type_is_struct(U), type_is_struct(V) ---
 
 constant_utf16_cstring :: proc($literal: string) -> [^]u16 ---
 

--- a/base/intrinsics/intrinsics.odin
+++ b/base/intrinsics/intrinsics.odin
@@ -73,7 +73,7 @@ prefetch_write_instruction :: proc(address: rawptr, #const locality: i32 /* 0..=
 prefetch_write_data        :: proc(address: rawptr, #const locality: i32 /* 0..=3 */) ---
 
 // Compiler Hints
-expect :: proc(val, expected_val: T) -> T ---
+expect :: proc(val, expected_val: $T) -> T ---
 
 // Linux and Darwin Only
 syscall :: proc(id: uintptr, args: ..uintptr) -> uintptr ---


### PR DESCRIPTION
Make some adjustments to "documentation only" files. This helps LSPs provide better code completion.