### PR TITLE
remove `-L/` and `-l:` from linker flags

### DIFF
--- a/src/gb/gb.h
+++ b/src/gb/gb.h
@@ -278,6 +278,11 @@ extern "C" {
 	#include <semaphore.h>
 #endif
 
+#if defined(GB_SYSTEM_LINUX)
+	#include <grp.h>
+	#include <pwd.h>
+#endif
+
 
 ////////////////////////////////////////////////////////////////
 //

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -615,7 +615,7 @@ try_cross_linking:;
 							//                local to the executable (unless the system collection is used, in which case we search
 							//                the system library paths for the library file).
 							if (string_ends_with(lib, str_lit(".a")) || string_ends_with(lib, str_lit(".o")) || string_ends_with(lib, str_lit(".so")) || string_contains_string(lib, str_lit(".so."))) {
-								lib_str = gb_string_append_fmt(lib_str, " -l:\"%.*s\" ", LIT(lib));
+								lib_str = gb_string_append_fmt(lib_str, " \"%.*s\" ", LIT(lib));
 							} else {
 								// dynamic or static system lib, just link regularly searching system library paths
 								lib_str = gb_string_append_fmt(lib_str, " -l%.*s ", LIT(lib));

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -439,6 +439,23 @@ try_cross_linking:;
 			#if !defined(GB_SYSTEM_WINDOWS)
 				lib_str = gb_string_appendc(lib_str, "-L/ ");
 			#endif
+
+			// Check if Odin is called inside Nix build environment.
+			bool nix_build = false;
+			#if defined(GB_SYSTEM_LINUX)
+				__uid_t uid = getuid();
+				passwd *passw = getpwuid(uid);
+				if (passw != NULL) {
+					int groups_len = 0;
+					getgrouplist(passw->pw_name, passw->pw_gid, NULL, &groups_len);
+					if (groups_len == 1) {
+						__gid_t groups[2];
+						getgrouplist(passw->pw_name, passw->pw_gid, groups, &groups_len);
+						const char *gr_name = getgrgid(groups[0])->gr_name;
+						nix_build = gb_strcmp(gr_name, "nixbld") == 0;
+					}
+				}
+			#endif
 			
 			StringSet asm_files = {};
 			string_set_init(&asm_files, 64);
@@ -615,7 +632,12 @@ try_cross_linking:;
 							//                local to the executable (unless the system collection is used, in which case we search
 							//                the system library paths for the library file).
 							if (string_ends_with(lib, str_lit(".a")) || string_ends_with(lib, str_lit(".o")) || string_ends_with(lib, str_lit(".so")) || string_contains_string(lib, str_lit(".so."))) {
-								lib_str = gb_string_append_fmt(lib_str, " \"%.*s\" ", LIT(lib));
+								// Inside Nix build environment, the linker will not be able to find the libraries if `-l:` is specified.
+								if (nix_build) {
+									lib_str = gb_string_append_fmt(lib_str, " \"%.*s\" ", LIT(lib));
+								} else {
+									lib_str = gb_string_append_fmt(lib_str, " -l:\"%.*s\" ", LIT(lib));
+								}
 							} else {
 								// dynamic or static system lib, just link regularly searching system library paths
 								lib_str = gb_string_append_fmt(lib_str, " -l%.*s ", LIT(lib));


### PR DESCRIPTION
This is the actual fix to <https://github.com/NixOS/nixpkgs/issues/338972> and many other issues with linking on Nix build system. The issue may have been caused by using `-l:` to specify the path to libraries and `-L/` to set the linker search path. The linker could not find the libraries only when building using Nix `stdenv`. Building inside a nix shell does not trigger this issue. Probably it has something to do with build sandboxing, but I'm not too knowledgeable on this matter.

I found the solution when I was trying to isolate the issue using a simple C program and a static library. Building this with nix `stdenv`, resulting in the linker not being able to found the library.
```nix
buildPhase = ''
    gcc -o main main.c -L/ -l:$(pwd)/lib/libh.a
'';
```
```
/nix/store/j7p46r8v9gcpbxx89pbqlh61zhd33gzv-binutils-2.43.1/bin/ld: cannot find -l:/build/source/lib/libh.a: No such file or directory
```
But removing `-L/` and `-l:` does the trick.
```nix
buildPhase = ''
    gcc -o main main.c $(pwd)/lib/libh.a
'';
```

I also tested this patch on Debian and it seemed to work fine.