### PR TITLE
Fixes crash when unused defines are used in conjunction with `-ignore-warnings`

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1801,7 +1801,10 @@ gb_internal void check_defines(BuildContext *bc, Checker *c) {
 		if (!found) {
 			ERROR_BLOCK();
 			warning(nullptr, "given -define:%.*s is unused in the project", LIT(name));
-			error_line("\tSuggestion: use the -show-defineables flag for an overview of the possible defines\n");
+
+			if (!global_ignore_warnings()) {
+				error_line("\tSuggestion: use the -show-defineables flag for an overview of the possible defines\n");
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes a crash that occurs when building with `-ignore-warnings`  enabled and an unused defined is also passed. It causes the following assert to trigger:

> src/error.cpp(59): Assertion Failure: `global_error_collector.curr_error_value_set.load() == true` Possible race condition in error handling system, please report this with an issue

#### To Reproduce:
Build:
```odin
package main
proc :: main() {}
```
with:
`odin build <path> -ignore-warnings -define:BOGUS=true`

