### PR TITLE
Output debug log messages, when debug level is "debug"

### DIFF
--- a/core/testing/runner.odin
+++ b/core/testing/runner.odin
@@ -611,7 +611,7 @@ runner :: proc(internal_tests: []Internal_Test) -> bool {
 						total_done_count += 1
 					}
 
-					when ODIN_DEBUG {
+					when ODIN_DEBUG || LOG_LEVEL == "debug" {
 						log.debugf("Test #%i %s.%s changed state to %v.", task_channel.test_index, it.pkg, it.name, event.new_state)
 					}
 


### PR DESCRIPTION
Allow debug messages to be displayed when debug level is set to debug. This allows users to create a release build of the test runner while also having the possibility to get debug messages. 

This is particularly useful when integrating the test runner in an IDE. In my test integration I use the command line output as a signal for determining when a test has started, failed, succeeded, etc.

![image](https://github.com/user-attachments/assets/4d0c2ad7-a478-4c46-abfa-c5c8e9bb4dd6)

This wouldn't be possible without the command line output. However, now I'm forced to build a debug build in order for this to be possible. With this fix, I can also just set the log level to debug    