### PR TITLE
Fix separate modules objc

### DIFF
--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -1147,22 +1147,14 @@ gb_internal void lb_finalize_objc_names(lbProcedure *p) {
 		String name = entry.key;
 		args[0] = lb_const_value(m, t_cstring, exact_value_string(name));
 		lbValue ptr = lb_emit_runtime_call(p, "objc_lookUpClass", args);
-
-		lbValue ptr_ = lb_find_value_from_entity(m, entry.value);
-		lbAddr local_addr = lb_addr(ptr_);
-
-		lb_addr_store(p, local_addr, ptr);
+		lb_addr_store(p, entry.value.local_module_addr, ptr);
 	}
 
 	for (auto const &entry : m->objc_selectors) {
 		String name = entry.key;
 		args[0] = lb_const_value(m, t_cstring, exact_value_string(name));
 		lbValue ptr = lb_emit_runtime_call(p, "sel_registerName", args);
-
-		lbValue ptr_ = lb_find_value_from_entity(m, entry.value);
-		lbAddr local_addr = lb_addr(ptr_);
-
-		lb_addr_store(p, local_addr, ptr);
+		lb_addr_store(p, entry.value.local_module_addr, ptr);
 	}
 
 	lb_end_procedure_body(p);

--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -1147,14 +1147,22 @@ gb_internal void lb_finalize_objc_names(lbProcedure *p) {
 		String name = entry.key;
 		args[0] = lb_const_value(m, t_cstring, exact_value_string(name));
 		lbValue ptr = lb_emit_runtime_call(p, "objc_lookUpClass", args);
-		lb_addr_store(p, entry.value, ptr);
+
+		lbValue ptr_ = lb_find_value_from_entity(m, entry.value);
+		lbAddr local_addr = lb_addr(ptr_);
+
+		lb_addr_store(p, local_addr, ptr);
 	}
 
 	for (auto const &entry : m->objc_selectors) {
 		String name = entry.key;
 		args[0] = lb_const_value(m, t_cstring, exact_value_string(name));
 		lbValue ptr = lb_emit_runtime_call(p, "sel_registerName", args);
-		lb_addr_store(p, entry.value, ptr);
+
+		lbValue ptr_ = lb_find_value_from_entity(m, entry.value);
+		lbAddr local_addr = lb_addr(ptr_);
+
+		lb_addr_store(p, local_addr, ptr);
 	}
 
 	lb_end_procedure_body(p);

