### PR TITLE
Fix the '+' sign placement in the presence of '0'-padding

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -1379,9 +1379,9 @@ _pad :: proc(fi: ^Info, s: string) {
 	if fi.minus { // right pad
 		io.write_string(fi.writer, s, &fi.n)
 		fmt_write_padding(fi, width)
-	} else if !fi.space && s != "" && s[0] == '-' {
+	} else if !fi.space && s != "" && (s[0] == '-' || s[0] == '+') {
 		// left pad accounting for zero pad of negative number
-		io.write_byte(fi.writer, '-', &fi.n)
+		io.write_byte(fi.writer, s[0], &fi.n)
 		fmt_write_padding(fi, width)
 		io.write_string(fi.writer, s[1:], &fi.n)
 	} else { // left pad


### PR DESCRIPTION

This PR fixes the incorrect padding of the plus sign when '0' flag is used in format specifier. Previously plus sign would print after the padding, resulting in a plus sign in between zeroes of the padding and the number.

Fixes #4715

