### PR TITLE
Do not warn about stack overflow in range loops 'by reference'

### DIFF
--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -749,9 +749,15 @@ gb_internal void check_scope_usage_internal(Checker *c, Scope *scope, u64 vet_fl
 			// TODO(bill): When is a good size warn?
 			// Is >256 KiB good enough?
 			if (sz > 1ll<<18) {
-				gbString type_str = type_to_string(e->type);
-				warning(e->token, "Declaration of '%.*s' may cause a stack overflow due to its type '%s' having a size of %lld bytes", LIT(e->token.string), type_str, cast(long long)sz);
-				gb_string_free(type_str);
+				bool is_ref = false;
+				if((e->flags & EntityFlag_ForValue) != 0) {
+					is_ref = type_deref(e->Variable.for_loop_parent_type) != NULL;
+				}
+				if(!is_ref) {
+					gbString type_str = type_to_string(e->type);
+					warning(e->token, "Declaration of '%.*s' may cause a stack overflow due to its type '%s' having a size of %lld bytes", LIT(e->token.string), type_str, cast(long long)sz);
+					gb_string_free(type_str);
+				}
 			}
 		}
 	}


### PR DESCRIPTION

This PR fixes the stack overflow warning that pops up in ranged loops, when looping over large arrays by reference. Since we're looping by reference, there are no stack copies of the entire loop, which makes the warning useless.

This PR resolves #4685.