### PR TITLE
Error if `-no-crt` is used without `-no-thread-locals`

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -2133,7 +2133,21 @@ gb_internal bool init_build_paths(String init_filename) {
 		case TargetOs_openbsd:
 		case TargetOs_netbsd:
 		case TargetOs_haiku:
-			gb_printf_err("-no-crt on unix systems requires either -default-to-nil-allocator or -default-to-panic-allocator to also be present because the default allocator requires crt\n");
+			gb_printf_err("-no-crt on unix systems requires either -default-to-nil-allocator or -default-to-panic-allocator to also be present, because the default allocator requires crt\n");
+			return false;
+		}
+	}
+
+	if (build_context.no_crt && !build_context.no_thread_local && !build_context.ODIN_DEFAULT_TO_NIL_ALLOCATOR) {
+		switch (build_context.metrics.os) {
+		case TargetOs_linux:
+		case TargetOs_darwin:
+		case TargetOs_essence:
+		case TargetOs_freebsd:
+		case TargetOs_openbsd:
+		case TargetOs_netbsd:
+		case TargetOs_haiku:
+			gb_printf_err("-no-crt on unix systems requires either -default-to-nil-allocator or -no-thread-local to also be present, because the temporary allocator is a thread local, which are inaccessible without CRT initializing TLS\n");
 			return false;
 		}
 	}

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -2124,6 +2124,7 @@ gb_internal bool init_build_paths(String init_filename) {
 		}
 	}
 
+	bool no_crt_checks_failed = false;
 	if (build_context.no_crt && !build_context.ODIN_DEFAULT_TO_NIL_ALLOCATOR && !build_context.ODIN_DEFAULT_TO_PANIC_ALLOCATOR) {
 		switch (build_context.metrics.os) {
 		case TargetOs_linux:
@@ -2133,12 +2134,12 @@ gb_internal bool init_build_paths(String init_filename) {
 		case TargetOs_openbsd:
 		case TargetOs_netbsd:
 		case TargetOs_haiku:
-			gb_printf_err("-no-crt on unix systems requires either -default-to-nil-allocator or -default-to-panic-allocator to also be present, because the default allocator requires crt\n");
-			return false;
+			gb_printf_err("-no-crt on Unix systems requires either -default-to-nil-allocator or -default-to-panic-allocator to also be present, because the default allocator requires CRT\n");
+			no_crt_checks_failed = true;
 		}
 	}
 
-	if (build_context.no_crt && !build_context.no_thread_local && !build_context.ODIN_DEFAULT_TO_NIL_ALLOCATOR) {
+	if (build_context.no_crt && !build_context.no_thread_local) {
 		switch (build_context.metrics.os) {
 		case TargetOs_linux:
 		case TargetOs_darwin:
@@ -2147,9 +2148,13 @@ gb_internal bool init_build_paths(String init_filename) {
 		case TargetOs_openbsd:
 		case TargetOs_netbsd:
 		case TargetOs_haiku:
-			gb_printf_err("-no-crt on unix systems requires either -default-to-nil-allocator or -no-thread-local to also be present, because the temporary allocator is a thread local, which are inaccessible without CRT initializing TLS\n");
-			return false;
+			gb_printf_err("-no-crt on Unix systems requires the -no-thread-local flag to also be present, because the TLS is inaccessible without CRT\n");
+			no_crt_checks_failed = true;
 		}
+	}
+
+	if (no_crt_checks_failed) {
+		return false;
 	}
 
 	return true;

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -1822,19 +1822,6 @@ gb_internal Entity *check_ident(CheckerContext *c, Operand *o, Ast *n, Type *nam
 		break;
 
 	case Entity_Variable:
-		if (e->kind == Entity_Variable && build_context.no_crt && !build_context.no_thread_local && e->Variable.thread_local_model != "") {
-			switch (build_context.metrics.os) {
-			case TargetOs_linux:
-			case TargetOs_darwin:
-			case TargetOs_essence:
-			case TargetOs_freebsd:
-			case TargetOs_openbsd:
-			case TargetOs_netbsd:
-			case TargetOs_haiku:
-				Token token = ast_token(n);
-				error(token, "Illegal usage of thread locals: '%.*s'", LIT(e->token.string));
-			}
-		}
 		e->flags |= EntityFlag_Used;
 		if (type == t_invalid) {
 			o->type = t_invalid;

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -1044,7 +1044,7 @@ gb_internal AstPackage *get_package_of_type(Type *type) {
 }
 
 
-// NOTE(bill): 'content_name' is for debugging and error messages
+// NOTE(bill): 'context_name' is for debugging and error messages
 gb_internal void check_assignment(CheckerContext *c, Operand *operand, Type *type, String context_name) {
 	check_not_tuple(c, operand);
 	if (operand->mode == Addressing_Invalid) {
@@ -1822,6 +1822,19 @@ gb_internal Entity *check_ident(CheckerContext *c, Operand *o, Ast *n, Type *nam
 		break;
 
 	case Entity_Variable:
+		if (e->kind == Entity_Variable && build_context.no_crt && !build_context.no_thread_local && e->Variable.thread_local_model != "") {
+			switch (build_context.metrics.os) {
+			case TargetOs_linux:
+			case TargetOs_darwin:
+			case TargetOs_essence:
+			case TargetOs_freebsd:
+			case TargetOs_openbsd:
+			case TargetOs_netbsd:
+			case TargetOs_haiku:
+				Token token = ast_token(n);
+				error(token, "Illegal usage of thread locals: '%.*s'", LIT(e->token.string));
+			}
+		}
 		e->flags |= EntityFlag_Used;
 		if (type == t_invalid) {
 			o->type = t_invalid;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2334,6 +2334,10 @@ gb_internal void print_show_help(String const arg0, String command, String optio
 			print_usage_line(2, "Sets the default allocator to be the nil_allocator, an allocator which does nothing.");
 		}
 
+		if (print_flag("-default-to-panic-allocator")) {
+			print_usage_line(2, "Sets the default allocator to be the panic_allocator, an allocator which calls panic() on any allocation attempt.");
+		}
+
 		if (print_flag("-define:<name>=<value>")) {
 			print_usage_line(2, "Defines a scalar boolean, integer or string as global constant.");
 			print_usage_line(2, "Example: -define:SPAM=123");


### PR DESCRIPTION
This PR enforces the use of `-no-thread-locals` when compiling with `-no-crt`. The reasoning is as follows: There are a few places in the `base:` collection that initialize things with thread locals, as well as a bunch of places in the `core:` collection. When `-no-crt` is used by itself, you'll just crash, because there's no libc to initialize the TLS and any access to TLS would lead to a crash. This makes it seem like an unintended behavior (#4614), but it is in fact very intended, because at the current stage we can't build our own TLS model, and we can't match any dynamic loaders' TLS model.

This PR resolves #4614 by making it an explicit error.

There's also a small typo fix in a comment that caught my eye. Oh, and I added `-default-to-panic-allocator` to `-help`, because just noticed it wasn't there.