### PR TITLE
Micro UI text wrapping bug

### DIFF
--- a/vendor/microui/microui.odin
+++ b/vendor/microui/microui.odin
@@ -921,25 +921,26 @@ text :: proc(ctx: ^Context, text: string) {
 	layout_row(ctx, {-1}, ctx.text_height(font))
 
 	outer: for len(text) > 0 {
-		last_space: int
 		r := layout_next(ctx)
+		last_space: int
 
 		for ch, i in text {
 			if ch == ' ' {
-				last_space = i
-			}
-
-			width := ctx.text_width(font, text[:i + 1])
-			newline := ch == '\n'
-			if width > r.w || newline {
-				if newline {
-					last_space = i
-				}
-				if last_space > 0 {
+				width := ctx.text_width(font, text[:i])
+				if width > r.w && last_space > 0 {
 					draw_text(ctx, font, text[:last_space], Vec2{r.x, r.y}, color)
-					text = text[last_space + 1:] // skip 1 char (space or newline)
+					text = text[last_space + 1:]
 					continue outer
 				}
+				else {
+					last_space = i
+				}
+			}
+
+			if ch == '\n' {
+				draw_text(ctx, font, text[:i], Vec2{r.x, r.y}, color)
+				text = text[i + 1:]
+				continue outer
 			}
 		}
 

--- a/vendor/microui/microui.odin
+++ b/vendor/microui/microui.odin
@@ -929,7 +929,7 @@ text :: proc(ctx: ^Context, text: string) {
 				last_space = i
 			}
 
-			width := ctx.text_width(font, text[:i])
+			width := ctx.text_width(font, text[:i + 1])
 			newline := ch == '\n'
 			if width > r.w || newline {
 				if newline {

--- a/vendor/microui/microui.odin
+++ b/vendor/microui/microui.odin
@@ -929,8 +929,7 @@ text :: proc(ctx: ^Context, text: string) {
 				width := ctx.text_width(font, text[:i])
 				if width > r.w && last_space > 0 {
 					break
-				}
-				else {
+				} else {
 					last_space = i
 				}
 			}

--- a/vendor/microui/microui.odin
+++ b/vendor/microui/microui.odin
@@ -916,21 +916,19 @@ text :: proc(ctx: ^Context, text: string) {
 	font  := ctx.style.font
 	color := ctx.style.colors[.TEXT]
 	layout_begin_column(ctx)
-	defer layout_end_column(ctx)
 
 	layout_row(ctx, {-1}, ctx.text_height(font))
 
-	outer: for len(text) > 0 {
+	for len(text) > 0 {
 		r := layout_next(ctx)
 		last_space: int
 
 		for ch, i in text {
-			if ch == ' ' {
+			end := i == len(text) - 1
+			if ch == ' ' || end {
 				width := ctx.text_width(font, text[:i])
 				if width > r.w && last_space > 0 {
-					draw_text(ctx, font, text[:last_space], Vec2{r.x, r.y}, color)
-					text = text[last_space + 1:]
-					continue outer
+					break
 				}
 				else {
 					last_space = i
@@ -938,16 +936,15 @@ text :: proc(ctx: ^Context, text: string) {
 			}
 
 			if ch == '\n' {
-				draw_text(ctx, font, text[:i], Vec2{r.x, r.y}, color)
-				text = text[i + 1:]
-				continue outer
+				last_space = i
+				break
 			}
 		}
-
-		// draw remainder of the text
-		draw_text(ctx, font, text[:], Vec2{r.x, r.y}, color)
-		break
+		draw_text(ctx, font, text[:last_space + 1], Vec2{r.x, r.y}, color)
+		text = text[last_space + 1:]
 	}
+
+	layout_end_column(ctx)
 }
 
 label :: proc(ctx: ^Context, text: string) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/15b8a50b-b3da-4be5-9799-f3fb5126d4b0)

currently microui makes an assumption in the text procedure that the width of a word + space individually is the same as both together. I have found that for certain fonts this is not the case, and causes text to be cut off before the line wraps. This change removes ambiguity by just measuring the whole line each time we increment a character. 