### PR TITLE
improve abs() on floats for more correct and faster results

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -3488,9 +3488,12 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 			case ExactValue_Integer:
 				mp_abs(&operand->value.value_integer, &operand->value.value_integer);
 				break;
-			case ExactValue_Float:
-				operand->value.value_float = gb_abs(operand->value.value_float);
+			case ExactValue_Float: {
+				u64 abs = bit_cast<u64>(operand->value.value_float);
+				abs &= 0x7FFFFFFFFFFFFFFF;
+				operand->value.value_float = bit_cast<f64>(abs);
 				break;
+			}
 			case ExactValue_Complex: {
 				f64 r = operand->value.value_complex->real;
 				f64 i = operand->value.value_complex->imag;

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -2175,9 +2175,9 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 			}
 			GB_PANIC("Unknown complex type");
 		} else if (is_type_float(t)) {
-			Type *t_float;
-			Type *t_unsigned;
-			lbValue mask;
+			Type *t_float = nullptr;
+			Type *t_unsigned = nullptr;
+			lbValue mask = {0};
 			switch (type_size_of(t)) {
 			case 2:
 				t_float = t_f16;

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -2175,24 +2175,21 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 			}
 			GB_PANIC("Unknown complex type");
 		} else if (is_type_float(t)) {
-			Type *t_float = nullptr;
+			bool little = is_type_endian_little(t) || (is_type_endian_platform(t) && build_context.endian_kind == TargetEndian_Little);
 			Type *t_unsigned = nullptr;
 			lbValue mask = {0};
 			switch (type_size_of(t)) {
 			case 2:
-				t_float = t_f16;
 				t_unsigned = t_u16;
-				mask = lb_const_int(p->module, t_unsigned, 0x7FFF);
+				mask = lb_const_int(p->module, t_unsigned, little ? 0x7FFF : 0xFF7F);
 				break;
 			case 4:
-				t_float = t_f32;
 				t_unsigned = t_u32;
-				mask = lb_const_int(p->module, t_unsigned, 0x7FFFFFFF);
+				mask = lb_const_int(p->module, t_unsigned, little ? 0x7FFFFFFF : 0xFFFFFF7F);
 				break;
 			case 8:
-				t_float = t_f64;
 				t_unsigned = t_u64;
-				mask = lb_const_int(p->module, t_unsigned, 0x7FFFFFFFFFFFFFFF);
+				mask = lb_const_int(p->module, t_unsigned, little ? 0x7FFFFFFFFFFFFFFF : 0xFFFFFFFFFFFFFF7F);
 				break;
 			default:
 				GB_PANIC("abs: unhandled float size");
@@ -2200,7 +2197,7 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 
 			lbValue as_unsigned = lb_emit_transmute(p, x, t_unsigned);
 			lbValue abs = lb_emit_arith(p, Token_And, as_unsigned, mask, t_unsigned);
-			return lb_emit_transmute(p, abs, t_float);
+			return lb_emit_transmute(p, abs, t);
 		}
 
 		lbValue zero = lb_const_nil(p->module, t);

--- a/tests/internal/test_abs.odin
+++ b/tests/internal/test_abs.odin
@@ -2,26 +2,65 @@ package test_internal
 
 import "core:testing"
 
-@(test)
-test_abs_float :: proc(t: ^testing.T) {
-	not_const :: proc(v: $T) -> T { return v }
+@(private="file")
+not_const :: proc(v: $T) -> T { return v }
 
+@(test)
+abs_f16_const :: proc(t: ^testing.T) {
 	// Constant f16
 	testing.expect_value(t, abs(f16(0.)), 0.)
 	testing.expect_value(t, abs(f16(-0.)), 0.)
 	testing.expect_value(t, abs(f16(-1.)), 1.)
 	testing.expect_value(t, abs(min(f16)), max(f16))
 	testing.expect_value(t, abs(max(f16)), max(f16))
-	testing.expect_value(t, abs(f16(-.12345)), .12345)
+	testing.expect_value(t, abs(f16(-.12)), .12)
 
+	// Constant f16le
+	testing.expect_value(t, abs(f16le(0.)), 0.)
+	testing.expect_value(t, abs(f16le(-0.)), 0.)
+	testing.expect_value(t, abs(f16le(-1.)), 1.)
+	testing.expect_value(t, abs(min(f16le)), max(f16le))
+	testing.expect_value(t, abs(max(f16le)), max(f16le))
+	testing.expect_value(t, abs(f16le(-.12)), .12)
+
+	// Constant f16be
+	testing.expect_value(t, abs(f16be(0.)), 0.)
+	testing.expect_value(t, abs(f16be(-0.)), 0.)
+	testing.expect_value(t, abs(f16be(-1.)), 1.)
+	testing.expect_value(t, abs(min(f16be)), max(f16be))
+	testing.expect_value(t, abs(max(f16be)), max(f16be))
+	testing.expect_value(t, abs(f16be(-.12)), .12)
+}
+
+@(test)
+abs_f16_variable :: proc(t: ^testing.T) {
 	// Variable f16
 	testing.expect_value(t, abs(not_const(f16(0.))), 0.)
 	testing.expect_value(t, abs(not_const(f16(-0.))), 0.)
 	testing.expect_value(t, abs(not_const(f16(-1.))), 1.)
 	testing.expect_value(t, abs(not_const(min(f16))), max(f16))
 	testing.expect_value(t, abs(not_const(max(f16))), max(f16))
-	testing.expect_value(t, abs(not_const(f16(-.12345))), .12345)
+	testing.expect_value(t, abs(not_const(f16(-.12))), .12)
 
+	// Variable f16le
+	testing.expect_value(t, abs(not_const(f16le(0.))), 0.)
+	testing.expect_value(t, abs(not_const(f16le(-0.))), 0.)
+	testing.expect_value(t, abs(not_const(f16le(-1.))), 1.)
+	testing.expect_value(t, abs(not_const(min(f16le))), max(f16le))
+	testing.expect_value(t, abs(not_const(max(f16le))), max(f16le))
+	testing.expect_value(t, abs(not_const(f16le(-.12))), .12)
+
+	// Variable f16be
+	testing.expect_value(t, abs(not_const(f16be(0.))), 0.)
+	testing.expect_value(t, abs(not_const(f16be(-0.))), 0.)
+	testing.expect_value(t, abs(not_const(f16be(-1.))), 1.)
+	testing.expect_value(t, abs(not_const(min(f16be))), max(f16be))
+	testing.expect_value(t, abs(not_const(max(f16be))), max(f16be))
+	testing.expect_value(t, abs(not_const(f16be(-.12))), .12)
+}
+
+@(test)
+abs_f32_const :: proc(t: ^testing.T) {
 	// Constant f32
 	testing.expect_value(t, abs(f32(0.)), 0.)
 	testing.expect_value(t, abs(f32(-0.)), 0.)
@@ -30,6 +69,25 @@ test_abs_float :: proc(t: ^testing.T) {
 	testing.expect_value(t, abs(max(f32)), max(f32))
 	testing.expect_value(t, abs(f32(-.12345)), .12345)
 
+	// Constant f32le
+	testing.expect_value(t, abs(f32le(0.)), 0.)
+	testing.expect_value(t, abs(f32le(-0.)), 0.)
+	testing.expect_value(t, abs(f32le(-1.)), 1.)
+	testing.expect_value(t, abs(min(f32le)), max(f32le))
+	testing.expect_value(t, abs(max(f32le)), max(f32le))
+	testing.expect_value(t, abs(f32le(-.12345)), .12345)
+
+	// Constant f32be
+	testing.expect_value(t, abs(f32be(0.)), 0.)
+	testing.expect_value(t, abs(f32be(-0.)), 0.)
+	testing.expect_value(t, abs(f32be(-1.)), 1.)
+	testing.expect_value(t, abs(min(f32be)), max(f32be))
+	testing.expect_value(t, abs(max(f32be)), max(f32be))
+	testing.expect_value(t, abs(f32be(-.12345)), .12345)
+}
+
+@(test)
+abs_f32_variable :: proc(t: ^testing.T) {
 	// Variable f32
 	testing.expect_value(t, abs(not_const(f32(0.))), 0.)
 	testing.expect_value(t, abs(not_const(f32(-0.))), 0.)
@@ -38,6 +96,25 @@ test_abs_float :: proc(t: ^testing.T) {
 	testing.expect_value(t, abs(not_const(max(f32))), max(f32))
 	testing.expect_value(t, abs(not_const(f32(-.12345))), .12345)
 
+	// Variable f32le
+	testing.expect_value(t, abs(not_const(f32le(0.))), 0.)
+	testing.expect_value(t, abs(not_const(f32le(-0.))), 0.)
+	testing.expect_value(t, abs(not_const(f32le(-1.))), 1.)
+	testing.expect_value(t, abs(not_const(min(f32le))), max(f32le))
+	testing.expect_value(t, abs(not_const(max(f32le))), max(f32le))
+	testing.expect_value(t, abs(not_const(f32le(-.12345))), .12345)
+
+	// Variable f32be
+	testing.expect_value(t, abs(not_const(f32be(0.))), 0.)
+	testing.expect_value(t, abs(not_const(f32be(-0.))), 0.)
+	testing.expect_value(t, abs(not_const(f32be(-1.))), 1.)
+	testing.expect_value(t, abs(not_const(min(f32be))), max(f32be))
+	testing.expect_value(t, abs(not_const(max(f32be))), max(f32be))
+	testing.expect_value(t, abs(not_const(f32be(-.12345))), .12345)
+}
+
+@(test)
+abs_f64_const :: proc(t: ^testing.T) {
 	// Constant f64
 	testing.expect_value(t, abs(f64(0.)), 0.)
 	testing.expect_value(t, abs(f64(-0.)), 0.)
@@ -46,6 +123,25 @@ test_abs_float :: proc(t: ^testing.T) {
 	testing.expect_value(t, abs(max(f64)), max(f64))
 	testing.expect_value(t, abs(f64(-.12345)), .12345)
 
+	// Constant f64le
+	testing.expect_value(t, abs(f64le(0.)), 0.)
+	testing.expect_value(t, abs(f64le(-0.)), 0.)
+	testing.expect_value(t, abs(f64le(-1.)), 1.)
+	testing.expect_value(t, abs(min(f64le)), max(f64le))
+	testing.expect_value(t, abs(max(f64le)), max(f64le))
+	testing.expect_value(t, abs(f64le(-.12345)), .12345)
+
+	// Constant f64be
+	testing.expect_value(t, abs(f64be(0.)), 0.)
+	testing.expect_value(t, abs(f64be(-0.)), 0.)
+	testing.expect_value(t, abs(f64be(-1.)), 1.)
+	testing.expect_value(t, abs(min(f64be)), max(f64be))
+	testing.expect_value(t, abs(max(f64be)), max(f64be))
+	testing.expect_value(t, abs(f64be(-.12345)), .12345)
+}
+
+@(test)
+abs_f64_variable :: proc(t: ^testing.T) {
 	// Variable f64
 	testing.expect_value(t, abs(not_const(f64(0.))), 0.)
 	testing.expect_value(t, abs(not_const(f64(-0.))), 0.)
@@ -53,4 +149,20 @@ test_abs_float :: proc(t: ^testing.T) {
 	testing.expect_value(t, abs(not_const(min(f64))), max(f64))
 	testing.expect_value(t, abs(not_const(max(f64))), max(f64))
 	testing.expect_value(t, abs(not_const(f64(-.12345))), .12345)
+
+	// Variable f64le
+	testing.expect_value(t, abs(not_const(f64le(0.))), 0.)
+	testing.expect_value(t, abs(not_const(f64le(-0.))), 0.)
+	testing.expect_value(t, abs(not_const(f64le(-1.))), 1.)
+	testing.expect_value(t, abs(not_const(min(f64le))), max(f64le))
+	testing.expect_value(t, abs(not_const(max(f64le))), max(f64le))
+	testing.expect_value(t, abs(not_const(f64le(-.12345))), .12345)
+
+	// Variable f64be
+	testing.expect_value(t, abs(not_const(f64be(0.))), 0.)
+	testing.expect_value(t, abs(not_const(f64be(-0.))), 0.)
+	testing.expect_value(t, abs(not_const(f64be(-1.))), 1.)
+	testing.expect_value(t, abs(not_const(min(f64be))), max(f64be))
+	testing.expect_value(t, abs(not_const(max(f64be))), max(f64be))
+	testing.expect_value(t, abs(not_const(f64be(-.12345))), .12345)
 }

--- a/tests/internal/test_abs.odin
+++ b/tests/internal/test_abs.odin
@@ -1,0 +1,56 @@
+package test_internal
+
+import "core:testing"
+
+@(test)
+test_abs_float :: proc(t: ^testing.T) {
+	not_const :: proc(v: $T) -> T { return v }
+
+	// Constant f16
+	testing.expect_value(t, abs(f16(0.)), 0.)
+	testing.expect_value(t, abs(f16(-0.)), 0.)
+	testing.expect_value(t, abs(f16(-1.)), 1.)
+	testing.expect_value(t, abs(min(f16)), max(f16))
+	testing.expect_value(t, abs(max(f16)), max(f16))
+	testing.expect_value(t, abs(f16(-.12345)), .12345)
+
+	// Variable f16
+	testing.expect_value(t, abs(not_const(f16(0.))), 0.)
+	testing.expect_value(t, abs(not_const(f16(-0.))), 0.)
+	testing.expect_value(t, abs(not_const(f16(-1.))), 1.)
+	testing.expect_value(t, abs(not_const(min(f16))), max(f16))
+	testing.expect_value(t, abs(not_const(max(f16))), max(f16))
+	testing.expect_value(t, abs(not_const(f16(-.12345))), .12345)
+
+	// Constant f32
+	testing.expect_value(t, abs(f32(0.)), 0.)
+	testing.expect_value(t, abs(f32(-0.)), 0.)
+	testing.expect_value(t, abs(f32(-1.)), 1.)
+	testing.expect_value(t, abs(min(f32)), max(f32))
+	testing.expect_value(t, abs(max(f32)), max(f32))
+	testing.expect_value(t, abs(f32(-.12345)), .12345)
+
+	// Variable f32
+	testing.expect_value(t, abs(not_const(f32(0.))), 0.)
+	testing.expect_value(t, abs(not_const(f32(-0.))), 0.)
+	testing.expect_value(t, abs(not_const(f32(-1.))), 1.)
+	testing.expect_value(t, abs(not_const(min(f32))), max(f32))
+	testing.expect_value(t, abs(not_const(max(f32))), max(f32))
+	testing.expect_value(t, abs(not_const(f32(-.12345))), .12345)
+
+	// Constant f64
+	testing.expect_value(t, abs(f64(0.)), 0.)
+	testing.expect_value(t, abs(f64(-0.)), 0.)
+	testing.expect_value(t, abs(f64(-1.)), 1.)
+	testing.expect_value(t, abs(min(f64)), max(f64))
+	testing.expect_value(t, abs(max(f64)), max(f64))
+	testing.expect_value(t, abs(f64(-.12345)), .12345)
+
+	// Variable f64
+	testing.expect_value(t, abs(not_const(f64(0.))), 0.)
+	testing.expect_value(t, abs(not_const(f64(-0.))), 0.)
+	testing.expect_value(t, abs(not_const(f64(-1.))), 1.)
+	testing.expect_value(t, abs(not_const(min(f64))), max(f64))
+	testing.expect_value(t, abs(not_const(max(f64))), max(f64))
+	testing.expect_value(t, abs(not_const(f64(-.12345))), .12345)
+}


### PR DESCRIPTION
Fixes #4787 

Seems like this is more correct (abs of -0 is +0), and also optimises better (into fabs and similar instructions, instead of a cmp&select)

~~draft because not handling endian types, want to add some tests, and need to apply it to gb_abs so constants also show the same behaviour.~~