### PR TITLE
os/os2: Properly update CWD on Linux when using _process_start()

### DIFF
--- a/core/os/os2/process_linux.odin
+++ b/core/os/os2/process_linux.odin
@@ -547,6 +547,10 @@ _process_start :: proc(desc: Process_Desc) -> (process: Process, err: Error) {
 		if _, errno = linux.dup2(stderr_fd, STDERR); errno != .NONE {
 			write_errno_to_parent_and_abort(child_pipe_fds[WRITE], errno)
 		}
+		if dir_fd != linux.AT_FDCWD {
+			errno = linux.fchdir(dir_fd)
+			assert(errno == nil)
+		}
 
 		errno = linux.execveat(dir_fd, exe_path, &cargs[0], env)
 		assert(errno != nil)

--- a/core/os/os2/process_linux.odin
+++ b/core/os/os2/process_linux.odin
@@ -548,8 +548,9 @@ _process_start :: proc(desc: Process_Desc) -> (process: Process, err: Error) {
 			write_errno_to_parent_and_abort(child_pipe_fds[WRITE], errno)
 		}
 		if dir_fd != linux.AT_FDCWD {
-			errno = linux.fchdir(dir_fd)
-			assert(errno == nil)
+			if errno = linux.fchdir(dir_fd); errno != .NONE {
+				write_errno_to_parent_and_abort(child_pipe_fds[WRITE], errno)
+			}
 		}
 
 		errno = linux.execveat(dir_fd, exe_path, &cargs[0], env)


### PR DESCRIPTION
The `dir_fd` argument to `execveat()` is not for setting the current working directory. It is used to resolve relative executable paths, hence explicit `chdir/fchdir` call is required to set CWD.