### PR TITLE
Variable Width/Precision Without Index in `fmt`

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -613,6 +613,10 @@ wprintf :: proc(w: io.Writer, fmt: string, args: ..any, flush := true, newline :
 			i += 1
 			width_index, _, index_ok := _arg_number(fmt, &i, len(args))
 
+			if !index_ok {
+				width_index, index_ok = error_check_arg(fi, false, unused_args^)
+			}
+
 			if index_ok {
 				unused_args^ -= {width_index}
 
@@ -637,6 +641,10 @@ wprintf :: proc(w: io.Writer, fmt: string, args: ..any, flush := true, newline :
 			if i < end && fmt[i] == '*' {
 				i += 1
 				precision_index, _, index_ok := _arg_number(fmt, &i, len(args))
+
+				if !index_ok {
+					precision_index, index_ok = error_check_arg(fi, false, unused_args^)
+				}
 
 				if index_ok {
 					unused_args^ -= {precision_index}


### PR DESCRIPTION
This allows `*` to be used in format strings in C fashion, without specifying an argument index to use. Like C, this results in the argument *preceding* the value for the format specifier itself.

Examples:
```odin
fmt.printfln("%*s", 16, "foo") // (13 spaces)foo
fmt.printfln("%*.*f", 16, 3, math.PI) // 000000000003.142
fmt.printfln("%.*f", 6, math.PI) // 3.141593
```