### PR TITLE
Added IP_ADD_MEMBERSHIP to  Socket_Option on Linux

### DIFF
--- a/core/sys/linux/bits.odin
+++ b/core/sys/linux/bits.odin
@@ -1329,6 +1329,7 @@ Socket_Option :: enum {
 	ACCEPTCONN                    = 30,
 	PEERSEC                       = 31,
 	PASSSEC                       = 34,
+	IP_ADD_MEMBERSHIP             = 35,
 	MARK                          = 36,
 	PROTOCOL                      = 38,
 	DOMAIN                        = 39,


### PR DESCRIPTION
Added IP_ADD_MEMBERSHIP Socket option on linux as I discovered it was missing when trying to create a mutlicast server.  Could possibly be added to `net.Socket_Option` but not sure about the interop with window but I know macos and linux use it. 

Manual link: https://man7.org/linux/man-pages/man7/ip.7.html
linux ref link: https://github.com/torvalds/linux/blob/72deda0abee6e705ae71a93f69f55e33be5bca5c/include/uapi/linux/in.h#L153