### PR TITLE
Allow captures in gfind and gmatch to be used in-loop

### DIFF
--- a/core/text/match/strlib.odin
+++ b/core/text/match/strlib.odin
@@ -698,11 +698,11 @@ gmatch :: proc(
 			first := length > 1 ? 1 : 0
 			cap := captures[first]
 			res = haystack[cap.byte_start:cap.byte_end]
-		} else {
-			captures^ = {}
 		}
 	} 
-
+	if !ok {
+		captures^ = {}
+	}
 	return
 }
 
@@ -813,11 +813,11 @@ gfind :: proc(
 			ok = true
 			cap := captures[0]
 			res = haystack[cap.byte_start:cap.byte_end]
-		} else {
-			captures^ = {}
 		}
 	} 
-
+	if !ok {
+		captures^ = {}
+	}
 	return
 }
 

--- a/core/text/match/strlib.odin
+++ b/core/text/match/strlib.odin
@@ -682,11 +682,14 @@ find_aux :: proc(
 
 // iterative matching which returns the 0th/1st match
 // rest has to be used from captures
+// assumes captures is zeroed on first iteration
+// resets captures to zero on last iteration
 gmatch :: proc(
 	haystack: ^string,
 	pattern: string,
 	captures: ^[MAX_CAPTURES]Match,
 ) -> (res: string, ok: bool) {
+	haystack^ = haystack[captures[0].byte_end:]
 	if len(haystack) > 0 {
 		length, err := find_aux(haystack^, pattern, 0, false, captures)
 
@@ -695,7 +698,8 @@ gmatch :: proc(
 			first := length > 1 ? 1 : 0
 			cap := captures[first]
 			res = haystack[cap.byte_start:cap.byte_end]
-			haystack^ = haystack[cap.byte_end:]
+		} else {
+			captures^ = {}
 		}
 	} 
 
@@ -794,11 +798,14 @@ gsub_with :: proc(
 gsub :: proc { gsub_builder, gsub_allocator }
 
 // iterative find with zeroth capture only
+// assumes captures is zeroed on first iteration
+// resets captures to zero on last iteration
 gfind :: proc(
 	haystack: ^string,
 	pattern: string,
 	captures: ^[MAX_CAPTURES]Match,
 ) -> (res: string, ok: bool) {
+	haystack^ = haystack[captures[0].byte_end:]
 	if len(haystack) > 0 {
 		length, err := find_aux(haystack^, pattern, 0, true, captures)
 
@@ -806,7 +813,8 @@ gfind :: proc(
 			ok = true
 			cap := captures[0]
 			res = haystack[cap.byte_start:cap.byte_end]
-			haystack^ = haystack[cap.byte_end:]
+		} else {
+			captures^ = {}
 		}
 	} 
 


### PR DESCRIPTION
As it is currently. Trying to slice the iterated string in gfind and gmatch will not work. The string is sliced at the end of the function, after the captures are found.

```
import "core:fmt"
import "core:text/match"

main :: proc() {
	src := `12356789123456789
		a cat with a hat
		a dog with a bone
	123456789123456789`
	caps: [match.MAX_CAPTURES]match.Match
	for _ in match.gmatch(&src, "a (%w+) with a (%w+)", &caps) {
		fmt.println(
			src[caps[1].byte_start:caps[1].byte_end],
			src[caps[2].byte_start:caps[2].byte_end],
		)
	}
	// Output:
	// th 123
	// 345 5678
}
```

I just moved that slice to the beginning of the next iteration. This does add an implicit requirement to have the captures array zeroed. I also made it automatically zero the captures array on the last iteration in case of reuse. 