### PR TITLE
Fix opengl's `check_error` helper procedure not printing errors in debug builds

### DIFF
--- a/vendor/OpenGL/helpers.odin
+++ b/vendor/OpenGL/helpers.odin
@@ -67,15 +67,14 @@ when GL_DEBUG {
 				last_compile_error_type = type
 
 				log_func(id, i32(info_log_length), nil, raw_data(last_compile_error_message), loc)
-				//fmt.printf_err("Error in %v:\n%s", type, string(last_compile_error_message[0:len(last_compile_error_message)-1]));
+				fmt.eprintf("Error in %v:\n%s", type, string(last_compile_error_message[0:len(last_compile_error_message)-1]));
 			} else {
-
 				delete(last_link_error_message)
 				last_link_error_message = make([]byte, info_log_length)
 				last_compile_error_type = type
 
 				log_func(id, i32(info_log_length), nil, raw_data(last_link_error_message), loc)
-				//fmt.printf_err("Error in %v:\n%s", type, string(last_link_error_message[0:len(last_link_error_message)-1]));
+				fmt.eprintf("Error in %v:\n%s", type, string(last_link_error_message[0:len(last_link_error_message)-1]));
 			}
 
 			return false
@@ -97,21 +96,20 @@ when GL_DEBUG {
 		if result == 0 {
 			if log_func == GetShaderInfoLog {
 				delete(last_compile_error_message)
-				last_compile_error_message = make([]u8, info_log_length)
-				last_link_error_type = type
+				last_compile_error_message = make([]byte, info_log_length)
+				last_compile_error_type = type
 
 				log_func(id, i32(info_log_length), nil, raw_data(last_compile_error_message))
-				fmt.eprintf("Error in %v:\n%s", type, string(last_compile_error_message[0:len(last_compile_error_message)-1]))
+				// fmt.eprintf("Error in %v:\n%s", type, string(last_compile_error_message[0:len(last_compile_error_message)-1]));
 			} else {
 				delete(last_link_error_message)
-				last_link_error_message = make([]u8, info_log_length)
-				last_link_error_type = type
+				last_link_error_message = make([]byte, info_log_length)
+				last_compile_error_type = type
 
 				log_func(id, i32(info_log_length), nil, raw_data(last_link_error_message))
-				fmt.eprintf("Error in %v:\n%s", type, string(last_link_error_message[0:len(last_link_error_message)-1]))
-
+				// fmt.eprintf("Error in %v:\n%s", type, string(last_link_error_message[0:len(last_link_error_message)-1]));
 			}
-
+			
 			return false
 		}
 


### PR DESCRIPTION
`check_error` procedures were flipped when defined in the `when GL_DEBUG { ... } else { ... }` blocks, so it didn't print errors by default in debug builds