### PR TITLE
Pass flags down from `os.send` in darwin and linux

### DIFF
--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -1287,7 +1287,7 @@ sendto :: proc(sd: Socket, data: []u8, flags: int, addr: ^SOCKADDR, addrlen: soc
 }
 
 send :: proc(sd: Socket, data: []byte, flags: int) -> (u32, Error) {
-	result := _unix_send(c.int(sd), raw_data(data), len(data), 0)
+	result := _unix_send(c.int(sd), raw_data(data), len(data), i32(flags))
 	if result < 0 {
 		return 0, get_last_error()
 	}

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -1155,7 +1155,7 @@ sendto :: proc(sd: Socket, data: []u8, flags: int, addr: ^SOCKADDR, addrlen: soc
 }
 
 send :: proc(sd: Socket, data: []byte, flags: int) -> (u32, Error) {
-	result := unix.sys_sendto(int(sd), raw_data(data), len(data), 0, nil, 0)
+	result := unix.sys_sendto(int(sd), raw_data(data), len(data), flags, nil, 0)
 	if result < 0 {
 		return 0, _get_errno(int(result))
 	}


### PR DESCRIPTION
The flags were not passed, so I just forwarded them down.
Edit: This fixes a bug in which passing flags had no effect, for example `os.MSG_NOSIGNAL`.