### PR TITLE
Add stringByAppendingString to NSString

### DIFF
--- a/core/sys/darwin/Foundation/NSString.odin
+++ b/core/sys/darwin/Foundation/NSString.odin
@@ -134,6 +134,11 @@ String_isEqualToString :: proc "c" (self, other: ^String) -> BOOL {
 	return msgSend(BOOL, self, "isEqualToString:", other)
 }
 
+@(objc_type=String, objc_name="stringByAppendingString")
+String_stringByAppendingString :: proc "c" (self, other: ^String) -> ^String {
+	return msgSend(^String, self, "stringByAppendingString:", other)
+}
+
 @(objc_type=String, objc_name="rangeOfString")
 String_rangeOfString :: proc "c" (self, other: ^String, options: StringCompareOptions) -> Range {
 	return msgSend(Range, self, "rangeOfString:options:", other, options)


### PR DESCRIPTION
Small addition that lets you write
```odin
running_app := Foundation.RunningApplication_currentApplication()
running_app_name := Foundation.RunningApplication_localizedName(running_app)
quit := Foundation.MakeConstantString("Quit")
quit_item_name := Foundation.String_stringByAppendingString(quit, running_app_name) // <--
```
or alternativly
```odin
running_app_name := Foundation.RunningApplication_currentApplication()->localizedName()
quit_item_name := Foundation.MakeConstantString("Quit")->stringByAppendingString(running_app_name)
```

(tested on mac locally)