### PR TITLE
Non-zeroed memory after Arena free

### DIFF
--- a/base/runtime/default_temp_allocator_arena.odin
+++ b/base/runtime/default_temp_allocator_arena.odin
@@ -282,9 +282,10 @@ arena_temp_end :: proc(temp: Arena_Temp, loc := #caller_location) {
 
 		if block := arena.curr_block; block != nil {
 			assert(block.used >= temp.used, "out of order use of arena_temp_end", loc)
-			amount_to_zero := min(block.used-temp.used, block.capacity-block.used)
+			amount_to_zero := block.used-temp.used
 			intrinsics.mem_zero(block.base[temp.used:], amount_to_zero)
 			block.used = temp.used
+			arena.total_used -= amount_to_zero
 		}
 	}
 

--- a/core/mem/virtual/arena.odin
+++ b/core/mem/virtual/arena.odin
@@ -402,9 +402,10 @@ arena_temp_end :: proc(temp: Arena_Temp, loc := #caller_location) {
 
 		if block := arena.curr_block; block != nil {
 			assert(block.used >= temp.used, "out of order use of arena_temp_end", loc)
-			amount_to_zero := min(block.used-temp.used, block.reserved-block.used)
+			amount_to_zero := block.used-temp.used
 			mem.zero_slice(block.base[temp.used:][:amount_to_zero])
 			block.used = temp.used
+			arena.total_used -= amount_to_zero
 		}
 	}
 


### PR DESCRIPTION
This PR fixes two issues in both the virtual growing Arena as well es the default_temp_allocator_arena implementation.

### Bug 1
When calling `arena_temp_end` the `total_used` field of the arena was not decremented when freeing a section of the last memory block. Memory blocks that are freed completely are doing this correctly.


### Bug 2
When freeing a section of an arena memory block via `arena_temp_end`, the section that has been freed is getting zeroed to ensure that allocations in the future return proper zero memory. The expression that is being used to calculate the size of the section that should be zeroed gives incorrect results for certain scenarios.  

Both arena implementations are semantically doing the same thing (`capacity` and `reserved` fields mean effectively the same thing in the respective context).
`amount_to_zero := min(block.used-temp.used, block.reserved-block.used)`

To be honest, I am not sure what the reasoning behind the usage of `min` is here.
For scenarios where `block.reserved-block.used` > `block.used-temp.used` it does nothing while for the scenario where `block.reserved-block.used` < `block.used-temp.used` we are now zeroing the wrong amount of memory (too little).
My fix just removes that part entirely and simply uses `amount_to_zero := block.used-temp.used`.
Maybe there is something I'm missing here but this doesn't look like it would really do anything useful.

In my specific scenario I allocted memory from the arena that was exactly the size of one memory block which result in 0 memory getting free'd since `block.reserved-block.used` == 0.
