### PR TITLE
fix compiler crash on assigning a variable to an unresolved bit_set

### DIFF
--- a/src/check_decl.cpp
+++ b/src/check_decl.cpp
@@ -60,7 +60,7 @@ gb_internal Type *check_init_variable(CheckerContext *ctx, Entity *e, Operand *o
 				error(operand->expr, "Cannot assign a type '%s' to variable '%.*s'", t, LIT(e->token.string));
 			}
 			if (e->type == nullptr) {
-				error_line("\tThe type of the variable '%.*s' cannot be inferred as a type does not have a default type\n", LIT(e->token.string));
+				error_line("\tThe type of the variable '%.*s' cannot be inferred as a type and does not have a default type\n", LIT(e->token.string));
 			}
 			e->type = operand->type;
 			return nullptr;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -4773,7 +4773,9 @@ gb_internal gbString write_type_to_string(gbString str, Type *type, bool shortha
 
 	case Type_BitSet:
 		str = gb_string_appendc(str, "bit_set[");
-		if (is_type_enum(type->BitSet.elem)) {
+		if (type->BitSet.elem == nullptr) {
+			str = gb_string_appendc(str, "<unresolved>");
+		} else if (is_type_enum(type->BitSet.elem)) {
 			str = write_type_to_string(str, type->BitSet.elem);
 		} else {
 			str = gb_string_append_fmt(str, "%lld", type->BitSet.lower);


### PR DESCRIPTION
Fixes issue #4738.  Compiler crashes trying to report the error on the following:

```odin
a := bit_set[0..<x]
```

It crashes trying to build the error message for trying to assign a variable to a type. Also, fixed some grammar in the error message itself.