### PR TITLE
add ensure and ensuref to fmt and log, fix some inconsistencies

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -314,7 +314,29 @@ assertf :: proc(condition: bool, fmt: string, args: ..any, loc := #caller_locati
 				p = runtime.default_assertion_failure_proc
 			}
 			message := tprintf(fmt, ..args)
-			p("Runtime assertion", message, loc)
+			p("runtime assertion", message, loc)
+		}
+		internal(loc, fmt, ..args)
+	}
+}
+// Runtime ensure with a formatted message
+//
+// Inputs:
+// - condition: The boolean condition to be asserted
+// - fmt: A format string with placeholders for the provided arguments
+// - args: A variadic list of arguments to be formatted
+// - loc: The location of the caller
+//
+ensuref :: proc(condition: bool, fmt: string, args: ..any, loc := #caller_location) {
+	if !condition {
+		@(cold)
+		internal :: proc(loc: runtime.Source_Code_Location, fmt: string, args: ..any) {
+			p := context.assertion_failure_proc
+			if p == nil {
+				p = runtime.default_assertion_failure_proc
+			}
+			message := tprintf(fmt, ..args)
+			p("unsatisfied ensure", message, loc)
 		}
 		internal(loc, fmt, ..args)
 	}
@@ -332,7 +354,7 @@ panicf :: proc(fmt: string, args: ..any, loc := #caller_location) -> ! {
 		p = runtime.default_assertion_failure_proc
 	}
 	message := tprintf(fmt, ..args)
-	p("Panic", message, loc)
+	p("panic", message, loc)
 }
 
 // 	Creates a formatted C string


### PR DESCRIPTION
adds:
- `fmt.ensuref`
- `log.ensuref`
- `log.ensure`

changes:
- `fmt.asserf` to have "runtime assertion" in lowercase like `runtime.assert`
- `fmt.panicf` to have "panic" in lowercase like `runtime.panic`
- `log.assertf` to have "runtime assertion" in lowercase like `runtime.assert`
- `log.assert` to use `#caller_expression(condition)` as the default message like `runtime.assert`