--- a/src/llvm_backend.hpp
+++ b/src/llvm_backend.hpp
@@ -196,8 +196,8 @@ struct lbModule {
 	RecursiveMutex debug_values_mutex;
 	PtrMap<void *, LLVMMetadataRef> debug_values; 
 
-	StringMap<lbAddr> objc_classes;
-	StringMap<lbAddr> objc_selectors;
+	StringMap<Entity *> objc_classes;
+	StringMap<Entity *> objc_selectors;
 
 	PtrMap<Type *, lbAddr> map_cell_info_map; // address of runtime.Map_Info
 	PtrMap<Type *, lbAddr> map_info_map;      // address of runtime.Map_Cell_Info

--- a/src/llvm_backend.hpp
+++ b/src/llvm_backend.hpp
@@ -143,6 +143,11 @@ struct lbPadType {
 	LLVMTypeRef type;
 };
 
+struct lbObjcRef {
+	Entity * entity;
+	lbAddr local_module_addr;
+};
+
 struct lbModule {
 	LLVMModuleRef mod;
 	LLVMContextRef ctx;
@@ -196,8 +201,8 @@ struct lbModule {
 	RecursiveMutex debug_values_mutex;
 	PtrMap<void *, LLVMMetadataRef> debug_values; 
 
-	StringMap<Entity *> objc_classes;
-	StringMap<Entity *> objc_selectors;
+	StringMap<lbObjcRef> objc_classes;
+	StringMap<lbObjcRef> objc_selectors;
 
 	PtrMap<Type *, lbAddr> map_cell_info_map; // address of runtime.Map_Info
 	PtrMap<Type *, lbAddr> map_info_map;      // address of runtime.Map_Cell_Info

--- a/src/llvm_backend_utility.cpp
+++ b/src/llvm_backend_utility.cpp
@@ -2093,23 +2093,36 @@ gb_internal void lb_set_wasm_export_attributes(LLVMValueRef value, String export
 
 
 gb_internal lbAddr lb_handle_objc_find_or_register_selector(lbProcedure *p, String const &name) {
-	lbAddr *found = string_map_get(&p->module->objc_selectors, name);
+	lbModule *default_module = &p->module->gen->default_module;
+	Entity *entity = {};
+
+	Entity **found = string_map_get(&p->module->objc_selectors, name);
 	if (found) {
-		return *found;
-	} else {
-		lbModule *default_module = &p->module->gen->default_module;
-		Entity *e = nullptr;
-		lbAddr default_addr = lb_add_global_generated(default_module, t_objc_SEL, {}, &e);
-
-		lbValue ptr = lb_find_value_from_entity(p->module, e);
-		lbAddr local_addr = lb_addr(ptr);
-
-		string_map_set(&default_module->objc_selectors, name, default_addr);
-		if (default_module != p->module) {
-			string_map_set(&p->module->objc_selectors, name, local_addr);
-		}
-		return local_addr;
+		entity = *found;
 	}
+
+	if (!entity) {
+		if (default_module != p->module) {
+			found = string_map_get(&default_module->objc_selectors, name);
+			if (found) {
+				entity = *found;
+			}
+		}
+
+		if (!entity) {
+			lbAddr default_addr = lb_add_global_generated(default_module, t_objc_SEL, {}, &entity);
+			string_map_set(&default_module->objc_selectors, name, entity);
+		}
+	}
+
+	lbValue ptr = lb_find_value_from_entity(p->module, entity);
+	lbAddr local_addr = lb_addr(ptr);
+
+	if (default_module != p->module) {
+		string_map_set(&p->module->objc_selectors, name, entity);
+	}
+
+	return local_addr;
 }
 
 gb_internal lbValue lb_handle_objc_find_selector(lbProcedure *p, Ast *expr) {
@@ -2139,23 +2152,36 @@ gb_internal lbValue lb_handle_objc_register_selector(lbProcedure *p, Ast *expr) 
 }
 
 gb_internal lbAddr lb_handle_objc_find_or_register_class(lbProcedure *p, String const &name) {
-	lbAddr *found = string_map_get(&p->module->objc_classes, name);
+	lbModule *default_module = &p->module->gen->default_module;
+	Entity *entity = {};
+
+	Entity **found = string_map_get(&p->module->objc_classes, name);
 	if (found) {
-		return *found;
-	} else {
-		lbModule *default_module = &p->module->gen->default_module;
-		Entity *e = nullptr;
-		lbAddr default_addr = lb_add_global_generated(default_module, t_objc_SEL, {}, &e);
-
-		lbValue ptr = lb_find_value_from_entity(p->module, e);
-		lbAddr local_addr = lb_addr(ptr);
-
-		string_map_set(&default_module->objc_classes, name, default_addr);
-		if (default_module != p->module) {
-			string_map_set(&p->module->objc_classes, name, local_addr);
-		}
-		return local_addr;
+		entity = *found;
 	}
+
+	if (!entity) {
+		if (default_module != p->module) {
+			found = string_map_get(&default_module->objc_classes, name);
+			if (found) {
+				entity = *found;
+			}
+		}
+
+		if (!entity) {
+			lbAddr default_addr = lb_add_global_generated(default_module, t_objc_Class, {}, &entity);
+			string_map_set(&default_module->objc_classes, name, entity);
+		}
+	}
+
+	lbValue ptr = lb_find_value_from_entity(p->module, entity);
+	lbAddr local_addr = lb_addr(ptr);
+
+	if (default_module != p->module) {
+		string_map_set(&p->module->objc_classes, name, entity);
+	}
+
+	return local_addr;
 }
 
 gb_internal lbValue lb_handle_objc_find_class(lbProcedure *p, Ast *expr) {
@@ -2196,23 +2222,7 @@ gb_internal lbValue lb_handle_objc_id(lbProcedure *p, Ast *expr) {
 		GB_ASSERT(e->kind == Entity_TypeName);
 		String name = e->TypeName.objc_class_name;
 
-		lbAddr *found = string_map_get(&p->module->objc_classes, name);
-		if (found) {
-			return lb_addr_load(p, *found);
-		} else {
-			lbModule *default_module = &p->module->gen->default_module;
-			Entity *e = nullptr;
-			lbAddr default_addr = lb_add_global_generated(default_module, t_objc_Class, {}, &e);
-
-			lbValue ptr = lb_find_value_from_entity(p->module, e);
-			lbAddr local_addr = lb_addr(ptr);
-
-			string_map_set(&default_module->objc_classes, name, default_addr);
-			if (default_module != p->module) {
-				string_map_set(&p->module->objc_classes, name, local_addr);
-			}
-			return lb_addr_load(p, local_addr);
-		}
+		return lb_addr_load(p, lb_handle_objc_find_or_register_class(p, name));
 	}
 
 	return lb_build_expr(p, expr);

--- a/src/llvm_backend_utility.cpp
+++ b/src/llvm_backend_utility.cpp
@@ -2093,33 +2093,31 @@ gb_internal void lb_set_wasm_export_attributes(LLVMValueRef value, String export
 
 
 gb_internal lbAddr lb_handle_objc_find_or_register_selector(lbProcedure *p, String const &name) {
+	lbObjcRef *found = string_map_get(&p->module->objc_selectors, name);
+	if (found) {
+		return found->local_module_addr;
+	}
+
 	lbModule *default_module = &p->module->gen->default_module;
 	Entity *entity = {};
 
-	Entity **found = string_map_get(&p->module->objc_selectors, name);
-	if (found) {
-		entity = *found;
+	if (default_module != p->module) {
+		found = string_map_get(&default_module->objc_selectors, name);
+		if (found) {
+			entity = found->entity;
+		}
 	}
 
 	if (!entity) {
-		if (default_module != p->module) {
-			found = string_map_get(&default_module->objc_selectors, name);
-			if (found) {
-				entity = *found;
-			}
-		}
-
-		if (!entity) {
-			lbAddr default_addr = lb_add_global_generated(default_module, t_objc_SEL, {}, &entity);
-			string_map_set(&default_module->objc_selectors, name, entity);
-		}
+		lbAddr default_addr = lb_add_global_generated(default_module, t_objc_SEL, {}, &entity);
+		string_map_set(&default_module->objc_selectors, name, lbObjcRef{entity, default_addr});
 	}
 
 	lbValue ptr = lb_find_value_from_entity(p->module, entity);
 	lbAddr local_addr = lb_addr(ptr);
 
 	if (default_module != p->module) {
-		string_map_set(&p->module->objc_selectors, name, entity);
+		string_map_set(&p->module->objc_selectors, name, lbObjcRef{entity, local_addr});
 	}
 
 	return local_addr;
@@ -2152,33 +2150,31 @@ gb_internal lbValue lb_handle_objc_register_selector(lbProcedure *p, Ast *expr) 
 }
 
 gb_internal lbAddr lb_handle_objc_find_or_register_class(lbProcedure *p, String const &name) {
+	lbObjcRef *found = string_map_get(&p->module->objc_classes, name);
+	if (found) {
+		return found->local_module_addr;
+	}
+
 	lbModule *default_module = &p->module->gen->default_module;
 	Entity *entity = {};
 
-	Entity **found = string_map_get(&p->module->objc_classes, name);
-	if (found) {
-		entity = *found;
+	if (default_module != p->module) {
+		found = string_map_get(&default_module->objc_classes, name);
+		if (found) {
+			entity = found->entity;
+		}
 	}
 
 	if (!entity) {
-		if (default_module != p->module) {
-			found = string_map_get(&default_module->objc_classes, name);
-			if (found) {
-				entity = *found;
-			}
-		}
-
-		if (!entity) {
-			lbAddr default_addr = lb_add_global_generated(default_module, t_objc_Class, {}, &entity);
-			string_map_set(&default_module->objc_classes, name, entity);
-		}
+		lbAddr default_addr = lb_add_global_generated(default_module, t_objc_Class, {}, &entity);
+		string_map_set(&default_module->objc_classes, name, lbObjcRef{entity, default_addr});
 	}
 
 	lbValue ptr = lb_find_value_from_entity(p->module, entity);
 	lbAddr local_addr = lb_addr(ptr);
 
 	if (default_module != p->module) {
-		string_map_set(&p->module->objc_classes, name, entity);
+		string_map_set(&p->module->objc_classes, name, lbObjcRef{entity, local_addr});
 	}
 
 	return local_addr;


### PR DESCRIPTION
if the symbol is not found in the current module, we first need to check if it's in the default module and use that, before generating another global.