### PR TITLE
fix wrong out of memory in edge cases, just try allocate from block for one source of truth

### DIFF
--- a/core/mem/virtual/virtual_darwin.odin
+++ b/core/mem/virtual/virtual_darwin.odin
@@ -1,0 +1,20 @@
+package mem_virtual
+
+import "core:sys/posix"
+
+_reserve :: proc "contextless" (size: uint) -> (data: []byte, err: Allocator_Error) {
+	result := posix.mmap(nil, size, {}, {.ANONYMOUS, .PRIVATE})
+	if result == posix.MAP_FAILED {
+		assert_contextless(posix.errno() == .ENOMEM)
+		return nil, .Out_Of_Memory
+	}
+
+	return ([^]byte)(uintptr(result))[:size], nil
+}
+
+_decommit :: proc "contextless" (data: rawptr, size: uint) {
+	MADV_FREE :: 5
+
+	posix.mprotect(data, size, {})
+	posix.posix_madvise(data, size, transmute(posix.MAdvice)i32(MADV_FREE))
+}

--- a/core/mem/virtual/virtual_freebsd.odin
+++ b/core/mem/virtual/virtual_freebsd.odin
@@ -1,0 +1,26 @@
+package mem_virtual
+
+import "core:sys/posix"
+
+_reserve :: proc "contextless" (size: uint) -> (data: []byte, err: Allocator_Error) {
+
+	PROT_MAX :: proc "contextless" (flags: posix.Prot_Flags) -> posix.Prot_Flags {
+		_PROT_MAX_SHIFT :: 16
+		return transmute(posix.Prot_Flags)(transmute(i32)flags << _PROT_MAX_SHIFT)
+	}
+
+	result := posix.mmap(nil, size, PROT_MAX({.READ, .WRITE, .EXEC}), {.ANONYMOUS, .PRIVATE})
+	if result == posix.MAP_FAILED {
+		assert_contextless(posix.errno() == .ENOMEM)
+		return nil, .Out_Of_Memory
+	}
+
+	return ([^]byte)(uintptr(result))[:size], nil
+}
+
+_decommit :: proc "contextless" (data: rawptr, size: uint) {
+	MADV_FREE :: 5
+
+	posix.mprotect(data, size, {})
+	posix.posix_madvise(data, size, transmute(posix.MAdvice)i32(MADV_FREE))
+}

--- a/core/mem/virtual/virtual_netbsd.odin
+++ b/core/mem/virtual/virtual_netbsd.odin
@@ -1,0 +1,25 @@
+package mem_virtual
+
+import "core:sys/posix"
+
+_reserve :: proc "contextless" (size: uint) -> (data: []byte, err: Allocator_Error) {
+
+	PROT_MPROTECT :: proc "contextless" (flags: posix.Prot_Flags) -> posix.Prot_Flags {
+		return transmute(posix.Prot_Flags)(transmute(i32)flags << 3)
+	}
+
+	result := posix.mmap(nil, size, PROT_MPROTECT({.READ, .WRITE, .EXEC}), {.ANONYMOUS, .PRIVATE})
+	if result == posix.MAP_FAILED {
+		assert_contextless(posix.errno() == .ENOMEM)
+		return nil, .Out_Of_Memory
+	}
+
+	return ([^]byte)(uintptr(result))[:size], nil
+}
+
+_decommit :: proc "contextless" (data: rawptr, size: uint) {
+	MADV_FREE :: 6
+
+	posix.mprotect(data, size, {})
+	posix.posix_madvise(data, size, transmute(posix.MAdvice)i32(MADV_FREE))
+}

--- a/core/mem/virtual/virtual_openbsd.odin
+++ b/core/mem/virtual/virtual_openbsd.odin
@@ -1,0 +1,20 @@
+package mem_virtual
+
+import "core:sys/posix"
+
+_reserve :: proc "contextless" (size: uint) -> (data: []byte, err: Allocator_Error) {
+	result := posix.mmap(nil, size, {}, {.ANONYMOUS, .PRIVATE})
+	if result == posix.MAP_FAILED {
+		assert_contextless(posix.errno() == .ENOMEM)
+		return nil, .Out_Of_Memory
+	}
+
+	return ([^]byte)(uintptr(result))[:size], nil
+}
+
+_decommit :: proc "contextless" (data: rawptr, size: uint) {
+	MADV_FREE :: 6
+
+	posix.mprotect(data, size, {})
+	posix.posix_madvise(data, size, transmute(posix.MAdvice)i32(MADV_FREE))
+}

