### PR TITLE
Added functionality to the mem.Arena allocator procedure, allowing for in-place growth.

### DIFF
--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -277,6 +277,7 @@ arena_resize_bytes_non_zeroed :: proc(
 		}
 
 		a.offset = new_offset
+		a.peak_used = max(a.peak_used, a.offset)
 		return a.data[old_data_offset:][:size], nil
 	} else {
 		if size == 0 {

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -285,7 +285,7 @@ arena_resize_bytes_non_zeroed :: proc(
 		}
 		new_data, err := arena_alloc_bytes_non_zeroed(a, size, alignment, loc)
 		if err != nil {
-			return old_data, nil
+			return old_data, err
 		}
 		copy_non_overlapping(raw_data(new_data), raw_data(old_data), len(old_data))
 		return new_data, nil


### PR DESCRIPTION
I added some `arena_resize` procedures for the mem.Arena allocator, supporting the following features:
- In-place growth when no memory is allocated after the block.
- Freeing allocations if no subsequent allocations exist (`size == 0`).
- Allocating a new block and copying data when in-place growth isn't possible.

In the case that an allocation is freed when calling the resize procedure, any padding before the actual allocation will not be removed since there is no good way (as far as I could tell) to determine the amount of padding with what is given.

Note: this is basically a copy of my previous pull request because I unknowingly modified my previous pull request. Apparently force pushing to my fork's master branch is a terrible idea. Because I am not a Github wizard, I decided to close it and create a new PR.