### PR TITLE
core:image add support for option .flip_vertical

### DIFF
--- a/core/image/bmp/bmp.odin
+++ b/core/image/bmp/bmp.odin
@@ -242,8 +242,8 @@ load_from_context :: proc(ctx: ^$C, options := Options{}, allocator := context.a
 	case: return img, .Unsupported_Compression
 	}
 
-	// Flipped vertically
-	if info.height < 0 {
+	// is flipped XOR user wants to flip
+	if (int(info.height < 0) ~ int(.flip_vertical in options)) == 1 {
 		image.flip_vertically(img)
 	}
 	return

--- a/core/image/bmp/bmp.odin
+++ b/core/image/bmp/bmp.odin
@@ -243,8 +243,8 @@ load_from_context :: proc(ctx: ^$C, options := Options{}, allocator := context.a
 	}
 
 	// is flipped XOR user wants to flip
-	if (int(info.height < 0) ~ int(.flip_vertical in options)) == 1 {
-		image.flip_vertically(img)
+	if (int(info.height < 0) ~ int(.vertical_flip in options)) == 1 {
+		image.vertical_flip(img)
 	}
 	return
 }

--- a/core/image/bmp/bmp.odin
+++ b/core/image/bmp/bmp.odin
@@ -244,15 +244,7 @@ load_from_context :: proc(ctx: ^$C, options := Options{}, allocator := context.a
 
 	// Flipped vertically
 	if info.height < 0 {
-		pixels := mem.slice_data_cast([]RGB_Pixel, img.pixels.buf[:])
-		for y in 0..<img.height / 2 {
-			for x in 0..<img.width {
-				top := y * img.width + x
-				bot := (img.height - y - 1) * img.width + x
-
-				pixels[top], pixels[bot] = pixels[bot], pixels[top]
-			}
-		}
+		image.flip_vertically(img)
 	}
 	return
 }

--- a/core/image/common.odin
+++ b/core/image/common.odin
@@ -5,6 +5,7 @@
 	List of contributors:
 		Jeroen van Rijn: Initial implementation, optimization.
 		Ginger Bill:     Cosmetic changes.
+		DerTee:          Vertical flip.
 */
 
 // package image implements a general 2D image library to be used with other image related packages
@@ -12,6 +13,7 @@ package image
 
 import "core:bytes"
 import "core:mem"
+import "core:slice"
 import "core:io"
 import "core:compress"
 import "base:runtime"
@@ -146,6 +148,7 @@ Option :: enum {
 	alpha_drop_if_present,         // Unimplemented for QOI. Returns error.
 	alpha_premultiply,             // Unimplemented for QOI. Returns error.
 	blend_background,              // Ignored for non-PNG formats
+	flip_vertical,
 
 	// Unimplemented
 	do_not_expand_grayscale,
@@ -1436,6 +1439,17 @@ expand_grayscale :: proc(img: ^Image, allocator := context.allocator) -> (ok: bo
 	img.pixels   = buf
 	img.channels += 2
 	return true
+}
+
+flip_vertically :: proc(img: ^Image) {
+    pixels := img.pixels.buf[:]
+    bpp := img.depth/8 * img.channels
+    bytes_per_line := img.width * bpp
+    for y in 0..<img.height / 2 {
+        top := y * bytes_per_line
+        bot := (img.height - y - 1) * bytes_per_line
+        slice.ptr_swap_non_overlapping(&pixels[top], &pixels[bot], bytes_per_line)
+    }
 }
 
 /*

--- a/core/image/common.odin
+++ b/core/image/common.odin
@@ -148,7 +148,7 @@ Option :: enum {
 	alpha_drop_if_present,         // Unimplemented for QOI. Returns error.
 	alpha_premultiply,             // Unimplemented for QOI. Returns error.
 	blend_background,              // Ignored for non-PNG formats
-	flip_vertical,
+	vertical_flip,                 // flip image vertically on load
 
 	// Unimplemented
 	do_not_expand_grayscale,
@@ -1441,7 +1441,7 @@ expand_grayscale :: proc(img: ^Image, allocator := context.allocator) -> (ok: bo
 	return true
 }
 
-flip_vertically :: proc(img: ^Image) {
+vertical_flip :: proc(img: ^Image) {
     pixels := img.pixels.buf[:]
     bpp := img.depth/8 * img.channels
     bytes_per_line := img.width * bpp

--- a/core/image/netpbm/netpbm.odin
+++ b/core/image/netpbm/netpbm.odin
@@ -11,6 +11,7 @@ import "core:unicode"
 import "base:runtime"
 
 Image        :: image.Image
+Options      :: image.Options
 Format       :: image.Netpbm_Format
 Header       :: image.Netpbm_Header
 Info         :: image.Netpbm_Info
@@ -27,7 +28,7 @@ PFM     :: Formats{.Pf, .PF}
 ASCII   :: Formats{.P1, .P2, .P3}
 BINARY  :: Formats{.P4, .P5, .P6} + PAM + PFM
 
-load_from_bytes :: proc(data: []byte, allocator := context.allocator) -> (img: ^Image, err: Error) {
+load_from_bytes :: proc(data: []byte, options := Options{}, allocator := context.allocator) -> (img: ^Image, err: Error) {
 	context.allocator = allocator
 
 	img = new(Image)
@@ -47,6 +48,9 @@ load_from_bytes :: proc(data: []byte, allocator := context.allocator) -> (img: ^
 	}
 	img.metadata = info
 
+	if .flip_vertical in options {
+		image.flip_vertically(img)
+	}
 	return img, nil
 }
 
@@ -722,7 +726,7 @@ autoselect_pbm_format_from_image :: proc(img: ^Image, prefer_binary := true, for
 @(init, private)
 _register :: proc() {
 	loader :: proc(data: []byte, options: image.Options, allocator: mem.Allocator) -> (img: ^Image, err: Error) {
-		return load_from_bytes(data, allocator)
+		return load_from_bytes(data, options, allocator)
 	}
 	destroyer :: proc(img: ^Image) {
 		_ = destroy(img)

--- a/core/image/netpbm/netpbm.odin
+++ b/core/image/netpbm/netpbm.odin
@@ -48,8 +48,8 @@ load_from_bytes :: proc(data: []byte, options := Options{}, allocator := context
 	}
 	img.metadata = info
 
-	if .flip_vertical in options {
-		image.flip_vertically(img)
+	if .vertical_flip in options {
+		image.vertical_flip(img)
 	}
 	return img, nil
 }

--- a/core/image/png/png.odin
+++ b/core/image/png/png.odin
@@ -1182,6 +1182,9 @@ load_from_context :: proc(ctx: ^$C, options := Options{}, allocator := context.a
 		panic("We should never see bit depths other than 8, 16 and 'Paletted' here.")
 	}
 
+	if .flip_vertical in options {
+		image.flip_vertically(img)
+	}
 	return img, nil
 }
 

--- a/core/image/png/png.odin
+++ b/core/image/png/png.odin
@@ -1182,8 +1182,8 @@ load_from_context :: proc(ctx: ^$C, options := Options{}, allocator := context.a
 		panic("We should never see bit depths other than 8, 16 and 'Paletted' here.")
 	}
 
-	if .flip_vertical in options {
-		image.flip_vertically(img)
+	if .vertical_flip in options {
+		image.vertical_flip(img)
 	}
 	return img, nil
 }

--- a/core/image/qoi/qoi.odin
+++ b/core/image/qoi/qoi.odin
@@ -323,8 +323,8 @@ load_from_context :: proc(ctx: ^$C, options := Options{}, allocator := context.a
 		return img, .Post_Processing_Error
 	}
 
-	if .flip_vertical in options {
-		image.flip_vertically(img)
+	if .vertical_flip in options {
+		image.vertical_flip(img)
 	}
 
 	return

--- a/core/image/qoi/qoi.odin
+++ b/core/image/qoi/qoi.odin
@@ -323,6 +323,10 @@ load_from_context :: proc(ctx: ^$C, options := Options{}, allocator := context.a
 		return img, .Post_Processing_Error
 	}
 
+	if .flip_vertical in options {
+		image.flip_vertically(img)
+	}
+
 	return
 }
 

--- a/core/image/tga/tga.odin
+++ b/core/image/tga/tga.odin
@@ -371,6 +371,9 @@ load_from_context :: proc(ctx: ^$C, options := Options{}, allocator := context.a
 		}
 		line += 1 if origin_is_top else -1
 	}
+	if .flip_vertical in options {
+		image.flip_vertically(img)
+	}
 	return img, nil
 }
 

--- a/core/image/tga/tga.odin
+++ b/core/image/tga/tga.odin
@@ -371,8 +371,8 @@ load_from_context :: proc(ctx: ^$C, options := Options{}, allocator := context.a
 		}
 		line += 1 if origin_is_top else -1
 	}
-	if .flip_vertical in options {
-		image.flip_vertically(img)
+	if .vertical_flip in options {
+		image.vertical_flip(img)
 	}
 	return img, nil
 }


### PR DESCRIPTION
This is basically the same as the option in stb_image to flip an image. One common use case is loading images for OpenGL which expects pixel data to be upside down, unlike most other graphics APIs and image formats.

I'm not super sure if this is useful to most people, plus it's trivial to write yourself if you do need it, so no problem if you decide not to accept this PR just for irrelevance :)