### PR TITLE
[core/strings] Fix _split_iterator when separator is empty

### DIFF
--- a/core/strings/strings.odin
+++ b/core/strings/strings.odin
@@ -1031,14 +1031,10 @@ Returns:
 */
 @private
 _split_iterator :: proc(s: ^string, sep: string, sep_save: int) -> (res: string, ok: bool) {
-	if sep == "" {
-		res = s[:]
-		ok = true
-		s^ = s[len(s):]
-		return
-	}
-
 	m := index(s^, sep)
+	if sep == "" {
+		m = 1 if len(s) > 0 else -1
+	}
 	if m < 0 {
 		// not found
 		res = s[:]

--- a/core/strings/strings.odin
+++ b/core/strings/strings.odin
@@ -1033,7 +1033,12 @@ Returns:
 _split_iterator :: proc(s: ^string, sep: string, sep_save: int) -> (res: string, ok: bool) {
 	m := index(s^, sep)
 	if sep == "" {
-		m = 1 if len(s) > 0 else -1
+		if len(s) == 0 {
+			m = -1
+		} else {
+			_, w := utf8.decode_rune_in_string(s^)
+			m = w
+		}
 	}
 	if m < 0 {
 		// not found

--- a/core/strings/strings.odin
+++ b/core/strings/strings.odin
@@ -1031,7 +1031,7 @@ Returns:
 */
 @private
 _split_iterator :: proc(s: ^string, sep: string, sep_save: int) -> (res: string, ok: bool) {
-	m := index(s^, sep)
+	m: int
 	if sep == "" {
 		if len(s) == 0 {
 			m = -1
@@ -1039,6 +1039,8 @@ _split_iterator :: proc(s: ^string, sep: string, sep_save: int) -> (res: string,
 			_, w := utf8.decode_rune_in_string(s^)
 			m = w
 		}
+	} else {
+		m = index(s^, sep)
 	}
 	if m < 0 {
 		// not found


### PR DESCRIPTION
Currently `split_iterator()` returns the entire string at once if the separator is empty, but it should rather split the string by runes. This was also mentioned in #2348.  The function also keeps returning ok=true which causes an infinite loop. Here is an example where this happens:
```odin
package test

import "core:fmt"
import "core:strings"

main :: proc() {
	mystr := "Hello world"
	for s in strings.split_iterator(&mystr, "") {
		fmt.printfln("(%s)", s)
	}
}
```
This PR fixes these issues