### PR TITLE
Cleanup allocated dns runtime data

### DIFF
--- a/core/net/dns.odin
+++ b/core/net/dns.odin
@@ -50,9 +50,12 @@ init_dns_configuration :: proc() {
 	dns_configuration.hosts_file,  _ = replace_environment_path(dns_configuration.hosts_file)
 }
 
+@(fini, private)
 destroy_dns_configuration :: proc() {
 	delete(dns_configuration.resolv_conf)
+	dns_configuration.resolv_conf = ""
 	delete(dns_configuration.hosts_file)
+	dns_configuration.hosts_file = ""
 }
 
 dns_configuration := DEFAULT_DNS_CONFIGURATION


### PR DESCRIPTION
While harmless, the runtime should clean up non-user allocated data. On the same veign of: https://github.com/odin-lang/Odin/pull/4680

I'm kinda new to Odin and wrote netcat, in order to get a clean valgrind run, one has to manually destroy dns_configuration:
https://github.com/haesbaert/learn-odin/blob/main/netcat/netcat.odin#L168-L169

While here unexport the destroy procedure and make destruction idempotent.