### PR TITLE
fix inverted error messages

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -1973,10 +1973,10 @@ gb_internal bool check_binary_op(CheckerContext *c, Operand *o, Token op) {
 	case Token_Quo:
 	case Token_QuoEq:
 		if (is_type_matrix(main_type)) {
-			error(op, "Operator '%.*s' is only allowed with matrix types", LIT(op.string));
+			error(op, "Operator '%.*s' is not allowed with matrix types", LIT(op.string));
 			return false;
 		} else if (is_type_simd_vector(main_type) && is_type_integer(type)) {
-			error(op, "Operator '%.*s' is only allowed with #simd types with integer elements", LIT(op.string));
+			error(op, "Operator '%.*s' is not allowed with #simd types with integer elements", LIT(op.string));
 			return false;
 		}
 		/*fallthrough*/
@@ -2023,14 +2023,14 @@ gb_internal bool check_binary_op(CheckerContext *c, Operand *o, Token op) {
 	case Token_ModEq:
 	case Token_ModModEq:
 		if (is_type_matrix(main_type)) {
-			error(op, "Operator '%.*s' is only allowed with matrix types", LIT(op.string));
+			error(op, "Operator '%.*s' is not allowed with matrix types", LIT(op.string));
 			return false;
 		}
 		if (!is_type_integer(type)) {
 			error(op, "Operator '%.*s' is only allowed with integers", LIT(op.string));
 			return false;
 		} else if (is_type_simd_vector(main_type)) {
-			error(op, "Operator '%.*s' is only allowed with #simd types with integer elements", LIT(op.string));
+			error(op, "Operator '%.*s' is not allowed with #simd types with integer elements", LIT(op.string));
 			return false;
 		}
 		break;


### PR DESCRIPTION
Before we'd have nonsense error messages like:
```
Operator '/' is only allowed with matrix types
```
Same thing for `%`.

I'm not sure if there's a testing suite for compile errors like in Zig, but let me know if there's anything else I need to change.