### PR TITLE
Reenable OpenGL compilation errors printing

### DIFF
--- a/vendor/OpenGL/helpers.odin
+++ b/vendor/OpenGL/helpers.odin
@@ -67,7 +67,7 @@ when GL_DEBUG {
 				last_compile_error_type = type
 
 				log_func(id, i32(info_log_length), nil, raw_data(last_compile_error_message), loc)
-				//fmt.printf_err("Error in %v:\n%s", type, string(last_compile_error_message[0:len(last_compile_error_message)-1]));
+				fmt.eprintf("Error in %v:\n%s", type, string(last_compile_error_message[0:len(last_compile_error_message)-1]))
 			} else {
 
 				delete(last_link_error_message)
@@ -75,7 +75,7 @@ when GL_DEBUG {
 				last_compile_error_type = type
 
 				log_func(id, i32(info_log_length), nil, raw_data(last_link_error_message), loc)
-				//fmt.printf_err("Error in %v:\n%s", type, string(last_link_error_message[0:len(last_link_error_message)-1]));
+				fmt.eprintf("Error in %v:\n%s", type, string(last_link_error_message[0:len(last_link_error_message)-1]))
 			}
 
 			return false


### PR DESCRIPTION
Uncommented and changed (seemingly old) `fmt.printf_err` to `fmt.eprintf`