### PR TITLE
make corrected linkage with -use-separate-modules apply hidden visibility

### DIFF
--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -169,11 +169,17 @@ gb_internal void lb_correct_entity_linkage(lbGenerator *gen) {
 			other_global = LLVMGetNamedGlobal(ec.other_module->mod, ec.cname);
 			if (other_global) {
 				LLVMSetLinkage(other_global, LLVMWeakAnyLinkage);
+				if (!ec.e->Variable.is_export) {
+					LLVMSetVisibility(other_global, LLVMHiddenVisibility);
+				}
 			}
 		} else if (ec.e->kind == Entity_Procedure) {
 			other_global = LLVMGetNamedFunction(ec.other_module->mod, ec.cname);
 			if (other_global) {
 				LLVMSetLinkage(other_global, LLVMWeakAnyLinkage);
+				if (!ec.e->Procedure.is_export) {
+					LLVMSetVisibility(other_global, LLVMHiddenVisibility);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #4798

The DLL was using the type info of the host/exe, causing crashes. This PR tries fixing by applying hidden visibility to these corrected symbols which makes sure that the DLL can't see the type table of the host/exe.