### PR TITLE
Fix tlsf block adjustment

### DIFF
--- a/core/mem/tlsf/tlsf_internal.odin
+++ b/core/mem/tlsf/tlsf_internal.odin
@@ -260,7 +260,7 @@ adjust_request_size :: proc(size, align: uint) -> (adjusted: uint) {
 
 	// aligned size must not exceed `BLOCK_SIZE_MAX`, or we'll go out of bounds on `sl_bitmap`.
 	if aligned := align_up(size, align); aligned < BLOCK_SIZE_MAX {
-		adjusted = min(aligned, BLOCK_SIZE_MAX)
+		adjusted = max(aligned, BLOCK_SIZE_MIN)
 	}
 	return
 }


### PR DESCRIPTION
If you were to allocate small numbers the adjust could be smaller than an actual block size. This meant headers would overlap headers and cause corruption to the tlsf allocator.
Refer to: https://github.com/mattconte/tlsf/blob/deff9ab509341f264addbd3c8ada533678591905/tlsf.c#L502