### PR TITLE
Preserve `#no_nil` in `intrinsics.type_convert_variants_to_pointers`

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -5544,6 +5544,9 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 			// NOTE(bill): Is this even correct?
 			new_type->Union.node = operand->expr;
 			new_type->Union.scope = bt->Union.scope;
+			if (bt->Union.kind == UnionType_no_nil) {
+				new_type->Union.kind = UnionType_no_nil;
+			}
 
 			operand->type = new_type;
 		}


### PR DESCRIPTION
Previously the newly returned type would not be marked as `#no_nil`.
This caused `reflect.get_union_as_ptr_variants` to break on `#no_nil` unions.

For example this program:
```odin
package main

import "core:reflect"
import "core:fmt"

Foo :: union {
	int,
	f32,
}

Bar :: union #no_nil {
	int,
	f32,
}

main :: proc() {
	foo: Foo = 1
	bar: Bar = 2

	_, foo_ok := reflect.get_union_as_ptr_variants(&foo).(^int)
	_, bar_ok := reflect.get_union_as_ptr_variants(&bar).(^int)

	fmt.println(foo_ok, bar_ok)
}
```
Would print `true false` instead of `true true`