--- a/core/mem/virtual/virtual_platform.odin
+++ b/core/mem/virtual/virtual_platform.odin
@@ -15,7 +15,9 @@ platform_memory_alloc :: proc "contextless" (to_commit, to_reserve: uint) -> (bl
 	to_commit = clamp(to_commit, size_of(Platform_Memory_Block), total_to_reserved)
 	
 	data := reserve(total_to_reserved) or_return
-	commit(raw_data(data), to_commit)
+
+	commit_err := commit(raw_data(data), to_commit)
+	assert_contextless(commit_err == nil)
 	
 	block = (^Platform_Memory_Block)(raw_data(data))
 	block.committed = to_commit

--- a/tests/core/mem/test_core_mem.odin
+++ b/tests/core/mem/test_core_mem.odin
@@ -1,6 +1,7 @@
 package test_core_mem
 
 import "core:mem/tlsf"
+import "core:mem/virtual"
 import "core:testing"
 
 @test
@@ -38,4 +39,17 @@ test_tlsf_bitscan :: proc(t: ^testing.T) {
 			testing.expectf(t, res == test.exp, "Expected tlsf.fls_uint(0x%16x) == %v, got %v", test.v, test.exp, res)
 		}
 	}
+}
+
+@(test)
+test_align_bumping_block_limit :: proc(t: ^testing.T) {
+	a: virtual.Arena
+
+	data, err := virtual.arena_alloc(&a, 4193371, 1)
+	testing.expect_value(t, err, nil)
+	testing.expect(t, len(data) == 4193371)
+
+	data, err = virtual.arena_alloc(&a, 896, 64)
+	testing.expect_value(t, err, nil)
+	testing.expect(t, len(data) == 896)
 }

--- a/tests/core/mem/test_core_mem.odin
+++ b/tests/core/mem/test_core_mem.odin
@@ -44,6 +44,7 @@ test_tlsf_bitscan :: proc(t: ^testing.T) {
 @(test)
 test_align_bumping_block_limit :: proc(t: ^testing.T) {
 	a: virtual.Arena
+	defer virtual.arena_destroy(&a)
 
 	data, err := virtual.arena_alloc(&a, 4193371, 1)
 	testing.expect_value(t, err, nil)

--- a/tests/core/runtime/test_core_runtime.odin
+++ b/tests/core/runtime/test_core_runtime.odin
@@ -35,6 +35,7 @@ test_temp_allocator_big_alloc_and_alignment :: proc(t: ^testing.T) {
 test_align_bumping_block_limit :: proc(t: ^testing.T) {
 	a: runtime.Arena
 	a.minimum_block_size = 8*mem.Megabyte
+	defer runtime.arena_destroy(&a)
 
 	data, err := runtime.arena_alloc(&a, 4193371, 1)
 	testing.expect_value(t, err, nil)

--- a/tests/core/runtime/test_core_runtime.odin
+++ b/tests/core/runtime/test_core_runtime.odin
@@ -32,6 +32,20 @@ test_temp_allocator_big_alloc_and_alignment :: proc(t: ^testing.T) {
 }
 
 @(test)
+test_align_bumping_block_limit :: proc(t: ^testing.T) {
+	a: runtime.Arena
+	a.minimum_block_size = 8*mem.Megabyte
+
+	data, err := runtime.arena_alloc(&a, 4193371, 1)
+	testing.expect_value(t, err, nil)
+	testing.expect(t, len(data) == 4193371)
+
+	data, err = runtime.arena_alloc(&a, 896, 64)
+	testing.expect_value(t, err, nil)
+	testing.expect(t, len(data) == 896)
+}
+
+@(test)
 test_temp_allocator_returns_correct_size :: proc(t: ^testing.T) {
 	arena: runtime.Arena
 	context.allocator = runtime.arena_allocator(&arena)


### PR DESCRIPTION
Follow up on #4835

Fixes #4834 

Also fixes an already existing bug where on NetBSD and FreeBSD we are doing `mmap` with no protection flags set, on these targets we need to specify a special "maximum" protection value in order to properly `mprotect` with more permissions.