### PR TITLE
Add miscellaneous missing WinAPI functions, constants, and structures (comctl32, user32, uxtheme)

### DIFF
--- a/core/sys/windows/comctl32.odin
+++ b/core/sys/windows/comctl32.odin
@@ -5,6 +5,30 @@ foreign import "system:Comctl32.lib"
 
 @(default_calling_convention="system")
 foreign Comctl32 {
+	InitCommonControlsEx :: proc(picce: ^INITCOMMONCONTROLSEX) -> BOOL ---
 	LoadIconWithScaleDown :: proc(hinst: HINSTANCE, pszName: PCWSTR, cx: c_int, cy: c_int, phico: ^HICON) -> HRESULT ---
 	SetWindowSubclass :: proc(hwnd: HWND, pfnSubclass: SUBCLASSPROC, uIdSubclass: UINT_PTR, dwRefData: DWORD_PTR) ---
+}
+
+ICC_LISTVIEW_CLASSES   :: 0x00000001
+ICC_TREEVIEW_CLASSES   :: 0x00000002
+ICC_BAR_CLASSES        :: 0x00000004
+ICC_TAB_CLASSES        :: 0x00000008
+ICC_UPDOWN_CLASS       :: 0x00000010
+ICC_PROGRESS_CLASS     :: 0x00000020
+ICC_HOTKEY_CLASS       :: 0x00000040
+ICC_ANIMATE_CLASS      :: 0x00000080
+ICC_WIN95_CLASSES      :: 0x000000FF
+ICC_DATE_CLASSES       :: 0x00000100
+ICC_USEREX_CLASSES     :: 0x00000200
+ICC_COOL_CLASSES       :: 0x00000400
+ICC_INTERNET_CLASSES   :: 0x00000800
+ICC_PAGESCROLLER_CLASS :: 0x00001000
+ICC_NATIVEFNTCTL_CLASS :: 0x00002000
+ICC_STANDARD_CLASSES   :: 0x00004000
+ICC_LINK_CLASS         :: 0x00008000
+
+INITCOMMONCONTROLSEX :: struct {
+	dwSize: DWORD,
+	dwICC: DWORD,
 }

--- a/core/sys/windows/user32.odin
+++ b/core/sys/windows/user32.odin
@@ -63,6 +63,8 @@ foreign user32 {
 	UpdateWindow :: proc(hWnd: HWND) -> BOOL ---
 	SetActiveWindow :: proc(hWnd: HWND) -> HWND ---
 	GetActiveWindow :: proc() -> HWND ---
+	SetFocus :: proc(hWnd: HWND) -> HWND ---
+	GetFocus :: proc() -> HWND ---
 	RedrawWindow :: proc(hwnd: HWND, lprcUpdate: LPRECT, hrgnUpdate: HRGN, flags: RedrawWindowFlags) -> BOOL ---
 	SetParent :: proc(hWndChild: HWND, hWndNewParent: HWND) -> HWND ---
 	SetPropW :: proc(hWnd: HWND, lpString: LPCWSTR, hData: HANDLE) -> BOOL ---
@@ -211,6 +213,7 @@ foreign user32 {
 	EnumDisplayMonitors :: proc(hdc: HDC, lprcClip: LPRECT, lpfnEnum: Monitor_Enum_Proc, dwData: LPARAM) -> BOOL ---
 
 	EnumWindows :: proc(lpEnumFunc: Window_Enum_Proc, lParam: LPARAM) -> BOOL ---
+	EnumChildWindows :: proc(hWndParent: HWND, lpEnumFunc: Window_Enum_Proc, lParam: LPARAM) -> BOOL ---
 
 	IsProcessDPIAware :: proc() -> BOOL ---
 	SetProcessDPIAware :: proc() -> BOOL ---
@@ -846,3 +849,23 @@ FKF_CONFIRMHOTKEY :: 0x8
 FKF_HOTKEYSOUND   :: 0x10
 FKF_INDICATOR     :: 0x20
 FKF_CLICKON       :: 0x40
+
+NONCLIENTMETRICSW :: struct {
+	cbSize: UINT,
+	iBorderWidth: i32,
+	iScrollWidth: i32,
+	iScrollHeight: i32,
+	iCaptionWidth: i32,
+	iCaptionHeight: i32,
+	lfCaptionFont: LOGFONTW,
+	iSmCaptionWidth: i32,
+	iSmCaptionHeight: i32,
+	lfSmCaptionFont: LOGFONTW,
+	iMenuWidth: i32,
+	iMenuHeight: i32,
+	lfMenuFont: LOGFONTW,
+	lfStatusFont: LOGFONTW,
+	lfMessageFont: LOGFONTW,
+	iPaddedBorderWidth: i32,
+}
+LPNONCLIENTMETRICSW :: ^NONCLIENTMETRICSW

--- a/core/sys/windows/ux_theme.odin
+++ b/core/sys/windows/ux_theme.odin
@@ -9,4 +9,5 @@ PMARGINS :: ^MARGINS
 @(default_calling_convention="system")
 foreign uxtheme {
     IsThemeActive :: proc() -> BOOL ---
+    SetWindowTheme :: proc(hWnd: HWND, pszSubAppName, pszSubIdList: LPCWSTR) -> HRESULT ---
 }


### PR DESCRIPTION
I added bindings to some missing functions in comctl32, user32, and ux_theme.

Most notably and surprisingly, `SetFocus` and `EnumChildWindows` were missing from user32.

More obscurely, I added the `NONCLIENTMETRICSW` structure, which is used by `SystemParametersInfoW` with `SPI_GETNONCLIENTMETRICS` or `SPI_SETNONCLIENTMETRICS`. My program required it for the former usage.

Each of the functions or structures added in this pull request have been added as a result of needing or wanting to use them in an app but finding they weren't present, so I believe they will be useful for others as well.