### PR TITLE
fix typo in float32_range doc string

### DIFF
--- a/core/math/rand/rand.odin
+++ b/core/math/rand/rand.odin
@@ -468,7 +468,7 @@ Example:
 Possible Output:
 
 	15.312
-	673.130
+	273.130
 
 */
 @(require_results) float32_range :: proc(low, high: f32, gen := context.random_generator) -> (val: f32) {


### PR DESCRIPTION
The doc string said this 
```
Example:
	import "core:math/rand"
	import "core:fmt"

	float32_range_example :: proc() {
		fmt.println(rand.float32_range(-10, 300))
	}

Possible Output:

	15.312
	673.130
```

673.130 is not possible as it is outside of -10 to 300