### PR TITLE
vulkan bindings update with bit_set/bit_field handling changes

### DIFF
--- a/vendor/cgltf/README.md
+++ b/vendor/cgltf/README.md
@@ -67,7 +67,7 @@ main :: proc() {
 ```
 
 Writing to memory:
-```c
+```odin
 package main
 
 import "vendor:cgltf"

--- a/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
+++ b/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
@@ -18,6 +18,7 @@ file_and_urls = [
     ("vulkan_wayland.h", 'https://raw.githubusercontent.com/KhronosGroup/Vulkan-Headers/main/include/vulkan/vulkan_wayland.h', False),
     ("vulkan_xlib.h",    'https://raw.githubusercontent.com/KhronosGroup/Vulkan-Headers/main/include/vulkan/vulkan_xlib.h',    False),
     ("vulkan_xcb.h",     'https://raw.githubusercontent.com/KhronosGroup/Vulkan-Headers/main/include/vulkan/vulkan_xcb.h',     False),
+    ("vulkan_beta.h",    'https://raw.githubusercontent.com/KhronosGroup/Vulkan-Headers/main/include/vulkan/vulkan_beta.h',    False),
     # Vulkan Video
     ("vulkan_video_codec_av1std.h",         'https://raw.githubusercontent.com/KhronosGroup/Vulkan-Headers/main/include/vk_video/vulkan_video_codec_av1std.h', False),
     ("vulkan_video_codec_av1std_decode.h",  'https://raw.githubusercontent.com/KhronosGroup/Vulkan-Headers/main/include/vk_video/vulkan_video_codec_av1std_decode.h', False),

--- a/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
+++ b/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
@@ -338,7 +338,6 @@ def parse_enums(f):
             generated_flags.add(flags_name)
             f.write("{} :: distinct bit_set[{}; Flags]\n".format(flags_name, enum_name))
 
-
         if is_flag_bit:
             f.write("{} :: enum Flags {{\n".format(name.replace("FlagBits", "Flag")))
         else:
@@ -537,80 +536,164 @@ def parse_fake_enums(f):
 
         f.write("}\n\n")
 
+class BitfieldError(ValueError):
+    pass
+
+def bitfield_type_to_size(type_):
+    if type_ == 'u8':
+        return 8
+    if type_ == 'u16':
+        return 16
+    if type_ == 'u32':
+        return 32
+    if type_ == 'u64':
+        return 64
+    if 'Flags' in type_:
+        return 32
+    else:
+        raise BitfieldError(f"Invalid type for bitfield: {type_}")
+
+def bitfield_size_to_type(size):
+    if size == 8:
+        return 'u8'
+    if size == 16:
+        return 'u16'
+    if size == 32:
+        return 'u32'
+    if size == 64:
+        return 'u64'
+    else:
+        raise BitfieldError(f"Invalid size for bitfield: {size}")
+
+
+class Bitfield:
+    class Field:
+        def __init__(self, name, type_, bitsize):
+            self.name = name
+            self.type = type_
+            self.bitsize = bitsize
+            
+    def __init__(self, type_):
+        self.bitsize = bitfield_type_to_size(type_)
+        self.type = bitfield_size_to_type(self.bitsize)
+        self.fields_bitsize = 0
+        self.fields = []
+
+    def add_field(self, name, type_, bitsize):
+        self.fields.append(Bitfield.Field(name, type_, bitsize))
+        self.fields_bitsize += bitsize
+        
+    def write(self, f, name=None, indent=0, justify=True):
+        max_name = 1 if not justify else max([len(f.name) for f in self.fields], default=0)
+        max_type = 1 if not justify else max([len(f.type) for f in self.fields], default=0)
+        is_bit_set = all([f.bitsize == 1 or f.name == "reserved" for f in self.fields])
+        if is_bit_set and name is None:
+            raise BitfieldError(f"bit_set can not be anonymous")
+            
+        if is_bit_set:
+            if not name.endswith("Flags"):
+                raise BitfieldError(f"bit_set name should end with 'Flags': {name}")
+            enum_name = re.sub('Flags$', 'Flag', name)
+            f.write("{}{} :: distinct bit_set[{}; {}]\n".format('\t' * indent, name, enum_name, self.type))
+            f.write("{}{} :: enum {} {{\n".format('\t' * indent, enum_name, self.type))
+            for field in self.fields:
+                if field.name != "reserved":
+                    f.write("{}{},\n".format('\t' * (indent + 1), field.name))
+            f.write(('\t' * indent) + "}\n")
+                
+        else:
+            f.write("{}{} bit_field {} {{\n".format('\t' * indent, name + ' ::' if name else 'using _:', self.type))
+            for field in self.fields:
+                type_ = field.type.replace("Flags", "Flag")
+                f.write("{}{} {} | {},\n".format(
+                    '\t' * (indent + 1),
+                    (field.name + ":").ljust(max_name + 1),
+                    type_.ljust(max_type),
+                    field.bitsize))
+            f.write(('\t' * indent) + "}" + ("," if name is None else "") + "\n")
+
 def parse_structs(f):
     data = re.findall(r"typedef (struct|union) Vk(\w+?) {(.+?)} \w+?;", src, re.S)
     data += re.findall(r"typedef (struct|union) Std(\w+?) {(.+?)} \w+?;", src, re.S)
 
-    for _type, name, fields in data:
+    for _type, struct_name, fields in data:
         fields = re.findall(r"\s+(.+?)[\s:]+([_a-zA-Z0-9[\]]+);", fields)
-        f.write("{} :: struct ".format(name))
-        if _type == "union":
-            f.write("#raw_union ")
-        f.write("{\n")
-
 
         prev_name = ""
         ffields = []
+        bitfield = None
         for type_, fname in fields:
-
             # If the field name only has a number in it, then it is a C bit field.
+            # We will collect all the bit fields and then create either a bit_field or a bit_set.
             if is_int(fname):
-                comment = None
-                bit_field = type_.split(' ')
+                bf_field = type_.split(' ')
                 # Get rid of empty spaces
-                bit_field = list(filter(bool, bit_field))
+                bf_field = list(filter(bool, bf_field))
                 # [type, fieldname]
-                assert len(bit_field) == 2, "Failed to parse the bit field!"
+                assert len(bf_field) == 2, "Failed to parse the bit field!"
+                field_type = do_type(bf_field[0])
+                bitsize = int(fname)
 
+                # Close the set because the field size is greater than the bitfield type
+                if bitfield and (bitfield.fields_bitsize + bitsize) > bitfield_type_to_size(field_type):
+                    ffields.append(tuple([None, bitfield]))
+                    bitfield = None
 
-                bit_field_type = ""
-                # Right now there are only two ways that C bit fields exist in
-                # the header files.
+                # Raise an error if the field type size is greater than the bitfield type size
+                if bitfield is not None and bitfield_type_to_size(bitfield.type) < bitfield_type_to_size(field_type):
+                    raise BitfieldError(f"field will not fit in the bitfield: {bitfield.type} < {field_type}")
 
-                # First one uses the 8 MOST significant bits for one field, and
-                # 24 bits for the other field.
-                # In the bindings these two fields are merged into one u32.
-                if int(fname) == 24:
-                    prev_name = bit_field[1]
-                    continue
+                # Create a new bitfield if we don't have one
+                if not bitfield:
+                    bitfield = Bitfield(field_type)
 
-                elif prev_name:
-                    bit_field_type = do_type("uint32_t")
-                    bit_field_name = prev_name + "And" + bit_field[1].capitalize()
-                    comment = " // Most significant byte is {}".format(bit_field[1])
-                    ffields.append(tuple([bit_field_name, bit_field_type, comment]))
-                    prev_name = ""
-                    continue
+                    # Add the field to the bitfield
+                bitfield.add_field(bf_field[1], 'bool' if bitsize == 1 else field_type, bitsize)
+                continue
 
-                # The second way has many fields that are each 1 bit
-                elif int(fname) == 1:
-                    bit_field_type = do_type(bit_field[0], prev_name, fname)
-                    ffields.append(tuple(["bitfield", bit_field_type, comment]))
-                    break
-
-
+            # Close the bitfield because this is not a field
+            elif bitfield:
+                ffields.append(tuple([None, bitfield]))
+                bitfield = None
 
             if '[' in fname:
                 fname, type_ = parse_array(fname, type_)
-            comment = None
             n = fix_arg(fname)
             if "Flag_Bits" in type_:
-                comment = " // only single bit set"
+                # comment = " // only single bit set"
+                raise BitfieldError("only single bit set")
             t = do_type(type_, prev_name, fname)
             if n == "matrix":
                 n = "mat"
 
-            ffields.append(tuple([n, t, comment]))
+            ffields.append(tuple([n, t]))
             prev_name = fname
 
-        max_len = max([len(n) for n, _, _ in ffields], default=0)
+        # Close the bitfield because we have no more fields
+        if bitfield:
+            ffields.append(tuple([None, bitfield]))
 
-        for n, t, comment in ffields:
-            k = max_len-len(n)+len(t)
-            f.write("\t{}: {},{}\n".format(n, t.rjust(k), comment or ""))
+        # Write the struct as a bitfield if it only has bit fields
+        if len(ffields) == 1 and ffields[0][0] is None:
+            ffields[0][1].write(f, struct_name, 0, True)
+            f.write("\n")
 
-
-        f.write("}\n\n")
+        # Write as a normal struct (or union) if it has other fields
+        # and inject anonymous bitfields into the struct if there are any
+        else:
+            has_anon_bitfield = any(name is None for name, _ in ffields)
+            max_len = 1 if has_anon_bitfield else max([len(n) for n, _ in ffields], default=0)
+            f.write("{} :: struct ".format(struct_name))
+            if _type == "union":
+                f.write("#raw_union ")
+            f.write("{\n")
+            for name, type_ in ffields:
+                if name is None:
+                    # Inject an anonymous bitfield into the struct
+                    type_.write(f, None, indent=1, justify=True)
+                else:
+                    f.write("\t{} {},\n".format((name + ":").ljust(max_len + 1), type_))
+            f.write("}\n\n")
 
     f.write("// Opaque structs\n")
     f.write(OPAQUE_STRUCTS)

--- a/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
+++ b/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
@@ -683,7 +683,7 @@ def parse_structs(f):
         # and inject anonymous bitfields into the struct if there are any
         else:
             has_anon_bitfield = any(name is None for name, _ in ffields)
-            max_len = 1 if has_anon_bitfield else max([len(n) for n, _ in ffields], default=0)
+            max_len = max([0 if n is None else len(n) for n, _ in ffields], default=0)
             f.write("{} :: struct ".format(struct_name))
             if _type == "union":
                 f.write("#raw_union ")

--- a/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
+++ b/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
@@ -647,8 +647,8 @@ def parse_structs(f):
                 if not bitfield:
                     bitfield = Bitfield(field_type)
 
-                    # Add the field to the bitfield
-                bitfield.add_field(bf_field[1], 'bool' if bitsize == 1 else field_type, bitsize)
+                # Add the field to the bitfield
+                bitfield.add_field(bf_field[1], field_type, bitsize)
                 continue
 
             # Close the bitfield because this is not a field

--- a/vendor/vulkan/_gen/vk_platform.h
+++ b/vendor/vulkan/_gen/vk_platform.h
@@ -2,7 +2,7 @@
 // File: vk_platform.h
 //
 /*
-** Copyright 2014-2024 The Khronos Group Inc.
+** Copyright 2014-2025 The Khronos Group Inc.
 **
 ** SPDX-License-Identifier: Apache-2.0
 */

--- a/vendor/vulkan/_gen/vulkan_beta.h
+++ b/vendor/vulkan/_gen/vulkan_beta.h
@@ -1,0 +1,226 @@
+#ifndef VULKAN_BETA_H_
+#define VULKAN_BETA_H_ 1
+
+/*
+** Copyright 2015-2025 The Khronos Group Inc.
+**
+** SPDX-License-Identifier: Apache-2.0
+*/
+
+/*
+** This header is generated from the Khronos Vulkan XML API Registry.
+**
+*/
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+// VK_KHR_portability_subset is a preprocessor guard. Do not pass it to API calls.
+#define VK_KHR_portability_subset 1
+#define VK_KHR_PORTABILITY_SUBSET_SPEC_VERSION 1
+#define VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME "VK_KHR_portability_subset"
+typedef struct VkPhysicalDevicePortabilitySubsetFeaturesKHR {
+    VkStructureType    sType;
+    void*              pNext;
+    VkBool32           constantAlphaColorBlendFactors;
+    VkBool32           events;
+    VkBool32           imageViewFormatReinterpretation;
+    VkBool32           imageViewFormatSwizzle;
+    VkBool32           imageView2DOn3DImage;
+    VkBool32           multisampleArrayImage;
+    VkBool32           mutableComparisonSamplers;
+    VkBool32           pointPolygons;
+    VkBool32           samplerMipLodBias;
+    VkBool32           separateStencilMaskRef;
+    VkBool32           shaderSampleRateInterpolationFunctions;
+    VkBool32           tessellationIsolines;
+    VkBool32           tessellationPointMode;
+    VkBool32           triangleFans;
+    VkBool32           vertexAttributeAccessBeyondStride;
+} VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+
+typedef struct VkPhysicalDevicePortabilitySubsetPropertiesKHR {
+    VkStructureType    sType;
+    void*              pNext;
+    uint32_t           minVertexInputBindingStrideAlignment;
+} VkPhysicalDevicePortabilitySubsetPropertiesKHR;
+
+
+
+// VK_AMDX_shader_enqueue is a preprocessor guard. Do not pass it to API calls.
+#define VK_AMDX_shader_enqueue 1
+#define VK_AMDX_SHADER_ENQUEUE_SPEC_VERSION 2
+#define VK_AMDX_SHADER_ENQUEUE_EXTENSION_NAME "VK_AMDX_shader_enqueue"
+#define VK_SHADER_INDEX_UNUSED_AMDX       (~0U)
+typedef struct VkPhysicalDeviceShaderEnqueueFeaturesAMDX {
+    VkStructureType    sType;
+    void*              pNext;
+    VkBool32           shaderEnqueue;
+    VkBool32           shaderMeshEnqueue;
+} VkPhysicalDeviceShaderEnqueueFeaturesAMDX;
+
+typedef struct VkPhysicalDeviceShaderEnqueuePropertiesAMDX {
+    VkStructureType    sType;
+    void*              pNext;
+    uint32_t           maxExecutionGraphDepth;
+    uint32_t           maxExecutionGraphShaderOutputNodes;
+    uint32_t           maxExecutionGraphShaderPayloadSize;
+    uint32_t           maxExecutionGraphShaderPayloadCount;
+    uint32_t           executionGraphDispatchAddressAlignment;
+    uint32_t           maxExecutionGraphWorkgroupCount[3];
+    uint32_t           maxExecutionGraphWorkgroups;
+} VkPhysicalDeviceShaderEnqueuePropertiesAMDX;
+
+typedef struct VkExecutionGraphPipelineScratchSizeAMDX {
+    VkStructureType    sType;
+    void*              pNext;
+    VkDeviceSize       minSize;
+    VkDeviceSize       maxSize;
+    VkDeviceSize       sizeGranularity;
+} VkExecutionGraphPipelineScratchSizeAMDX;
+
+typedef struct VkExecutionGraphPipelineCreateInfoAMDX {
+    VkStructureType                           sType;
+    const void*                               pNext;
+    VkPipelineCreateFlags                     flags;
+    uint32_t                                  stageCount;
+    const VkPipelineShaderStageCreateInfo*    pStages;
+    const VkPipelineLibraryCreateInfoKHR*     pLibraryInfo;
+    VkPipelineLayout                          layout;
+    VkPipeline                                basePipelineHandle;
+    int32_t                                   basePipelineIndex;
+} VkExecutionGraphPipelineCreateInfoAMDX;
+
+typedef union VkDeviceOrHostAddressConstAMDX {
+    VkDeviceAddress    deviceAddress;
+    const void*        hostAddress;
+} VkDeviceOrHostAddressConstAMDX;
+
+typedef struct VkDispatchGraphInfoAMDX {
+    uint32_t                          nodeIndex;
+    uint32_t                          payloadCount;
+    VkDeviceOrHostAddressConstAMDX    payloads;
+    uint64_t                          payloadStride;
+} VkDispatchGraphInfoAMDX;
+
+typedef struct VkDispatchGraphCountInfoAMDX {
+    uint32_t                          count;
+    VkDeviceOrHostAddressConstAMDX    infos;
+    uint64_t                          stride;
+} VkDispatchGraphCountInfoAMDX;
+
+typedef struct VkPipelineShaderStageNodeCreateInfoAMDX {
+      VkStructureType    sType;
+    const void*          pNext;
+    const char*          pName;
+    uint32_t             index;
+} VkPipelineShaderStageNodeCreateInfoAMDX;
+
+typedef VkResult (VKAPI_PTR *PFN_vkCreateExecutionGraphPipelinesAMDX)(VkDevice                                        device, VkPipelineCache                 pipelineCache, uint32_t                                        createInfoCount, const VkExecutionGraphPipelineCreateInfoAMDX* pCreateInfos, const VkAllocationCallbacks*    pAllocator, VkPipeline*               pPipelines);
+typedef VkResult (VKAPI_PTR *PFN_vkGetExecutionGraphPipelineScratchSizeAMDX)(VkDevice                                        device, VkPipeline                                      executionGraph, VkExecutionGraphPipelineScratchSizeAMDX*        pSizeInfo);
+typedef VkResult (VKAPI_PTR *PFN_vkGetExecutionGraphPipelineNodeIndexAMDX)(VkDevice                                        device, VkPipeline                                      executionGraph, const VkPipelineShaderStageNodeCreateInfoAMDX*  pNodeInfo, uint32_t*                                       pNodeIndex);
+typedef void (VKAPI_PTR *PFN_vkCmdInitializeGraphScratchMemoryAMDX)(VkCommandBuffer                                 commandBuffer, VkPipeline                                      executionGraph, VkDeviceAddress                                 scratch, VkDeviceSize                                    scratchSize);
+typedef void (VKAPI_PTR *PFN_vkCmdDispatchGraphAMDX)(VkCommandBuffer                                 commandBuffer, VkDeviceAddress                                 scratch, VkDeviceSize                                    scratchSize, const VkDispatchGraphCountInfoAMDX*             pCountInfo);
+typedef void (VKAPI_PTR *PFN_vkCmdDispatchGraphIndirectAMDX)(VkCommandBuffer                                 commandBuffer, VkDeviceAddress                                 scratch, VkDeviceSize                                    scratchSize, const VkDispatchGraphCountInfoAMDX*             pCountInfo);
+typedef void (VKAPI_PTR *PFN_vkCmdDispatchGraphIndirectCountAMDX)(VkCommandBuffer                                 commandBuffer, VkDeviceAddress                                 scratch, VkDeviceSize                                    scratchSize, VkDeviceAddress                                 countInfo);
+
+#ifndef VK_NO_PROTOTYPES
+VKAPI_ATTR VkResult VKAPI_CALL vkCreateExecutionGraphPipelinesAMDX(
+    VkDevice                                    device,
+    VkPipelineCache                             pipelineCache,
+    uint32_t                                    createInfoCount,
+    const VkExecutionGraphPipelineCreateInfoAMDX* pCreateInfos,
+    const VkAllocationCallbacks*                pAllocator,
+    VkPipeline*                                 pPipelines);
+
+VKAPI_ATTR VkResult VKAPI_CALL vkGetExecutionGraphPipelineScratchSizeAMDX(
+    VkDevice                                    device,
+    VkPipeline                                  executionGraph,
+    VkExecutionGraphPipelineScratchSizeAMDX*    pSizeInfo);
+
+VKAPI_ATTR VkResult VKAPI_CALL vkGetExecutionGraphPipelineNodeIndexAMDX(
+    VkDevice                                    device,
+    VkPipeline                                  executionGraph,
+    const VkPipelineShaderStageNodeCreateInfoAMDX* pNodeInfo,
+    uint32_t*                                   pNodeIndex);
+
+VKAPI_ATTR void VKAPI_CALL vkCmdInitializeGraphScratchMemoryAMDX(
+    VkCommandBuffer                             commandBuffer,
+    VkPipeline                                  executionGraph,
+    VkDeviceAddress                             scratch,
+    VkDeviceSize                                scratchSize);
+
+VKAPI_ATTR void VKAPI_CALL vkCmdDispatchGraphAMDX(
+    VkCommandBuffer                             commandBuffer,
+    VkDeviceAddress                             scratch,
+    VkDeviceSize                                scratchSize,
+    const VkDispatchGraphCountInfoAMDX*         pCountInfo);
+
+VKAPI_ATTR void VKAPI_CALL vkCmdDispatchGraphIndirectAMDX(
+    VkCommandBuffer                             commandBuffer,
+    VkDeviceAddress                             scratch,
+    VkDeviceSize                                scratchSize,
+    const VkDispatchGraphCountInfoAMDX*         pCountInfo);
+
+VKAPI_ATTR void VKAPI_CALL vkCmdDispatchGraphIndirectCountAMDX(
+    VkCommandBuffer                             commandBuffer,
+    VkDeviceAddress                             scratch,
+    VkDeviceSize                                scratchSize,
+    VkDeviceAddress                             countInfo);
+#endif
+
+
+// VK_NV_displacement_micromap is a preprocessor guard. Do not pass it to API calls.
+#define VK_NV_displacement_micromap 1
+#define VK_NV_DISPLACEMENT_MICROMAP_SPEC_VERSION 2
+#define VK_NV_DISPLACEMENT_MICROMAP_EXTENSION_NAME "VK_NV_displacement_micromap"
+
+typedef enum VkDisplacementMicromapFormatNV {
+    VK_DISPLACEMENT_MICROMAP_FORMAT_64_TRIANGLES_64_BYTES_NV = 1,
+    VK_DISPLACEMENT_MICROMAP_FORMAT_256_TRIANGLES_128_BYTES_NV = 2,
+    VK_DISPLACEMENT_MICROMAP_FORMAT_1024_TRIANGLES_128_BYTES_NV = 3,
+    VK_DISPLACEMENT_MICROMAP_FORMAT_MAX_ENUM_NV = 0x7FFFFFFF
+} VkDisplacementMicromapFormatNV;
+typedef struct VkPhysicalDeviceDisplacementMicromapFeaturesNV {
+    VkStructureType    sType;
+    void*              pNext;
+    VkBool32           displacementMicromap;
+} VkPhysicalDeviceDisplacementMicromapFeaturesNV;
+
+typedef struct VkPhysicalDeviceDisplacementMicromapPropertiesNV {
+    VkStructureType    sType;
+    void*              pNext;
+    uint32_t           maxDisplacementMicromapSubdivisionLevel;
+} VkPhysicalDeviceDisplacementMicromapPropertiesNV;
+
+typedef struct VkAccelerationStructureTrianglesDisplacementMicromapNV {
+    VkStructureType                     sType;
+    void*                               pNext;
+    VkFormat                            displacementBiasAndScaleFormat;
+    VkFormat                            displacementVectorFormat;
+    VkDeviceOrHostAddressConstKHR       displacementBiasAndScaleBuffer;
+    VkDeviceSize                        displacementBiasAndScaleStride;
+    VkDeviceOrHostAddressConstKHR       displacementVectorBuffer;
+    VkDeviceSize                        displacementVectorStride;
+    VkDeviceOrHostAddressConstKHR       displacedMicromapPrimitiveFlags;
+    VkDeviceSize                        displacedMicromapPrimitiveFlagsStride;
+    VkIndexType                         indexType;
+    VkDeviceOrHostAddressConstKHR       indexBuffer;
+    VkDeviceSize                        indexStride;
+    uint32_t                            baseTriangle;
+    uint32_t                            usageCountsCount;
+    const VkMicromapUsageEXT*           pUsageCounts;
+    const VkMicromapUsageEXT* const*    ppUsageCounts;
+    VkMicromapEXT                       micromap;
+} VkAccelerationStructureTrianglesDisplacementMicromapNV;
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/vendor/vulkan/_gen/vulkan_core.h
+++ b/vendor/vulkan/_gen/vulkan_core.h
@@ -2,7 +2,7 @@
 #define VULKAN_CORE_H_ 1
 
 /*
-** Copyright 2015-2024 The Khronos Group Inc.
+** Copyright 2015-2025 The Khronos Group Inc.
 **
 ** SPDX-License-Identifier: Apache-2.0
 */
@@ -69,7 +69,7 @@ extern "C" {
 #define VK_API_VERSION_1_0 VK_MAKE_API_VERSION(0, 1, 0, 0)// Patch version should always be set to 0
 
 // Version of this file
-#define VK_HEADER_VERSION 303
+#define VK_HEADER_VERSION 309
 
 // Complete version of this file
 #define VK_HEADER_VERSION_COMPLETE VK_MAKE_API_VERSION(0, 1, 4, VK_HEADER_VERSION)
@@ -1008,7 +1008,6 @@ typedef enum VkStructureType {
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_SET_HOST_MAPPING_FEATURES_VALVE = 1000420000,
     VK_STRUCTURE_TYPE_DESCRIPTOR_SET_BINDING_REFERENCE_VALVE = 1000420001,
     VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_HOST_MAPPING_INFO_VALVE = 1000420002,
-    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLAMP_ZERO_ONE_FEATURES_EXT = 1000421000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NON_SEAMLESS_CUBE_MAP_FEATURES_EXT = 1000422000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RENDER_PASS_STRIPED_FEATURES_ARM = 1000424000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RENDER_PASS_STRIPED_PROPERTIES_ARM = 1000424001,
@@ -1025,6 +1024,9 @@ typedef enum VkStructureType {
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_COMPUTE_FEATURES_NV = 1000428000,
     VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_INDIRECT_BUFFER_INFO_NV = 1000428001,
     VK_STRUCTURE_TYPE_PIPELINE_INDIRECT_DEVICE_ADDRESS_INFO_NV = 1000428002,
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_LINEAR_SWEPT_SPHERES_FEATURES_NV = 1000429008,
+    VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_LINEAR_SWEPT_SPHERES_DATA_NV = 1000429009,
+    VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_SPHERES_DATA_NV = 1000429010,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINEAR_COLOR_ATTACHMENT_FEATURES_NV = 1000430000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MAXIMAL_RECONVERGENCE_FEATURES_KHR = 1000434000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_FEATURES_EXT = 1000437000,
@@ -1082,6 +1084,10 @@ typedef enum VkStructureType {
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_VIEWPORTS_FEATURES_QCOM = 1000488000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_FEATURES_NV = 1000490000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_PROPERTIES_NV = 1000490001,
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_VECTOR_FEATURES_NV = 1000491000,
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_VECTOR_PROPERTIES_NV = 1000491001,
+    VK_STRUCTURE_TYPE_COOPERATIVE_VECTOR_PROPERTIES_NV = 1000491002,
+    VK_STRUCTURE_TYPE_CONVERT_COOPERATIVE_VECTOR_MATRIX_INFO_NV = 1000491004,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_FEATURES_NV = 1000492000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_PROPERTIES_NV = 1000492001,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MUTABLE_DESCRIPTOR_TYPE_FEATURES_EXT = 1000351000,
@@ -1171,6 +1177,20 @@ typedef enum VkStructureType {
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT16_VECTOR_FEATURES_NV = 1000563000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_REPLICATED_COMPOSITES_FEATURES_EXT = 1000564000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_VALIDATION_FEATURES_NV = 1000568000,
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_ACCELERATION_STRUCTURE_FEATURES_NV = 1000569000,
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_ACCELERATION_STRUCTURE_PROPERTIES_NV = 1000569001,
+    VK_STRUCTURE_TYPE_CLUSTER_ACCELERATION_STRUCTURE_CLUSTERS_BOTTOM_LEVEL_INPUT_NV = 1000569002,
+    VK_STRUCTURE_TYPE_CLUSTER_ACCELERATION_STRUCTURE_TRIANGLE_CLUSTER_INPUT_NV = 1000569003,
+    VK_STRUCTURE_TYPE_CLUSTER_ACCELERATION_STRUCTURE_MOVE_OBJECTS_INPUT_NV = 1000569004,
+    VK_STRUCTURE_TYPE_CLUSTER_ACCELERATION_STRUCTURE_INPUT_INFO_NV = 1000569005,
+    VK_STRUCTURE_TYPE_CLUSTER_ACCELERATION_STRUCTURE_COMMANDS_INFO_NV = 1000569006,
+    VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CLUSTER_ACCELERATION_STRUCTURE_CREATE_INFO_NV = 1000569007,
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PARTITIONED_ACCELERATION_STRUCTURE_FEATURES_NV = 1000570000,
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PARTITIONED_ACCELERATION_STRUCTURE_PROPERTIES_NV = 1000570001,
+    VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_PARTITIONED_ACCELERATION_STRUCTURE_NV = 1000570002,
+    VK_STRUCTURE_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_INSTANCES_INPUT_NV = 1000570003,
+    VK_STRUCTURE_TYPE_BUILD_PARTITIONED_ACCELERATION_STRUCTURE_INFO_NV = 1000570004,
+    VK_STRUCTURE_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_FLAGS_NV = 1000570005,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_EXT = 1000572000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_PROPERTIES_EXT = 1000572001,
     VK_STRUCTURE_TYPE_GENERATED_COMMANDS_MEMORY_REQUIREMENTS_INFO_EXT = 1000572002,
@@ -1185,17 +1205,34 @@ typedef enum VkStructureType {
     VK_STRUCTURE_TYPE_INDIRECT_EXECUTION_SET_SHADER_LAYOUT_INFO_EXT = 1000572012,
     VK_STRUCTURE_TYPE_GENERATED_COMMANDS_PIPELINE_INFO_EXT = 1000572013,
     VK_STRUCTURE_TYPE_GENERATED_COMMANDS_SHADER_INFO_EXT = 1000572014,
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_8_FEATURES_KHR = 1000574000,
+    VK_STRUCTURE_TYPE_MEMORY_BARRIER_ACCESS_FLAGS_3_KHR = 1000574002,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ALIGNMENT_CONTROL_FEATURES_MESA = 1000575000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ALIGNMENT_CONTROL_PROPERTIES_MESA = 1000575001,
     VK_STRUCTURE_TYPE_IMAGE_ALIGNMENT_CONTROL_CREATE_INFO_MESA = 1000575002,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLAMP_CONTROL_FEATURES_EXT = 1000582000,
     VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_DEPTH_CLAMP_CONTROL_CREATE_INFO_EXT = 1000582001,
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_MAINTENANCE_2_FEATURES_KHR = 1000586000,
+    VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_INLINE_SESSION_PARAMETERS_INFO_KHR = 1000586001,
+    VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_INLINE_SESSION_PARAMETERS_INFO_KHR = 1000586002,
+    VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_INLINE_SESSION_PARAMETERS_INFO_KHR = 1000586003,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HDR_VIVID_FEATURES_HUAWEI = 1000590000,
     VK_STRUCTURE_TYPE_HDR_VIVID_DYNAMIC_METADATA_HUAWEI = 1000590001,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_2_FEATURES_NV = 1000593000,
     VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_FLEXIBLE_DIMENSIONS_PROPERTIES_NV = 1000593001,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_2_PROPERTIES_NV = 1000593002,
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_OPACITY_MICROMAP_FEATURES_ARM = 1000596000,
+    VK_STRUCTURE_TYPE_IMPORT_MEMORY_METAL_HANDLE_INFO_EXT = 1000602000,
+    VK_STRUCTURE_TYPE_MEMORY_METAL_HANDLE_PROPERTIES_EXT = 1000602001,
+    VK_STRUCTURE_TYPE_MEMORY_GET_METAL_HANDLE_INFO_EXT = 1000602002,
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLAMP_ZERO_ONE_FEATURES_KHR = 1000421000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_ROBUSTNESS_FEATURES_EXT = 1000608000,
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+    VK_STRUCTURE_TYPE_SET_PRESENT_CONFIG_NV = 1000613000,
+#endif
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_METERING_FEATURES_NV = 1000613001,
+#endif
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETER_FEATURES = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES,
   // VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT is a deprecated alias
@@ -1405,6 +1442,7 @@ typedef enum VkStructureType {
     VK_STRUCTURE_TYPE_DEVICE_BUFFER_MEMORY_REQUIREMENTS_KHR = VK_STRUCTURE_TYPE_DEVICE_BUFFER_MEMORY_REQUIREMENTS,
     VK_STRUCTURE_TYPE_DEVICE_IMAGE_MEMORY_REQUIREMENTS_KHR = VK_STRUCTURE_TYPE_DEVICE_IMAGE_MEMORY_REQUIREMENTS,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_ROTATE_FEATURES_KHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_ROTATE_FEATURES,
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLAMP_ZERO_ONE_FEATURES_EXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLAMP_ZERO_ONE_FEATURES_KHR,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_PROTECTED_ACCESS_FEATURES_EXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_PROTECTED_ACCESS_FEATURES,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_PROPERTIES_KHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_PROPERTIES,
@@ -2260,6 +2298,7 @@ typedef enum VkDescriptorType {
     VK_DESCRIPTOR_TYPE_SAMPLE_WEIGHT_IMAGE_QCOM = 1000440000,
     VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM = 1000440001,
     VK_DESCRIPTOR_TYPE_MUTABLE_EXT = 1000351000,
+    VK_DESCRIPTOR_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_NV = 1000570000,
     VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT = VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK,
     VK_DESCRIPTOR_TYPE_MUTABLE_VALVE = VK_DESCRIPTOR_TYPE_MUTABLE_EXT,
     VK_DESCRIPTOR_TYPE_MAX_ENUM = 0x7FFFFFFF
@@ -2716,6 +2755,7 @@ typedef VkFlags VkShaderModuleCreateFlags;
 
 typedef enum VkPipelineCacheCreateFlagBits {
     VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT = 0x00000001,
+    VK_PIPELINE_CACHE_CREATE_INTERNALLY_SYNCHRONIZED_MERGE_BIT_KHR = 0x00000008,
     VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT_EXT = VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT,
     VK_PIPELINE_CACHE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
 } VkPipelineCacheCreateFlagBits;
@@ -2906,6 +2946,7 @@ typedef enum VkDependencyFlagBits {
     VK_DEPENDENCY_DEVICE_GROUP_BIT = 0x00000004,
     VK_DEPENDENCY_VIEW_LOCAL_BIT = 0x00000002,
     VK_DEPENDENCY_FEEDBACK_LOOP_BIT_EXT = 0x00000008,
+    VK_DEPENDENCY_QUEUE_FAMILY_OWNERSHIP_TRANSFER_USE_ALL_STAGES_BIT_KHR = 0x00000020,
     VK_DEPENDENCY_VIEW_LOCAL_BIT_KHR = VK_DEPENDENCY_VIEW_LOCAL_BIT,
     VK_DEPENDENCY_DEVICE_GROUP_BIT_KHR = VK_DEPENDENCY_DEVICE_GROUP_BIT,
     VK_DEPENDENCY_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
@@ -5171,6 +5212,9 @@ typedef enum VkExternalMemoryHandleTypeFlagBits {
     VK_EXTERNAL_MEMORY_HANDLE_TYPE_ZIRCON_VMO_BIT_FUCHSIA = 0x00000800,
     VK_EXTERNAL_MEMORY_HANDLE_TYPE_RDMA_ADDRESS_BIT_NV = 0x00001000,
     VK_EXTERNAL_MEMORY_HANDLE_TYPE_SCREEN_BUFFER_BIT_QNX = 0x00004000,
+    VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_EXT = 0x00010000,
+    VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_EXT = 0x00020000,
+    VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLHEAP_BIT_EXT = 0x00040000,
     VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT,
     VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT,
     VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT_KHR = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT,
@@ -5954,7 +5998,7 @@ typedef enum VkDriverId {
     VK_DRIVER_ID_MESA_NVK = 24,
     VK_DRIVER_ID_IMAGINATION_OPEN_SOURCE_MESA = 25,
     VK_DRIVER_ID_MESA_HONEYKRISP = 26,
-    VK_DRIVER_ID_RESERVED_27 = 27,
+    VK_DRIVER_ID_VULKAN_SC_EMULATION_ON_VULKAN = 27,
     VK_DRIVER_ID_AMD_PROPRIETARY_KHR = VK_DRIVER_ID_AMD_PROPRIETARY,
     VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR = VK_DRIVER_ID_AMD_OPEN_SOURCE,
     VK_DRIVER_ID_MESA_RADV_KHR = VK_DRIVER_ID_MESA_RADV,
@@ -6795,6 +6839,7 @@ static const VkPipelineStageFlagBits2 VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE
 static const VkPipelineStageFlagBits2 VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT = 0x40000000ULL;
 static const VkPipelineStageFlagBits2 VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI = 0x20000000000ULL;
 static const VkPipelineStageFlagBits2 VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV = 0x20000000ULL;
+static const VkPipelineStageFlagBits2 VK_PIPELINE_STAGE_2_CONVERT_COOPERATIVE_VECTOR_MATRIX_BIT_NV = 0x100000000000ULL;
 
 typedef VkFlags64 VkAccessFlags2;
 
@@ -6958,6 +7003,7 @@ static const VkFormatFeatureFlagBits2 VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_
 static const VkFormatFeatureFlagBits2 VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR = 0x200000000ULL;
 static const VkFormatFeatureFlagBits2 VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR = 0x00010000ULL;
 static const VkFormatFeatureFlagBits2 VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT = 0x00002000ULL;
+static const VkFormatFeatureFlagBits2 VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_RADIUS_BUFFER_BIT_NV = 0x8000000000000ULL;
 static const VkFormatFeatureFlagBits2 VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV = 0x4000000000ULL;
 static const VkFormatFeatureFlagBits2 VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM = 0x400000000ULL;
 static const VkFormatFeatureFlagBits2 VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM = 0x800000000ULL;
@@ -7805,6 +7851,8 @@ static const VkPipelineCreateFlagBits2 VK_PIPELINE_CREATE_2_PROTECTED_ACCESS_ONL
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 static const VkPipelineCreateFlagBits2 VK_PIPELINE_CREATE_2_EXECUTION_GRAPH_BIT_AMDX = 0x100000000ULL;
 #endif
+static const VkPipelineCreateFlagBits2 VK_PIPELINE_CREATE_2_RAY_TRACING_SKIP_BUILT_IN_PRIMITIVES_BIT_KHR = 0x00001000ULL;
+static const VkPipelineCreateFlagBits2 VK_PIPELINE_CREATE_2_RAY_TRACING_ALLOW_SPHERES_AND_LINEAR_SWEPT_SPHERES_BIT_NV = 0x200000000ULL;
 static const VkPipelineCreateFlagBits2 VK_PIPELINE_CREATE_2_ENABLE_LEGACY_DITHERING_BIT_EXT = 0x400000000ULL;
 static const VkPipelineCreateFlagBits2 VK_PIPELINE_CREATE_2_DISABLE_OPTIMIZATION_BIT_KHR = 0x00000001ULL;
 static const VkPipelineCreateFlagBits2 VK_PIPELINE_CREATE_2_ALLOW_DERIVATIVES_BIT_KHR = 0x00000002ULL;
@@ -7837,6 +7885,7 @@ static const VkPipelineCreateFlagBits2 VK_PIPELINE_CREATE_2_NO_PROTECTED_ACCESS_
 static const VkPipelineCreateFlagBits2 VK_PIPELINE_CREATE_2_PROTECTED_ACCESS_ONLY_BIT_EXT = 0x40000000ULL;
 static const VkPipelineCreateFlagBits2 VK_PIPELINE_CREATE_2_RAY_TRACING_DISPLACEMENT_MICROMAP_BIT_NV = 0x10000000ULL;
 static const VkPipelineCreateFlagBits2 VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT = 0x20000000ULL;
+static const VkPipelineCreateFlagBits2 VK_PIPELINE_CREATE_2_DISALLOW_OPACITY_MICROMAP_BIT_ARM = 0x2000000000ULL;
 static const VkPipelineCreateFlagBits2 VK_PIPELINE_CREATE_2_CAPTURE_DATA_BIT_KHR = 0x80000000ULL;
 static const VkPipelineCreateFlagBits2 VK_PIPELINE_CREATE_2_INDIRECT_BINDABLE_BIT_EXT = 0x4000000000ULL;
 
@@ -8941,6 +8990,7 @@ typedef enum VkVideoSessionCreateFlagBitsKHR {
     VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR = 0x00000004,
     VK_VIDEO_SESSION_CREATE_ALLOW_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR = 0x00000008,
     VK_VIDEO_SESSION_CREATE_ALLOW_ENCODE_EMPHASIS_MAP_BIT_KHR = 0x00000010,
+    VK_VIDEO_SESSION_CREATE_INLINE_SESSION_PARAMETERS_BIT_KHR = 0x00000020,
     VK_VIDEO_SESSION_CREATE_FLAG_BITS_MAX_ENUM_KHR = 0x7FFFFFFF
 } VkVideoSessionCreateFlagBitsKHR;
 typedef VkFlags VkVideoSessionCreateFlagsKHR;
@@ -12127,6 +12177,10 @@ typedef enum VkComponentTypeKHR {
     VK_COMPONENT_TYPE_UINT16_KHR = 8,
     VK_COMPONENT_TYPE_UINT32_KHR = 9,
     VK_COMPONENT_TYPE_UINT64_KHR = 10,
+    VK_COMPONENT_TYPE_SINT8_PACKED_NV = 1000491000,
+    VK_COMPONENT_TYPE_UINT8_PACKED_NV = 1000491001,
+    VK_COMPONENT_TYPE_FLOAT_E4M3_NV = 1000491002,
+    VK_COMPONENT_TYPE_FLOAT_E5M2_NV = 1000491003,
     VK_COMPONENT_TYPE_FLOAT16_NV = VK_COMPONENT_TYPE_FLOAT16_KHR,
     VK_COMPONENT_TYPE_FLOAT32_NV = VK_COMPONENT_TYPE_FLOAT32_KHR,
     VK_COMPONENT_TYPE_FLOAT64_NV = VK_COMPONENT_TYPE_FLOAT64_KHR,
@@ -12779,6 +12833,76 @@ typedef struct VkPhysicalDeviceLayeredApiVulkanPropertiesKHR {
     void*                          pNext;
     VkPhysicalDeviceProperties2    properties;
 } VkPhysicalDeviceLayeredApiVulkanPropertiesKHR;
+
+
+
+// VK_KHR_maintenance8 is a preprocessor guard. Do not pass it to API calls.
+#define VK_KHR_maintenance8 1
+#define VK_KHR_MAINTENANCE_8_SPEC_VERSION 1
+#define VK_KHR_MAINTENANCE_8_EXTENSION_NAME "VK_KHR_maintenance8"
+typedef VkFlags64 VkAccessFlags3KHR;
+
+// Flag bits for VkAccessFlagBits3KHR
+typedef VkFlags64 VkAccessFlagBits3KHR;
+static const VkAccessFlagBits3KHR VK_ACCESS_3_NONE_KHR = 0ULL;
+
+typedef struct VkPhysicalDeviceMaintenance8FeaturesKHR {
+    VkStructureType    sType;
+    void*              pNext;
+    VkBool32           maintenance8;
+} VkPhysicalDeviceMaintenance8FeaturesKHR;
+
+typedef struct VkMemoryBarrierAccessFlags3KHR {
+    VkStructureType      sType;
+    const void*          pNext;
+    VkAccessFlags3KHR    srcAccessMask3;
+    VkAccessFlags3KHR    dstAccessMask3;
+} VkMemoryBarrierAccessFlags3KHR;
+
+
+
+// VK_KHR_video_maintenance2 is a preprocessor guard. Do not pass it to API calls.
+#define VK_KHR_video_maintenance2 1
+#define VK_KHR_VIDEO_MAINTENANCE_2_SPEC_VERSION 1
+#define VK_KHR_VIDEO_MAINTENANCE_2_EXTENSION_NAME "VK_KHR_video_maintenance2"
+typedef struct VkPhysicalDeviceVideoMaintenance2FeaturesKHR {
+    VkStructureType    sType;
+    void*              pNext;
+    VkBool32           videoMaintenance2;
+} VkPhysicalDeviceVideoMaintenance2FeaturesKHR;
+
+typedef struct VkVideoDecodeH264InlineSessionParametersInfoKHR {
+    VkStructureType                            sType;
+    const void*                                pNext;
+    const StdVideoH264SequenceParameterSet*    pStdSPS;
+    const StdVideoH264PictureParameterSet*     pStdPPS;
+} VkVideoDecodeH264InlineSessionParametersInfoKHR;
+
+typedef struct VkVideoDecodeH265InlineSessionParametersInfoKHR {
+    VkStructureType                            sType;
+    const void*                                pNext;
+    const StdVideoH265VideoParameterSet*       pStdVPS;
+    const StdVideoH265SequenceParameterSet*    pStdSPS;
+    const StdVideoH265PictureParameterSet*     pStdPPS;
+} VkVideoDecodeH265InlineSessionParametersInfoKHR;
+
+typedef struct VkVideoDecodeAV1InlineSessionParametersInfoKHR {
+    VkStructureType                     sType;
+    const void*                         pNext;
+    const StdVideoAV1SequenceHeader*    pStdSequenceHeader;
+} VkVideoDecodeAV1InlineSessionParametersInfoKHR;
+
+
+
+// VK_KHR_depth_clamp_zero_one is a preprocessor guard. Do not pass it to API calls.
+#define VK_KHR_depth_clamp_zero_one 1
+#define VK_KHR_DEPTH_CLAMP_ZERO_ONE_SPEC_VERSION 1
+#define VK_KHR_DEPTH_CLAMP_ZERO_ONE_EXTENSION_NAME "VK_KHR_depth_clamp_zero_one"
+typedef struct VkPhysicalDeviceDepthClampZeroOneFeaturesKHR {
+    VkStructureType    sType;
+    void*              pNext;
+    VkBool32           depthClampZeroOne;
+} VkPhysicalDeviceDepthClampZeroOneFeaturesKHR;
 
 
 
@@ -14644,6 +14768,8 @@ typedef enum VkGeometryTypeKHR {
     VK_GEOMETRY_TYPE_TRIANGLES_KHR = 0,
     VK_GEOMETRY_TYPE_AABBS_KHR = 1,
     VK_GEOMETRY_TYPE_INSTANCES_KHR = 2,
+    VK_GEOMETRY_TYPE_SPHERES_NV = 1000429004,
+    VK_GEOMETRY_TYPE_LINEAR_SWEPT_SPHERES_NV = 1000429005,
     VK_GEOMETRY_TYPE_TRIANGLES_NV = VK_GEOMETRY_TYPE_TRIANGLES_KHR,
     VK_GEOMETRY_TYPE_AABBS_NV = VK_GEOMETRY_TYPE_AABBS_KHR,
     VK_GEOMETRY_TYPE_MAX_ENUM_KHR = 0x7FFFFFFF
@@ -18253,6 +18379,7 @@ typedef enum VkOpacityMicromapSpecialIndexEXT {
     VK_OPACITY_MICROMAP_SPECIAL_INDEX_FULLY_OPAQUE_EXT = -2,
     VK_OPACITY_MICROMAP_SPECIAL_INDEX_FULLY_UNKNOWN_TRANSPARENT_EXT = -3,
     VK_OPACITY_MICROMAP_SPECIAL_INDEX_FULLY_UNKNOWN_OPAQUE_EXT = -4,
+    VK_OPACITY_MICROMAP_SPECIAL_INDEX_CLUSTER_GEOMETRY_DISABLE_OPACITY_MICROMAP_NV = -5,
     VK_OPACITY_MICROMAP_SPECIAL_INDEX_MAX_ENUM_EXT = 0x7FFFFFFF
 } VkOpacityMicromapSpecialIndexEXT;
 
@@ -18684,11 +18811,7 @@ VKAPI_ATTR void VKAPI_CALL vkGetDescriptorSetHostMappingVALVE(
 #define VK_EXT_depth_clamp_zero_one 1
 #define VK_EXT_DEPTH_CLAMP_ZERO_ONE_SPEC_VERSION 1
 #define VK_EXT_DEPTH_CLAMP_ZERO_ONE_EXTENSION_NAME "VK_EXT_depth_clamp_zero_one"
-typedef struct VkPhysicalDeviceDepthClampZeroOneFeaturesEXT {
-    VkStructureType    sType;
-    void*              pNext;
-    VkBool32           depthClampZeroOne;
-} VkPhysicalDeviceDepthClampZeroOneFeaturesEXT;
+typedef VkPhysicalDeviceDepthClampZeroOneFeaturesKHR VkPhysicalDeviceDepthClampZeroOneFeaturesEXT;
 
 
 
@@ -18918,6 +19041,61 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL vkGetPipelineIndirectDeviceAddressNV(
     VkDevice                                    device,
     const VkPipelineIndirectDeviceAddressInfoNV* pInfo);
 #endif
+
+
+// VK_NV_ray_tracing_linear_swept_spheres is a preprocessor guard. Do not pass it to API calls.
+#define VK_NV_ray_tracing_linear_swept_spheres 1
+#define VK_NV_RAY_TRACING_LINEAR_SWEPT_SPHERES_SPEC_VERSION 1
+#define VK_NV_RAY_TRACING_LINEAR_SWEPT_SPHERES_EXTENSION_NAME "VK_NV_ray_tracing_linear_swept_spheres"
+
+typedef enum VkRayTracingLssIndexingModeNV {
+    VK_RAY_TRACING_LSS_INDEXING_MODE_LIST_NV = 0,
+    VK_RAY_TRACING_LSS_INDEXING_MODE_SUCCESSIVE_NV = 1,
+    VK_RAY_TRACING_LSS_INDEXING_MODE_MAX_ENUM_NV = 0x7FFFFFFF
+} VkRayTracingLssIndexingModeNV;
+
+typedef enum VkRayTracingLssPrimitiveEndCapsModeNV {
+    VK_RAY_TRACING_LSS_PRIMITIVE_END_CAPS_MODE_NONE_NV = 0,
+    VK_RAY_TRACING_LSS_PRIMITIVE_END_CAPS_MODE_CHAINED_NV = 1,
+    VK_RAY_TRACING_LSS_PRIMITIVE_END_CAPS_MODE_MAX_ENUM_NV = 0x7FFFFFFF
+} VkRayTracingLssPrimitiveEndCapsModeNV;
+typedef struct VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV {
+    VkStructureType    sType;
+    void*              pNext;
+    VkBool32           spheres;
+    VkBool32           linearSweptSpheres;
+} VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV;
+
+typedef struct VkAccelerationStructureGeometryLinearSweptSpheresDataNV {
+    VkStructureType                          sType;
+    const void*                              pNext;
+    VkFormat                                 vertexFormat;
+    VkDeviceOrHostAddressConstKHR            vertexData;
+    VkDeviceSize                             vertexStride;
+    VkFormat                                 radiusFormat;
+    VkDeviceOrHostAddressConstKHR            radiusData;
+    VkDeviceSize                             radiusStride;
+    VkIndexType                              indexType;
+    VkDeviceOrHostAddressConstKHR            indexData;
+    VkDeviceSize                             indexStride;
+    VkRayTracingLssIndexingModeNV            indexingMode;
+    VkRayTracingLssPrimitiveEndCapsModeNV    endCapsMode;
+} VkAccelerationStructureGeometryLinearSweptSpheresDataNV;
+
+typedef struct VkAccelerationStructureGeometrySpheresDataNV {
+    VkStructureType                  sType;
+    const void*                      pNext;
+    VkFormat                         vertexFormat;
+    VkDeviceOrHostAddressConstKHR    vertexData;
+    VkDeviceSize                     vertexStride;
+    VkFormat                         radiusFormat;
+    VkDeviceOrHostAddressConstKHR    radiusData;
+    VkDeviceSize                     radiusStride;
+    VkIndexType                      indexType;
+    VkDeviceOrHostAddressConstKHR    indexData;
+    VkDeviceSize                     indexStride;
+} VkAccelerationStructureGeometrySpheresDataNV;
+
 
 
 // VK_NV_linear_color_attachment is a preprocessor guard. Do not pass it to API calls.
@@ -19816,6 +19994,83 @@ typedef struct VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV {
 
 
 
+// VK_NV_cooperative_vector is a preprocessor guard. Do not pass it to API calls.
+#define VK_NV_cooperative_vector 1
+#define VK_NV_COOPERATIVE_VECTOR_SPEC_VERSION 4
+#define VK_NV_COOPERATIVE_VECTOR_EXTENSION_NAME "VK_NV_cooperative_vector"
+
+typedef enum VkCooperativeVectorMatrixLayoutNV {
+    VK_COOPERATIVE_VECTOR_MATRIX_LAYOUT_ROW_MAJOR_NV = 0,
+    VK_COOPERATIVE_VECTOR_MATRIX_LAYOUT_COLUMN_MAJOR_NV = 1,
+    VK_COOPERATIVE_VECTOR_MATRIX_LAYOUT_INFERENCING_OPTIMAL_NV = 2,
+    VK_COOPERATIVE_VECTOR_MATRIX_LAYOUT_TRAINING_OPTIMAL_NV = 3,
+    VK_COOPERATIVE_VECTOR_MATRIX_LAYOUT_MAX_ENUM_NV = 0x7FFFFFFF
+} VkCooperativeVectorMatrixLayoutNV;
+typedef struct VkPhysicalDeviceCooperativeVectorPropertiesNV {
+    VkStructureType       sType;
+    void*                 pNext;
+    VkShaderStageFlags    cooperativeVectorSupportedStages;
+    VkBool32              cooperativeVectorTrainingFloat16Accumulation;
+    VkBool32              cooperativeVectorTrainingFloat32Accumulation;
+    uint32_t              maxCooperativeVectorComponents;
+} VkPhysicalDeviceCooperativeVectorPropertiesNV;
+
+typedef struct VkPhysicalDeviceCooperativeVectorFeaturesNV {
+    VkStructureType    sType;
+    void*              pNext;
+    VkBool32           cooperativeVector;
+    VkBool32           cooperativeVectorTraining;
+} VkPhysicalDeviceCooperativeVectorFeaturesNV;
+
+typedef struct VkCooperativeVectorPropertiesNV {
+    VkStructureType       sType;
+    void*                 pNext;
+    VkComponentTypeKHR    inputType;
+    VkComponentTypeKHR    inputInterpretation;
+    VkComponentTypeKHR    matrixInterpretation;
+    VkComponentTypeKHR    biasInterpretation;
+    VkComponentTypeKHR    resultType;
+    VkBool32              transpose;
+} VkCooperativeVectorPropertiesNV;
+
+typedef struct VkConvertCooperativeVectorMatrixInfoNV {
+    VkStructureType                      sType;
+    const void*                          pNext;
+    size_t                               srcSize;
+    VkDeviceOrHostAddressConstKHR        srcData;
+    size_t*                              pDstSize;
+    VkDeviceOrHostAddressKHR             dstData;
+    VkComponentTypeKHR                   srcComponentType;
+    VkComponentTypeKHR                   dstComponentType;
+    uint32_t                             numRows;
+    uint32_t                             numColumns;
+    VkCooperativeVectorMatrixLayoutNV    srcLayout;
+    size_t                               srcStride;
+    VkCooperativeVectorMatrixLayoutNV    dstLayout;
+    size_t                               dstStride;
+} VkConvertCooperativeVectorMatrixInfoNV;
+
+typedef VkResult (VKAPI_PTR *PFN_vkGetPhysicalDeviceCooperativeVectorPropertiesNV)(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount, VkCooperativeVectorPropertiesNV* pProperties);
+typedef VkResult (VKAPI_PTR *PFN_vkConvertCooperativeVectorMatrixNV)(VkDevice device, const VkConvertCooperativeVectorMatrixInfoNV* pInfo);
+typedef void (VKAPI_PTR *PFN_vkCmdConvertCooperativeVectorMatrixNV)(VkCommandBuffer commandBuffer, uint32_t infoCount, const VkConvertCooperativeVectorMatrixInfoNV* pInfos);
+
+#ifndef VK_NO_PROTOTYPES
+VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceCooperativeVectorPropertiesNV(
+    VkPhysicalDevice                            physicalDevice,
+    uint32_t*                                   pPropertyCount,
+    VkCooperativeVectorPropertiesNV*            pProperties);
+
+VKAPI_ATTR VkResult VKAPI_CALL vkConvertCooperativeVectorMatrixNV(
+    VkDevice                                    device,
+    const VkConvertCooperativeVectorMatrixInfoNV* pInfo);
+
+VKAPI_ATTR void VKAPI_CALL vkCmdConvertCooperativeVectorMatrixNV(
+    VkCommandBuffer                             commandBuffer,
+    uint32_t                                    infoCount,
+    const VkConvertCooperativeVectorMatrixInfoNV* pInfos);
+#endif
+
+
 // VK_NV_extended_sparse_address_space is a preprocessor guard. Do not pass it to API calls.
 #define VK_NV_extended_sparse_address_space 1
 #define VK_NV_EXTENDED_SPARSE_ADDRESS_SPACE_SPEC_VERSION 1
@@ -20330,6 +20585,359 @@ typedef struct VkPhysicalDeviceRayTracingValidationFeaturesNV {
 
 
 
+// VK_NV_cluster_acceleration_structure is a preprocessor guard. Do not pass it to API calls.
+#define VK_NV_cluster_acceleration_structure 1
+#define VK_NV_CLUSTER_ACCELERATION_STRUCTURE_SPEC_VERSION 2
+#define VK_NV_CLUSTER_ACCELERATION_STRUCTURE_EXTENSION_NAME "VK_NV_cluster_acceleration_structure"
+
+typedef enum VkClusterAccelerationStructureTypeNV {
+    VK_CLUSTER_ACCELERATION_STRUCTURE_TYPE_CLUSTERS_BOTTOM_LEVEL_NV = 0,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_TYPE_TRIANGLE_CLUSTER_NV = 1,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_TYPE_TRIANGLE_CLUSTER_TEMPLATE_NV = 2,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_TYPE_MAX_ENUM_NV = 0x7FFFFFFF
+} VkClusterAccelerationStructureTypeNV;
+
+typedef enum VkClusterAccelerationStructureOpTypeNV {
+    VK_CLUSTER_ACCELERATION_STRUCTURE_OP_TYPE_MOVE_OBJECTS_NV = 0,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_OP_TYPE_BUILD_CLUSTERS_BOTTOM_LEVEL_NV = 1,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_OP_TYPE_BUILD_TRIANGLE_CLUSTER_NV = 2,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_OP_TYPE_BUILD_TRIANGLE_CLUSTER_TEMPLATE_NV = 3,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_OP_TYPE_INSTANTIATE_TRIANGLE_CLUSTER_NV = 4,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_OP_TYPE_MAX_ENUM_NV = 0x7FFFFFFF
+} VkClusterAccelerationStructureOpTypeNV;
+
+typedef enum VkClusterAccelerationStructureOpModeNV {
+    VK_CLUSTER_ACCELERATION_STRUCTURE_OP_MODE_IMPLICIT_DESTINATIONS_NV = 0,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_OP_MODE_EXPLICIT_DESTINATIONS_NV = 1,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_OP_MODE_COMPUTE_SIZES_NV = 2,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_OP_MODE_MAX_ENUM_NV = 0x7FFFFFFF
+} VkClusterAccelerationStructureOpModeNV;
+
+typedef enum VkClusterAccelerationStructureAddressResolutionFlagBitsNV {
+    VK_CLUSTER_ACCELERATION_STRUCTURE_ADDRESS_RESOLUTION_INDIRECTED_DST_IMPLICIT_DATA_BIT_NV = 0x00000001,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_ADDRESS_RESOLUTION_INDIRECTED_SCRATCH_DATA_BIT_NV = 0x00000002,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_ADDRESS_RESOLUTION_INDIRECTED_DST_ADDRESS_ARRAY_BIT_NV = 0x00000004,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_ADDRESS_RESOLUTION_INDIRECTED_DST_SIZES_ARRAY_BIT_NV = 0x00000008,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_ADDRESS_RESOLUTION_INDIRECTED_SRC_INFOS_ARRAY_BIT_NV = 0x00000010,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_ADDRESS_RESOLUTION_INDIRECTED_SRC_INFOS_COUNT_BIT_NV = 0x00000020,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_ADDRESS_RESOLUTION_FLAG_BITS_MAX_ENUM_NV = 0x7FFFFFFF
+} VkClusterAccelerationStructureAddressResolutionFlagBitsNV;
+typedef VkFlags VkClusterAccelerationStructureAddressResolutionFlagsNV;
+
+typedef enum VkClusterAccelerationStructureClusterFlagBitsNV {
+    VK_CLUSTER_ACCELERATION_STRUCTURE_CLUSTER_ALLOW_DISABLE_OPACITY_MICROMAPS_NV = 0x00000001,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_CLUSTER_FLAG_BITS_MAX_ENUM_NV = 0x7FFFFFFF
+} VkClusterAccelerationStructureClusterFlagBitsNV;
+typedef VkFlags VkClusterAccelerationStructureClusterFlagsNV;
+
+typedef enum VkClusterAccelerationStructureGeometryFlagBitsNV {
+    VK_CLUSTER_ACCELERATION_STRUCTURE_GEOMETRY_CULL_DISABLE_BIT_NV = 0x00000001,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_GEOMETRY_NO_DUPLICATE_ANYHIT_INVOCATION_BIT_NV = 0x00000002,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_GEOMETRY_OPAQUE_BIT_NV = 0x00000004,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_GEOMETRY_FLAG_BITS_MAX_ENUM_NV = 0x7FFFFFFF
+} VkClusterAccelerationStructureGeometryFlagBitsNV;
+typedef VkFlags VkClusterAccelerationStructureGeometryFlagsNV;
+
+typedef enum VkClusterAccelerationStructureIndexFormatFlagBitsNV {
+    VK_CLUSTER_ACCELERATION_STRUCTURE_INDEX_FORMAT_8BIT_NV = 0x00000001,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_INDEX_FORMAT_16BIT_NV = 0x00000002,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_INDEX_FORMAT_32BIT_NV = 0x00000004,
+    VK_CLUSTER_ACCELERATION_STRUCTURE_INDEX_FORMAT_FLAG_BITS_MAX_ENUM_NV = 0x7FFFFFFF
+} VkClusterAccelerationStructureIndexFormatFlagBitsNV;
+typedef VkFlags VkClusterAccelerationStructureIndexFormatFlagsNV;
+typedef struct VkPhysicalDeviceClusterAccelerationStructureFeaturesNV {
+    VkStructureType    sType;
+    void*              pNext;
+    VkBool32           clusterAccelerationStructure;
+} VkPhysicalDeviceClusterAccelerationStructureFeaturesNV;
+
+typedef struct VkPhysicalDeviceClusterAccelerationStructurePropertiesNV {
+    VkStructureType    sType;
+    void*              pNext;
+    uint32_t           maxVerticesPerCluster;
+    uint32_t           maxTrianglesPerCluster;
+    uint32_t           clusterScratchByteAlignment;
+    uint32_t           clusterByteAlignment;
+    uint32_t           clusterTemplateByteAlignment;
+    uint32_t           clusterBottomLevelByteAlignment;
+    uint32_t           clusterTemplateBoundsByteAlignment;
+    uint32_t           maxClusterGeometryIndex;
+} VkPhysicalDeviceClusterAccelerationStructurePropertiesNV;
+
+typedef struct VkClusterAccelerationStructureClustersBottomLevelInputNV {
+    VkStructureType    sType;
+    void*              pNext;
+    uint32_t           maxTotalClusterCount;
+    uint32_t           maxClusterCountPerAccelerationStructure;
+} VkClusterAccelerationStructureClustersBottomLevelInputNV;
+
+typedef struct VkClusterAccelerationStructureTriangleClusterInputNV {
+    VkStructureType    sType;
+    void*              pNext;
+    VkFormat           vertexFormat;
+    uint32_t           maxGeometryIndexValue;
+    uint32_t           maxClusterUniqueGeometryCount;
+    uint32_t           maxClusterTriangleCount;
+    uint32_t           maxClusterVertexCount;
+    uint32_t           maxTotalTriangleCount;
+    uint32_t           maxTotalVertexCount;
+    uint32_t           minPositionTruncateBitCount;
+} VkClusterAccelerationStructureTriangleClusterInputNV;
+
+typedef struct VkClusterAccelerationStructureMoveObjectsInputNV {
+    VkStructureType                         sType;
+    void*                                   pNext;
+    VkClusterAccelerationStructureTypeNV    type;
+    VkBool32                                noMoveOverlap;
+    VkDeviceSize                            maxMovedBytes;
+} VkClusterAccelerationStructureMoveObjectsInputNV;
+
+typedef union VkClusterAccelerationStructureOpInputNV {
+    VkClusterAccelerationStructureClustersBottomLevelInputNV*    pClustersBottomLevel;
+    VkClusterAccelerationStructureTriangleClusterInputNV*        pTriangleClusters;
+    VkClusterAccelerationStructureMoveObjectsInputNV*            pMoveObjects;
+} VkClusterAccelerationStructureOpInputNV;
+
+typedef struct VkClusterAccelerationStructureInputInfoNV {
+    VkStructureType                            sType;
+    void*                                      pNext;
+    uint32_t                                   maxAccelerationStructureCount;
+    VkBuildAccelerationStructureFlagsKHR       flags;
+    VkClusterAccelerationStructureOpTypeNV     opType;
+    VkClusterAccelerationStructureOpModeNV     opMode;
+    VkClusterAccelerationStructureOpInputNV    opInput;
+} VkClusterAccelerationStructureInputInfoNV;
+
+typedef struct VkStridedDeviceAddressRegionKHR {
+    VkDeviceAddress    deviceAddress;
+    VkDeviceSize       stride;
+    VkDeviceSize       size;
+} VkStridedDeviceAddressRegionKHR;
+
+typedef struct VkClusterAccelerationStructureCommandsInfoNV {
+    VkStructureType                                           sType;
+    void*                                                     pNext;
+    VkClusterAccelerationStructureInputInfoNV                 input;
+    VkDeviceAddress                                           dstImplicitData;
+    VkDeviceAddress                                           scratchData;
+    VkStridedDeviceAddressRegionKHR                           dstAddressesArray;
+    VkStridedDeviceAddressRegionKHR                           dstSizesArray;
+    VkStridedDeviceAddressRegionKHR                           srcInfosArray;
+    VkDeviceAddress                                           srcInfosCount;
+    VkClusterAccelerationStructureAddressResolutionFlagsNV    addressResolutionFlags;
+} VkClusterAccelerationStructureCommandsInfoNV;
+
+typedef struct VkStridedDeviceAddressNV {
+    VkDeviceAddress    startAddress;
+    VkDeviceSize       strideInBytes;
+} VkStridedDeviceAddressNV;
+
+typedef struct VkClusterAccelerationStructureGeometryIndexAndGeometryFlagsNV {
+    uint32_t    geometryIndex:24;
+    uint32_t    reserved:5;
+    uint32_t    geometryFlags:3;
+} VkClusterAccelerationStructureGeometryIndexAndGeometryFlagsNV;
+
+typedef struct VkClusterAccelerationStructureMoveObjectsInfoNV {
+    VkDeviceAddress    srcAccelerationStructure;
+} VkClusterAccelerationStructureMoveObjectsInfoNV;
+
+typedef struct VkClusterAccelerationStructureBuildClustersBottomLevelInfoNV {
+    uint32_t           clusterReferencesCount;
+    uint32_t           clusterReferencesStride;
+    VkDeviceAddress    clusterReferences;
+} VkClusterAccelerationStructureBuildClustersBottomLevelInfoNV;
+
+typedef struct VkClusterAccelerationStructureBuildTriangleClusterInfoNV {
+    uint32_t                                                         clusterID;
+    VkClusterAccelerationStructureClusterFlagsNV                     clusterFlags;
+    uint32_t                                                         triangleCount:9;
+    uint32_t                                                         vertexCount:9;
+    uint32_t                                                         positionTruncateBitCount:6;
+    uint32_t                                                         indexType:4;
+    uint32_t                                                         opacityMicromapIndexType:4;
+    VkClusterAccelerationStructureGeometryIndexAndGeometryFlagsNV    baseGeometryIndexAndGeometryFlags;
+    uint16_t                                                         indexBufferStride;
+    uint16_t                                                         vertexBufferStride;
+    uint16_t                                                         geometryIndexAndFlagsBufferStride;
+    uint16_t                                                         opacityMicromapIndexBufferStride;
+    VkDeviceAddress                                                  indexBuffer;
+    VkDeviceAddress                                                  vertexBuffer;
+    VkDeviceAddress                                                  geometryIndexAndFlagsBuffer;
+    VkDeviceAddress                                                  opacityMicromapArray;
+    VkDeviceAddress                                                  opacityMicromapIndexBuffer;
+} VkClusterAccelerationStructureBuildTriangleClusterInfoNV;
+
+typedef struct VkClusterAccelerationStructureBuildTriangleClusterTemplateInfoNV {
+    uint32_t                                                         clusterID;
+    VkClusterAccelerationStructureClusterFlagsNV                     clusterFlags;
+    uint32_t                                                         triangleCount:9;
+    uint32_t                                                         vertexCount:9;
+    uint32_t                                                         positionTruncateBitCount:6;
+    uint32_t                                                         indexType:4;
+    uint32_t                                                         opacityMicromapIndexType:4;
+    VkClusterAccelerationStructureGeometryIndexAndGeometryFlagsNV    baseGeometryIndexAndGeometryFlags;
+    uint16_t                                                         indexBufferStride;
+    uint16_t                                                         vertexBufferStride;
+    uint16_t                                                         geometryIndexAndFlagsBufferStride;
+    uint16_t                                                         opacityMicromapIndexBufferStride;
+    VkDeviceAddress                                                  indexBuffer;
+    VkDeviceAddress                                                  vertexBuffer;
+    VkDeviceAddress                                                  geometryIndexAndFlagsBuffer;
+    VkDeviceAddress                                                  opacityMicromapArray;
+    VkDeviceAddress                                                  opacityMicromapIndexBuffer;
+    VkDeviceAddress                                                  instantiationBoundingBoxLimit;
+} VkClusterAccelerationStructureBuildTriangleClusterTemplateInfoNV;
+
+typedef struct VkClusterAccelerationStructureInstantiateClusterInfoNV {
+    uint32_t                    clusterIdOffset;
+    uint32_t                    geometryIndexOffset:24;
+    uint32_t                    reserved:8;
+    VkDeviceAddress             clusterTemplateAddress;
+    VkStridedDeviceAddressNV    vertexBuffer;
+} VkClusterAccelerationStructureInstantiateClusterInfoNV;
+
+typedef struct VkAccelerationStructureBuildSizesInfoKHR {
+    VkStructureType    sType;
+    const void*        pNext;
+    VkDeviceSize       accelerationStructureSize;
+    VkDeviceSize       updateScratchSize;
+    VkDeviceSize       buildScratchSize;
+} VkAccelerationStructureBuildSizesInfoKHR;
+
+typedef struct VkRayTracingPipelineClusterAccelerationStructureCreateInfoNV {
+    VkStructureType    sType;
+    void*              pNext;
+    VkBool32           allowClusterAccelerationStructure;
+} VkRayTracingPipelineClusterAccelerationStructureCreateInfoNV;
+
+typedef void (VKAPI_PTR *PFN_vkGetClusterAccelerationStructureBuildSizesNV)(VkDevice device, const VkClusterAccelerationStructureInputInfoNV* pInfo, VkAccelerationStructureBuildSizesInfoKHR* pSizeInfo);
+typedef void (VKAPI_PTR *PFN_vkCmdBuildClusterAccelerationStructureIndirectNV)(VkCommandBuffer                     commandBuffer, const VkClusterAccelerationStructureCommandsInfoNV*  pCommandInfos);
+
+#ifndef VK_NO_PROTOTYPES
+VKAPI_ATTR void VKAPI_CALL vkGetClusterAccelerationStructureBuildSizesNV(
+    VkDevice                                    device,
+    const VkClusterAccelerationStructureInputInfoNV* pInfo,
+    VkAccelerationStructureBuildSizesInfoKHR*   pSizeInfo);
+
+VKAPI_ATTR void VKAPI_CALL vkCmdBuildClusterAccelerationStructureIndirectNV(
+    VkCommandBuffer                             commandBuffer,
+    const VkClusterAccelerationStructureCommandsInfoNV* pCommandInfos);
+#endif
+
+
+// VK_NV_partitioned_acceleration_structure is a preprocessor guard. Do not pass it to API calls.
+#define VK_NV_partitioned_acceleration_structure 1
+#define VK_NV_PARTITIONED_ACCELERATION_STRUCTURE_SPEC_VERSION 1
+#define VK_NV_PARTITIONED_ACCELERATION_STRUCTURE_EXTENSION_NAME "VK_NV_partitioned_acceleration_structure"
+#define VK_PARTITIONED_ACCELERATION_STRUCTURE_PARTITION_INDEX_GLOBAL_NV (~0U)
+
+typedef enum VkPartitionedAccelerationStructureOpTypeNV {
+    VK_PARTITIONED_ACCELERATION_STRUCTURE_OP_TYPE_WRITE_INSTANCE_NV = 0,
+    VK_PARTITIONED_ACCELERATION_STRUCTURE_OP_TYPE_UPDATE_INSTANCE_NV = 1,
+    VK_PARTITIONED_ACCELERATION_STRUCTURE_OP_TYPE_WRITE_PARTITION_TRANSLATION_NV = 2,
+    VK_PARTITIONED_ACCELERATION_STRUCTURE_OP_TYPE_MAX_ENUM_NV = 0x7FFFFFFF
+} VkPartitionedAccelerationStructureOpTypeNV;
+
+typedef enum VkPartitionedAccelerationStructureInstanceFlagBitsNV {
+    VK_PARTITIONED_ACCELERATION_STRUCTURE_INSTANCE_FLAG_TRIANGLE_FACING_CULL_DISABLE_BIT_NV = 0x00000001,
+    VK_PARTITIONED_ACCELERATION_STRUCTURE_INSTANCE_FLAG_TRIANGLE_FLIP_FACING_BIT_NV = 0x00000002,
+    VK_PARTITIONED_ACCELERATION_STRUCTURE_INSTANCE_FLAG_FORCE_OPAQUE_BIT_NV = 0x00000004,
+    VK_PARTITIONED_ACCELERATION_STRUCTURE_INSTANCE_FLAG_FORCE_NO_OPAQUE_BIT_NV = 0x00000008,
+    VK_PARTITIONED_ACCELERATION_STRUCTURE_INSTANCE_FLAG_ENABLE_EXPLICIT_BOUNDING_BOX_NV = 0x00000010,
+    VK_PARTITIONED_ACCELERATION_STRUCTURE_INSTANCE_FLAG_BITS_MAX_ENUM_NV = 0x7FFFFFFF
+} VkPartitionedAccelerationStructureInstanceFlagBitsNV;
+typedef VkFlags VkPartitionedAccelerationStructureInstanceFlagsNV;
+typedef struct VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV {
+    VkStructureType    sType;
+    void*              pNext;
+    VkBool32           partitionedAccelerationStructure;
+} VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV;
+
+typedef struct VkPhysicalDevicePartitionedAccelerationStructurePropertiesNV {
+    VkStructureType    sType;
+    void*              pNext;
+    uint32_t           maxPartitionCount;
+} VkPhysicalDevicePartitionedAccelerationStructurePropertiesNV;
+
+typedef struct VkPartitionedAccelerationStructureFlagsNV {
+    VkStructureType    sType;
+    void*              pNext;
+    VkBool32           enablePartitionTranslation;
+} VkPartitionedAccelerationStructureFlagsNV;
+
+typedef struct VkBuildPartitionedAccelerationStructureIndirectCommandNV {
+    VkPartitionedAccelerationStructureOpTypeNV    opType;
+    uint32_t                                      argCount;
+    VkStridedDeviceAddressNV                      argData;
+} VkBuildPartitionedAccelerationStructureIndirectCommandNV;
+
+typedef struct VkPartitionedAccelerationStructureWriteInstanceDataNV {
+    VkTransformMatrixKHR                                 transform;
+    float                                                explicitAABB[6];
+    uint32_t                                             instanceID;
+    uint32_t                                             instanceMask;
+    uint32_t                                             instanceContributionToHitGroupIndex;
+    VkPartitionedAccelerationStructureInstanceFlagsNV    instanceFlags;
+    uint32_t                                             instanceIndex;
+    uint32_t                                             partitionIndex;
+    VkDeviceAddress                                      accelerationStructure;
+} VkPartitionedAccelerationStructureWriteInstanceDataNV;
+
+typedef struct VkPartitionedAccelerationStructureUpdateInstanceDataNV {
+    uint32_t           instanceIndex;
+    uint32_t           instanceContributionToHitGroupIndex;
+    VkDeviceAddress    accelerationStructure;
+} VkPartitionedAccelerationStructureUpdateInstanceDataNV;
+
+typedef struct VkPartitionedAccelerationStructureWritePartitionTranslationDataNV {
+    uint32_t    partitionIndex;
+    float       partitionTranslation[3];
+} VkPartitionedAccelerationStructureWritePartitionTranslationDataNV;
+
+typedef struct VkWriteDescriptorSetPartitionedAccelerationStructureNV {
+    VkStructureType           sType;
+    void*                     pNext;
+    uint32_t                  accelerationStructureCount;
+    const VkDeviceAddress*    pAccelerationStructures;
+} VkWriteDescriptorSetPartitionedAccelerationStructureNV;
+
+typedef struct VkPartitionedAccelerationStructureInstancesInputNV {
+    VkStructureType                         sType;
+    void*                                   pNext;
+    VkBuildAccelerationStructureFlagsKHR    flags;
+    uint32_t                                instanceCount;
+    uint32_t                                maxInstancePerPartitionCount;
+    uint32_t                                partitionCount;
+    uint32_t                                maxInstanceInGlobalPartitionCount;
+} VkPartitionedAccelerationStructureInstancesInputNV;
+
+typedef struct VkBuildPartitionedAccelerationStructureInfoNV {
+    VkStructureType                                       sType;
+    void*                                                 pNext;
+    VkPartitionedAccelerationStructureInstancesInputNV    input;
+    VkDeviceAddress                                       srcAccelerationStructureData;
+    VkDeviceAddress                                       dstAccelerationStructureData;
+    VkDeviceAddress                                       scratchData;
+    VkDeviceAddress                                       srcInfos;
+    VkDeviceAddress                                       srcInfosCount;
+} VkBuildPartitionedAccelerationStructureInfoNV;
+
+typedef void (VKAPI_PTR *PFN_vkGetPartitionedAccelerationStructuresBuildSizesNV)(VkDevice device, const VkPartitionedAccelerationStructureInstancesInputNV* pInfo, VkAccelerationStructureBuildSizesInfoKHR*                  pSizeInfo);
+typedef void (VKAPI_PTR *PFN_vkCmdBuildPartitionedAccelerationStructuresNV)(VkCommandBuffer                     commandBuffer, const VkBuildPartitionedAccelerationStructureInfoNV*  pBuildInfo);
+
+#ifndef VK_NO_PROTOTYPES
+VKAPI_ATTR void VKAPI_CALL vkGetPartitionedAccelerationStructuresBuildSizesNV(
+    VkDevice                                    device,
+    const VkPartitionedAccelerationStructureInstancesInputNV* pInfo,
+    VkAccelerationStructureBuildSizesInfoKHR*   pSizeInfo);
+
+VKAPI_ATTR void VKAPI_CALL vkCmdBuildPartitionedAccelerationStructuresNV(
+    VkCommandBuffer                             commandBuffer,
+    const VkBuildPartitionedAccelerationStructureInfoNV* pBuildInfo);
+#endif
+
+
 // VK_EXT_device_generated_commands is a preprocessor guard. Do not pass it to API calls.
 #define VK_EXT_device_generated_commands 1
 VK_DEFINE_NON_DISPATCHABLE_HANDLE(VkIndirectExecutionSetEXT)
@@ -20721,6 +21329,18 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceCooperativeMatrixFlexibleDimen
 #endif
 
 
+// VK_ARM_pipeline_opacity_micromap is a preprocessor guard. Do not pass it to API calls.
+#define VK_ARM_pipeline_opacity_micromap 1
+#define VK_ARM_PIPELINE_OPACITY_MICROMAP_SPEC_VERSION 1
+#define VK_ARM_PIPELINE_OPACITY_MICROMAP_EXTENSION_NAME "VK_ARM_pipeline_opacity_micromap"
+typedef struct VkPhysicalDevicePipelineOpacityMicromapFeaturesARM {
+    VkStructureType    sType;
+    void*              pNext;
+    VkBool32           pipelineOpacityMicromap;
+} VkPhysicalDevicePipelineOpacityMicromapFeaturesARM;
+
+
+
 // VK_EXT_vertex_attribute_robustness is a preprocessor guard. Do not pass it to API calls.
 #define VK_EXT_vertex_attribute_robustness 1
 #define VK_EXT_VERTEX_ATTRIBUTE_ROBUSTNESS_SPEC_VERSION 1
@@ -20730,6 +21350,25 @@ typedef struct VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT {
     void*              pNext;
     VkBool32           vertexAttributeRobustness;
 } VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT;
+
+
+
+// VK_NV_present_metering is a preprocessor guard. Do not pass it to API calls.
+#define VK_NV_present_metering 1
+#define VK_NV_PRESENT_METERING_SPEC_VERSION 1
+#define VK_NV_PRESENT_METERING_EXTENSION_NAME "VK_NV_present_metering"
+typedef struct VkSetPresentConfigNV {
+    VkStructureType    sType;
+    const void*        pNext;
+    uint32_t           numFramesPerBatch;
+    uint32_t           presentConfigFeedback;
+} VkSetPresentConfigNV;
+
+typedef struct VkPhysicalDevicePresentMeteringFeaturesNV {
+    VkStructureType    sType;
+    void*              pNext;
+    VkBool32           presentMetering;
+} VkPhysicalDevicePresentMeteringFeaturesNV;
 
 
 
@@ -20888,14 +21527,6 @@ typedef struct VkCopyAccelerationStructureInfoKHR {
     VkAccelerationStructureKHR            dst;
     VkCopyAccelerationStructureModeKHR    mode;
 } VkCopyAccelerationStructureInfoKHR;
-
-typedef struct VkAccelerationStructureBuildSizesInfoKHR {
-    VkStructureType    sType;
-    const void*        pNext;
-    VkDeviceSize       accelerationStructureSize;
-    VkDeviceSize       updateScratchSize;
-    VkDeviceSize       buildScratchSize;
-} VkAccelerationStructureBuildSizesInfoKHR;
 
 typedef VkResult (VKAPI_PTR *PFN_vkCreateAccelerationStructureKHR)(VkDevice                                           device, const VkAccelerationStructureCreateInfoKHR*        pCreateInfo, const VkAllocationCallbacks*       pAllocator, VkAccelerationStructureKHR*                        pAccelerationStructure);
 typedef void (VKAPI_PTR *PFN_vkDestroyAccelerationStructureKHR)(VkDevice device, VkAccelerationStructureKHR accelerationStructure, const VkAllocationCallbacks* pAllocator);
@@ -21078,12 +21709,6 @@ typedef struct VkPhysicalDeviceRayTracingPipelinePropertiesKHR {
     uint32_t           shaderGroupHandleAlignment;
     uint32_t           maxRayHitAttributeSize;
 } VkPhysicalDeviceRayTracingPipelinePropertiesKHR;
-
-typedef struct VkStridedDeviceAddressRegionKHR {
-    VkDeviceAddress    deviceAddress;
-    VkDeviceSize       stride;
-    VkDeviceSize       size;
-} VkStridedDeviceAddressRegionKHR;
 
 typedef struct VkTraceRaysIndirectCommandKHR {
     uint32_t    width;

--- a/vendor/vulkan/_gen/vulkan_ios.h
+++ b/vendor/vulkan/_gen/vulkan_ios.h
@@ -2,7 +2,7 @@
 #define VULKAN_IOS_H_ 1
 
 /*
-** Copyright 2015-2024 The Khronos Group Inc.
+** Copyright 2015-2025 The Khronos Group Inc.
 **
 ** SPDX-License-Identifier: Apache-2.0
 */

--- a/vendor/vulkan/_gen/vulkan_macos.h
+++ b/vendor/vulkan/_gen/vulkan_macos.h
@@ -2,7 +2,7 @@
 #define VULKAN_MACOS_H_ 1
 
 /*
-** Copyright 2015-2024 The Khronos Group Inc.
+** Copyright 2015-2025 The Khronos Group Inc.
 **
 ** SPDX-License-Identifier: Apache-2.0
 */

--- a/vendor/vulkan/_gen/vulkan_metal.h
+++ b/vendor/vulkan/_gen/vulkan_metal.h
@@ -2,7 +2,7 @@
 #define VULKAN_METAL_H_ 1
 
 /*
-** Copyright 2015-2024 The Khronos Group Inc.
+** Copyright 2015-2025 The Khronos Group Inc.
 **
 ** SPDX-License-Identifier: Apache-2.0
 */
@@ -186,6 +186,47 @@ typedef void (VKAPI_PTR *PFN_vkExportMetalObjectsEXT)(VkDevice device, VkExportM
 VKAPI_ATTR void VKAPI_CALL vkExportMetalObjectsEXT(
     VkDevice                                    device,
     VkExportMetalObjectsInfoEXT*                pMetalObjectsInfo);
+#endif
+
+
+// VK_EXT_external_memory_metal is a preprocessor guard. Do not pass it to API calls.
+#define VK_EXT_external_memory_metal 1
+#define VK_EXT_EXTERNAL_MEMORY_METAL_SPEC_VERSION 1
+#define VK_EXT_EXTERNAL_MEMORY_METAL_EXTENSION_NAME "VK_EXT_external_memory_metal"
+typedef struct VkImportMemoryMetalHandleInfoEXT {
+    VkStructureType                       sType;
+    const void*                           pNext;
+    VkExternalMemoryHandleTypeFlagBits    handleType;
+    void*                                 handle;
+} VkImportMemoryMetalHandleInfoEXT;
+
+typedef struct VkMemoryMetalHandlePropertiesEXT {
+    VkStructureType    sType;
+    void*              pNext;
+    uint32_t           memoryTypeBits;
+} VkMemoryMetalHandlePropertiesEXT;
+
+typedef struct VkMemoryGetMetalHandleInfoEXT {
+    VkStructureType                       sType;
+    const void*                           pNext;
+    VkDeviceMemory                        memory;
+    VkExternalMemoryHandleTypeFlagBits    handleType;
+} VkMemoryGetMetalHandleInfoEXT;
+
+typedef VkResult (VKAPI_PTR *PFN_vkGetMemoryMetalHandleEXT)(VkDevice device, const VkMemoryGetMetalHandleInfoEXT* pGetMetalHandleInfo, void** pHandle);
+typedef VkResult (VKAPI_PTR *PFN_vkGetMemoryMetalHandlePropertiesEXT)(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, const void* pHandle, VkMemoryMetalHandlePropertiesEXT* pMemoryMetalHandleProperties);
+
+#ifndef VK_NO_PROTOTYPES
+VKAPI_ATTR VkResult VKAPI_CALL vkGetMemoryMetalHandleEXT(
+    VkDevice                                    device,
+    const VkMemoryGetMetalHandleInfoEXT*        pGetMetalHandleInfo,
+    void**                                      pHandle);
+
+VKAPI_ATTR VkResult VKAPI_CALL vkGetMemoryMetalHandlePropertiesEXT(
+    VkDevice                                    device,
+    VkExternalMemoryHandleTypeFlagBits          handleType,
+    const void*                                 pHandle,
+    VkMemoryMetalHandlePropertiesEXT*           pMemoryMetalHandleProperties);
 #endif
 
 #ifdef __cplusplus

--- a/vendor/vulkan/_gen/vulkan_video_codec_av1std.h
+++ b/vendor/vulkan/_gen/vulkan_video_codec_av1std.h
@@ -2,7 +2,7 @@
 #define VULKAN_VIDEO_CODEC_AV1STD_H_ 1
 
 /*
-** Copyright 2015-2024 The Khronos Group Inc.
+** Copyright 2015-2025 The Khronos Group Inc.
 **
 ** SPDX-License-Identifier: Apache-2.0
 */

--- a/vendor/vulkan/_gen/vulkan_video_codec_av1std_decode.h
+++ b/vendor/vulkan/_gen/vulkan_video_codec_av1std_decode.h
@@ -2,7 +2,7 @@
 #define VULKAN_VIDEO_CODEC_AV1STD_DECODE_H_ 1
 
 /*
-** Copyright 2015-2024 The Khronos Group Inc.
+** Copyright 2015-2025 The Khronos Group Inc.
 **
 ** SPDX-License-Identifier: Apache-2.0
 */

--- a/vendor/vulkan/_gen/vulkan_video_codec_av1std_encode.h
+++ b/vendor/vulkan/_gen/vulkan_video_codec_av1std_encode.h
@@ -2,7 +2,7 @@
 #define VULKAN_VIDEO_CODEC_AV1STD_ENCODE_H_ 1
 
 /*
-** Copyright 2015-2024 The Khronos Group Inc.
+** Copyright 2015-2025 The Khronos Group Inc.
 **
 ** SPDX-License-Identifier: Apache-2.0
 */

--- a/vendor/vulkan/_gen/vulkan_video_codec_h264std.h
+++ b/vendor/vulkan/_gen/vulkan_video_codec_h264std.h
@@ -2,7 +2,7 @@
 #define VULKAN_VIDEO_CODEC_H264STD_H_ 1
 
 /*
-** Copyright 2015-2024 The Khronos Group Inc.
+** Copyright 2015-2025 The Khronos Group Inc.
 **
 ** SPDX-License-Identifier: Apache-2.0
 */

--- a/vendor/vulkan/_gen/vulkan_video_codec_h264std_decode.h
+++ b/vendor/vulkan/_gen/vulkan_video_codec_h264std_decode.h
@@ -2,7 +2,7 @@
 #define VULKAN_VIDEO_CODEC_H264STD_DECODE_H_ 1
 
 /*
-** Copyright 2015-2024 The Khronos Group Inc.
+** Copyright 2015-2025 The Khronos Group Inc.
 **
 ** SPDX-License-Identifier: Apache-2.0
 */

--- a/vendor/vulkan/_gen/vulkan_video_codec_h264std_encode.h
+++ b/vendor/vulkan/_gen/vulkan_video_codec_h264std_encode.h
@@ -2,7 +2,7 @@
 #define VULKAN_VIDEO_CODEC_H264STD_ENCODE_H_ 1
 
 /*
-** Copyright 2015-2024 The Khronos Group Inc.
+** Copyright 2015-2025 The Khronos Group Inc.
 **
 ** SPDX-License-Identifier: Apache-2.0
 */

--- a/vendor/vulkan/_gen/vulkan_video_codec_h265std.h
+++ b/vendor/vulkan/_gen/vulkan_video_codec_h265std.h
@@ -2,7 +2,7 @@
 #define VULKAN_VIDEO_CODEC_H265STD_H_ 1
 
 /*
-** Copyright 2015-2024 The Khronos Group Inc.
+** Copyright 2015-2025 The Khronos Group Inc.
 **
 ** SPDX-License-Identifier: Apache-2.0
 */

--- a/vendor/vulkan/_gen/vulkan_video_codec_h265std_decode.h
+++ b/vendor/vulkan/_gen/vulkan_video_codec_h265std_decode.h
@@ -2,7 +2,7 @@
 #define VULKAN_VIDEO_CODEC_H265STD_DECODE_H_ 1
 
 /*
-** Copyright 2015-2024 The Khronos Group Inc.
+** Copyright 2015-2025 The Khronos Group Inc.
 **
 ** SPDX-License-Identifier: Apache-2.0
 */

--- a/vendor/vulkan/_gen/vulkan_video_codec_h265std_encode.h
+++ b/vendor/vulkan/_gen/vulkan_video_codec_h265std_encode.h
@@ -2,7 +2,7 @@
 #define VULKAN_VIDEO_CODEC_H265STD_ENCODE_H_ 1
 
 /*
-** Copyright 2015-2024 The Khronos Group Inc.
+** Copyright 2015-2025 The Khronos Group Inc.
 **
 ** SPDX-License-Identifier: Apache-2.0
 */

--- a/vendor/vulkan/_gen/vulkan_wayland.h
+++ b/vendor/vulkan/_gen/vulkan_wayland.h
@@ -2,7 +2,7 @@
 #define VULKAN_WAYLAND_H_ 1
 
 /*
-** Copyright 2015-2024 The Khronos Group Inc.
+** Copyright 2015-2025 The Khronos Group Inc.
 **
 ** SPDX-License-Identifier: Apache-2.0
 */

--- a/vendor/vulkan/_gen/vulkan_win32.h
+++ b/vendor/vulkan/_gen/vulkan_win32.h
@@ -2,7 +2,7 @@
 #define VULKAN_WIN32_H_ 1
 
 /*
-** Copyright 2015-2024 The Khronos Group Inc.
+** Copyright 2015-2025 The Khronos Group Inc.
 **
 ** SPDX-License-Identifier: Apache-2.0
 */

--- a/vendor/vulkan/_gen/vulkan_xcb.h
+++ b/vendor/vulkan/_gen/vulkan_xcb.h
@@ -2,7 +2,7 @@
 #define VULKAN_XCB_H_ 1
 
 /*
-** Copyright 2015-2024 The Khronos Group Inc.
+** Copyright 2015-2025 The Khronos Group Inc.
 **
 ** SPDX-License-Identifier: Apache-2.0
 */

--- a/vendor/vulkan/_gen/vulkan_xlib.h
+++ b/vendor/vulkan/_gen/vulkan_xlib.h
@@ -2,7 +2,7 @@
 #define VULKAN_XLIB_H_ 1
 
 /*
-** Copyright 2015-2024 The Khronos Group Inc.
+** Copyright 2015-2025 The Khronos Group Inc.
 **
 ** SPDX-License-Identifier: Apache-2.0
 */

--- a/vendor/vulkan/core.odin
+++ b/vendor/vulkan/core.odin
@@ -1194,6 +1194,15 @@ KHR_XLIB_SURFACE_EXTENSION_NAME                           :: "VK_KHR_xlib_surfac
 KHR_xcb_surface                                           :: 1
 KHR_XCB_SURFACE_SPEC_VERSION                              :: 6
 KHR_XCB_SURFACE_EXTENSION_NAME                            :: "VK_KHR_xcb_surface"
+KHR_portability_subset                                    :: 1
+KHR_PORTABILITY_SUBSET_SPEC_VERSION                       :: 1
+KHR_PORTABILITY_SUBSET_EXTENSION_NAME                     :: "VK_KHR_portability_subset"
+AMDX_shader_enqueue                                       :: 1
+AMDX_SHADER_ENQUEUE_SPEC_VERSION                          :: 2
+AMDX_SHADER_ENQUEUE_EXTENSION_NAME                        :: "VK_AMDX_shader_enqueue"
+NV_displacement_micromap                                  :: 1
+NV_DISPLACEMENT_MICROMAP_SPEC_VERSION                     :: 2
+NV_DISPLACEMENT_MICROMAP_EXTENSION_NAME                   :: "VK_NV_displacement_micromap"
 
 // Handles types
 Instance       :: distinct Handle

--- a/vendor/vulkan/core.odin
+++ b/vendor/vulkan/core.odin
@@ -71,7 +71,7 @@ VULKAN_VIDEO_CODEC_H265_ENCODE_SPEC_VERSION :: VULKAN_VIDEO_CODEC_H265_ENCODE_AP
 MAKE_VIDEO_STD_VERSION :: MAKE_VERSION
 
 // General Constants
-HEADER_VERSION       :: 303
+HEADER_VERSION       :: 309
 MAX_DRIVER_NAME_SIZE :: 256
 MAX_DRIVER_INFO_SIZE :: 256
 
@@ -481,6 +481,15 @@ KHR_SHADER_RELAXED_EXTENDED_INSTRUCTION_EXTENSION_NAME    :: "VK_KHR_shader_rela
 KHR_maintenance7                                          :: 1
 KHR_MAINTENANCE_7_SPEC_VERSION                            :: 1
 KHR_MAINTENANCE_7_EXTENSION_NAME                          :: "VK_KHR_maintenance7"
+KHR_maintenance8                                          :: 1
+KHR_MAINTENANCE_8_SPEC_VERSION                            :: 1
+KHR_MAINTENANCE_8_EXTENSION_NAME                          :: "VK_KHR_maintenance8"
+KHR_video_maintenance2                                    :: 1
+KHR_VIDEO_MAINTENANCE_2_SPEC_VERSION                      :: 1
+KHR_VIDEO_MAINTENANCE_2_EXTENSION_NAME                    :: "VK_KHR_video_maintenance2"
+KHR_depth_clamp_zero_one                                  :: 1
+KHR_DEPTH_CLAMP_ZERO_ONE_SPEC_VERSION                     :: 1
+KHR_DEPTH_CLAMP_ZERO_ONE_EXTENSION_NAME                   :: "VK_KHR_depth_clamp_zero_one"
 EXT_debug_report                                          :: 1
 EXT_DEBUG_REPORT_SPEC_VERSION                             :: 10
 EXT_DEBUG_REPORT_EXTENSION_NAME                           :: "VK_EXT_debug_report"
@@ -1008,6 +1017,9 @@ NV_MEMORY_DECOMPRESSION_EXTENSION_NAME                    :: "VK_NV_memory_decom
 NV_device_generated_commands_compute                      :: 1
 NV_DEVICE_GENERATED_COMMANDS_COMPUTE_SPEC_VERSION         :: 2
 NV_DEVICE_GENERATED_COMMANDS_COMPUTE_EXTENSION_NAME       :: "VK_NV_device_generated_commands_compute"
+NV_ray_tracing_linear_swept_spheres                       :: 1
+NV_RAY_TRACING_LINEAR_SWEPT_SPHERES_SPEC_VERSION          :: 1
+NV_RAY_TRACING_LINEAR_SWEPT_SPHERES_EXTENSION_NAME        :: "VK_NV_ray_tracing_linear_swept_spheres"
 NV_linear_color_attachment                                :: 1
 NV_LINEAR_COLOR_ATTACHMENT_SPEC_VERSION                   :: 1
 NV_LINEAR_COLOR_ATTACHMENT_EXTENSION_NAME                 :: "VK_NV_linear_color_attachment"
@@ -1053,6 +1065,9 @@ EXT_SHADER_OBJECT_EXTENSION_NAME                          :: "VK_EXT_shader_obje
 NV_ray_tracing_invocation_reorder                         :: 1
 NV_RAY_TRACING_INVOCATION_REORDER_SPEC_VERSION            :: 1
 NV_RAY_TRACING_INVOCATION_REORDER_EXTENSION_NAME          :: "VK_NV_ray_tracing_invocation_reorder"
+NV_cooperative_vector                                     :: 1
+NV_COOPERATIVE_VECTOR_SPEC_VERSION                        :: 4
+NV_COOPERATIVE_VECTOR_EXTENSION_NAME                      :: "VK_NV_cooperative_vector"
 NV_extended_sparse_address_space                          :: 1
 NV_EXTENDED_SPARSE_ADDRESS_SPACE_SPEC_VERSION             :: 1
 NV_EXTENDED_SPARSE_ADDRESS_SPACE_EXTENSION_NAME           :: "VK_NV_extended_sparse_address_space"
@@ -1101,6 +1116,12 @@ EXT_SHADER_REPLICATED_COMPOSITES_EXTENSION_NAME           :: "VK_EXT_shader_repl
 NV_ray_tracing_validation                                 :: 1
 NV_RAY_TRACING_VALIDATION_SPEC_VERSION                    :: 1
 NV_RAY_TRACING_VALIDATION_EXTENSION_NAME                  :: "VK_NV_ray_tracing_validation"
+NV_cluster_acceleration_structure                         :: 1
+NV_CLUSTER_ACCELERATION_STRUCTURE_SPEC_VERSION            :: 2
+NV_CLUSTER_ACCELERATION_STRUCTURE_EXTENSION_NAME          :: "VK_NV_cluster_acceleration_structure"
+NV_partitioned_acceleration_structure                     :: 1
+NV_PARTITIONED_ACCELERATION_STRUCTURE_SPEC_VERSION        :: 1
+NV_PARTITIONED_ACCELERATION_STRUCTURE_EXTENSION_NAME      :: "VK_NV_partitioned_acceleration_structure"
 EXT_device_generated_commands                             :: 1
 EXT_DEVICE_GENERATED_COMMANDS_SPEC_VERSION                :: 1
 EXT_DEVICE_GENERATED_COMMANDS_EXTENSION_NAME              :: "VK_EXT_device_generated_commands"
@@ -1113,6 +1134,9 @@ NV_COOPERATIVE_MATRIX_2_EXTENSION_NAME                    :: "VK_NV_cooperative_
 EXT_vertex_attribute_robustness                           :: 1
 EXT_VERTEX_ATTRIBUTE_ROBUSTNESS_SPEC_VERSION              :: 1
 EXT_VERTEX_ATTRIBUTE_ROBUSTNESS_EXTENSION_NAME            :: "VK_EXT_vertex_attribute_robustness"
+NV_present_metering                                       :: 1
+NV_PRESENT_METERING_SPEC_VERSION                          :: 1
+NV_PRESENT_METERING_EXTENSION_NAME                        :: "VK_NV_present_metering"
 KHR_acceleration_structure                                :: 1
 KHR_ACCELERATION_STRUCTURE_SPEC_VERSION                   :: 13
 KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME                 :: "VK_KHR_acceleration_structure"
@@ -1158,6 +1182,9 @@ EXT_METAL_SURFACE_EXTENSION_NAME                          :: "VK_EXT_metal_surfa
 EXT_metal_objects                                         :: 1
 EXT_METAL_OBJECTS_SPEC_VERSION                            :: 2
 EXT_METAL_OBJECTS_EXTENSION_NAME                          :: "VK_EXT_metal_objects"
+EXT_external_memory_metal                                 :: 1
+EXT_EXTERNAL_MEMORY_METAL_SPEC_VERSION                    :: 1
+EXT_EXTERNAL_MEMORY_METAL_EXTENSION_NAME                  :: "VK_EXT_external_memory_metal"
 KHR_wayland_surface                                       :: 1
 KHR_WAYLAND_SURFACE_SPEC_VERSION                          :: 6
 KHR_WAYLAND_SURFACE_EXTENSION_NAME                        :: "VK_KHR_wayland_surface"

--- a/vendor/vulkan/enums.odin
+++ b/vendor/vulkan/enums.odin
@@ -304,6 +304,55 @@ ChromaLocation :: enum c.int {
 	MIDPOINT_KHR     = MIDPOINT,
 }
 
+ClusterAccelerationStructureAddressResolutionFlagsNV :: distinct bit_set[ClusterAccelerationStructureAddressResolutionFlagNV; Flags]
+ClusterAccelerationStructureAddressResolutionFlagNV :: enum Flags {
+	INDIRECTED_DST_IMPLICIT_DATA = 0,
+	INDIRECTED_SCRATCH_DATA      = 1,
+	INDIRECTED_DST_ADDRESS_ARRAY = 2,
+	INDIRECTED_DST_SIZES_ARRAY   = 3,
+	INDIRECTED_SRC_INFOS_ARRAY   = 4,
+	INDIRECTED_SRC_INFOS_COUNT   = 5,
+}
+
+ClusterAccelerationStructureClusterFlagsNV :: distinct bit_set[ClusterAccelerationStructureClusterFlagNV; Flags]
+ClusterAccelerationStructureClusterFlagNV :: enum Flags {
+	ALLOW_DISABLE_OPACITY_MICROMAPS = 0,
+}
+
+ClusterAccelerationStructureGeometryFlagsNV :: distinct bit_set[ClusterAccelerationStructureGeometryFlagNV; Flags]
+ClusterAccelerationStructureGeometryFlagNV :: enum Flags {
+	CULL_DISABLE                   = 0,
+	NO_DUPLICATE_ANYHIT_INVOCATION = 1,
+	OPAQUE                         = 2,
+}
+
+ClusterAccelerationStructureIndexFormatFlagsNV :: distinct bit_set[ClusterAccelerationStructureIndexFormatFlagNV; Flags]
+ClusterAccelerationStructureIndexFormatFlagNV :: enum Flags {
+	_8BIT  = 0,
+	_16BIT = 1,
+	_32BIT = 2,
+}
+
+ClusterAccelerationStructureOpModeNV :: enum c.int {
+	IMPLICIT_DESTINATIONS = 0,
+	EXPLICIT_DESTINATIONS = 1,
+	COMPUTE_SIZES         = 2,
+}
+
+ClusterAccelerationStructureOpTypeNV :: enum c.int {
+	MOVE_OBJECTS                    = 0,
+	BUILD_CLUSTERS_BOTTOM_LEVEL     = 1,
+	BUILD_TRIANGLE_CLUSTER          = 2,
+	BUILD_TRIANGLE_CLUSTER_TEMPLATE = 3,
+	INSTANTIATE_TRIANGLE_CLUSTER    = 4,
+}
+
+ClusterAccelerationStructureTypeNV :: enum c.int {
+	CLUSTERS_BOTTOM_LEVEL     = 0,
+	TRIANGLE_CLUSTER          = 1,
+	TRIANGLE_CLUSTER_TEMPLATE = 2,
+}
+
 CoarseSampleOrderTypeNV :: enum c.int {
 	DEFAULT      = 0,
 	CUSTOM       = 1,
@@ -391,28 +440,32 @@ ComponentSwizzle :: enum c.int {
 }
 
 ComponentTypeKHR :: enum c.int {
-	FLOAT16    = 0,
-	FLOAT32    = 1,
-	FLOAT64    = 2,
-	SINT8      = 3,
-	SINT16     = 4,
-	SINT32     = 5,
-	SINT64     = 6,
-	UINT8      = 7,
-	UINT16     = 8,
-	UINT32     = 9,
-	UINT64     = 10,
-	FLOAT16_NV = FLOAT16,
-	FLOAT32_NV = FLOAT32,
-	FLOAT64_NV = FLOAT64,
-	SINT8_NV   = SINT8,
-	SINT16_NV  = SINT16,
-	SINT32_NV  = SINT32,
-	SINT64_NV  = SINT64,
-	UINT8_NV   = UINT8,
-	UINT16_NV  = UINT16,
-	UINT32_NV  = UINT32,
-	UINT64_NV  = UINT64,
+	FLOAT16         = 0,
+	FLOAT32         = 1,
+	FLOAT64         = 2,
+	SINT8           = 3,
+	SINT16          = 4,
+	SINT32          = 5,
+	SINT64          = 6,
+	UINT8           = 7,
+	UINT16          = 8,
+	UINT32          = 9,
+	UINT64          = 10,
+	SINT8_PACKED_NV = 1000491000,
+	UINT8_PACKED_NV = 1000491001,
+	FLOAT_E4M3_NV   = 1000491002,
+	FLOAT_E5M2_NV   = 1000491003,
+	FLOAT16_NV      = FLOAT16,
+	FLOAT32_NV      = FLOAT32,
+	FLOAT64_NV      = FLOAT64,
+	SINT8_NV        = SINT8,
+	SINT16_NV       = SINT16,
+	SINT32_NV       = SINT32,
+	SINT64_NV       = SINT64,
+	UINT8_NV        = UINT8,
+	UINT16_NV       = UINT16,
+	UINT32_NV       = UINT32,
+	UINT64_NV       = UINT64,
 }
 
 CompositeAlphaFlagsKHR :: distinct bit_set[CompositeAlphaFlagKHR; Flags]
@@ -432,6 +485,13 @@ ConservativeRasterizationModeEXT :: enum c.int {
 	DISABLED      = 0,
 	OVERESTIMATE  = 1,
 	UNDERESTIMATE = 2,
+}
+
+CooperativeVectorMatrixLayoutNV :: enum c.int {
+	ROW_MAJOR           = 0,
+	COLUMN_MAJOR        = 1,
+	INFERENCING_OPTIMAL = 2,
+	TRAINING_OPTIMAL    = 3,
 }
 
 CopyAccelerationStructureModeKHR :: enum c.int {
@@ -554,12 +614,13 @@ DebugUtilsMessageTypeFlagEXT :: enum Flags {
 
 DependencyFlags :: distinct bit_set[DependencyFlag; Flags]
 DependencyFlag :: enum Flags {
-	BY_REGION         = 0,
-	DEVICE_GROUP      = 2,
-	VIEW_LOCAL        = 1,
-	FEEDBACK_LOOP_EXT = 3,
-	VIEW_LOCAL_KHR    = VIEW_LOCAL,
-	DEVICE_GROUP_KHR  = DEVICE_GROUP,
+	BY_REGION                                          = 0,
+	DEVICE_GROUP                                       = 2,
+	VIEW_LOCAL                                         = 1,
+	FEEDBACK_LOOP_EXT                                  = 3,
+	QUEUE_FAMILY_OWNERSHIP_TRANSFER_USE_ALL_STAGES_KHR = 5,
+	VIEW_LOCAL_KHR                                     = VIEW_LOCAL,
+	DEVICE_GROUP_KHR                                   = DEVICE_GROUP,
 }
 
 DepthBiasRepresentationEXT :: enum c.int {
@@ -611,25 +672,26 @@ DescriptorSetLayoutCreateFlag :: enum Flags {
 }
 
 DescriptorType :: enum c.int {
-	SAMPLER                    = 0,
-	COMBINED_IMAGE_SAMPLER     = 1,
-	SAMPLED_IMAGE              = 2,
-	STORAGE_IMAGE              = 3,
-	UNIFORM_TEXEL_BUFFER       = 4,
-	STORAGE_TEXEL_BUFFER       = 5,
-	UNIFORM_BUFFER             = 6,
-	STORAGE_BUFFER             = 7,
-	UNIFORM_BUFFER_DYNAMIC     = 8,
-	STORAGE_BUFFER_DYNAMIC     = 9,
-	INPUT_ATTACHMENT           = 10,
-	INLINE_UNIFORM_BLOCK       = 1000138000,
-	ACCELERATION_STRUCTURE_KHR = 1000150000,
-	ACCELERATION_STRUCTURE_NV  = 1000165000,
-	SAMPLE_WEIGHT_IMAGE_QCOM   = 1000440000,
-	BLOCK_MATCH_IMAGE_QCOM     = 1000440001,
-	MUTABLE_EXT                = 1000351000,
-	INLINE_UNIFORM_BLOCK_EXT   = INLINE_UNIFORM_BLOCK,
-	MUTABLE_VALVE              = MUTABLE_EXT,
+	SAMPLER                               = 0,
+	COMBINED_IMAGE_SAMPLER                = 1,
+	SAMPLED_IMAGE                         = 2,
+	STORAGE_IMAGE                         = 3,
+	UNIFORM_TEXEL_BUFFER                  = 4,
+	STORAGE_TEXEL_BUFFER                  = 5,
+	UNIFORM_BUFFER                        = 6,
+	STORAGE_BUFFER                        = 7,
+	UNIFORM_BUFFER_DYNAMIC                = 8,
+	STORAGE_BUFFER_DYNAMIC                = 9,
+	INPUT_ATTACHMENT                      = 10,
+	INLINE_UNIFORM_BLOCK                  = 1000138000,
+	ACCELERATION_STRUCTURE_KHR            = 1000150000,
+	ACCELERATION_STRUCTURE_NV             = 1000165000,
+	SAMPLE_WEIGHT_IMAGE_QCOM              = 1000440000,
+	BLOCK_MATCH_IMAGE_QCOM                = 1000440001,
+	MUTABLE_EXT                           = 1000351000,
+	PARTITIONED_ACCELERATION_STRUCTURE_NV = 1000570000,
+	INLINE_UNIFORM_BLOCK_EXT              = INLINE_UNIFORM_BLOCK,
+	MUTABLE_VALVE                         = MUTABLE_EXT,
 }
 
 DescriptorUpdateTemplateType :: enum c.int {
@@ -758,7 +820,7 @@ DriverId :: enum c.int {
 	MESA_NVK                      = 24,
 	IMAGINATION_OPEN_SOURCE_MESA  = 25,
 	MESA_HONEYKRISP               = 26,
-	RESERVED_27                   = 27,
+	VULKAN_SC_EMULATION_ON_VULKAN = 27,
 	AMD_PROPRIETARY_KHR           = AMD_PROPRIETARY,
 	AMD_OPEN_SOURCE_KHR           = AMD_OPEN_SOURCE,
 	MESA_RADV_KHR                 = MESA_RADV,
@@ -935,6 +997,9 @@ ExternalMemoryHandleTypeFlag :: enum Flags {
 	ZIRCON_VMO_FUCHSIA              = 11,
 	RDMA_ADDRESS_NV                 = 12,
 	SCREEN_BUFFER_QNX               = 14,
+	MTLBUFFER_EXT                   = 16,
+	MTLTEXTURE_EXT                  = 17,
+	MTLHEAP_EXT                     = 18,
 	OPAQUE_FD_KHR                   = OPAQUE_FD,
 	OPAQUE_WIN32_KHR                = OPAQUE_WIN32,
 	OPAQUE_WIN32_KMT_KHR            = OPAQUE_WIN32_KMT,
@@ -1425,11 +1490,13 @@ GeometryInstanceFlagKHR :: enum Flags {
 }
 
 GeometryTypeKHR :: enum c.int {
-	TRIANGLES    = 0,
-	AABBS        = 1,
-	INSTANCES    = 2,
-	TRIANGLES_NV = TRIANGLES,
-	AABBS_NV     = AABBS,
+	TRIANGLES               = 0,
+	AABBS                   = 1,
+	INSTANCES               = 2,
+	SPHERES_NV              = 1000429004,
+	LINEAR_SWEPT_SPHERES_NV = 1000429005,
+	TRIANGLES_NV            = TRIANGLES,
+	AABBS_NV                = AABBS,
 }
 
 GraphicsPipelineLibraryFlagsEXT :: distinct bit_set[GraphicsPipelineLibraryFlagEXT; Flags]
@@ -1906,10 +1973,11 @@ OpacityMicromapFormatEXT :: enum c.int {
 }
 
 OpacityMicromapSpecialIndexEXT :: enum c.int {
-	FULLY_TRANSPARENT         = -1,
-	FULLY_OPAQUE              = -2,
-	FULLY_UNKNOWN_TRANSPARENT = -3,
-	FULLY_UNKNOWN_OPAQUE      = -4,
+	FULLY_TRANSPARENT                            = -1,
+	FULLY_OPAQUE                                 = -2,
+	FULLY_UNKNOWN_TRANSPARENT                    = -3,
+	FULLY_UNKNOWN_OPAQUE                         = -4,
+	CLUSTER_GEOMETRY_DISABLE_OPACITY_MICROMAP_NV = -5,
 }
 
 OpticalFlowExecuteFlagsNV :: distinct bit_set[OpticalFlowExecuteFlagNV; Flags]
@@ -1971,6 +2039,21 @@ OpticalFlowUsageFlagsNV_UNKNOWN :: OpticalFlowUsageFlagsNV{}
 OutOfBandQueueTypeNV :: enum c.int {
 	RENDER  = 0,
 	PRESENT = 1,
+}
+
+PartitionedAccelerationStructureInstanceFlagsNV :: distinct bit_set[PartitionedAccelerationStructureInstanceFlagNV; Flags]
+PartitionedAccelerationStructureInstanceFlagNV :: enum Flags {
+	FLAG_TRIANGLE_FACING_CULL_DISABLE = 0,
+	FLAG_TRIANGLE_FLIP_FACING         = 1,
+	FLAG_FORCE_OPAQUE                 = 2,
+	FLAG_FORCE_NO_OPAQUE              = 3,
+	FLAG_ENABLE_EXPLICIT_BOUNDING_BOX = 4,
+}
+
+PartitionedAccelerationStructureOpTypeNV :: enum c.int {
+	WRITE_INSTANCE              = 0,
+	UPDATE_INSTANCE             = 1,
+	WRITE_PARTITION_TRANSLATION = 2,
 }
 
 PeerMemoryFeatureFlags :: distinct bit_set[PeerMemoryFeatureFlag; Flags]
@@ -2072,8 +2155,9 @@ PipelineBindPoint :: enum c.int {
 
 PipelineCacheCreateFlags :: distinct bit_set[PipelineCacheCreateFlag; Flags]
 PipelineCacheCreateFlag :: enum Flags {
-	EXTERNALLY_SYNCHRONIZED     = 0,
-	EXTERNALLY_SYNCHRONIZED_EXT = EXTERNALLY_SYNCHRONIZED,
+	EXTERNALLY_SYNCHRONIZED           = 0,
+	INTERNALLY_SYNCHRONIZED_MERGE_KHR = 3,
+	EXTERNALLY_SYNCHRONIZED_EXT       = EXTERNALLY_SYNCHRONIZED,
 }
 
 PipelineCacheHeaderVersion :: enum c.int {
@@ -2387,6 +2471,16 @@ RasterizationOrderAMD :: enum c.int {
 RayTracingInvocationReorderModeNV :: enum c.int {
 	NONE    = 0,
 	REORDER = 1,
+}
+
+RayTracingLssIndexingModeNV :: enum c.int {
+	LIST       = 0,
+	SUCCESSIVE = 1,
+}
+
+RayTracingLssPrimitiveEndCapsModeNV :: enum c.int {
+	NONE    = 0,
+	CHAINED = 1,
 }
 
 RayTracingShaderGroupTypeKHR :: enum c.int {
@@ -3498,7 +3592,6 @@ StructureType :: enum c.int {
 	PHYSICAL_DEVICE_DESCRIPTOR_SET_HOST_MAPPING_FEATURES_VALVE          = 1000420000,
 	DESCRIPTOR_SET_BINDING_REFERENCE_VALVE                              = 1000420001,
 	DESCRIPTOR_SET_LAYOUT_HOST_MAPPING_INFO_VALVE                       = 1000420002,
-	PHYSICAL_DEVICE_DEPTH_CLAMP_ZERO_ONE_FEATURES_EXT                   = 1000421000,
 	PHYSICAL_DEVICE_NON_SEAMLESS_CUBE_MAP_FEATURES_EXT                  = 1000422000,
 	PHYSICAL_DEVICE_RENDER_PASS_STRIPED_FEATURES_ARM                    = 1000424000,
 	PHYSICAL_DEVICE_RENDER_PASS_STRIPED_PROPERTIES_ARM                  = 1000424001,
@@ -3515,6 +3608,9 @@ StructureType :: enum c.int {
 	PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_COMPUTE_FEATURES_NV       = 1000428000,
 	COMPUTE_PIPELINE_INDIRECT_BUFFER_INFO_NV                            = 1000428001,
 	PIPELINE_INDIRECT_DEVICE_ADDRESS_INFO_NV                            = 1000428002,
+	PHYSICAL_DEVICE_RAY_TRACING_LINEAR_SWEPT_SPHERES_FEATURES_NV        = 1000429008,
+	ACCELERATION_STRUCTURE_GEOMETRY_LINEAR_SWEPT_SPHERES_DATA_NV        = 1000429009,
+	ACCELERATION_STRUCTURE_GEOMETRY_SPHERES_DATA_NV                     = 1000429010,
 	PHYSICAL_DEVICE_LINEAR_COLOR_ATTACHMENT_FEATURES_NV                 = 1000430000,
 	PHYSICAL_DEVICE_SHADER_MAXIMAL_RECONVERGENCE_FEATURES_KHR           = 1000434000,
 	PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_FEATURES_EXT    = 1000437000,
@@ -3572,6 +3668,10 @@ StructureType :: enum c.int {
 	PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_VIEWPORTS_FEATURES_QCOM          = 1000488000,
 	PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_FEATURES_NV          = 1000490000,
 	PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_PROPERTIES_NV        = 1000490001,
+	PHYSICAL_DEVICE_COOPERATIVE_VECTOR_FEATURES_NV                      = 1000491000,
+	PHYSICAL_DEVICE_COOPERATIVE_VECTOR_PROPERTIES_NV                    = 1000491001,
+	COOPERATIVE_VECTOR_PROPERTIES_NV                                    = 1000491002,
+	CONVERT_COOPERATIVE_VECTOR_MATRIX_INFO_NV                           = 1000491004,
 	PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_FEATURES_NV           = 1000492000,
 	PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_PROPERTIES_NV         = 1000492001,
 	PHYSICAL_DEVICE_MUTABLE_DESCRIPTOR_TYPE_FEATURES_EXT                = 1000351000,
@@ -3661,6 +3761,20 @@ StructureType :: enum c.int {
 	PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT16_VECTOR_FEATURES_NV            = 1000563000,
 	PHYSICAL_DEVICE_SHADER_REPLICATED_COMPOSITES_FEATURES_EXT           = 1000564000,
 	PHYSICAL_DEVICE_RAY_TRACING_VALIDATION_FEATURES_NV                  = 1000568000,
+	PHYSICAL_DEVICE_CLUSTER_ACCELERATION_STRUCTURE_FEATURES_NV          = 1000569000,
+	PHYSICAL_DEVICE_CLUSTER_ACCELERATION_STRUCTURE_PROPERTIES_NV        = 1000569001,
+	CLUSTER_ACCELERATION_STRUCTURE_CLUSTERS_BOTTOM_LEVEL_INPUT_NV       = 1000569002,
+	CLUSTER_ACCELERATION_STRUCTURE_TRIANGLE_CLUSTER_INPUT_NV            = 1000569003,
+	CLUSTER_ACCELERATION_STRUCTURE_MOVE_OBJECTS_INPUT_NV                = 1000569004,
+	CLUSTER_ACCELERATION_STRUCTURE_INPUT_INFO_NV                        = 1000569005,
+	CLUSTER_ACCELERATION_STRUCTURE_COMMANDS_INFO_NV                     = 1000569006,
+	RAY_TRACING_PIPELINE_CLUSTER_ACCELERATION_STRUCTURE_CREATE_INFO_NV  = 1000569007,
+	PHYSICAL_DEVICE_PARTITIONED_ACCELERATION_STRUCTURE_FEATURES_NV      = 1000570000,
+	PHYSICAL_DEVICE_PARTITIONED_ACCELERATION_STRUCTURE_PROPERTIES_NV    = 1000570001,
+	WRITE_DESCRIPTOR_SET_PARTITIONED_ACCELERATION_STRUCTURE_NV          = 1000570002,
+	PARTITIONED_ACCELERATION_STRUCTURE_INSTANCES_INPUT_NV               = 1000570003,
+	BUILD_PARTITIONED_ACCELERATION_STRUCTURE_INFO_NV                    = 1000570004,
+	PARTITIONED_ACCELERATION_STRUCTURE_FLAGS_NV                         = 1000570005,
 	PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_EXT              = 1000572000,
 	PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_PROPERTIES_EXT            = 1000572001,
 	GENERATED_COMMANDS_MEMORY_REQUIREMENTS_INFO_EXT                     = 1000572002,
@@ -3675,17 +3789,30 @@ StructureType :: enum c.int {
 	INDIRECT_EXECUTION_SET_SHADER_LAYOUT_INFO_EXT                       = 1000572012,
 	GENERATED_COMMANDS_PIPELINE_INFO_EXT                                = 1000572013,
 	GENERATED_COMMANDS_SHADER_INFO_EXT                                  = 1000572014,
+	PHYSICAL_DEVICE_MAINTENANCE_8_FEATURES_KHR                          = 1000574000,
+	MEMORY_BARRIER_ACCESS_FLAGS_3_KHR                                   = 1000574002,
 	PHYSICAL_DEVICE_IMAGE_ALIGNMENT_CONTROL_FEATURES_MESA               = 1000575000,
 	PHYSICAL_DEVICE_IMAGE_ALIGNMENT_CONTROL_PROPERTIES_MESA             = 1000575001,
 	IMAGE_ALIGNMENT_CONTROL_CREATE_INFO_MESA                            = 1000575002,
 	PHYSICAL_DEVICE_DEPTH_CLAMP_CONTROL_FEATURES_EXT                    = 1000582000,
 	PIPELINE_VIEWPORT_DEPTH_CLAMP_CONTROL_CREATE_INFO_EXT               = 1000582001,
+	PHYSICAL_DEVICE_VIDEO_MAINTENANCE_2_FEATURES_KHR                    = 1000586000,
+	VIDEO_DECODE_H264_INLINE_SESSION_PARAMETERS_INFO_KHR                = 1000586001,
+	VIDEO_DECODE_H265_INLINE_SESSION_PARAMETERS_INFO_KHR                = 1000586002,
+	VIDEO_DECODE_AV1_INLINE_SESSION_PARAMETERS_INFO_KHR                 = 1000586003,
 	PHYSICAL_DEVICE_HDR_VIVID_FEATURES_HUAWEI                           = 1000590000,
 	HDR_VIVID_DYNAMIC_METADATA_HUAWEI                                   = 1000590001,
 	PHYSICAL_DEVICE_COOPERATIVE_MATRIX_2_FEATURES_NV                    = 1000593000,
 	COOPERATIVE_MATRIX_FLEXIBLE_DIMENSIONS_PROPERTIES_NV                = 1000593001,
 	PHYSICAL_DEVICE_COOPERATIVE_MATRIX_2_PROPERTIES_NV                  = 1000593002,
+	PHYSICAL_DEVICE_PIPELINE_OPACITY_MICROMAP_FEATURES_ARM              = 1000596000,
+	IMPORT_MEMORY_METAL_HANDLE_INFO_EXT                                 = 1000602000,
+	MEMORY_METAL_HANDLE_PROPERTIES_EXT                                  = 1000602001,
+	MEMORY_GET_METAL_HANDLE_INFO_EXT                                    = 1000602002,
+	PHYSICAL_DEVICE_DEPTH_CLAMP_ZERO_ONE_FEATURES_KHR                   = 1000421000,
 	PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_ROBUSTNESS_FEATURES_EXT            = 1000608000,
+	SET_PRESENT_CONFIG_NV                                               = 1000613000,
+	PHYSICAL_DEVICE_PRESENT_METERING_FEATURES_NV                        = 1000613001,
 	PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES                           = PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES,
 	PHYSICAL_DEVICE_SHADER_DRAW_PARAMETER_FEATURES                      = PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES,
 	DEBUG_REPORT_CREATE_INFO_EXT                                        = DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT,
@@ -3892,6 +4019,7 @@ StructureType :: enum c.int {
 	DEVICE_BUFFER_MEMORY_REQUIREMENTS_KHR                               = DEVICE_BUFFER_MEMORY_REQUIREMENTS,
 	DEVICE_IMAGE_MEMORY_REQUIREMENTS_KHR                                = DEVICE_IMAGE_MEMORY_REQUIREMENTS,
 	PHYSICAL_DEVICE_SHADER_SUBGROUP_ROTATE_FEATURES_KHR                 = PHYSICAL_DEVICE_SHADER_SUBGROUP_ROTATE_FEATURES,
+	PHYSICAL_DEVICE_DEPTH_CLAMP_ZERO_ONE_FEATURES_EXT                   = PHYSICAL_DEVICE_DEPTH_CLAMP_ZERO_ONE_FEATURES_KHR,
 	PHYSICAL_DEVICE_PIPELINE_PROTECTED_ACCESS_FEATURES_EXT              = PHYSICAL_DEVICE_PIPELINE_PROTECTED_ACCESS_FEATURES,
 	PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR                          = PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES,
 	PHYSICAL_DEVICE_MAINTENANCE_5_PROPERTIES_KHR                        = PHYSICAL_DEVICE_MAINTENANCE_5_PROPERTIES,
@@ -4481,6 +4609,7 @@ VideoSessionCreateFlagKHR :: enum Flags {
 	INLINE_QUERIES                       = 2,
 	ALLOW_ENCODE_QUANTIZATION_DELTA_MAP  = 3,
 	ALLOW_ENCODE_EMPHASIS_MAP            = 4,
+	INLINE_SESSION_PARAMETERS            = 5,
 }
 
 VideoSessionParametersCreateFlagsKHR :: distinct bit_set[VideoSessionParametersCreateFlagKHR; Flags]
@@ -4767,6 +4896,7 @@ FormatFeatureFlag2 :: enum Flags64 {
 	SAMPLED_IMAGE_DEPTH_COMPARISON_KHR                                          = 33,
 	SAMPLED_IMAGE_FILTER_MINMAX_KHR                                             = 16,
 	SAMPLED_IMAGE_FILTER_CUBIC_EXT                                              = 13,
+	ACCELERATION_STRUCTURE_RADIUS_BUFFER_NV                                     = 51,
 	LINEAR_COLOR_ATTACHMENT_NV                                                  = 38,
 	WEIGHT_IMAGE_QCOM                                                           = 34,
 	WEIGHT_SAMPLED_IMAGE_QCOM                                                   = 35,
@@ -4781,50 +4911,53 @@ FormatFeatureFlag2 :: enum Flags64 {
 
 PipelineCreateFlags2 :: distinct bit_set[PipelineCreateFlag2; Flags64]
 PipelineCreateFlag2 :: enum Flags64 {
-	DISABLE_OPTIMIZATION                               = 0,
-	ALLOW_DERIVATIVES                                  = 1,
-	DERIVATIVE                                         = 2,
-	VIEW_INDEX_FROM_DEVICE_INDEX                       = 3,
-	DISPATCH_BASE                                      = 4,
-	FAIL_ON_PIPELINE_COMPILE_REQUIRED                  = 8,
-	EARLY_RETURN_ON_FAILURE                            = 9,
-	NO_PROTECTED_ACCESS                                = 27,
-	PROTECTED_ACCESS_ONLY                              = 30,
-	EXECUTION_GRAPH_AMDX                               = 32,
-	ENABLE_LEGACY_DITHERING_EXT                        = 34,
-	DISABLE_OPTIMIZATION_KHR                           = 0,
-	ALLOW_DERIVATIVES_KHR                              = 1,
-	DERIVATIVE_KHR                                     = 2,
-	VIEW_INDEX_FROM_DEVICE_INDEX_KHR                   = 3,
-	DISPATCH_BASE_KHR                                  = 4,
-	DEFER_COMPILE_NV                                   = 5,
-	CAPTURE_STATISTICS_KHR                             = 6,
-	CAPTURE_INTERNAL_REPRESENTATIONS_KHR               = 7,
-	FAIL_ON_PIPELINE_COMPILE_REQUIRED_KHR              = 8,
-	EARLY_RETURN_ON_FAILURE_KHR                        = 9,
-	LINK_TIME_OPTIMIZATION_EXT                         = 10,
-	RETAIN_LINK_TIME_OPTIMIZATION_INFO_EXT             = 23,
-	LIBRARY_KHR                                        = 11,
-	RAY_TRACING_SKIP_TRIANGLES_KHR                     = 12,
-	RAY_TRACING_SKIP_AABBS_KHR                         = 13,
-	RAY_TRACING_NO_NULL_ANY_HIT_SHADERS_KHR            = 14,
-	RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_KHR        = 15,
-	RAY_TRACING_NO_NULL_MISS_SHADERS_KHR               = 16,
-	RAY_TRACING_NO_NULL_INTERSECTION_SHADERS_KHR       = 17,
-	RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_KHR = 19,
-	INDIRECT_BINDABLE_NV                               = 18,
-	RAY_TRACING_ALLOW_MOTION_NV                        = 20,
-	RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_KHR     = 21,
-	RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_EXT      = 22,
-	RAY_TRACING_OPACITY_MICROMAP_EXT                   = 24,
-	COLOR_ATTACHMENT_FEEDBACK_LOOP_EXT                 = 25,
-	DEPTH_STENCIL_ATTACHMENT_FEEDBACK_LOOP_EXT         = 26,
-	NO_PROTECTED_ACCESS_EXT                            = 27,
-	PROTECTED_ACCESS_ONLY_EXT                          = 30,
-	RAY_TRACING_DISPLACEMENT_MICROMAP_NV               = 28,
-	DESCRIPTOR_BUFFER_EXT                              = 29,
-	CAPTURE_DATA_KHR                                   = 31,
-	INDIRECT_BINDABLE_EXT                              = 38,
+	DISABLE_OPTIMIZATION                                  = 0,
+	ALLOW_DERIVATIVES                                     = 1,
+	DERIVATIVE                                            = 2,
+	VIEW_INDEX_FROM_DEVICE_INDEX                          = 3,
+	DISPATCH_BASE                                         = 4,
+	FAIL_ON_PIPELINE_COMPILE_REQUIRED                     = 8,
+	EARLY_RETURN_ON_FAILURE                               = 9,
+	NO_PROTECTED_ACCESS                                   = 27,
+	PROTECTED_ACCESS_ONLY                                 = 30,
+	EXECUTION_GRAPH_AMDX                                  = 32,
+	RAY_TRACING_SKIP_BUILT_IN_PRIMITIVES_KHR              = 12,
+	RAY_TRACING_ALLOW_SPHERES_AND_LINEAR_SWEPT_SPHERES_NV = 33,
+	ENABLE_LEGACY_DITHERING_EXT                           = 34,
+	DISABLE_OPTIMIZATION_KHR                              = 0,
+	ALLOW_DERIVATIVES_KHR                                 = 1,
+	DERIVATIVE_KHR                                        = 2,
+	VIEW_INDEX_FROM_DEVICE_INDEX_KHR                      = 3,
+	DISPATCH_BASE_KHR                                     = 4,
+	DEFER_COMPILE_NV                                      = 5,
+	CAPTURE_STATISTICS_KHR                                = 6,
+	CAPTURE_INTERNAL_REPRESENTATIONS_KHR                  = 7,
+	FAIL_ON_PIPELINE_COMPILE_REQUIRED_KHR                 = 8,
+	EARLY_RETURN_ON_FAILURE_KHR                           = 9,
+	LINK_TIME_OPTIMIZATION_EXT                            = 10,
+	RETAIN_LINK_TIME_OPTIMIZATION_INFO_EXT                = 23,
+	LIBRARY_KHR                                           = 11,
+	RAY_TRACING_SKIP_TRIANGLES_KHR                        = 12,
+	RAY_TRACING_SKIP_AABBS_KHR                            = 13,
+	RAY_TRACING_NO_NULL_ANY_HIT_SHADERS_KHR               = 14,
+	RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_KHR           = 15,
+	RAY_TRACING_NO_NULL_MISS_SHADERS_KHR                  = 16,
+	RAY_TRACING_NO_NULL_INTERSECTION_SHADERS_KHR          = 17,
+	RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_KHR    = 19,
+	INDIRECT_BINDABLE_NV                                  = 18,
+	RAY_TRACING_ALLOW_MOTION_NV                           = 20,
+	RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_KHR        = 21,
+	RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_EXT         = 22,
+	RAY_TRACING_OPACITY_MICROMAP_EXT                      = 24,
+	COLOR_ATTACHMENT_FEEDBACK_LOOP_EXT                    = 25,
+	DEPTH_STENCIL_ATTACHMENT_FEEDBACK_LOOP_EXT            = 26,
+	NO_PROTECTED_ACCESS_EXT                               = 27,
+	PROTECTED_ACCESS_ONLY_EXT                             = 30,
+	RAY_TRACING_DISPLACEMENT_MICROMAP_NV                  = 28,
+	DESCRIPTOR_BUFFER_EXT                                 = 29,
+	DISALLOW_OPACITY_MICROMAP_ARM                         = 37,
+	CAPTURE_DATA_KHR                                      = 31,
+	INDIRECT_BINDABLE_EXT                                 = 38,
 }
 
 PipelineStageFlags2 :: distinct bit_set[PipelineStageFlag2; Flags64]
@@ -4903,6 +5036,7 @@ PipelineStageFlag2 :: enum Flags64 {
 	MICROMAP_BUILD_EXT                   = 30,
 	CLUSTER_CULLING_SHADER_HUAWEI        = 41,
 	OPTICAL_FLOW_NV                      = 29,
+	CONVERT_COOPERATIVE_VECTOR_MATRIX_NV = 44,
 }
 
 

--- a/vendor/vulkan/enums.odin
+++ b/vendor/vulkan/enums.odin
@@ -768,6 +768,12 @@ DiscardRectangleModeEXT :: enum c.int {
 	EXCLUSIVE = 1,
 }
 
+DisplacementMicromapFormatNV :: enum c.int {
+	_64_TRIANGLES_64_BYTES    = 1,
+	_256_TRIANGLES_128_BYTES  = 2,
+	_1024_TRIANGLES_128_BYTES = 3,
+}
+
 DisplayEventTypeEXT :: enum c.int {
 	FIRST_PIXEL_OUT = 0,
 }

--- a/vendor/vulkan/procedures.odin
+++ b/vendor/vulkan/procedures.odin
@@ -220,6 +220,9 @@ ProcCmdDecompressMemoryNV                                  :: #type proc "system
 ProcCmdDispatch                                            :: #type proc "system" (commandBuffer: CommandBuffer, groupCountX: u32, groupCountY: u32, groupCountZ: u32)
 ProcCmdDispatchBase                                        :: #type proc "system" (commandBuffer: CommandBuffer, baseGroupX: u32, baseGroupY: u32, baseGroupZ: u32, groupCountX: u32, groupCountY: u32, groupCountZ: u32)
 ProcCmdDispatchBaseKHR                                     :: #type proc "system" (commandBuffer: CommandBuffer, baseGroupX: u32, baseGroupY: u32, baseGroupZ: u32, groupCountX: u32, groupCountY: u32, groupCountZ: u32)
+ProcCmdDispatchGraphAMDX                                   :: #type proc "system" (commandBuffer: CommandBuffer, scratch: DeviceAddress, scratchSize: DeviceSize, pCountInfo: ^DispatchGraphCountInfoAMDX)
+ProcCmdDispatchGraphIndirectAMDX                           :: #type proc "system" (commandBuffer: CommandBuffer, scratch: DeviceAddress, scratchSize: DeviceSize, pCountInfo: ^DispatchGraphCountInfoAMDX)
+ProcCmdDispatchGraphIndirectCountAMDX                      :: #type proc "system" (commandBuffer: CommandBuffer, scratch: DeviceAddress, scratchSize: DeviceSize, countInfo: DeviceAddress)
 ProcCmdDispatchIndirect                                    :: #type proc "system" (commandBuffer: CommandBuffer, buffer: Buffer, offset: DeviceSize)
 ProcCmdDraw                                                :: #type proc "system" (commandBuffer: CommandBuffer, vertexCount: u32, instanceCount: u32, firstVertex: u32, firstInstance: u32)
 ProcCmdDrawClusterHUAWEI                                   :: #type proc "system" (commandBuffer: CommandBuffer, groupCountX: u32, groupCountY: u32, groupCountZ: u32)
@@ -258,6 +261,7 @@ ProcCmdExecuteCommands                                     :: #type proc "system
 ProcCmdExecuteGeneratedCommandsEXT                         :: #type proc "system" (commandBuffer: CommandBuffer, isPreprocessed: b32, pGeneratedCommandsInfo: ^GeneratedCommandsInfoEXT)
 ProcCmdExecuteGeneratedCommandsNV                          :: #type proc "system" (commandBuffer: CommandBuffer, isPreprocessed: b32, pGeneratedCommandsInfo: ^GeneratedCommandsInfoNV)
 ProcCmdFillBuffer                                          :: #type proc "system" (commandBuffer: CommandBuffer, dstBuffer: Buffer, dstOffset: DeviceSize, size: DeviceSize, data: u32)
+ProcCmdInitializeGraphScratchMemoryAMDX                    :: #type proc "system" (commandBuffer: CommandBuffer, executionGraph: Pipeline, scratch: DeviceAddress, scratchSize: DeviceSize)
 ProcCmdInsertDebugUtilsLabelEXT                            :: #type proc "system" (commandBuffer: CommandBuffer, pLabelInfo: ^DebugUtilsLabelEXT)
 ProcCmdNextSubpass                                         :: #type proc "system" (commandBuffer: CommandBuffer, contents: SubpassContents)
 ProcCmdNextSubpass2                                        :: #type proc "system" (commandBuffer: CommandBuffer, pSubpassBeginInfo: ^SubpassBeginInfo, pSubpassEndInfo: ^SubpassEndInfo)
@@ -438,6 +442,7 @@ ProcCreateDescriptorSetLayout                              :: #type proc "system
 ProcCreateDescriptorUpdateTemplate                         :: #type proc "system" (device: Device, pCreateInfo: ^DescriptorUpdateTemplateCreateInfo, pAllocator: ^AllocationCallbacks, pDescriptorUpdateTemplate: ^DescriptorUpdateTemplate) -> Result
 ProcCreateDescriptorUpdateTemplateKHR                      :: #type proc "system" (device: Device, pCreateInfo: ^DescriptorUpdateTemplateCreateInfo, pAllocator: ^AllocationCallbacks, pDescriptorUpdateTemplate: ^DescriptorUpdateTemplate) -> Result
 ProcCreateEvent                                            :: #type proc "system" (device: Device, pCreateInfo: ^EventCreateInfo, pAllocator: ^AllocationCallbacks, pEvent: ^Event) -> Result
+ProcCreateExecutionGraphPipelinesAMDX                      :: #type proc "system" (device: Device, pipelineCache: PipelineCache, createInfoCount: u32, pCreateInfos: [^]ExecutionGraphPipelineCreateInfoAMDX, pAllocator: ^AllocationCallbacks, pPipelines: [^]Pipeline) -> Result
 ProcCreateFence                                            :: #type proc "system" (device: Device, pCreateInfo: ^FenceCreateInfo, pAllocator: ^AllocationCallbacks, pFence: ^Fence) -> Result
 ProcCreateFramebuffer                                      :: #type proc "system" (device: Device, pCreateInfo: ^FramebufferCreateInfo, pAllocator: ^AllocationCallbacks, pFramebuffer: ^Framebuffer) -> Result
 ProcCreateGraphicsPipelines                                :: #type proc "system" (device: Device, pipelineCache: PipelineCache, createInfoCount: u32, pCreateInfos: [^]GraphicsPipelineCreateInfo, pAllocator: ^AllocationCallbacks, pPipelines: [^]Pipeline) -> Result
@@ -577,6 +582,8 @@ ProcGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI          :: #type proc "system
 ProcGetDynamicRenderingTilePropertiesQCOM                  :: #type proc "system" (device: Device, pRenderingInfo: ^RenderingInfo, pProperties: [^]TilePropertiesQCOM) -> Result
 ProcGetEncodedVideoSessionParametersKHR                    :: #type proc "system" (device: Device, pVideoSessionParametersInfo: ^VideoEncodeSessionParametersGetInfoKHR, pFeedbackInfo: ^VideoEncodeSessionParametersFeedbackInfoKHR, pDataSize: ^int, pData: rawptr) -> Result
 ProcGetEventStatus                                         :: #type proc "system" (device: Device, event: Event) -> Result
+ProcGetExecutionGraphPipelineNodeIndexAMDX                 :: #type proc "system" (device: Device, executionGraph: Pipeline, pNodeInfo: ^PipelineShaderStageNodeCreateInfoAMDX, pNodeIndex: ^u32) -> Result
+ProcGetExecutionGraphPipelineScratchSizeAMDX               :: #type proc "system" (device: Device, executionGraph: Pipeline, pSizeInfo: ^ExecutionGraphPipelineScratchSizeAMDX) -> Result
 ProcGetFenceFdKHR                                          :: #type proc "system" (device: Device, pGetFdInfo: ^FenceGetFdInfoKHR, pFd: ^c.int) -> Result
 ProcGetFenceStatus                                         :: #type proc "system" (device: Device, fence: Fence) -> Result
 ProcGetFenceWin32HandleKHR                                 :: #type proc "system" (device: Device, pGetWin32HandleInfo: ^FenceGetWin32HandleInfoKHR, pHandle: ^HANDLE) -> Result
@@ -926,6 +933,9 @@ CmdDecompressMemoryNV:                                  ProcCmdDecompressMemoryN
 CmdDispatch:                                            ProcCmdDispatch
 CmdDispatchBase:                                        ProcCmdDispatchBase
 CmdDispatchBaseKHR:                                     ProcCmdDispatchBaseKHR
+CmdDispatchGraphAMDX:                                   ProcCmdDispatchGraphAMDX
+CmdDispatchGraphIndirectAMDX:                           ProcCmdDispatchGraphIndirectAMDX
+CmdDispatchGraphIndirectCountAMDX:                      ProcCmdDispatchGraphIndirectCountAMDX
 CmdDispatchIndirect:                                    ProcCmdDispatchIndirect
 CmdDraw:                                                ProcCmdDraw
 CmdDrawClusterHUAWEI:                                   ProcCmdDrawClusterHUAWEI
@@ -964,6 +974,7 @@ CmdExecuteCommands:                                     ProcCmdExecuteCommands
 CmdExecuteGeneratedCommandsEXT:                         ProcCmdExecuteGeneratedCommandsEXT
 CmdExecuteGeneratedCommandsNV:                          ProcCmdExecuteGeneratedCommandsNV
 CmdFillBuffer:                                          ProcCmdFillBuffer
+CmdInitializeGraphScratchMemoryAMDX:                    ProcCmdInitializeGraphScratchMemoryAMDX
 CmdInsertDebugUtilsLabelEXT:                            ProcCmdInsertDebugUtilsLabelEXT
 CmdNextSubpass:                                         ProcCmdNextSubpass
 CmdNextSubpass2:                                        ProcCmdNextSubpass2
@@ -1144,6 +1155,7 @@ CreateDescriptorSetLayout:                              ProcCreateDescriptorSetL
 CreateDescriptorUpdateTemplate:                         ProcCreateDescriptorUpdateTemplate
 CreateDescriptorUpdateTemplateKHR:                      ProcCreateDescriptorUpdateTemplateKHR
 CreateEvent:                                            ProcCreateEvent
+CreateExecutionGraphPipelinesAMDX:                      ProcCreateExecutionGraphPipelinesAMDX
 CreateFence:                                            ProcCreateFence
 CreateFramebuffer:                                      ProcCreateFramebuffer
 CreateGraphicsPipelines:                                ProcCreateGraphicsPipelines
@@ -1283,6 +1295,8 @@ GetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI:          ProcGetDeviceSubpassShad
 GetDynamicRenderingTilePropertiesQCOM:                  ProcGetDynamicRenderingTilePropertiesQCOM
 GetEncodedVideoSessionParametersKHR:                    ProcGetEncodedVideoSessionParametersKHR
 GetEventStatus:                                         ProcGetEventStatus
+GetExecutionGraphPipelineNodeIndexAMDX:                 ProcGetExecutionGraphPipelineNodeIndexAMDX
+GetExecutionGraphPipelineScratchSizeAMDX:               ProcGetExecutionGraphPipelineScratchSizeAMDX
 GetFenceFdKHR:                                          ProcGetFenceFdKHR
 GetFenceStatus:                                         ProcGetFenceStatus
 GetFenceWin32HandleKHR:                                 ProcGetFenceWin32HandleKHR
@@ -1632,6 +1646,9 @@ load_proc_addresses_custom :: proc(set_proc_address: SetProcAddressType) {
 	set_proc_address(&CmdDispatch,                                            "vkCmdDispatch")
 	set_proc_address(&CmdDispatchBase,                                        "vkCmdDispatchBase")
 	set_proc_address(&CmdDispatchBaseKHR,                                     "vkCmdDispatchBaseKHR")
+	set_proc_address(&CmdDispatchGraphAMDX,                                   "vkCmdDispatchGraphAMDX")
+	set_proc_address(&CmdDispatchGraphIndirectAMDX,                           "vkCmdDispatchGraphIndirectAMDX")
+	set_proc_address(&CmdDispatchGraphIndirectCountAMDX,                      "vkCmdDispatchGraphIndirectCountAMDX")
 	set_proc_address(&CmdDispatchIndirect,                                    "vkCmdDispatchIndirect")
 	set_proc_address(&CmdDraw,                                                "vkCmdDraw")
 	set_proc_address(&CmdDrawClusterHUAWEI,                                   "vkCmdDrawClusterHUAWEI")
@@ -1670,6 +1687,7 @@ load_proc_addresses_custom :: proc(set_proc_address: SetProcAddressType) {
 	set_proc_address(&CmdExecuteGeneratedCommandsEXT,                         "vkCmdExecuteGeneratedCommandsEXT")
 	set_proc_address(&CmdExecuteGeneratedCommandsNV,                          "vkCmdExecuteGeneratedCommandsNV")
 	set_proc_address(&CmdFillBuffer,                                          "vkCmdFillBuffer")
+	set_proc_address(&CmdInitializeGraphScratchMemoryAMDX,                    "vkCmdInitializeGraphScratchMemoryAMDX")
 	set_proc_address(&CmdInsertDebugUtilsLabelEXT,                            "vkCmdInsertDebugUtilsLabelEXT")
 	set_proc_address(&CmdNextSubpass,                                         "vkCmdNextSubpass")
 	set_proc_address(&CmdNextSubpass2,                                        "vkCmdNextSubpass2")
@@ -1850,6 +1868,7 @@ load_proc_addresses_custom :: proc(set_proc_address: SetProcAddressType) {
 	set_proc_address(&CreateDescriptorUpdateTemplate,                         "vkCreateDescriptorUpdateTemplate")
 	set_proc_address(&CreateDescriptorUpdateTemplateKHR,                      "vkCreateDescriptorUpdateTemplateKHR")
 	set_proc_address(&CreateEvent,                                            "vkCreateEvent")
+	set_proc_address(&CreateExecutionGraphPipelinesAMDX,                      "vkCreateExecutionGraphPipelinesAMDX")
 	set_proc_address(&CreateFence,                                            "vkCreateFence")
 	set_proc_address(&CreateFramebuffer,                                      "vkCreateFramebuffer")
 	set_proc_address(&CreateGraphicsPipelines,                                "vkCreateGraphicsPipelines")
@@ -1989,6 +2008,8 @@ load_proc_addresses_custom :: proc(set_proc_address: SetProcAddressType) {
 	set_proc_address(&GetDynamicRenderingTilePropertiesQCOM,                  "vkGetDynamicRenderingTilePropertiesQCOM")
 	set_proc_address(&GetEncodedVideoSessionParametersKHR,                    "vkGetEncodedVideoSessionParametersKHR")
 	set_proc_address(&GetEventStatus,                                         "vkGetEventStatus")
+	set_proc_address(&GetExecutionGraphPipelineNodeIndexAMDX,                 "vkGetExecutionGraphPipelineNodeIndexAMDX")
+	set_proc_address(&GetExecutionGraphPipelineScratchSizeAMDX,               "vkGetExecutionGraphPipelineScratchSizeAMDX")
 	set_proc_address(&GetFenceFdKHR,                                          "vkGetFenceFdKHR")
 	set_proc_address(&GetFenceStatus,                                         "vkGetFenceStatus")
 	set_proc_address(&GetFenceWin32HandleKHR,                                 "vkGetFenceWin32HandleKHR")
@@ -2232,6 +2253,9 @@ Device_VTable :: struct {
 	CmdDispatch:                                            ProcCmdDispatch,
 	CmdDispatchBase:                                        ProcCmdDispatchBase,
 	CmdDispatchBaseKHR:                                     ProcCmdDispatchBaseKHR,
+	CmdDispatchGraphAMDX:                                   ProcCmdDispatchGraphAMDX,
+	CmdDispatchGraphIndirectAMDX:                           ProcCmdDispatchGraphIndirectAMDX,
+	CmdDispatchGraphIndirectCountAMDX:                      ProcCmdDispatchGraphIndirectCountAMDX,
 	CmdDispatchIndirect:                                    ProcCmdDispatchIndirect,
 	CmdDraw:                                                ProcCmdDraw,
 	CmdDrawClusterHUAWEI:                                   ProcCmdDrawClusterHUAWEI,
@@ -2270,6 +2294,7 @@ Device_VTable :: struct {
 	CmdExecuteGeneratedCommandsEXT:                         ProcCmdExecuteGeneratedCommandsEXT,
 	CmdExecuteGeneratedCommandsNV:                          ProcCmdExecuteGeneratedCommandsNV,
 	CmdFillBuffer:                                          ProcCmdFillBuffer,
+	CmdInitializeGraphScratchMemoryAMDX:                    ProcCmdInitializeGraphScratchMemoryAMDX,
 	CmdInsertDebugUtilsLabelEXT:                            ProcCmdInsertDebugUtilsLabelEXT,
 	CmdNextSubpass:                                         ProcCmdNextSubpass,
 	CmdNextSubpass2:                                        ProcCmdNextSubpass2,
@@ -2450,6 +2475,7 @@ Device_VTable :: struct {
 	CreateDescriptorUpdateTemplate:                         ProcCreateDescriptorUpdateTemplate,
 	CreateDescriptorUpdateTemplateKHR:                      ProcCreateDescriptorUpdateTemplateKHR,
 	CreateEvent:                                            ProcCreateEvent,
+	CreateExecutionGraphPipelinesAMDX:                      ProcCreateExecutionGraphPipelinesAMDX,
 	CreateFence:                                            ProcCreateFence,
 	CreateFramebuffer:                                      ProcCreateFramebuffer,
 	CreateGraphicsPipelines:                                ProcCreateGraphicsPipelines,
@@ -2589,6 +2615,8 @@ Device_VTable :: struct {
 	GetDynamicRenderingTilePropertiesQCOM:                  ProcGetDynamicRenderingTilePropertiesQCOM,
 	GetEncodedVideoSessionParametersKHR:                    ProcGetEncodedVideoSessionParametersKHR,
 	GetEventStatus:                                         ProcGetEventStatus,
+	GetExecutionGraphPipelineNodeIndexAMDX:                 ProcGetExecutionGraphPipelineNodeIndexAMDX,
+	GetExecutionGraphPipelineScratchSizeAMDX:               ProcGetExecutionGraphPipelineScratchSizeAMDX,
 	GetFenceFdKHR:                                          ProcGetFenceFdKHR,
 	GetFenceStatus:                                         ProcGetFenceStatus,
 	GetFenceWin32HandleKHR:                                 ProcGetFenceWin32HandleKHR,
@@ -2830,6 +2858,9 @@ load_proc_addresses_device_vtable :: proc(device: Device, vtable: ^Device_VTable
 	vtable.CmdDispatch                                            = auto_cast GetDeviceProcAddr(device, "vkCmdDispatch")
 	vtable.CmdDispatchBase                                        = auto_cast GetDeviceProcAddr(device, "vkCmdDispatchBase")
 	vtable.CmdDispatchBaseKHR                                     = auto_cast GetDeviceProcAddr(device, "vkCmdDispatchBaseKHR")
+	vtable.CmdDispatchGraphAMDX                                   = auto_cast GetDeviceProcAddr(device, "vkCmdDispatchGraphAMDX")
+	vtable.CmdDispatchGraphIndirectAMDX                           = auto_cast GetDeviceProcAddr(device, "vkCmdDispatchGraphIndirectAMDX")
+	vtable.CmdDispatchGraphIndirectCountAMDX                      = auto_cast GetDeviceProcAddr(device, "vkCmdDispatchGraphIndirectCountAMDX")
 	vtable.CmdDispatchIndirect                                    = auto_cast GetDeviceProcAddr(device, "vkCmdDispatchIndirect")
 	vtable.CmdDraw                                                = auto_cast GetDeviceProcAddr(device, "vkCmdDraw")
 	vtable.CmdDrawClusterHUAWEI                                   = auto_cast GetDeviceProcAddr(device, "vkCmdDrawClusterHUAWEI")
@@ -2868,6 +2899,7 @@ load_proc_addresses_device_vtable :: proc(device: Device, vtable: ^Device_VTable
 	vtable.CmdExecuteGeneratedCommandsEXT                         = auto_cast GetDeviceProcAddr(device, "vkCmdExecuteGeneratedCommandsEXT")
 	vtable.CmdExecuteGeneratedCommandsNV                          = auto_cast GetDeviceProcAddr(device, "vkCmdExecuteGeneratedCommandsNV")
 	vtable.CmdFillBuffer                                          = auto_cast GetDeviceProcAddr(device, "vkCmdFillBuffer")
+	vtable.CmdInitializeGraphScratchMemoryAMDX                    = auto_cast GetDeviceProcAddr(device, "vkCmdInitializeGraphScratchMemoryAMDX")
 	vtable.CmdInsertDebugUtilsLabelEXT                            = auto_cast GetDeviceProcAddr(device, "vkCmdInsertDebugUtilsLabelEXT")
 	vtable.CmdNextSubpass                                         = auto_cast GetDeviceProcAddr(device, "vkCmdNextSubpass")
 	vtable.CmdNextSubpass2                                        = auto_cast GetDeviceProcAddr(device, "vkCmdNextSubpass2")
@@ -3048,6 +3080,7 @@ load_proc_addresses_device_vtable :: proc(device: Device, vtable: ^Device_VTable
 	vtable.CreateDescriptorUpdateTemplate                         = auto_cast GetDeviceProcAddr(device, "vkCreateDescriptorUpdateTemplate")
 	vtable.CreateDescriptorUpdateTemplateKHR                      = auto_cast GetDeviceProcAddr(device, "vkCreateDescriptorUpdateTemplateKHR")
 	vtable.CreateEvent                                            = auto_cast GetDeviceProcAddr(device, "vkCreateEvent")
+	vtable.CreateExecutionGraphPipelinesAMDX                      = auto_cast GetDeviceProcAddr(device, "vkCreateExecutionGraphPipelinesAMDX")
 	vtable.CreateFence                                            = auto_cast GetDeviceProcAddr(device, "vkCreateFence")
 	vtable.CreateFramebuffer                                      = auto_cast GetDeviceProcAddr(device, "vkCreateFramebuffer")
 	vtable.CreateGraphicsPipelines                                = auto_cast GetDeviceProcAddr(device, "vkCreateGraphicsPipelines")
@@ -3187,6 +3220,8 @@ load_proc_addresses_device_vtable :: proc(device: Device, vtable: ^Device_VTable
 	vtable.GetDynamicRenderingTilePropertiesQCOM                  = auto_cast GetDeviceProcAddr(device, "vkGetDynamicRenderingTilePropertiesQCOM")
 	vtable.GetEncodedVideoSessionParametersKHR                    = auto_cast GetDeviceProcAddr(device, "vkGetEncodedVideoSessionParametersKHR")
 	vtable.GetEventStatus                                         = auto_cast GetDeviceProcAddr(device, "vkGetEventStatus")
+	vtable.GetExecutionGraphPipelineNodeIndexAMDX                 = auto_cast GetDeviceProcAddr(device, "vkGetExecutionGraphPipelineNodeIndexAMDX")
+	vtable.GetExecutionGraphPipelineScratchSizeAMDX               = auto_cast GetDeviceProcAddr(device, "vkGetExecutionGraphPipelineScratchSizeAMDX")
 	vtable.GetFenceFdKHR                                          = auto_cast GetDeviceProcAddr(device, "vkGetFenceFdKHR")
 	vtable.GetFenceStatus                                         = auto_cast GetDeviceProcAddr(device, "vkGetFenceStatus")
 	vtable.GetFenceWin32HandleKHR                                 = auto_cast GetDeviceProcAddr(device, "vkGetFenceWin32HandleKHR")
@@ -3428,6 +3463,9 @@ load_proc_addresses_device :: proc(device: Device) {
 	CmdDispatch                                            = auto_cast GetDeviceProcAddr(device, "vkCmdDispatch")
 	CmdDispatchBase                                        = auto_cast GetDeviceProcAddr(device, "vkCmdDispatchBase")
 	CmdDispatchBaseKHR                                     = auto_cast GetDeviceProcAddr(device, "vkCmdDispatchBaseKHR")
+	CmdDispatchGraphAMDX                                   = auto_cast GetDeviceProcAddr(device, "vkCmdDispatchGraphAMDX")
+	CmdDispatchGraphIndirectAMDX                           = auto_cast GetDeviceProcAddr(device, "vkCmdDispatchGraphIndirectAMDX")
+	CmdDispatchGraphIndirectCountAMDX                      = auto_cast GetDeviceProcAddr(device, "vkCmdDispatchGraphIndirectCountAMDX")
 	CmdDispatchIndirect                                    = auto_cast GetDeviceProcAddr(device, "vkCmdDispatchIndirect")
 	CmdDraw                                                = auto_cast GetDeviceProcAddr(device, "vkCmdDraw")
 	CmdDrawClusterHUAWEI                                   = auto_cast GetDeviceProcAddr(device, "vkCmdDrawClusterHUAWEI")
@@ -3466,6 +3504,7 @@ load_proc_addresses_device :: proc(device: Device) {
 	CmdExecuteGeneratedCommandsEXT                         = auto_cast GetDeviceProcAddr(device, "vkCmdExecuteGeneratedCommandsEXT")
 	CmdExecuteGeneratedCommandsNV                          = auto_cast GetDeviceProcAddr(device, "vkCmdExecuteGeneratedCommandsNV")
 	CmdFillBuffer                                          = auto_cast GetDeviceProcAddr(device, "vkCmdFillBuffer")
+	CmdInitializeGraphScratchMemoryAMDX                    = auto_cast GetDeviceProcAddr(device, "vkCmdInitializeGraphScratchMemoryAMDX")
 	CmdInsertDebugUtilsLabelEXT                            = auto_cast GetDeviceProcAddr(device, "vkCmdInsertDebugUtilsLabelEXT")
 	CmdNextSubpass                                         = auto_cast GetDeviceProcAddr(device, "vkCmdNextSubpass")
 	CmdNextSubpass2                                        = auto_cast GetDeviceProcAddr(device, "vkCmdNextSubpass2")
@@ -3646,6 +3685,7 @@ load_proc_addresses_device :: proc(device: Device) {
 	CreateDescriptorUpdateTemplate                         = auto_cast GetDeviceProcAddr(device, "vkCreateDescriptorUpdateTemplate")
 	CreateDescriptorUpdateTemplateKHR                      = auto_cast GetDeviceProcAddr(device, "vkCreateDescriptorUpdateTemplateKHR")
 	CreateEvent                                            = auto_cast GetDeviceProcAddr(device, "vkCreateEvent")
+	CreateExecutionGraphPipelinesAMDX                      = auto_cast GetDeviceProcAddr(device, "vkCreateExecutionGraphPipelinesAMDX")
 	CreateFence                                            = auto_cast GetDeviceProcAddr(device, "vkCreateFence")
 	CreateFramebuffer                                      = auto_cast GetDeviceProcAddr(device, "vkCreateFramebuffer")
 	CreateGraphicsPipelines                                = auto_cast GetDeviceProcAddr(device, "vkCreateGraphicsPipelines")
@@ -3785,6 +3825,8 @@ load_proc_addresses_device :: proc(device: Device) {
 	GetDynamicRenderingTilePropertiesQCOM                  = auto_cast GetDeviceProcAddr(device, "vkGetDynamicRenderingTilePropertiesQCOM")
 	GetEncodedVideoSessionParametersKHR                    = auto_cast GetDeviceProcAddr(device, "vkGetEncodedVideoSessionParametersKHR")
 	GetEventStatus                                         = auto_cast GetDeviceProcAddr(device, "vkGetEventStatus")
+	GetExecutionGraphPipelineNodeIndexAMDX                 = auto_cast GetDeviceProcAddr(device, "vkGetExecutionGraphPipelineNodeIndexAMDX")
+	GetExecutionGraphPipelineScratchSizeAMDX               = auto_cast GetDeviceProcAddr(device, "vkGetExecutionGraphPipelineScratchSizeAMDX")
 	GetFenceFdKHR                                          = auto_cast GetDeviceProcAddr(device, "vkGetFenceFdKHR")
 	GetFenceStatus                                         = auto_cast GetDeviceProcAddr(device, "vkGetFenceStatus")
 	GetFenceWin32HandleKHR                                 = auto_cast GetDeviceProcAddr(device, "vkGetFenceWin32HandleKHR")
@@ -4125,6 +4167,9 @@ load_proc_addresses_instance :: proc(instance: Instance) {
 	CmdDispatch                                            = auto_cast GetInstanceProcAddr(instance, "vkCmdDispatch")
 	CmdDispatchBase                                        = auto_cast GetInstanceProcAddr(instance, "vkCmdDispatchBase")
 	CmdDispatchBaseKHR                                     = auto_cast GetInstanceProcAddr(instance, "vkCmdDispatchBaseKHR")
+	CmdDispatchGraphAMDX                                   = auto_cast GetInstanceProcAddr(instance, "vkCmdDispatchGraphAMDX")
+	CmdDispatchGraphIndirectAMDX                           = auto_cast GetInstanceProcAddr(instance, "vkCmdDispatchGraphIndirectAMDX")
+	CmdDispatchGraphIndirectCountAMDX                      = auto_cast GetInstanceProcAddr(instance, "vkCmdDispatchGraphIndirectCountAMDX")
 	CmdDispatchIndirect                                    = auto_cast GetInstanceProcAddr(instance, "vkCmdDispatchIndirect")
 	CmdDraw                                                = auto_cast GetInstanceProcAddr(instance, "vkCmdDraw")
 	CmdDrawClusterHUAWEI                                   = auto_cast GetInstanceProcAddr(instance, "vkCmdDrawClusterHUAWEI")
@@ -4163,6 +4208,7 @@ load_proc_addresses_instance :: proc(instance: Instance) {
 	CmdExecuteGeneratedCommandsEXT                         = auto_cast GetInstanceProcAddr(instance, "vkCmdExecuteGeneratedCommandsEXT")
 	CmdExecuteGeneratedCommandsNV                          = auto_cast GetInstanceProcAddr(instance, "vkCmdExecuteGeneratedCommandsNV")
 	CmdFillBuffer                                          = auto_cast GetInstanceProcAddr(instance, "vkCmdFillBuffer")
+	CmdInitializeGraphScratchMemoryAMDX                    = auto_cast GetInstanceProcAddr(instance, "vkCmdInitializeGraphScratchMemoryAMDX")
 	CmdInsertDebugUtilsLabelEXT                            = auto_cast GetInstanceProcAddr(instance, "vkCmdInsertDebugUtilsLabelEXT")
 	CmdNextSubpass                                         = auto_cast GetInstanceProcAddr(instance, "vkCmdNextSubpass")
 	CmdNextSubpass2                                        = auto_cast GetInstanceProcAddr(instance, "vkCmdNextSubpass2")
@@ -4343,6 +4389,7 @@ load_proc_addresses_instance :: proc(instance: Instance) {
 	CreateDescriptorUpdateTemplate                         = auto_cast GetInstanceProcAddr(instance, "vkCreateDescriptorUpdateTemplate")
 	CreateDescriptorUpdateTemplateKHR                      = auto_cast GetInstanceProcAddr(instance, "vkCreateDescriptorUpdateTemplateKHR")
 	CreateEvent                                            = auto_cast GetInstanceProcAddr(instance, "vkCreateEvent")
+	CreateExecutionGraphPipelinesAMDX                      = auto_cast GetInstanceProcAddr(instance, "vkCreateExecutionGraphPipelinesAMDX")
 	CreateFence                                            = auto_cast GetInstanceProcAddr(instance, "vkCreateFence")
 	CreateFramebuffer                                      = auto_cast GetInstanceProcAddr(instance, "vkCreateFramebuffer")
 	CreateGraphicsPipelines                                = auto_cast GetInstanceProcAddr(instance, "vkCreateGraphicsPipelines")
@@ -4482,6 +4529,8 @@ load_proc_addresses_instance :: proc(instance: Instance) {
 	GetDynamicRenderingTilePropertiesQCOM                  = auto_cast GetInstanceProcAddr(instance, "vkGetDynamicRenderingTilePropertiesQCOM")
 	GetEncodedVideoSessionParametersKHR                    = auto_cast GetInstanceProcAddr(instance, "vkGetEncodedVideoSessionParametersKHR")
 	GetEventStatus                                         = auto_cast GetInstanceProcAddr(instance, "vkGetEventStatus")
+	GetExecutionGraphPipelineNodeIndexAMDX                 = auto_cast GetInstanceProcAddr(instance, "vkGetExecutionGraphPipelineNodeIndexAMDX")
+	GetExecutionGraphPipelineScratchSizeAMDX               = auto_cast GetInstanceProcAddr(instance, "vkGetExecutionGraphPipelineScratchSizeAMDX")
 	GetFenceFdKHR                                          = auto_cast GetInstanceProcAddr(instance, "vkGetFenceFdKHR")
 	GetFenceStatus                                         = auto_cast GetInstanceProcAddr(instance, "vkGetFenceStatus")
 	GetFenceWin32HandleKHR                                 = auto_cast GetInstanceProcAddr(instance, "vkGetFenceWin32HandleKHR")

--- a/vendor/vulkan/procedures.odin
+++ b/vendor/vulkan/procedures.odin
@@ -62,6 +62,7 @@ ProcGetPhysicalDeviceCalibrateableTimeDomainsKHR                     :: #type pr
 ProcGetPhysicalDeviceCooperativeMatrixFlexibleDimensionsPropertiesNV :: #type proc "system" (physicalDevice: PhysicalDevice, pPropertyCount: ^u32, pProperties: [^]CooperativeMatrixFlexibleDimensionsPropertiesNV) -> Result
 ProcGetPhysicalDeviceCooperativeMatrixPropertiesKHR                  :: #type proc "system" (physicalDevice: PhysicalDevice, pPropertyCount: ^u32, pProperties: [^]CooperativeMatrixPropertiesKHR) -> Result
 ProcGetPhysicalDeviceCooperativeMatrixPropertiesNV                   :: #type proc "system" (physicalDevice: PhysicalDevice, pPropertyCount: ^u32, pProperties: [^]CooperativeMatrixPropertiesNV) -> Result
+ProcGetPhysicalDeviceCooperativeVectorPropertiesNV                   :: #type proc "system" (physicalDevice: PhysicalDevice, pPropertyCount: ^u32, pProperties: [^]CooperativeVectorPropertiesNV) -> Result
 ProcGetPhysicalDeviceDisplayPlaneProperties2KHR                      :: #type proc "system" (physicalDevice: PhysicalDevice, pPropertyCount: ^u32, pProperties: [^]DisplayPlaneProperties2KHR) -> Result
 ProcGetPhysicalDeviceDisplayPlanePropertiesKHR                       :: #type proc "system" (physicalDevice: PhysicalDevice, pPropertyCount: ^u32, pProperties: [^]DisplayPlanePropertiesKHR) -> Result
 ProcGetPhysicalDeviceDisplayProperties2KHR                           :: #type proc "system" (physicalDevice: PhysicalDevice, pPropertyCount: ^u32, pProperties: [^]DisplayProperties2KHR) -> Result
@@ -178,11 +179,14 @@ ProcCmdBlitImage2KHR                                       :: #type proc "system
 ProcCmdBuildAccelerationStructureNV                        :: #type proc "system" (commandBuffer: CommandBuffer, pInfo: ^AccelerationStructureInfoNV, instanceData: Buffer, instanceOffset: DeviceSize, update: b32, dst: AccelerationStructureNV, src: AccelerationStructureNV, scratch: Buffer, scratchOffset: DeviceSize)
 ProcCmdBuildAccelerationStructuresIndirectKHR              :: #type proc "system" (commandBuffer: CommandBuffer, infoCount: u32, pInfos: [^]AccelerationStructureBuildGeometryInfoKHR, pIndirectDeviceAddresses: [^]DeviceAddress, pIndirectStrides: [^]u32, ppMaxPrimitiveCounts: ^[^]u32)
 ProcCmdBuildAccelerationStructuresKHR                      :: #type proc "system" (commandBuffer: CommandBuffer, infoCount: u32, pInfos: [^]AccelerationStructureBuildGeometryInfoKHR, ppBuildRangeInfos: ^[^]AccelerationStructureBuildRangeInfoKHR)
+ProcCmdBuildClusterAccelerationStructureIndirectNV         :: #type proc "system" (commandBuffer: CommandBuffer, pCommandInfos: [^]ClusterAccelerationStructureCommandsInfoNV)
 ProcCmdBuildMicromapsEXT                                   :: #type proc "system" (commandBuffer: CommandBuffer, infoCount: u32, pInfos: [^]MicromapBuildInfoEXT)
+ProcCmdBuildPartitionedAccelerationStructuresNV            :: #type proc "system" (commandBuffer: CommandBuffer, pBuildInfo: ^BuildPartitionedAccelerationStructureInfoNV)
 ProcCmdClearAttachments                                    :: #type proc "system" (commandBuffer: CommandBuffer, attachmentCount: u32, pAttachments: [^]ClearAttachment, rectCount: u32, pRects: [^]ClearRect)
 ProcCmdClearColorImage                                     :: #type proc "system" (commandBuffer: CommandBuffer, image: Image, imageLayout: ImageLayout, pColor: ^ClearColorValue, rangeCount: u32, pRanges: [^]ImageSubresourceRange)
 ProcCmdClearDepthStencilImage                              :: #type proc "system" (commandBuffer: CommandBuffer, image: Image, imageLayout: ImageLayout, pDepthStencil: ^ClearDepthStencilValue, rangeCount: u32, pRanges: [^]ImageSubresourceRange)
 ProcCmdControlVideoCodingKHR                               :: #type proc "system" (commandBuffer: CommandBuffer, pCodingControlInfo: ^VideoCodingControlInfoKHR)
+ProcCmdConvertCooperativeVectorMatrixNV                    :: #type proc "system" (commandBuffer: CommandBuffer, infoCount: u32, pInfos: [^]ConvertCooperativeVectorMatrixInfoNV)
 ProcCmdCopyAccelerationStructureKHR                        :: #type proc "system" (commandBuffer: CommandBuffer, pInfo: ^CopyAccelerationStructureInfoKHR)
 ProcCmdCopyAccelerationStructureNV                         :: #type proc "system" (commandBuffer: CommandBuffer, dst: AccelerationStructureNV, src: AccelerationStructureNV, mode: CopyAccelerationStructureModeKHR)
 ProcCmdCopyAccelerationStructureToMemoryKHR                :: #type proc "system" (commandBuffer: CommandBuffer, pInfo: ^CopyAccelerationStructureToMemoryInfoKHR)
@@ -405,6 +409,7 @@ ProcCmdWriteTimestamp                                      :: #type proc "system
 ProcCmdWriteTimestamp2                                     :: #type proc "system" (commandBuffer: CommandBuffer, stage: PipelineStageFlags2, queryPool: QueryPool, query: u32)
 ProcCmdWriteTimestamp2KHR                                  :: #type proc "system" (commandBuffer: CommandBuffer, stage: PipelineStageFlags2, queryPool: QueryPool, query: u32)
 ProcCompileDeferredNV                                      :: #type proc "system" (device: Device, pipeline: Pipeline, shader: u32) -> Result
+ProcConvertCooperativeVectorMatrixNV                       :: #type proc "system" (device: Device, pInfo: ^ConvertCooperativeVectorMatrixInfoNV) -> Result
 ProcCopyAccelerationStructureKHR                           :: #type proc "system" (device: Device, deferredOperation: DeferredOperationKHR, pInfo: ^CopyAccelerationStructureInfoKHR) -> Result
 ProcCopyAccelerationStructureToMemoryKHR                   :: #type proc "system" (device: Device, deferredOperation: DeferredOperationKHR, pInfo: ^CopyAccelerationStructureToMemoryInfoKHR) -> Result
 ProcCopyImageToImage                                       :: #type proc "system" (device: Device, pCopyImageToImageInfo: ^CopyImageToImageInfo) -> Result
@@ -535,6 +540,7 @@ ProcGetBufferOpaqueCaptureAddressKHR                       :: #type proc "system
 ProcGetBufferOpaqueCaptureDescriptorDataEXT                :: #type proc "system" (device: Device, pInfo: ^BufferCaptureDescriptorDataInfoEXT, pData: rawptr) -> Result
 ProcGetCalibratedTimestampsEXT                             :: #type proc "system" (device: Device, timestampCount: u32, pTimestampInfos: [^]CalibratedTimestampInfoKHR, pTimestamps: [^]u64, pMaxDeviation: ^u64) -> Result
 ProcGetCalibratedTimestampsKHR                             :: #type proc "system" (device: Device, timestampCount: u32, pTimestampInfos: [^]CalibratedTimestampInfoKHR, pTimestamps: [^]u64, pMaxDeviation: ^u64) -> Result
+ProcGetClusterAccelerationStructureBuildSizesNV            :: #type proc "system" (device: Device, pInfo: ^ClusterAccelerationStructureInputInfoNV, pSizeInfo: ^AccelerationStructureBuildSizesInfoKHR)
 ProcGetCudaModuleCacheNV                                   :: #type proc "system" (device: Device, module: CudaModuleNV, pCacheSize: ^int, pCacheData: rawptr) -> Result
 ProcGetDeferredOperationMaxConcurrencyKHR                  :: #type proc "system" (device: Device, operation: DeferredOperationKHR) -> u32
 ProcGetDeferredOperationResultKHR                          :: #type proc "system" (device: Device, operation: DeferredOperationKHR) -> Result
@@ -597,11 +603,14 @@ ProcGetLatencyTimingsNV                                    :: #type proc "system
 ProcGetMemoryFdKHR                                         :: #type proc "system" (device: Device, pGetFdInfo: ^MemoryGetFdInfoKHR, pFd: ^c.int) -> Result
 ProcGetMemoryFdPropertiesKHR                               :: #type proc "system" (device: Device, handleType: ExternalMemoryHandleTypeFlags, fd: c.int, pMemoryFdProperties: [^]MemoryFdPropertiesKHR) -> Result
 ProcGetMemoryHostPointerPropertiesEXT                      :: #type proc "system" (device: Device, handleType: ExternalMemoryHandleTypeFlags, pHostPointer: rawptr, pMemoryHostPointerProperties: [^]MemoryHostPointerPropertiesEXT) -> Result
+ProcGetMemoryMetalHandleEXT                                :: #type proc "system" (device: Device, pGetMetalHandleInfo: ^MemoryGetMetalHandleInfoEXT, pHandle: ^rawptr) -> Result
+ProcGetMemoryMetalHandlePropertiesEXT                      :: #type proc "system" (device: Device, handleType: ExternalMemoryHandleTypeFlags, pHandle: rawptr, pMemoryMetalHandleProperties: [^]MemoryMetalHandlePropertiesEXT) -> Result
 ProcGetMemoryRemoteAddressNV                               :: #type proc "system" (device: Device, pMemoryGetRemoteAddressInfo: ^MemoryGetRemoteAddressInfoNV, pAddress: [^]RemoteAddressNV) -> Result
 ProcGetMemoryWin32HandleKHR                                :: #type proc "system" (device: Device, pGetWin32HandleInfo: ^MemoryGetWin32HandleInfoKHR, pHandle: ^HANDLE) -> Result
 ProcGetMemoryWin32HandleNV                                 :: #type proc "system" (device: Device, memory: DeviceMemory, handleType: ExternalMemoryHandleTypeFlagsNV, pHandle: ^HANDLE) -> Result
 ProcGetMemoryWin32HandlePropertiesKHR                      :: #type proc "system" (device: Device, handleType: ExternalMemoryHandleTypeFlags, handle: HANDLE, pMemoryWin32HandleProperties: [^]MemoryWin32HandlePropertiesKHR) -> Result
 ProcGetMicromapBuildSizesEXT                               :: #type proc "system" (device: Device, buildType: AccelerationStructureBuildTypeKHR, pBuildInfo: ^MicromapBuildInfoEXT, pSizeInfo: ^MicromapBuildSizesInfoEXT)
+ProcGetPartitionedAccelerationStructuresBuildSizesNV       :: #type proc "system" (device: Device, pInfo: ^PartitionedAccelerationStructureInstancesInputNV, pSizeInfo: ^AccelerationStructureBuildSizesInfoKHR)
 ProcGetPastPresentationTimingGOOGLE                        :: #type proc "system" (device: Device, swapchain: SwapchainKHR, pPresentationTimingCount: ^u32, pPresentationTimings: [^]PastPresentationTimingGOOGLE) -> Result
 ProcGetPerformanceParameterINTEL                           :: #type proc "system" (device: Device, parameter: PerformanceParameterTypeINTEL, pValue: ^PerformanceValueINTEL) -> Result
 ProcGetPipelineBinaryDataKHR                               :: #type proc "system" (device: Device, pInfo: ^PipelineBinaryDataInfoKHR, pPipelineBinaryKey: ^PipelineBinaryKeyKHR, pPipelineBinaryDataSize: ^int, pPipelineBinaryData: rawptr) -> Result
@@ -759,6 +768,7 @@ GetPhysicalDeviceCalibrateableTimeDomainsKHR:                     ProcGetPhysica
 GetPhysicalDeviceCooperativeMatrixFlexibleDimensionsPropertiesNV: ProcGetPhysicalDeviceCooperativeMatrixFlexibleDimensionsPropertiesNV
 GetPhysicalDeviceCooperativeMatrixPropertiesKHR:                  ProcGetPhysicalDeviceCooperativeMatrixPropertiesKHR
 GetPhysicalDeviceCooperativeMatrixPropertiesNV:                   ProcGetPhysicalDeviceCooperativeMatrixPropertiesNV
+GetPhysicalDeviceCooperativeVectorPropertiesNV:                   ProcGetPhysicalDeviceCooperativeVectorPropertiesNV
 GetPhysicalDeviceDisplayPlaneProperties2KHR:                      ProcGetPhysicalDeviceDisplayPlaneProperties2KHR
 GetPhysicalDeviceDisplayPlanePropertiesKHR:                       ProcGetPhysicalDeviceDisplayPlanePropertiesKHR
 GetPhysicalDeviceDisplayProperties2KHR:                           ProcGetPhysicalDeviceDisplayProperties2KHR
@@ -875,11 +885,14 @@ CmdBlitImage2KHR:                                       ProcCmdBlitImage2KHR
 CmdBuildAccelerationStructureNV:                        ProcCmdBuildAccelerationStructureNV
 CmdBuildAccelerationStructuresIndirectKHR:              ProcCmdBuildAccelerationStructuresIndirectKHR
 CmdBuildAccelerationStructuresKHR:                      ProcCmdBuildAccelerationStructuresKHR
+CmdBuildClusterAccelerationStructureIndirectNV:         ProcCmdBuildClusterAccelerationStructureIndirectNV
 CmdBuildMicromapsEXT:                                   ProcCmdBuildMicromapsEXT
+CmdBuildPartitionedAccelerationStructuresNV:            ProcCmdBuildPartitionedAccelerationStructuresNV
 CmdClearAttachments:                                    ProcCmdClearAttachments
 CmdClearColorImage:                                     ProcCmdClearColorImage
 CmdClearDepthStencilImage:                              ProcCmdClearDepthStencilImage
 CmdControlVideoCodingKHR:                               ProcCmdControlVideoCodingKHR
+CmdConvertCooperativeVectorMatrixNV:                    ProcCmdConvertCooperativeVectorMatrixNV
 CmdCopyAccelerationStructureKHR:                        ProcCmdCopyAccelerationStructureKHR
 CmdCopyAccelerationStructureNV:                         ProcCmdCopyAccelerationStructureNV
 CmdCopyAccelerationStructureToMemoryKHR:                ProcCmdCopyAccelerationStructureToMemoryKHR
@@ -1102,6 +1115,7 @@ CmdWriteTimestamp:                                      ProcCmdWriteTimestamp
 CmdWriteTimestamp2:                                     ProcCmdWriteTimestamp2
 CmdWriteTimestamp2KHR:                                  ProcCmdWriteTimestamp2KHR
 CompileDeferredNV:                                      ProcCompileDeferredNV
+ConvertCooperativeVectorMatrixNV:                       ProcConvertCooperativeVectorMatrixNV
 CopyAccelerationStructureKHR:                           ProcCopyAccelerationStructureKHR
 CopyAccelerationStructureToMemoryKHR:                   ProcCopyAccelerationStructureToMemoryKHR
 CopyImageToImage:                                       ProcCopyImageToImage
@@ -1232,6 +1246,7 @@ GetBufferOpaqueCaptureAddressKHR:                       ProcGetBufferOpaqueCaptu
 GetBufferOpaqueCaptureDescriptorDataEXT:                ProcGetBufferOpaqueCaptureDescriptorDataEXT
 GetCalibratedTimestampsEXT:                             ProcGetCalibratedTimestampsEXT
 GetCalibratedTimestampsKHR:                             ProcGetCalibratedTimestampsKHR
+GetClusterAccelerationStructureBuildSizesNV:            ProcGetClusterAccelerationStructureBuildSizesNV
 GetCudaModuleCacheNV:                                   ProcGetCudaModuleCacheNV
 GetDeferredOperationMaxConcurrencyKHR:                  ProcGetDeferredOperationMaxConcurrencyKHR
 GetDeferredOperationResultKHR:                          ProcGetDeferredOperationResultKHR
@@ -1294,11 +1309,14 @@ GetLatencyTimingsNV:                                    ProcGetLatencyTimingsNV
 GetMemoryFdKHR:                                         ProcGetMemoryFdKHR
 GetMemoryFdPropertiesKHR:                               ProcGetMemoryFdPropertiesKHR
 GetMemoryHostPointerPropertiesEXT:                      ProcGetMemoryHostPointerPropertiesEXT
+GetMemoryMetalHandleEXT:                                ProcGetMemoryMetalHandleEXT
+GetMemoryMetalHandlePropertiesEXT:                      ProcGetMemoryMetalHandlePropertiesEXT
 GetMemoryRemoteAddressNV:                               ProcGetMemoryRemoteAddressNV
 GetMemoryWin32HandleKHR:                                ProcGetMemoryWin32HandleKHR
 GetMemoryWin32HandleNV:                                 ProcGetMemoryWin32HandleNV
 GetMemoryWin32HandlePropertiesKHR:                      ProcGetMemoryWin32HandlePropertiesKHR
 GetMicromapBuildSizesEXT:                               ProcGetMicromapBuildSizesEXT
+GetPartitionedAccelerationStructuresBuildSizesNV:       ProcGetPartitionedAccelerationStructuresBuildSizesNV
 GetPastPresentationTimingGOOGLE:                        ProcGetPastPresentationTimingGOOGLE
 GetPerformanceParameterINTEL:                           ProcGetPerformanceParameterINTEL
 GetPipelineBinaryDataKHR:                               ProcGetPipelineBinaryDataKHR
@@ -1456,6 +1474,7 @@ load_proc_addresses_custom :: proc(set_proc_address: SetProcAddressType) {
 	set_proc_address(&GetPhysicalDeviceCooperativeMatrixFlexibleDimensionsPropertiesNV, "vkGetPhysicalDeviceCooperativeMatrixFlexibleDimensionsPropertiesNV")
 	set_proc_address(&GetPhysicalDeviceCooperativeMatrixPropertiesKHR,                  "vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR")
 	set_proc_address(&GetPhysicalDeviceCooperativeMatrixPropertiesNV,                   "vkGetPhysicalDeviceCooperativeMatrixPropertiesNV")
+	set_proc_address(&GetPhysicalDeviceCooperativeVectorPropertiesNV,                   "vkGetPhysicalDeviceCooperativeVectorPropertiesNV")
 	set_proc_address(&GetPhysicalDeviceDisplayPlaneProperties2KHR,                      "vkGetPhysicalDeviceDisplayPlaneProperties2KHR")
 	set_proc_address(&GetPhysicalDeviceDisplayPlanePropertiesKHR,                       "vkGetPhysicalDeviceDisplayPlanePropertiesKHR")
 	set_proc_address(&GetPhysicalDeviceDisplayProperties2KHR,                           "vkGetPhysicalDeviceDisplayProperties2KHR")
@@ -1572,11 +1591,14 @@ load_proc_addresses_custom :: proc(set_proc_address: SetProcAddressType) {
 	set_proc_address(&CmdBuildAccelerationStructureNV,                        "vkCmdBuildAccelerationStructureNV")
 	set_proc_address(&CmdBuildAccelerationStructuresIndirectKHR,              "vkCmdBuildAccelerationStructuresIndirectKHR")
 	set_proc_address(&CmdBuildAccelerationStructuresKHR,                      "vkCmdBuildAccelerationStructuresKHR")
+	set_proc_address(&CmdBuildClusterAccelerationStructureIndirectNV,         "vkCmdBuildClusterAccelerationStructureIndirectNV")
 	set_proc_address(&CmdBuildMicromapsEXT,                                   "vkCmdBuildMicromapsEXT")
+	set_proc_address(&CmdBuildPartitionedAccelerationStructuresNV,            "vkCmdBuildPartitionedAccelerationStructuresNV")
 	set_proc_address(&CmdClearAttachments,                                    "vkCmdClearAttachments")
 	set_proc_address(&CmdClearColorImage,                                     "vkCmdClearColorImage")
 	set_proc_address(&CmdClearDepthStencilImage,                              "vkCmdClearDepthStencilImage")
 	set_proc_address(&CmdControlVideoCodingKHR,                               "vkCmdControlVideoCodingKHR")
+	set_proc_address(&CmdConvertCooperativeVectorMatrixNV,                    "vkCmdConvertCooperativeVectorMatrixNV")
 	set_proc_address(&CmdCopyAccelerationStructureKHR,                        "vkCmdCopyAccelerationStructureKHR")
 	set_proc_address(&CmdCopyAccelerationStructureNV,                         "vkCmdCopyAccelerationStructureNV")
 	set_proc_address(&CmdCopyAccelerationStructureToMemoryKHR,                "vkCmdCopyAccelerationStructureToMemoryKHR")
@@ -1799,6 +1821,7 @@ load_proc_addresses_custom :: proc(set_proc_address: SetProcAddressType) {
 	set_proc_address(&CmdWriteTimestamp2,                                     "vkCmdWriteTimestamp2")
 	set_proc_address(&CmdWriteTimestamp2KHR,                                  "vkCmdWriteTimestamp2KHR")
 	set_proc_address(&CompileDeferredNV,                                      "vkCompileDeferredNV")
+	set_proc_address(&ConvertCooperativeVectorMatrixNV,                       "vkConvertCooperativeVectorMatrixNV")
 	set_proc_address(&CopyAccelerationStructureKHR,                           "vkCopyAccelerationStructureKHR")
 	set_proc_address(&CopyAccelerationStructureToMemoryKHR,                   "vkCopyAccelerationStructureToMemoryKHR")
 	set_proc_address(&CopyImageToImage,                                       "vkCopyImageToImage")
@@ -1929,6 +1952,7 @@ load_proc_addresses_custom :: proc(set_proc_address: SetProcAddressType) {
 	set_proc_address(&GetBufferOpaqueCaptureDescriptorDataEXT,                "vkGetBufferOpaqueCaptureDescriptorDataEXT")
 	set_proc_address(&GetCalibratedTimestampsEXT,                             "vkGetCalibratedTimestampsEXT")
 	set_proc_address(&GetCalibratedTimestampsKHR,                             "vkGetCalibratedTimestampsKHR")
+	set_proc_address(&GetClusterAccelerationStructureBuildSizesNV,            "vkGetClusterAccelerationStructureBuildSizesNV")
 	set_proc_address(&GetCudaModuleCacheNV,                                   "vkGetCudaModuleCacheNV")
 	set_proc_address(&GetDeferredOperationMaxConcurrencyKHR,                  "vkGetDeferredOperationMaxConcurrencyKHR")
 	set_proc_address(&GetDeferredOperationResultKHR,                          "vkGetDeferredOperationResultKHR")
@@ -1991,11 +2015,14 @@ load_proc_addresses_custom :: proc(set_proc_address: SetProcAddressType) {
 	set_proc_address(&GetMemoryFdKHR,                                         "vkGetMemoryFdKHR")
 	set_proc_address(&GetMemoryFdPropertiesKHR,                               "vkGetMemoryFdPropertiesKHR")
 	set_proc_address(&GetMemoryHostPointerPropertiesEXT,                      "vkGetMemoryHostPointerPropertiesEXT")
+	set_proc_address(&GetMemoryMetalHandleEXT,                                "vkGetMemoryMetalHandleEXT")
+	set_proc_address(&GetMemoryMetalHandlePropertiesEXT,                      "vkGetMemoryMetalHandlePropertiesEXT")
 	set_proc_address(&GetMemoryRemoteAddressNV,                               "vkGetMemoryRemoteAddressNV")
 	set_proc_address(&GetMemoryWin32HandleKHR,                                "vkGetMemoryWin32HandleKHR")
 	set_proc_address(&GetMemoryWin32HandleNV,                                 "vkGetMemoryWin32HandleNV")
 	set_proc_address(&GetMemoryWin32HandlePropertiesKHR,                      "vkGetMemoryWin32HandlePropertiesKHR")
 	set_proc_address(&GetMicromapBuildSizesEXT,                               "vkGetMicromapBuildSizesEXT")
+	set_proc_address(&GetPartitionedAccelerationStructuresBuildSizesNV,       "vkGetPartitionedAccelerationStructuresBuildSizesNV")
 	set_proc_address(&GetPastPresentationTimingGOOGLE,                        "vkGetPastPresentationTimingGOOGLE")
 	set_proc_address(&GetPerformanceParameterINTEL,                           "vkGetPerformanceParameterINTEL")
 	set_proc_address(&GetPipelineBinaryDataKHR,                               "vkGetPipelineBinaryDataKHR")
@@ -2164,11 +2191,14 @@ Device_VTable :: struct {
 	CmdBuildAccelerationStructureNV:                        ProcCmdBuildAccelerationStructureNV,
 	CmdBuildAccelerationStructuresIndirectKHR:              ProcCmdBuildAccelerationStructuresIndirectKHR,
 	CmdBuildAccelerationStructuresKHR:                      ProcCmdBuildAccelerationStructuresKHR,
+	CmdBuildClusterAccelerationStructureIndirectNV:         ProcCmdBuildClusterAccelerationStructureIndirectNV,
 	CmdBuildMicromapsEXT:                                   ProcCmdBuildMicromapsEXT,
+	CmdBuildPartitionedAccelerationStructuresNV:            ProcCmdBuildPartitionedAccelerationStructuresNV,
 	CmdClearAttachments:                                    ProcCmdClearAttachments,
 	CmdClearColorImage:                                     ProcCmdClearColorImage,
 	CmdClearDepthStencilImage:                              ProcCmdClearDepthStencilImage,
 	CmdControlVideoCodingKHR:                               ProcCmdControlVideoCodingKHR,
+	CmdConvertCooperativeVectorMatrixNV:                    ProcCmdConvertCooperativeVectorMatrixNV,
 	CmdCopyAccelerationStructureKHR:                        ProcCmdCopyAccelerationStructureKHR,
 	CmdCopyAccelerationStructureNV:                         ProcCmdCopyAccelerationStructureNV,
 	CmdCopyAccelerationStructureToMemoryKHR:                ProcCmdCopyAccelerationStructureToMemoryKHR,
@@ -2391,6 +2421,7 @@ Device_VTable :: struct {
 	CmdWriteTimestamp2:                                     ProcCmdWriteTimestamp2,
 	CmdWriteTimestamp2KHR:                                  ProcCmdWriteTimestamp2KHR,
 	CompileDeferredNV:                                      ProcCompileDeferredNV,
+	ConvertCooperativeVectorMatrixNV:                       ProcConvertCooperativeVectorMatrixNV,
 	CopyAccelerationStructureKHR:                           ProcCopyAccelerationStructureKHR,
 	CopyAccelerationStructureToMemoryKHR:                   ProcCopyAccelerationStructureToMemoryKHR,
 	CopyImageToImage:                                       ProcCopyImageToImage,
@@ -2521,6 +2552,7 @@ Device_VTable :: struct {
 	GetBufferOpaqueCaptureDescriptorDataEXT:                ProcGetBufferOpaqueCaptureDescriptorDataEXT,
 	GetCalibratedTimestampsEXT:                             ProcGetCalibratedTimestampsEXT,
 	GetCalibratedTimestampsKHR:                             ProcGetCalibratedTimestampsKHR,
+	GetClusterAccelerationStructureBuildSizesNV:            ProcGetClusterAccelerationStructureBuildSizesNV,
 	GetCudaModuleCacheNV:                                   ProcGetCudaModuleCacheNV,
 	GetDeferredOperationMaxConcurrencyKHR:                  ProcGetDeferredOperationMaxConcurrencyKHR,
 	GetDeferredOperationResultKHR:                          ProcGetDeferredOperationResultKHR,
@@ -2583,11 +2615,14 @@ Device_VTable :: struct {
 	GetMemoryFdKHR:                                         ProcGetMemoryFdKHR,
 	GetMemoryFdPropertiesKHR:                               ProcGetMemoryFdPropertiesKHR,
 	GetMemoryHostPointerPropertiesEXT:                      ProcGetMemoryHostPointerPropertiesEXT,
+	GetMemoryMetalHandleEXT:                                ProcGetMemoryMetalHandleEXT,
+	GetMemoryMetalHandlePropertiesEXT:                      ProcGetMemoryMetalHandlePropertiesEXT,
 	GetMemoryRemoteAddressNV:                               ProcGetMemoryRemoteAddressNV,
 	GetMemoryWin32HandleKHR:                                ProcGetMemoryWin32HandleKHR,
 	GetMemoryWin32HandleNV:                                 ProcGetMemoryWin32HandleNV,
 	GetMemoryWin32HandlePropertiesKHR:                      ProcGetMemoryWin32HandlePropertiesKHR,
 	GetMicromapBuildSizesEXT:                               ProcGetMicromapBuildSizesEXT,
+	GetPartitionedAccelerationStructuresBuildSizesNV:       ProcGetPartitionedAccelerationStructuresBuildSizesNV,
 	GetPastPresentationTimingGOOGLE:                        ProcGetPastPresentationTimingGOOGLE,
 	GetPerformanceParameterINTEL:                           ProcGetPerformanceParameterINTEL,
 	GetPipelineBinaryDataKHR:                               ProcGetPipelineBinaryDataKHR,
@@ -2754,11 +2789,14 @@ load_proc_addresses_device_vtable :: proc(device: Device, vtable: ^Device_VTable
 	vtable.CmdBuildAccelerationStructureNV                        = auto_cast GetDeviceProcAddr(device, "vkCmdBuildAccelerationStructureNV")
 	vtable.CmdBuildAccelerationStructuresIndirectKHR              = auto_cast GetDeviceProcAddr(device, "vkCmdBuildAccelerationStructuresIndirectKHR")
 	vtable.CmdBuildAccelerationStructuresKHR                      = auto_cast GetDeviceProcAddr(device, "vkCmdBuildAccelerationStructuresKHR")
+	vtable.CmdBuildClusterAccelerationStructureIndirectNV         = auto_cast GetDeviceProcAddr(device, "vkCmdBuildClusterAccelerationStructureIndirectNV")
 	vtable.CmdBuildMicromapsEXT                                   = auto_cast GetDeviceProcAddr(device, "vkCmdBuildMicromapsEXT")
+	vtable.CmdBuildPartitionedAccelerationStructuresNV            = auto_cast GetDeviceProcAddr(device, "vkCmdBuildPartitionedAccelerationStructuresNV")
 	vtable.CmdClearAttachments                                    = auto_cast GetDeviceProcAddr(device, "vkCmdClearAttachments")
 	vtable.CmdClearColorImage                                     = auto_cast GetDeviceProcAddr(device, "vkCmdClearColorImage")
 	vtable.CmdClearDepthStencilImage                              = auto_cast GetDeviceProcAddr(device, "vkCmdClearDepthStencilImage")
 	vtable.CmdControlVideoCodingKHR                               = auto_cast GetDeviceProcAddr(device, "vkCmdControlVideoCodingKHR")
+	vtable.CmdConvertCooperativeVectorMatrixNV                    = auto_cast GetDeviceProcAddr(device, "vkCmdConvertCooperativeVectorMatrixNV")
 	vtable.CmdCopyAccelerationStructureKHR                        = auto_cast GetDeviceProcAddr(device, "vkCmdCopyAccelerationStructureKHR")
 	vtable.CmdCopyAccelerationStructureNV                         = auto_cast GetDeviceProcAddr(device, "vkCmdCopyAccelerationStructureNV")
 	vtable.CmdCopyAccelerationStructureToMemoryKHR                = auto_cast GetDeviceProcAddr(device, "vkCmdCopyAccelerationStructureToMemoryKHR")
@@ -2981,6 +3019,7 @@ load_proc_addresses_device_vtable :: proc(device: Device, vtable: ^Device_VTable
 	vtable.CmdWriteTimestamp2                                     = auto_cast GetDeviceProcAddr(device, "vkCmdWriteTimestamp2")
 	vtable.CmdWriteTimestamp2KHR                                  = auto_cast GetDeviceProcAddr(device, "vkCmdWriteTimestamp2KHR")
 	vtable.CompileDeferredNV                                      = auto_cast GetDeviceProcAddr(device, "vkCompileDeferredNV")
+	vtable.ConvertCooperativeVectorMatrixNV                       = auto_cast GetDeviceProcAddr(device, "vkConvertCooperativeVectorMatrixNV")
 	vtable.CopyAccelerationStructureKHR                           = auto_cast GetDeviceProcAddr(device, "vkCopyAccelerationStructureKHR")
 	vtable.CopyAccelerationStructureToMemoryKHR                   = auto_cast GetDeviceProcAddr(device, "vkCopyAccelerationStructureToMemoryKHR")
 	vtable.CopyImageToImage                                       = auto_cast GetDeviceProcAddr(device, "vkCopyImageToImage")
@@ -3111,6 +3150,7 @@ load_proc_addresses_device_vtable :: proc(device: Device, vtable: ^Device_VTable
 	vtable.GetBufferOpaqueCaptureDescriptorDataEXT                = auto_cast GetDeviceProcAddr(device, "vkGetBufferOpaqueCaptureDescriptorDataEXT")
 	vtable.GetCalibratedTimestampsEXT                             = auto_cast GetDeviceProcAddr(device, "vkGetCalibratedTimestampsEXT")
 	vtable.GetCalibratedTimestampsKHR                             = auto_cast GetDeviceProcAddr(device, "vkGetCalibratedTimestampsKHR")
+	vtable.GetClusterAccelerationStructureBuildSizesNV            = auto_cast GetDeviceProcAddr(device, "vkGetClusterAccelerationStructureBuildSizesNV")
 	vtable.GetCudaModuleCacheNV                                   = auto_cast GetDeviceProcAddr(device, "vkGetCudaModuleCacheNV")
 	vtable.GetDeferredOperationMaxConcurrencyKHR                  = auto_cast GetDeviceProcAddr(device, "vkGetDeferredOperationMaxConcurrencyKHR")
 	vtable.GetDeferredOperationResultKHR                          = auto_cast GetDeviceProcAddr(device, "vkGetDeferredOperationResultKHR")
@@ -3173,11 +3213,14 @@ load_proc_addresses_device_vtable :: proc(device: Device, vtable: ^Device_VTable
 	vtable.GetMemoryFdKHR                                         = auto_cast GetDeviceProcAddr(device, "vkGetMemoryFdKHR")
 	vtable.GetMemoryFdPropertiesKHR                               = auto_cast GetDeviceProcAddr(device, "vkGetMemoryFdPropertiesKHR")
 	vtable.GetMemoryHostPointerPropertiesEXT                      = auto_cast GetDeviceProcAddr(device, "vkGetMemoryHostPointerPropertiesEXT")
+	vtable.GetMemoryMetalHandleEXT                                = auto_cast GetDeviceProcAddr(device, "vkGetMemoryMetalHandleEXT")
+	vtable.GetMemoryMetalHandlePropertiesEXT                      = auto_cast GetDeviceProcAddr(device, "vkGetMemoryMetalHandlePropertiesEXT")
 	vtable.GetMemoryRemoteAddressNV                               = auto_cast GetDeviceProcAddr(device, "vkGetMemoryRemoteAddressNV")
 	vtable.GetMemoryWin32HandleKHR                                = auto_cast GetDeviceProcAddr(device, "vkGetMemoryWin32HandleKHR")
 	vtable.GetMemoryWin32HandleNV                                 = auto_cast GetDeviceProcAddr(device, "vkGetMemoryWin32HandleNV")
 	vtable.GetMemoryWin32HandlePropertiesKHR                      = auto_cast GetDeviceProcAddr(device, "vkGetMemoryWin32HandlePropertiesKHR")
 	vtable.GetMicromapBuildSizesEXT                               = auto_cast GetDeviceProcAddr(device, "vkGetMicromapBuildSizesEXT")
+	vtable.GetPartitionedAccelerationStructuresBuildSizesNV       = auto_cast GetDeviceProcAddr(device, "vkGetPartitionedAccelerationStructuresBuildSizesNV")
 	vtable.GetPastPresentationTimingGOOGLE                        = auto_cast GetDeviceProcAddr(device, "vkGetPastPresentationTimingGOOGLE")
 	vtable.GetPerformanceParameterINTEL                           = auto_cast GetDeviceProcAddr(device, "vkGetPerformanceParameterINTEL")
 	vtable.GetPipelineBinaryDataKHR                               = auto_cast GetDeviceProcAddr(device, "vkGetPipelineBinaryDataKHR")
@@ -3344,11 +3387,14 @@ load_proc_addresses_device :: proc(device: Device) {
 	CmdBuildAccelerationStructureNV                        = auto_cast GetDeviceProcAddr(device, "vkCmdBuildAccelerationStructureNV")
 	CmdBuildAccelerationStructuresIndirectKHR              = auto_cast GetDeviceProcAddr(device, "vkCmdBuildAccelerationStructuresIndirectKHR")
 	CmdBuildAccelerationStructuresKHR                      = auto_cast GetDeviceProcAddr(device, "vkCmdBuildAccelerationStructuresKHR")
+	CmdBuildClusterAccelerationStructureIndirectNV         = auto_cast GetDeviceProcAddr(device, "vkCmdBuildClusterAccelerationStructureIndirectNV")
 	CmdBuildMicromapsEXT                                   = auto_cast GetDeviceProcAddr(device, "vkCmdBuildMicromapsEXT")
+	CmdBuildPartitionedAccelerationStructuresNV            = auto_cast GetDeviceProcAddr(device, "vkCmdBuildPartitionedAccelerationStructuresNV")
 	CmdClearAttachments                                    = auto_cast GetDeviceProcAddr(device, "vkCmdClearAttachments")
 	CmdClearColorImage                                     = auto_cast GetDeviceProcAddr(device, "vkCmdClearColorImage")
 	CmdClearDepthStencilImage                              = auto_cast GetDeviceProcAddr(device, "vkCmdClearDepthStencilImage")
 	CmdControlVideoCodingKHR                               = auto_cast GetDeviceProcAddr(device, "vkCmdControlVideoCodingKHR")
+	CmdConvertCooperativeVectorMatrixNV                    = auto_cast GetDeviceProcAddr(device, "vkCmdConvertCooperativeVectorMatrixNV")
 	CmdCopyAccelerationStructureKHR                        = auto_cast GetDeviceProcAddr(device, "vkCmdCopyAccelerationStructureKHR")
 	CmdCopyAccelerationStructureNV                         = auto_cast GetDeviceProcAddr(device, "vkCmdCopyAccelerationStructureNV")
 	CmdCopyAccelerationStructureToMemoryKHR                = auto_cast GetDeviceProcAddr(device, "vkCmdCopyAccelerationStructureToMemoryKHR")
@@ -3571,6 +3617,7 @@ load_proc_addresses_device :: proc(device: Device) {
 	CmdWriteTimestamp2                                     = auto_cast GetDeviceProcAddr(device, "vkCmdWriteTimestamp2")
 	CmdWriteTimestamp2KHR                                  = auto_cast GetDeviceProcAddr(device, "vkCmdWriteTimestamp2KHR")
 	CompileDeferredNV                                      = auto_cast GetDeviceProcAddr(device, "vkCompileDeferredNV")
+	ConvertCooperativeVectorMatrixNV                       = auto_cast GetDeviceProcAddr(device, "vkConvertCooperativeVectorMatrixNV")
 	CopyAccelerationStructureKHR                           = auto_cast GetDeviceProcAddr(device, "vkCopyAccelerationStructureKHR")
 	CopyAccelerationStructureToMemoryKHR                   = auto_cast GetDeviceProcAddr(device, "vkCopyAccelerationStructureToMemoryKHR")
 	CopyImageToImage                                       = auto_cast GetDeviceProcAddr(device, "vkCopyImageToImage")
@@ -3701,6 +3748,7 @@ load_proc_addresses_device :: proc(device: Device) {
 	GetBufferOpaqueCaptureDescriptorDataEXT                = auto_cast GetDeviceProcAddr(device, "vkGetBufferOpaqueCaptureDescriptorDataEXT")
 	GetCalibratedTimestampsEXT                             = auto_cast GetDeviceProcAddr(device, "vkGetCalibratedTimestampsEXT")
 	GetCalibratedTimestampsKHR                             = auto_cast GetDeviceProcAddr(device, "vkGetCalibratedTimestampsKHR")
+	GetClusterAccelerationStructureBuildSizesNV            = auto_cast GetDeviceProcAddr(device, "vkGetClusterAccelerationStructureBuildSizesNV")
 	GetCudaModuleCacheNV                                   = auto_cast GetDeviceProcAddr(device, "vkGetCudaModuleCacheNV")
 	GetDeferredOperationMaxConcurrencyKHR                  = auto_cast GetDeviceProcAddr(device, "vkGetDeferredOperationMaxConcurrencyKHR")
 	GetDeferredOperationResultKHR                          = auto_cast GetDeviceProcAddr(device, "vkGetDeferredOperationResultKHR")
@@ -3763,11 +3811,14 @@ load_proc_addresses_device :: proc(device: Device) {
 	GetMemoryFdKHR                                         = auto_cast GetDeviceProcAddr(device, "vkGetMemoryFdKHR")
 	GetMemoryFdPropertiesKHR                               = auto_cast GetDeviceProcAddr(device, "vkGetMemoryFdPropertiesKHR")
 	GetMemoryHostPointerPropertiesEXT                      = auto_cast GetDeviceProcAddr(device, "vkGetMemoryHostPointerPropertiesEXT")
+	GetMemoryMetalHandleEXT                                = auto_cast GetDeviceProcAddr(device, "vkGetMemoryMetalHandleEXT")
+	GetMemoryMetalHandlePropertiesEXT                      = auto_cast GetDeviceProcAddr(device, "vkGetMemoryMetalHandlePropertiesEXT")
 	GetMemoryRemoteAddressNV                               = auto_cast GetDeviceProcAddr(device, "vkGetMemoryRemoteAddressNV")
 	GetMemoryWin32HandleKHR                                = auto_cast GetDeviceProcAddr(device, "vkGetMemoryWin32HandleKHR")
 	GetMemoryWin32HandleNV                                 = auto_cast GetDeviceProcAddr(device, "vkGetMemoryWin32HandleNV")
 	GetMemoryWin32HandlePropertiesKHR                      = auto_cast GetDeviceProcAddr(device, "vkGetMemoryWin32HandlePropertiesKHR")
 	GetMicromapBuildSizesEXT                               = auto_cast GetDeviceProcAddr(device, "vkGetMicromapBuildSizesEXT")
+	GetPartitionedAccelerationStructuresBuildSizesNV       = auto_cast GetDeviceProcAddr(device, "vkGetPartitionedAccelerationStructuresBuildSizesNV")
 	GetPastPresentationTimingGOOGLE                        = auto_cast GetDeviceProcAddr(device, "vkGetPastPresentationTimingGOOGLE")
 	GetPerformanceParameterINTEL                           = auto_cast GetDeviceProcAddr(device, "vkGetPerformanceParameterINTEL")
 	GetPipelineBinaryDataKHR                               = auto_cast GetDeviceProcAddr(device, "vkGetPipelineBinaryDataKHR")
@@ -3916,6 +3967,7 @@ load_proc_addresses_instance :: proc(instance: Instance) {
 	GetPhysicalDeviceCooperativeMatrixFlexibleDimensionsPropertiesNV = auto_cast GetInstanceProcAddr(instance, "vkGetPhysicalDeviceCooperativeMatrixFlexibleDimensionsPropertiesNV")
 	GetPhysicalDeviceCooperativeMatrixPropertiesKHR                  = auto_cast GetInstanceProcAddr(instance, "vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR")
 	GetPhysicalDeviceCooperativeMatrixPropertiesNV                   = auto_cast GetInstanceProcAddr(instance, "vkGetPhysicalDeviceCooperativeMatrixPropertiesNV")
+	GetPhysicalDeviceCooperativeVectorPropertiesNV                   = auto_cast GetInstanceProcAddr(instance, "vkGetPhysicalDeviceCooperativeVectorPropertiesNV")
 	GetPhysicalDeviceDisplayPlaneProperties2KHR                      = auto_cast GetInstanceProcAddr(instance, "vkGetPhysicalDeviceDisplayPlaneProperties2KHR")
 	GetPhysicalDeviceDisplayPlanePropertiesKHR                       = auto_cast GetInstanceProcAddr(instance, "vkGetPhysicalDeviceDisplayPlanePropertiesKHR")
 	GetPhysicalDeviceDisplayProperties2KHR                           = auto_cast GetInstanceProcAddr(instance, "vkGetPhysicalDeviceDisplayProperties2KHR")
@@ -4032,11 +4084,14 @@ load_proc_addresses_instance :: proc(instance: Instance) {
 	CmdBuildAccelerationStructureNV                        = auto_cast GetInstanceProcAddr(instance, "vkCmdBuildAccelerationStructureNV")
 	CmdBuildAccelerationStructuresIndirectKHR              = auto_cast GetInstanceProcAddr(instance, "vkCmdBuildAccelerationStructuresIndirectKHR")
 	CmdBuildAccelerationStructuresKHR                      = auto_cast GetInstanceProcAddr(instance, "vkCmdBuildAccelerationStructuresKHR")
+	CmdBuildClusterAccelerationStructureIndirectNV         = auto_cast GetInstanceProcAddr(instance, "vkCmdBuildClusterAccelerationStructureIndirectNV")
 	CmdBuildMicromapsEXT                                   = auto_cast GetInstanceProcAddr(instance, "vkCmdBuildMicromapsEXT")
+	CmdBuildPartitionedAccelerationStructuresNV            = auto_cast GetInstanceProcAddr(instance, "vkCmdBuildPartitionedAccelerationStructuresNV")
 	CmdClearAttachments                                    = auto_cast GetInstanceProcAddr(instance, "vkCmdClearAttachments")
 	CmdClearColorImage                                     = auto_cast GetInstanceProcAddr(instance, "vkCmdClearColorImage")
 	CmdClearDepthStencilImage                              = auto_cast GetInstanceProcAddr(instance, "vkCmdClearDepthStencilImage")
 	CmdControlVideoCodingKHR                               = auto_cast GetInstanceProcAddr(instance, "vkCmdControlVideoCodingKHR")
+	CmdConvertCooperativeVectorMatrixNV                    = auto_cast GetInstanceProcAddr(instance, "vkCmdConvertCooperativeVectorMatrixNV")
 	CmdCopyAccelerationStructureKHR                        = auto_cast GetInstanceProcAddr(instance, "vkCmdCopyAccelerationStructureKHR")
 	CmdCopyAccelerationStructureNV                         = auto_cast GetInstanceProcAddr(instance, "vkCmdCopyAccelerationStructureNV")
 	CmdCopyAccelerationStructureToMemoryKHR                = auto_cast GetInstanceProcAddr(instance, "vkCmdCopyAccelerationStructureToMemoryKHR")
@@ -4259,6 +4314,7 @@ load_proc_addresses_instance :: proc(instance: Instance) {
 	CmdWriteTimestamp2                                     = auto_cast GetInstanceProcAddr(instance, "vkCmdWriteTimestamp2")
 	CmdWriteTimestamp2KHR                                  = auto_cast GetInstanceProcAddr(instance, "vkCmdWriteTimestamp2KHR")
 	CompileDeferredNV                                      = auto_cast GetInstanceProcAddr(instance, "vkCompileDeferredNV")
+	ConvertCooperativeVectorMatrixNV                       = auto_cast GetInstanceProcAddr(instance, "vkConvertCooperativeVectorMatrixNV")
 	CopyAccelerationStructureKHR                           = auto_cast GetInstanceProcAddr(instance, "vkCopyAccelerationStructureKHR")
 	CopyAccelerationStructureToMemoryKHR                   = auto_cast GetInstanceProcAddr(instance, "vkCopyAccelerationStructureToMemoryKHR")
 	CopyImageToImage                                       = auto_cast GetInstanceProcAddr(instance, "vkCopyImageToImage")
@@ -4389,6 +4445,7 @@ load_proc_addresses_instance :: proc(instance: Instance) {
 	GetBufferOpaqueCaptureDescriptorDataEXT                = auto_cast GetInstanceProcAddr(instance, "vkGetBufferOpaqueCaptureDescriptorDataEXT")
 	GetCalibratedTimestampsEXT                             = auto_cast GetInstanceProcAddr(instance, "vkGetCalibratedTimestampsEXT")
 	GetCalibratedTimestampsKHR                             = auto_cast GetInstanceProcAddr(instance, "vkGetCalibratedTimestampsKHR")
+	GetClusterAccelerationStructureBuildSizesNV            = auto_cast GetInstanceProcAddr(instance, "vkGetClusterAccelerationStructureBuildSizesNV")
 	GetCudaModuleCacheNV                                   = auto_cast GetInstanceProcAddr(instance, "vkGetCudaModuleCacheNV")
 	GetDeferredOperationMaxConcurrencyKHR                  = auto_cast GetInstanceProcAddr(instance, "vkGetDeferredOperationMaxConcurrencyKHR")
 	GetDeferredOperationResultKHR                          = auto_cast GetInstanceProcAddr(instance, "vkGetDeferredOperationResultKHR")
@@ -4451,11 +4508,14 @@ load_proc_addresses_instance :: proc(instance: Instance) {
 	GetMemoryFdKHR                                         = auto_cast GetInstanceProcAddr(instance, "vkGetMemoryFdKHR")
 	GetMemoryFdPropertiesKHR                               = auto_cast GetInstanceProcAddr(instance, "vkGetMemoryFdPropertiesKHR")
 	GetMemoryHostPointerPropertiesEXT                      = auto_cast GetInstanceProcAddr(instance, "vkGetMemoryHostPointerPropertiesEXT")
+	GetMemoryMetalHandleEXT                                = auto_cast GetInstanceProcAddr(instance, "vkGetMemoryMetalHandleEXT")
+	GetMemoryMetalHandlePropertiesEXT                      = auto_cast GetInstanceProcAddr(instance, "vkGetMemoryMetalHandlePropertiesEXT")
 	GetMemoryRemoteAddressNV                               = auto_cast GetInstanceProcAddr(instance, "vkGetMemoryRemoteAddressNV")
 	GetMemoryWin32HandleKHR                                = auto_cast GetInstanceProcAddr(instance, "vkGetMemoryWin32HandleKHR")
 	GetMemoryWin32HandleNV                                 = auto_cast GetInstanceProcAddr(instance, "vkGetMemoryWin32HandleNV")
 	GetMemoryWin32HandlePropertiesKHR                      = auto_cast GetInstanceProcAddr(instance, "vkGetMemoryWin32HandlePropertiesKHR")
 	GetMicromapBuildSizesEXT                               = auto_cast GetInstanceProcAddr(instance, "vkGetMicromapBuildSizesEXT")
+	GetPartitionedAccelerationStructuresBuildSizesNV       = auto_cast GetInstanceProcAddr(instance, "vkGetPartitionedAccelerationStructuresBuildSizesNV")
 	GetPastPresentationTimingGOOGLE                        = auto_cast GetInstanceProcAddr(instance, "vkGetPastPresentationTimingGOOGLE")
 	GetPerformanceParameterINTEL                           = auto_cast GetInstanceProcAddr(instance, "vkGetPerformanceParameterINTEL")
 	GetPipelineBinaryDataKHR                               = auto_cast GetInstanceProcAddr(instance, "vkGetPipelineBinaryDataKHR")

--- a/vendor/vulkan/structs.odin
+++ b/vendor/vulkan/structs.odin
@@ -10013,13 +10013,13 @@ VideoH265SubLayerHrdParameters :: struct {
 }
 
 VideoH265HrdFlags :: bit_field u32 {
-	nal_hrd_parameters_present_flag:           bool | 1,
-	vcl_hrd_parameters_present_flag:           bool | 1,
-	sub_pic_hrd_params_present_flag:           bool | 1,
-	sub_pic_cpb_params_in_pic_timing_sei_flag: bool | 1,
-	fixed_pic_rate_general_flag:               u32  | 8,
-	fixed_pic_rate_within_cvs_flag:            u32  | 8,
-	low_delay_hrd_flag:                        u32  | 8,
+	nal_hrd_parameters_present_flag:           u32 | 1,
+	vcl_hrd_parameters_present_flag:           u32 | 1,
+	sub_pic_hrd_params_present_flag:           u32 | 1,
+	sub_pic_cpb_params_in_pic_timing_sei_flag: u32 | 1,
+	fixed_pic_rate_general_flag:               u32 | 8,
+	fixed_pic_rate_within_cvs_flag:            u32 | 8,
+	low_delay_hrd_flag:                        u32 | 8,
 }
 
 VideoH265HrdParameters :: struct {

--- a/vendor/vulkan/structs.odin
+++ b/vendor/vulkan/structs.odin
@@ -5681,7 +5681,7 @@ AabbPositionsKHR :: struct {
 }
 
 AccelerationStructureInstanceKHR :: struct {
-	transform: TransformMatrixKHR,
+	transform:                      TransformMatrixKHR,
 	using _: bit_field u32 {
 		instanceCustomIndex: u32 | 24,
 		mask:                u32 | 8,
@@ -6752,8 +6752,8 @@ AccelerationStructureMotionInfoNV :: struct {
 }
 
 AccelerationStructureMatrixMotionInstanceNV :: struct {
-	transformT0: TransformMatrixKHR,
-	transformT1: TransformMatrixKHR,
+	transformT0:                    TransformMatrixKHR,
+	transformT1:                    TransformMatrixKHR,
 	using _: bit_field u32 {
 		instanceCustomIndex: u32 | 24,
 		mask:                u32 | 8,
@@ -6785,8 +6785,8 @@ SRTDataNV :: struct {
 }
 
 AccelerationStructureSRTMotionInstanceNV :: struct {
-	transformT0: SRTDataNV,
-	transformT1: SRTDataNV,
+	transformT0:                    SRTDataNV,
+	transformT1:                    SRTDataNV,
 	using _: bit_field u32 {
 		instanceCustomIndex: u32 | 24,
 		mask:                u32 | 8,
@@ -8378,8 +8378,8 @@ ClusterAccelerationStructureBuildClustersBottomLevelInfoNV :: struct {
 }
 
 ClusterAccelerationStructureBuildTriangleClusterInfoNV :: struct {
-	clusterID: u32,
-	clusterFlags: ClusterAccelerationStructureClusterFlagsNV,
+	clusterID:                         u32,
+	clusterFlags:                      ClusterAccelerationStructureClusterFlagsNV,
 	using _: bit_field u32 {
 		triangleCount:            u32 | 9,
 		vertexCount:              u32 | 9,
@@ -8388,20 +8388,20 @@ ClusterAccelerationStructureBuildTriangleClusterInfoNV :: struct {
 		opacityMicromapIndexType: u32 | 4,
 	},
 	baseGeometryIndexAndGeometryFlags: ClusterAccelerationStructureGeometryIndexAndGeometryFlagsNV,
-	indexBufferStride: u16,
-	vertexBufferStride: u16,
+	indexBufferStride:                 u16,
+	vertexBufferStride:                u16,
 	geometryIndexAndFlagsBufferStride: u16,
-	opacityMicromapIndexBufferStride: u16,
-	indexBuffer: DeviceAddress,
-	vertexBuffer: DeviceAddress,
-	geometryIndexAndFlagsBuffer: DeviceAddress,
-	opacityMicromapArray: DeviceAddress,
-	opacityMicromapIndexBuffer: DeviceAddress,
+	opacityMicromapIndexBufferStride:  u16,
+	indexBuffer:                       DeviceAddress,
+	vertexBuffer:                      DeviceAddress,
+	geometryIndexAndFlagsBuffer:       DeviceAddress,
+	opacityMicromapArray:              DeviceAddress,
+	opacityMicromapIndexBuffer:        DeviceAddress,
 }
 
 ClusterAccelerationStructureBuildTriangleClusterTemplateInfoNV :: struct {
-	clusterID: u32,
-	clusterFlags: ClusterAccelerationStructureClusterFlagsNV,
+	clusterID:                         u32,
+	clusterFlags:                      ClusterAccelerationStructureClusterFlagsNV,
 	using _: bit_field u32 {
 		triangleCount:            u32 | 9,
 		vertexCount:              u32 | 9,
@@ -8410,26 +8410,26 @@ ClusterAccelerationStructureBuildTriangleClusterTemplateInfoNV :: struct {
 		opacityMicromapIndexType: u32 | 4,
 	},
 	baseGeometryIndexAndGeometryFlags: ClusterAccelerationStructureGeometryIndexAndGeometryFlagsNV,
-	indexBufferStride: u16,
-	vertexBufferStride: u16,
+	indexBufferStride:                 u16,
+	vertexBufferStride:                u16,
 	geometryIndexAndFlagsBufferStride: u16,
-	opacityMicromapIndexBufferStride: u16,
-	indexBuffer: DeviceAddress,
-	vertexBuffer: DeviceAddress,
-	geometryIndexAndFlagsBuffer: DeviceAddress,
-	opacityMicromapArray: DeviceAddress,
-	opacityMicromapIndexBuffer: DeviceAddress,
-	instantiationBoundingBoxLimit: DeviceAddress,
+	opacityMicromapIndexBufferStride:  u16,
+	indexBuffer:                       DeviceAddress,
+	vertexBuffer:                      DeviceAddress,
+	geometryIndexAndFlagsBuffer:       DeviceAddress,
+	opacityMicromapArray:              DeviceAddress,
+	opacityMicromapIndexBuffer:        DeviceAddress,
+	instantiationBoundingBoxLimit:     DeviceAddress,
 }
 
 ClusterAccelerationStructureInstantiateClusterInfoNV :: struct {
-	clusterIdOffset: u32,
+	clusterIdOffset:        u32,
 	using _: bit_field u32 {
 		geometryIndexOffset: u32 | 24,
 		reserved:            u32 | 8,
 	},
 	clusterTemplateAddress: DeviceAddress,
-	vertexBuffer: StridedDeviceAddressNV,
+	vertexBuffer:           StridedDeviceAddressNV,
 }
 
 AccelerationStructureBuildSizesInfoKHR :: struct {

--- a/vendor/vulkan/structs.odin
+++ b/vendor/vulkan/structs.odin
@@ -9353,6 +9353,129 @@ XcbSurfaceCreateInfoKHR :: struct {
 	window:     xcb_window_t,
 }
 
+PhysicalDevicePortabilitySubsetFeaturesKHR :: struct {
+	sType:                                  StructureType,
+	pNext:                                  rawptr,
+	constantAlphaColorBlendFactors:         b32,
+	events:                                 b32,
+	imageViewFormatReinterpretation:        b32,
+	imageViewFormatSwizzle:                 b32,
+	imageView2DOn3DImage:                   b32,
+	multisampleArrayImage:                  b32,
+	mutableComparisonSamplers:              b32,
+	pointPolygons:                          b32,
+	samplerMipLodBias:                      b32,
+	separateStencilMaskRef:                 b32,
+	shaderSampleRateInterpolationFunctions: b32,
+	tessellationIsolines:                   b32,
+	tessellationPointMode:                  b32,
+	triangleFans:                           b32,
+	vertexAttributeAccessBeyondStride:      b32,
+}
+
+PhysicalDevicePortabilitySubsetPropertiesKHR :: struct {
+	sType:                                StructureType,
+	pNext:                                rawptr,
+	minVertexInputBindingStrideAlignment: u32,
+}
+
+PhysicalDeviceShaderEnqueueFeaturesAMDX :: struct {
+	sType:             StructureType,
+	pNext:             rawptr,
+	shaderEnqueue:     b32,
+	shaderMeshEnqueue: b32,
+}
+
+PhysicalDeviceShaderEnqueuePropertiesAMDX :: struct {
+	sType:                                  StructureType,
+	pNext:                                  rawptr,
+	maxExecutionGraphDepth:                 u32,
+	maxExecutionGraphShaderOutputNodes:     u32,
+	maxExecutionGraphShaderPayloadSize:     u32,
+	maxExecutionGraphShaderPayloadCount:    u32,
+	executionGraphDispatchAddressAlignment: u32,
+	maxExecutionGraphWorkgroupCount:        [3]u32,
+	maxExecutionGraphWorkgroups:            u32,
+}
+
+ExecutionGraphPipelineScratchSizeAMDX :: struct {
+	sType:           StructureType,
+	pNext:           rawptr,
+	minSize:         DeviceSize,
+	maxSize:         DeviceSize,
+	sizeGranularity: DeviceSize,
+}
+
+ExecutionGraphPipelineCreateInfoAMDX :: struct {
+	sType:              StructureType,
+	pNext:              rawptr,
+	flags:              PipelineCreateFlags,
+	stageCount:         u32,
+	pStages:            [^]PipelineShaderStageCreateInfo,
+	pLibraryInfo:       ^PipelineLibraryCreateInfoKHR,
+	layout:             PipelineLayout,
+	basePipelineHandle: Pipeline,
+	basePipelineIndex:  i32,
+}
+
+DeviceOrHostAddressConstAMDX :: struct #raw_union {
+	deviceAddress: DeviceAddress,
+	hostAddress:   rawptr,
+}
+
+DispatchGraphInfoAMDX :: struct {
+	nodeIndex:     u32,
+	payloadCount:  u32,
+	payloads:      DeviceOrHostAddressConstAMDX,
+	payloadStride: u64,
+}
+
+DispatchGraphCountInfoAMDX :: struct {
+	count:  u32,
+	infos:  DeviceOrHostAddressConstAMDX,
+	stride: u64,
+}
+
+PipelineShaderStageNodeCreateInfoAMDX :: struct {
+	sType: StructureType,
+	pNext: rawptr,
+	pName: cstring,
+	index: u32,
+}
+
+PhysicalDeviceDisplacementMicromapFeaturesNV :: struct {
+	sType:                StructureType,
+	pNext:                rawptr,
+	displacementMicromap: b32,
+}
+
+PhysicalDeviceDisplacementMicromapPropertiesNV :: struct {
+	sType:                                   StructureType,
+	pNext:                                   rawptr,
+	maxDisplacementMicromapSubdivisionLevel: u32,
+}
+
+AccelerationStructureTrianglesDisplacementMicromapNV :: struct {
+	sType:                                 StructureType,
+	pNext:                                 rawptr,
+	displacementBiasAndScaleFormat:        Format,
+	displacementVectorFormat:              Format,
+	displacementBiasAndScaleBuffer:        DeviceOrHostAddressConstKHR,
+	displacementBiasAndScaleStride:        DeviceSize,
+	displacementVectorBuffer:              DeviceOrHostAddressConstKHR,
+	displacementVectorStride:              DeviceSize,
+	displacedMicromapPrimitiveFlags:       DeviceOrHostAddressConstKHR,
+	displacedMicromapPrimitiveFlagsStride: DeviceSize,
+	indexType:                             IndexType,
+	indexBuffer:                           DeviceOrHostAddressConstKHR,
+	indexStride:                           DeviceSize,
+	baseTriangle:                          u32,
+	usageCountsCount:                      u32,
+	pUsageCounts:                          [^]MicromapUsageEXT,
+	ppUsageCounts:                         ^[^]MicromapUsageEXT,
+	micromap:                              MicromapEXT,
+}
+
 VideoAV1ColorConfigFlags :: distinct bit_set[VideoAV1ColorConfigFlag; u32]
 VideoAV1ColorConfigFlag :: enum u32 {
 	mono_chrome,

--- a/vendor/vulkan/structs.odin
+++ b/vendor/vulkan/structs.odin
@@ -4809,6 +4809,52 @@ PhysicalDeviceLayeredApiVulkanPropertiesKHR :: struct {
 	properties: PhysicalDeviceProperties2,
 }
 
+PhysicalDeviceMaintenance8FeaturesKHR :: struct {
+	sType:        StructureType,
+	pNext:        rawptr,
+	maintenance8: b32,
+}
+
+MemoryBarrierAccessFlags3KHR :: struct {
+	sType:          StructureType,
+	pNext:          rawptr,
+	srcAccessMask3: AccessFlags3KHR,
+	dstAccessMask3: AccessFlags3KHR,
+}
+
+PhysicalDeviceVideoMaintenance2FeaturesKHR :: struct {
+	sType:             StructureType,
+	pNext:             rawptr,
+	videoMaintenance2: b32,
+}
+
+VideoDecodeH264InlineSessionParametersInfoKHR :: struct {
+	sType:   StructureType,
+	pNext:   rawptr,
+	pStdSPS: ^VideoH264SequenceParameterSet,
+	pStdPPS: ^VideoH264PictureParameterSet,
+}
+
+VideoDecodeH265InlineSessionParametersInfoKHR :: struct {
+	sType:   StructureType,
+	pNext:   rawptr,
+	pStdVPS: ^VideoH265VideoParameterSet,
+	pStdSPS: ^VideoH265SequenceParameterSet,
+	pStdPPS: ^VideoH265PictureParameterSet,
+}
+
+VideoDecodeAV1InlineSessionParametersInfoKHR :: struct {
+	sType:              StructureType,
+	pNext:              rawptr,
+	pStdSequenceHeader: ^VideoAV1SequenceHeader,
+}
+
+PhysicalDeviceDepthClampZeroOneFeaturesKHR :: struct {
+	sType:             StructureType,
+	pNext:             rawptr,
+	depthClampZeroOne: b32,
+}
+
 DebugReportCallbackCreateInfoEXT :: struct {
 	sType:       StructureType,
 	pNext:       rawptr,
@@ -5635,10 +5681,16 @@ AabbPositionsKHR :: struct {
 }
 
 AccelerationStructureInstanceKHR :: struct {
-	transform:                                      TransformMatrixKHR,
-	instanceCustomIndexAndMask:                     u32, // Most significant byte is mask
-	instanceShaderBindingTableRecordOffsetAndFlags: u32, // Most significant byte is flags
-	accelerationStructureReference:                 u64,
+	transform: TransformMatrixKHR,
+	using _: bit_field u32 {
+		instanceCustomIndex: u32 | 24,
+		mask:                u32 | 8,
+	},
+	using _: bit_field u32 {
+		instanceShaderBindingTableRecordOffset: u32                      | 24,
+		flags:                                  GeometryInstanceFlagKHR  | 8,
+	},
+	accelerationStructureReference: u64,
 }
 
 PhysicalDeviceRepresentativeFragmentTestFeaturesNV :: struct {
@@ -6700,11 +6752,17 @@ AccelerationStructureMotionInfoNV :: struct {
 }
 
 AccelerationStructureMatrixMotionInstanceNV :: struct {
-	transformT0:                                    TransformMatrixKHR,
-	transformT1:                                    TransformMatrixKHR,
-	instanceCustomIndexAndMask:                     u32, // Most significant byte is mask
-	instanceShaderBindingTableRecordOffsetAndFlags: u32, // Most significant byte is flags
-	accelerationStructureReference:                 u64,
+	transformT0: TransformMatrixKHR,
+	transformT1: TransformMatrixKHR,
+	using _: bit_field u32 {
+		instanceCustomIndex: u32 | 24,
+		mask:                u32 | 8,
+	},
+	using _: bit_field u32 {
+		instanceShaderBindingTableRecordOffset: u32                      | 24,
+		flags:                                  GeometryInstanceFlagKHR  | 8,
+	},
+	accelerationStructureReference: u64,
 }
 
 SRTDataNV :: struct {
@@ -6727,11 +6785,17 @@ SRTDataNV :: struct {
 }
 
 AccelerationStructureSRTMotionInstanceNV :: struct {
-	transformT0:                                    SRTDataNV,
-	transformT1:                                    SRTDataNV,
-	instanceCustomIndexAndMask:                     u32, // Most significant byte is mask
-	instanceShaderBindingTableRecordOffsetAndFlags: u32, // Most significant byte is flags
-	accelerationStructureReference:                 u64,
+	transformT0: SRTDataNV,
+	transformT1: SRTDataNV,
+	using _: bit_field u32 {
+		instanceCustomIndex: u32 | 24,
+		mask:                u32 | 8,
+	},
+	using _: bit_field u32 {
+		instanceShaderBindingTableRecordOffset: u32                      | 24,
+		flags:                                  GeometryInstanceFlagKHR  | 8,
+	},
+	accelerationStructureReference: u64,
 }
 
 AccelerationStructureMotionInstanceDataNV :: struct #raw_union {
@@ -7358,12 +7422,6 @@ DescriptorSetLayoutHostMappingInfoVALVE :: struct {
 	descriptorSize:   u32,
 }
 
-PhysicalDeviceDepthClampZeroOneFeaturesEXT :: struct {
-	sType:             StructureType,
-	pNext:             rawptr,
-	depthClampZeroOne: b32,
-}
-
 PhysicalDeviceNonSeamlessCubeMapFeaturesEXT :: struct {
 	sType:              StructureType,
 	pNext:              rawptr,
@@ -7495,6 +7553,43 @@ PipelineIndirectDeviceAddressInfoNV :: struct {
 
 BindPipelineIndirectCommandNV :: struct {
 	pipelineAddress: DeviceAddress,
+}
+
+PhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV :: struct {
+	sType:              StructureType,
+	pNext:              rawptr,
+	spheres:            b32,
+	linearSweptSpheres: b32,
+}
+
+AccelerationStructureGeometryLinearSweptSpheresDataNV :: struct {
+	sType:        StructureType,
+	pNext:        rawptr,
+	vertexFormat: Format,
+	vertexData:   DeviceOrHostAddressConstKHR,
+	vertexStride: DeviceSize,
+	radiusFormat: Format,
+	radiusData:   DeviceOrHostAddressConstKHR,
+	radiusStride: DeviceSize,
+	indexType:    IndexType,
+	indexData:    DeviceOrHostAddressConstKHR,
+	indexStride:  DeviceSize,
+	indexingMode: RayTracingLssIndexingModeNV,
+	endCapsMode:  RayTracingLssPrimitiveEndCapsModeNV,
+}
+
+AccelerationStructureGeometrySpheresDataNV :: struct {
+	sType:        StructureType,
+	pNext:        rawptr,
+	vertexFormat: Format,
+	vertexData:   DeviceOrHostAddressConstKHR,
+	vertexStride: DeviceSize,
+	radiusFormat: Format,
+	radiusData:   DeviceOrHostAddressConstKHR,
+	radiusStride: DeviceSize,
+	indexType:    IndexType,
+	indexData:    DeviceOrHostAddressConstKHR,
+	indexStride:  DeviceSize,
 }
 
 PhysicalDeviceLinearColorAttachmentFeaturesNV :: struct {
@@ -7859,6 +7954,50 @@ PhysicalDeviceRayTracingInvocationReorderFeaturesNV :: struct {
 	rayTracingInvocationReorder: b32,
 }
 
+PhysicalDeviceCooperativeVectorPropertiesNV :: struct {
+	sType:                                        StructureType,
+	pNext:                                        rawptr,
+	cooperativeVectorSupportedStages:             ShaderStageFlags,
+	cooperativeVectorTrainingFloat16Accumulation: b32,
+	cooperativeVectorTrainingFloat32Accumulation: b32,
+	maxCooperativeVectorComponents:               u32,
+}
+
+PhysicalDeviceCooperativeVectorFeaturesNV :: struct {
+	sType:                     StructureType,
+	pNext:                     rawptr,
+	cooperativeVector:         b32,
+	cooperativeVectorTraining: b32,
+}
+
+CooperativeVectorPropertiesNV :: struct {
+	sType:                StructureType,
+	pNext:                rawptr,
+	inputType:            ComponentTypeKHR,
+	inputInterpretation:  ComponentTypeKHR,
+	matrixInterpretation: ComponentTypeKHR,
+	biasInterpretation:   ComponentTypeKHR,
+	resultType:           ComponentTypeKHR,
+	transpose:            b32,
+}
+
+ConvertCooperativeVectorMatrixInfoNV :: struct {
+	sType:            StructureType,
+	pNext:            rawptr,
+	srcSize:          int,
+	srcData:          DeviceOrHostAddressConstKHR,
+	pDstSize:         ^int,
+	dstData:          DeviceOrHostAddressKHR,
+	srcComponentType: ComponentTypeKHR,
+	dstComponentType: ComponentTypeKHR,
+	numRows:          u32,
+	numColumns:       u32,
+	srcLayout:        CooperativeVectorMatrixLayoutNV,
+	srcStride:        int,
+	dstLayout:        CooperativeVectorMatrixLayoutNV,
+	dstStride:        int,
+}
+
 PhysicalDeviceExtendedSparseAddressSpaceFeaturesNV :: struct {
 	sType:                      StructureType,
 	pNext:                      rawptr,
@@ -8135,6 +8274,253 @@ PhysicalDeviceRayTracingValidationFeaturesNV :: struct {
 	rayTracingValidation: b32,
 }
 
+PhysicalDeviceClusterAccelerationStructureFeaturesNV :: struct {
+	sType:                        StructureType,
+	pNext:                        rawptr,
+	clusterAccelerationStructure: b32,
+}
+
+PhysicalDeviceClusterAccelerationStructurePropertiesNV :: struct {
+	sType:                              StructureType,
+	pNext:                              rawptr,
+	maxVerticesPerCluster:              u32,
+	maxTrianglesPerCluster:             u32,
+	clusterScratchByteAlignment:        u32,
+	clusterByteAlignment:               u32,
+	clusterTemplateByteAlignment:       u32,
+	clusterBottomLevelByteAlignment:    u32,
+	clusterTemplateBoundsByteAlignment: u32,
+	maxClusterGeometryIndex:            u32,
+}
+
+ClusterAccelerationStructureClustersBottomLevelInputNV :: struct {
+	sType:                                   StructureType,
+	pNext:                                   rawptr,
+	maxTotalClusterCount:                    u32,
+	maxClusterCountPerAccelerationStructure: u32,
+}
+
+ClusterAccelerationStructureTriangleClusterInputNV :: struct {
+	sType:                         StructureType,
+	pNext:                         rawptr,
+	vertexFormat:                  Format,
+	maxGeometryIndexValue:         u32,
+	maxClusterUniqueGeometryCount: u32,
+	maxClusterTriangleCount:       u32,
+	maxClusterVertexCount:         u32,
+	maxTotalTriangleCount:         u32,
+	maxTotalVertexCount:           u32,
+	minPositionTruncateBitCount:   u32,
+}
+
+ClusterAccelerationStructureMoveObjectsInputNV :: struct {
+	sType:         StructureType,
+	pNext:         rawptr,
+	type:          ClusterAccelerationStructureTypeNV,
+	noMoveOverlap: b32,
+	maxMovedBytes: DeviceSize,
+}
+
+ClusterAccelerationStructureOpInputNV :: struct #raw_union {
+	pClustersBottomLevel: ^ClusterAccelerationStructureClustersBottomLevelInputNV,
+	pTriangleClusters:    [^]ClusterAccelerationStructureTriangleClusterInputNV,
+	pMoveObjects:         [^]ClusterAccelerationStructureMoveObjectsInputNV,
+}
+
+ClusterAccelerationStructureInputInfoNV :: struct {
+	sType:                         StructureType,
+	pNext:                         rawptr,
+	maxAccelerationStructureCount: u32,
+	flags:                         BuildAccelerationStructureFlagsKHR,
+	opType:                        ClusterAccelerationStructureOpTypeNV,
+	opMode:                        ClusterAccelerationStructureOpModeNV,
+	opInput:                       ClusterAccelerationStructureOpInputNV,
+}
+
+StridedDeviceAddressRegionKHR :: struct {
+	deviceAddress: DeviceAddress,
+	stride:        DeviceSize,
+	size:          DeviceSize,
+}
+
+ClusterAccelerationStructureCommandsInfoNV :: struct {
+	sType:                  StructureType,
+	pNext:                  rawptr,
+	input:                  ClusterAccelerationStructureInputInfoNV,
+	dstImplicitData:        DeviceAddress,
+	scratchData:            DeviceAddress,
+	dstAddressesArray:      StridedDeviceAddressRegionKHR,
+	dstSizesArray:          StridedDeviceAddressRegionKHR,
+	srcInfosArray:          StridedDeviceAddressRegionKHR,
+	srcInfosCount:          DeviceAddress,
+	addressResolutionFlags: ClusterAccelerationStructureAddressResolutionFlagsNV,
+}
+
+StridedDeviceAddressNV :: struct {
+	startAddress:  DeviceAddress,
+	strideInBytes: DeviceSize,
+}
+
+ClusterAccelerationStructureGeometryIndexAndGeometryFlagsNV :: bit_field u32 {
+	geometryIndex: u32 | 24,
+	reserved:      u32 | 5,
+	geometryFlags: u32 | 3,
+}
+
+ClusterAccelerationStructureMoveObjectsInfoNV :: struct {
+	srcAccelerationStructure: DeviceAddress,
+}
+
+ClusterAccelerationStructureBuildClustersBottomLevelInfoNV :: struct {
+	clusterReferencesCount:  u32,
+	clusterReferencesStride: u32,
+	clusterReferences:       DeviceAddress,
+}
+
+ClusterAccelerationStructureBuildTriangleClusterInfoNV :: struct {
+	clusterID: u32,
+	clusterFlags: ClusterAccelerationStructureClusterFlagsNV,
+	using _: bit_field u32 {
+		triangleCount:            u32 | 9,
+		vertexCount:              u32 | 9,
+		positionTruncateBitCount: u32 | 6,
+		indexType:                u32 | 4,
+		opacityMicromapIndexType: u32 | 4,
+	},
+	baseGeometryIndexAndGeometryFlags: ClusterAccelerationStructureGeometryIndexAndGeometryFlagsNV,
+	indexBufferStride: u16,
+	vertexBufferStride: u16,
+	geometryIndexAndFlagsBufferStride: u16,
+	opacityMicromapIndexBufferStride: u16,
+	indexBuffer: DeviceAddress,
+	vertexBuffer: DeviceAddress,
+	geometryIndexAndFlagsBuffer: DeviceAddress,
+	opacityMicromapArray: DeviceAddress,
+	opacityMicromapIndexBuffer: DeviceAddress,
+}
+
+ClusterAccelerationStructureBuildTriangleClusterTemplateInfoNV :: struct {
+	clusterID: u32,
+	clusterFlags: ClusterAccelerationStructureClusterFlagsNV,
+	using _: bit_field u32 {
+		triangleCount:            u32 | 9,
+		vertexCount:              u32 | 9,
+		positionTruncateBitCount: u32 | 6,
+		indexType:                u32 | 4,
+		opacityMicromapIndexType: u32 | 4,
+	},
+	baseGeometryIndexAndGeometryFlags: ClusterAccelerationStructureGeometryIndexAndGeometryFlagsNV,
+	indexBufferStride: u16,
+	vertexBufferStride: u16,
+	geometryIndexAndFlagsBufferStride: u16,
+	opacityMicromapIndexBufferStride: u16,
+	indexBuffer: DeviceAddress,
+	vertexBuffer: DeviceAddress,
+	geometryIndexAndFlagsBuffer: DeviceAddress,
+	opacityMicromapArray: DeviceAddress,
+	opacityMicromapIndexBuffer: DeviceAddress,
+	instantiationBoundingBoxLimit: DeviceAddress,
+}
+
+ClusterAccelerationStructureInstantiateClusterInfoNV :: struct {
+	clusterIdOffset: u32,
+	using _: bit_field u32 {
+		geometryIndexOffset: u32 | 24,
+		reserved:            u32 | 8,
+	},
+	clusterTemplateAddress: DeviceAddress,
+	vertexBuffer: StridedDeviceAddressNV,
+}
+
+AccelerationStructureBuildSizesInfoKHR :: struct {
+	sType:                     StructureType,
+	pNext:                     rawptr,
+	accelerationStructureSize: DeviceSize,
+	updateScratchSize:         DeviceSize,
+	buildScratchSize:          DeviceSize,
+}
+
+RayTracingPipelineClusterAccelerationStructureCreateInfoNV :: struct {
+	sType:                             StructureType,
+	pNext:                             rawptr,
+	allowClusterAccelerationStructure: b32,
+}
+
+PhysicalDevicePartitionedAccelerationStructureFeaturesNV :: struct {
+	sType:                            StructureType,
+	pNext:                            rawptr,
+	partitionedAccelerationStructure: b32,
+}
+
+PhysicalDevicePartitionedAccelerationStructurePropertiesNV :: struct {
+	sType:             StructureType,
+	pNext:             rawptr,
+	maxPartitionCount: u32,
+}
+
+PartitionedAccelerationStructureFlagsNV :: struct {
+	sType:                      StructureType,
+	pNext:                      rawptr,
+	enablePartitionTranslation: b32,
+}
+
+BuildPartitionedAccelerationStructureIndirectCommandNV :: struct {
+	opType:   PartitionedAccelerationStructureOpTypeNV,
+	argCount: u32,
+	argData:  StridedDeviceAddressNV,
+}
+
+PartitionedAccelerationStructureWriteInstanceDataNV :: struct {
+	transform:                           TransformMatrixKHR,
+	explicitAABB:                        [6]f32,
+	instanceID:                          u32,
+	instanceMask:                        u32,
+	instanceContributionToHitGroupIndex: u32,
+	instanceFlags:                       PartitionedAccelerationStructureInstanceFlagsNV,
+	instanceIndex:                       u32,
+	partitionIndex:                      u32,
+	accelerationStructure:               DeviceAddress,
+}
+
+PartitionedAccelerationStructureUpdateInstanceDataNV :: struct {
+	instanceIndex:                       u32,
+	instanceContributionToHitGroupIndex: u32,
+	accelerationStructure:               DeviceAddress,
+}
+
+PartitionedAccelerationStructureWritePartitionTranslationDataNV :: struct {
+	partitionIndex:       u32,
+	partitionTranslation: [3]f32,
+}
+
+WriteDescriptorSetPartitionedAccelerationStructureNV :: struct {
+	sType:                      StructureType,
+	pNext:                      rawptr,
+	accelerationStructureCount: u32,
+	pAccelerationStructures:    [^]DeviceAddress,
+}
+
+PartitionedAccelerationStructureInstancesInputNV :: struct {
+	sType:                             StructureType,
+	pNext:                             rawptr,
+	flags:                             BuildAccelerationStructureFlagsKHR,
+	instanceCount:                     u32,
+	maxInstancePerPartitionCount:      u32,
+	partitionCount:                    u32,
+	maxInstanceInGlobalPartitionCount: u32,
+}
+
+BuildPartitionedAccelerationStructureInfoNV :: struct {
+	sType:                        StructureType,
+	pNext:                        rawptr,
+	input:                        PartitionedAccelerationStructureInstancesInputNV,
+	srcAccelerationStructureData: DeviceAddress,
+	dstAccelerationStructureData: DeviceAddress,
+	scratchData:                  DeviceAddress,
+	srcInfos:                     DeviceAddress,
+	srcInfosCount:                DeviceAddress,
+}
+
 PhysicalDeviceDeviceGeneratedCommandsFeaturesEXT :: struct {
 	sType:                          StructureType,
 	pNext:                          rawptr,
@@ -8387,10 +8773,29 @@ PhysicalDeviceCooperativeMatrix2PropertiesNV :: struct {
 	cooperativeMatrixWorkgroupScopeReservedSharedMemory: u32,
 }
 
+PhysicalDevicePipelineOpacityMicromapFeaturesARM :: struct {
+	sType:                   StructureType,
+	pNext:                   rawptr,
+	pipelineOpacityMicromap: b32,
+}
+
 PhysicalDeviceVertexAttributeRobustnessFeaturesEXT :: struct {
 	sType:                     StructureType,
 	pNext:                     rawptr,
 	vertexAttributeRobustness: b32,
+}
+
+SetPresentConfigNV :: struct {
+	sType:                 StructureType,
+	pNext:                 rawptr,
+	numFramesPerBatch:     u32,
+	presentConfigFeedback: u32,
+}
+
+PhysicalDevicePresentMeteringFeaturesNV :: struct {
+	sType:           StructureType,
+	pNext:           rawptr,
+	presentMetering: b32,
 }
 
 AccelerationStructureBuildRangeInfoKHR :: struct {
@@ -8531,14 +8936,6 @@ CopyAccelerationStructureInfoKHR :: struct {
 	mode:  CopyAccelerationStructureModeKHR,
 }
 
-AccelerationStructureBuildSizesInfoKHR :: struct {
-	sType:                     StructureType,
-	pNext:                     rawptr,
-	accelerationStructureSize: DeviceSize,
-	updateScratchSize:         DeviceSize,
-	buildScratchSize:          DeviceSize,
-}
-
 RayTracingShaderGroupCreateInfoKHR :: struct {
 	sType:                           StructureType,
 	pNext:                           rawptr,
@@ -8595,12 +8992,6 @@ PhysicalDeviceRayTracingPipelinePropertiesKHR :: struct {
 	maxRayDispatchInvocationCount:      u32,
 	shaderGroupHandleAlignment:         u32,
 	maxRayHitAttributeSize:             u32,
-}
-
-StridedDeviceAddressRegionKHR :: struct {
-	deviceAddress: DeviceAddress,
-	stride:        DeviceSize,
-	size:          DeviceSize,
 }
 
 TraceRaysIndirectCommandKHR :: struct {
@@ -8904,6 +9295,26 @@ ImportMetalSharedEventInfoEXT :: struct {
 	mtlSharedEvent: MTLSharedEvent_id,
 }
 
+ImportMemoryMetalHandleInfoEXT :: struct {
+	sType:      StructureType,
+	pNext:      rawptr,
+	handleType: ExternalMemoryHandleTypeFlags,
+	handle:     rawptr,
+}
+
+MemoryMetalHandlePropertiesEXT :: struct {
+	sType:          StructureType,
+	pNext:          rawptr,
+	memoryTypeBits: u32,
+}
+
+MemoryGetMetalHandleInfoEXT :: struct {
+	sType:      StructureType,
+	pNext:      rawptr,
+	memory:     DeviceMemory,
+	handleType: ExternalMemoryHandleTypeFlags,
+}
+
 MacOSSurfaceCreateInfoMVK :: struct {
 	sType: StructureType,
 	pNext: rawptr,
@@ -8942,8 +9353,12 @@ XcbSurfaceCreateInfoKHR :: struct {
 	window:     xcb_window_t,
 }
 
-VideoAV1ColorConfigFlags :: struct {
-	bitfield: u32,
+VideoAV1ColorConfigFlags :: distinct bit_set[VideoAV1ColorConfigFlag; u32]
+VideoAV1ColorConfigFlag :: enum u32 {
+	mono_chrome,
+	color_range,
+	separate_uv_delta_q,
+	color_description_present_flag,
 }
 
 VideoAV1ColorConfig :: struct {
@@ -8958,8 +9373,9 @@ VideoAV1ColorConfig :: struct {
 	chroma_sample_position:   VideoAV1ChromaSamplePosition,
 }
 
-VideoAV1TimingInfoFlags :: struct {
-	bitfield: u32,
+VideoAV1TimingInfoFlags :: distinct bit_set[VideoAV1TimingInfoFlag; u32]
+VideoAV1TimingInfoFlag :: enum u32 {
+	equal_picture_interval,
 }
 
 VideoAV1TimingInfo :: struct {
@@ -8969,8 +9385,10 @@ VideoAV1TimingInfo :: struct {
 	num_ticks_per_picture_minus_1: u32,
 }
 
-VideoAV1LoopFilterFlags :: struct {
-	bitfield: u32,
+VideoAV1LoopFilterFlags :: distinct bit_set[VideoAV1LoopFilterFlag; u32]
+VideoAV1LoopFilterFlag :: enum u32 {
+	loop_filter_delta_enabled,
+	loop_filter_delta_update,
 }
 
 VideoAV1LoopFilter :: struct {
@@ -8983,8 +9401,10 @@ VideoAV1LoopFilter :: struct {
 	loop_filter_mode_deltas: [VIDEO_AV1_LOOP_FILTER_ADJUSTMENTS]i8,
 }
 
-VideoAV1QuantizationFlags :: struct {
-	bitfield: u32,
+VideoAV1QuantizationFlags :: distinct bit_set[VideoAV1QuantizationFlag; u32]
+VideoAV1QuantizationFlag :: enum u32 {
+	using_qmatrix,
+	diff_uv_delta,
 }
 
 VideoAV1Quantization :: struct {
@@ -9005,8 +9425,9 @@ VideoAV1Segmentation :: struct {
 	FeatureData:    [VIDEO_AV1_MAX_SEGMENTS][VIDEO_AV1_SEG_LVL_MAX]i16,
 }
 
-VideoAV1TileInfoFlags :: struct {
-	bitfield: u32,
+VideoAV1TileInfoFlags :: distinct bit_set[VideoAV1TileInfoFlag; u32]
+VideoAV1TileInfoFlag :: enum u32 {
+	uniform_tile_spacing_flag,
 }
 
 VideoAV1TileInfo :: struct {
@@ -9041,8 +9462,12 @@ VideoAV1GlobalMotion :: struct {
 	gm_params: [VIDEO_AV1_NUM_REF_FRAMES][VIDEO_AV1_GLOBAL_MOTION_PARAMS]i32,
 }
 
-VideoAV1FilmGrainFlags :: struct {
-	bitfield: u32,
+VideoAV1FilmGrainFlags :: distinct bit_set[VideoAV1FilmGrainFlag; u32]
+VideoAV1FilmGrainFlag :: enum u32 {
+	chroma_scaling_from_luma,
+	overlap_flag,
+	clip_to_restricted_range,
+	update_grain,
 }
 
 VideoAV1FilmGrain :: struct {
@@ -9073,8 +9498,27 @@ VideoAV1FilmGrain :: struct {
 	cr_offset:                 u16,
 }
 
-VideoAV1SequenceHeaderFlags :: struct {
-	bitfield: u32,
+VideoAV1SequenceHeaderFlags :: distinct bit_set[VideoAV1SequenceHeaderFlag; u32]
+VideoAV1SequenceHeaderFlag :: enum u32 {
+	still_picture,
+	reduced_still_picture_header,
+	use_128x128_superblock,
+	enable_filter_intra,
+	enable_intra_edge_filter,
+	enable_interintra_compound,
+	enable_masked_compound,
+	enable_warped_motion,
+	enable_dual_filter,
+	enable_order_hint,
+	enable_jnt_comp,
+	enable_ref_frame_mvs,
+	frame_id_numbers_present_flag,
+	enable_superres,
+	enable_cdef,
+	enable_restoration,
+	film_grain_params_present,
+	timing_info_present_flag,
+	initial_display_delay_present_flag,
 }
 
 VideoAV1SequenceHeader :: struct {
@@ -9094,8 +9538,37 @@ VideoAV1SequenceHeader :: struct {
 	pTimingInfo:                        ^VideoAV1TimingInfo,
 }
 
-VideoDecodeAV1PictureInfoFlags :: struct {
-	bitfield: u32,
+VideoDecodeAV1PictureInfoFlags :: distinct bit_set[VideoDecodeAV1PictureInfoFlag; u32]
+VideoDecodeAV1PictureInfoFlag :: enum u32 {
+	error_resilient_mode,
+	disable_cdf_update,
+	use_superres,
+	render_and_frame_size_different,
+	allow_screen_content_tools,
+	is_filter_switchable,
+	force_integer_mv,
+	frame_size_override_flag,
+	buffer_removal_time_present_flag,
+	allow_intrabc,
+	frame_refs_short_signaling,
+	allow_high_precision_mv,
+	is_motion_mode_switchable,
+	use_ref_frame_mvs,
+	disable_frame_end_update_cdf,
+	allow_warped_motion,
+	reduced_tx_set,
+	reference_select,
+	skip_mode_present,
+	delta_q_present,
+	delta_lf_present,
+	delta_lf_multi,
+	segmentation_enabled,
+	segmentation_update_map,
+	segmentation_temporal_update,
+	segmentation_update_data,
+	UsesLr,
+	usesChromaLr,
+	apply_grain,
 }
 
 VideoDecodeAV1PictureInfo :: struct {
@@ -9125,8 +9598,10 @@ VideoDecodeAV1PictureInfo :: struct {
 	pFilmGrain:           ^VideoAV1FilmGrain,
 }
 
-VideoDecodeAV1ReferenceInfoFlags :: struct {
-	bitfield: u32,
+VideoDecodeAV1ReferenceInfoFlags :: distinct bit_set[VideoDecodeAV1ReferenceInfoFlag; u32]
+VideoDecodeAV1ReferenceInfoFlag :: enum u32 {
+	disable_frame_end_update_cdf,
+	segmentation_enabled,
 }
 
 VideoDecodeAV1ReferenceInfo :: struct {
@@ -9150,8 +9625,11 @@ VideoEncodeAV1ExtensionHeader :: struct {
 	spatial_id:  u8,
 }
 
-VideoEncodeAV1OperatingPointInfoFlags :: struct {
-	bitfield: u32,
+VideoEncodeAV1OperatingPointInfoFlags :: distinct bit_set[VideoEncodeAV1OperatingPointInfoFlag; u32]
+VideoEncodeAV1OperatingPointInfoFlag :: enum u32 {
+	decoder_model_present_for_this_op,
+	low_delay_mode_flag,
+	initial_display_delay_present_for_this_op,
 }
 
 VideoEncodeAV1OperatingPointInfo :: struct {
@@ -9164,8 +9642,37 @@ VideoEncodeAV1OperatingPointInfo :: struct {
 	initial_display_delay_minus_1: u8,
 }
 
-VideoEncodeAV1PictureInfoFlags :: struct {
-	bitfield: u32,
+VideoEncodeAV1PictureInfoFlags :: distinct bit_set[VideoEncodeAV1PictureInfoFlag; u32]
+VideoEncodeAV1PictureInfoFlag :: enum u32 {
+	error_resilient_mode,
+	disable_cdf_update,
+	use_superres,
+	render_and_frame_size_different,
+	allow_screen_content_tools,
+	is_filter_switchable,
+	force_integer_mv,
+	frame_size_override_flag,
+	buffer_removal_time_present_flag,
+	allow_intrabc,
+	frame_refs_short_signaling,
+	allow_high_precision_mv,
+	is_motion_mode_switchable,
+	use_ref_frame_mvs,
+	disable_frame_end_update_cdf,
+	allow_warped_motion,
+	reduced_tx_set,
+	skip_mode_present,
+	delta_q_present,
+	delta_lf_present,
+	delta_lf_multi,
+	segmentation_enabled,
+	segmentation_update_map,
+	segmentation_temporal_update,
+	segmentation_update_data,
+	UsesLr,
+	usesChromaLr,
+	show_frame,
+	showable_frame,
 }
 
 VideoEncodeAV1PictureInfo :: struct {
@@ -9198,8 +9705,10 @@ VideoEncodeAV1PictureInfo :: struct {
 	pBufferRemovalTimes:     [^]u32,
 }
 
-VideoEncodeAV1ReferenceInfoFlags :: struct {
-	bitfield: u32,
+VideoEncodeAV1ReferenceInfoFlags :: distinct bit_set[VideoEncodeAV1ReferenceInfoFlag; u32]
+VideoEncodeAV1ReferenceInfoFlag :: enum u32 {
+	disable_frame_end_update_cdf,
+	segmentation_enabled,
 }
 
 VideoEncodeAV1ReferenceInfo :: struct {
@@ -9211,8 +9720,20 @@ VideoEncodeAV1ReferenceInfo :: struct {
 	pExtensionHeader: ^VideoEncodeAV1ExtensionHeader,
 }
 
-VideoH264SpsVuiFlags :: struct {
-	bitfield: u32,
+VideoH264SpsVuiFlags :: distinct bit_set[VideoH264SpsVuiFlag; u32]
+VideoH264SpsVuiFlag :: enum u32 {
+	aspect_ratio_info_present_flag,
+	overscan_info_present_flag,
+	overscan_appropriate_flag,
+	video_signal_type_present_flag,
+	video_full_range_flag,
+	color_description_present_flag,
+	chroma_loc_info_present_flag,
+	timing_info_present_flag,
+	fixed_frame_rate_flag,
+	bitstream_restriction_flag,
+	nal_hrd_parameters_present_flag,
+	vcl_hrd_parameters_present_flag,
 }
 
 VideoH264HrdParameters :: struct {
@@ -9248,8 +9769,24 @@ VideoH264SequenceParameterSetVui :: struct {
 	pHrdParameters:                      [^]VideoH264HrdParameters,
 }
 
-VideoH264SpsFlags :: struct {
-	bitfield: u32,
+VideoH264SpsFlags :: distinct bit_set[VideoH264SpsFlag; u32]
+VideoH264SpsFlag :: enum u32 {
+	constraint_set0_flag,
+	constraint_set1_flag,
+	constraint_set2_flag,
+	constraint_set3_flag,
+	constraint_set4_flag,
+	constraint_set5_flag,
+	direct_8x8_inference_flag,
+	mb_adaptive_frame_field_flag,
+	frame_mbs_only_flag,
+	delta_pic_order_always_zero_flag,
+	separate_colour_plane_flag,
+	gaps_in_frame_num_value_allowed_flag,
+	qpprime_y_zero_transform_bypass_flag,
+	frame_cropping_flag,
+	seq_scaling_matrix_present_flag,
+	vui_parameters_present_flag,
 }
 
 VideoH264ScalingLists :: struct {
@@ -9287,8 +9824,16 @@ VideoH264SequenceParameterSet :: struct {
 	pSequenceParameterSetVui:              ^VideoH264SequenceParameterSetVui,
 }
 
-VideoH264PpsFlags :: struct {
-	bitfield: u32,
+VideoH264PpsFlags :: distinct bit_set[VideoH264PpsFlag; u32]
+VideoH264PpsFlag :: enum u32 {
+	transform_8x8_mode_flag,
+	redundant_pic_cnt_present_flag,
+	constrained_intra_pred_flag,
+	deblocking_filter_control_present_flag,
+	weighted_pred_flag,
+	bottom_field_pic_order_in_frame_present_flag,
+	entropy_coding_mode_flag,
+	pic_scaling_matrix_present_flag,
 }
 
 VideoH264PictureParameterSet :: struct {
@@ -9305,8 +9850,14 @@ VideoH264PictureParameterSet :: struct {
 	pScalingLists:                        [^]VideoH264ScalingLists,
 }
 
-VideoDecodeH264PictureInfoFlags :: struct {
-	bitfield: u32,
+VideoDecodeH264PictureInfoFlags :: distinct bit_set[VideoDecodeH264PictureInfoFlag; u32]
+VideoDecodeH264PictureInfoFlag :: enum u32 {
+	field_pic_flag,
+	is_intra,
+	IdrPicFlag,
+	bottom_field_flag,
+	is_reference,
+	complementary_field_pair,
 }
 
 VideoDecodeH264PictureInfo :: struct {
@@ -9320,8 +9871,12 @@ VideoDecodeH264PictureInfo :: struct {
 	PicOrderCnt:          [VIDEO_DECODE_H264_FIELD_ORDER_COUNT_LIST_SIZE]i32,
 }
 
-VideoDecodeH264ReferenceInfoFlags :: struct {
-	bitfield: u32,
+VideoDecodeH264ReferenceInfoFlags :: distinct bit_set[VideoDecodeH264ReferenceInfoFlag; u32]
+VideoDecodeH264ReferenceInfoFlag :: enum u32 {
+	top_field_flag,
+	bottom_field_flag,
+	used_for_long_term_reference,
+	is_non_existing,
 }
 
 VideoDecodeH264ReferenceInfo :: struct {
@@ -9352,20 +9907,30 @@ VideoEncodeH264WeightTable :: struct {
 	chroma_offset_l1:         [VIDEO_H264_MAX_NUM_LIST_REF][VIDEO_H264_MAX_CHROMA_PLANES]i8,
 }
 
-VideoEncodeH264SliceHeaderFlags :: struct {
-	bitfield: u32,
+VideoEncodeH264SliceHeaderFlags :: distinct bit_set[VideoEncodeH264SliceHeaderFlag; u32]
+VideoEncodeH264SliceHeaderFlag :: enum u32 {
+	direct_spatial_mv_pred_flag,
+	num_ref_idx_active_override_flag,
 }
 
-VideoEncodeH264PictureInfoFlags :: struct {
-	bitfield: u32,
+VideoEncodeH264PictureInfoFlags :: distinct bit_set[VideoEncodeH264PictureInfoFlag; u32]
+VideoEncodeH264PictureInfoFlag :: enum u32 {
+	IdrPicFlag,
+	is_reference,
+	no_output_of_prior_pics_flag,
+	long_term_reference_flag,
+	adaptive_ref_pic_marking_mode_flag,
 }
 
-VideoEncodeH264ReferenceInfoFlags :: struct {
-	bitfield: u32,
+VideoEncodeH264ReferenceInfoFlags :: distinct bit_set[VideoEncodeH264ReferenceInfoFlag; u32]
+VideoEncodeH264ReferenceInfoFlag :: enum u32 {
+	used_for_long_term_reference,
 }
 
-VideoEncodeH264ReferenceListsInfoFlags :: struct {
-	bitfield: u32,
+VideoEncodeH264ReferenceListsInfoFlags :: distinct bit_set[VideoEncodeH264ReferenceListsInfoFlag; u32]
+VideoEncodeH264ReferenceListsInfoFlag :: enum u32 {
+	ref_pic_list_modification_flag_l0,
+	ref_pic_list_modification_flag_l1,
 }
 
 VideoEncodeH264RefListModEntry :: struct {
@@ -9447,8 +10012,14 @@ VideoH265SubLayerHrdParameters :: struct {
 	cbr_flag:                 u32,
 }
 
-VideoH265HrdFlags :: struct {
-	bitfield: u32,
+VideoH265HrdFlags :: bit_field u32 {
+	nal_hrd_parameters_present_flag:           bool | 1,
+	vcl_hrd_parameters_present_flag:           bool | 1,
+	sub_pic_hrd_params_present_flag:           bool | 1,
+	sub_pic_cpb_params_in_pic_timing_sei_flag: bool | 1,
+	fixed_pic_rate_general_flag:               u32  | 8,
+	fixed_pic_rate_within_cvs_flag:            u32  | 8,
+	low_delay_hrd_flag:                        u32  | 8,
 }
 
 VideoH265HrdParameters :: struct {
@@ -9469,12 +10040,21 @@ VideoH265HrdParameters :: struct {
 	pSubLayerHrdParametersVcl:                    ^VideoH265SubLayerHrdParameters,
 }
 
-VideoH265VpsFlags :: struct {
-	bitfield: u32,
+VideoH265VpsFlags :: distinct bit_set[VideoH265VpsFlag; u32]
+VideoH265VpsFlag :: enum u32 {
+	vps_temporal_id_nesting_flag,
+	vps_sub_layer_ordering_info_present_flag,
+	vps_timing_info_present_flag,
+	vps_poc_proportional_to_timing_flag,
 }
 
-VideoH265ProfileTierLevelFlags :: struct {
-	bitfield: u32,
+VideoH265ProfileTierLevelFlags :: distinct bit_set[VideoH265ProfileTierLevelFlag; u32]
+VideoH265ProfileTierLevelFlag :: enum u32 {
+	general_tier_flag,
+	general_progressive_source_flag,
+	general_interlaced_source_flag,
+	general_non_packed_constraint_flag,
+	general_frame_only_constraint_flag,
 }
 
 VideoH265ProfileTierLevel :: struct {
@@ -9507,8 +10087,26 @@ VideoH265ScalingLists :: struct {
 	ScalingListDCCoef32x32: [VIDEO_H265_SCALING_LIST_32X32_NUM_LISTS]u8,
 }
 
-VideoH265SpsVuiFlags :: struct {
-	bitfield: u32,
+VideoH265SpsVuiFlags :: distinct bit_set[VideoH265SpsVuiFlag; u32]
+VideoH265SpsVuiFlag :: enum u32 {
+	aspect_ratio_info_present_flag,
+	overscan_info_present_flag,
+	overscan_appropriate_flag,
+	video_signal_type_present_flag,
+	video_full_range_flag,
+	colour_description_present_flag,
+	chroma_loc_info_present_flag,
+	neutral_chroma_indication_flag,
+	field_seq_flag,
+	frame_field_info_present_flag,
+	default_display_window_flag,
+	vui_timing_info_present_flag,
+	vui_poc_proportional_to_timing_flag,
+	vui_hrd_parameters_present_flag,
+	bitstream_restriction_flag,
+	tiles_fixed_structure_flag,
+	motion_vectors_over_pic_boundaries_flag,
+	restricted_ref_pic_lists_flag,
 }
 
 VideoH265SequenceParameterSetVui :: struct {
@@ -9544,12 +10142,44 @@ VideoH265PredictorPaletteEntries :: struct {
 	PredictorPaletteEntries: [VIDEO_H265_PREDICTOR_PALETTE_COMPONENTS_LIST_SIZE][VIDEO_H265_PREDICTOR_PALETTE_COMP_ENTRIES_LIST_SIZE]u16,
 }
 
-VideoH265SpsFlags :: struct {
-	bitfield: u32,
+VideoH265SpsFlags :: distinct bit_set[VideoH265SpsFlag; u32]
+VideoH265SpsFlag :: enum u32 {
+	sps_temporal_id_nesting_flag,
+	separate_colour_plane_flag,
+	conformance_window_flag,
+	sps_sub_layer_ordering_info_present_flag,
+	scaling_list_enabled_flag,
+	sps_scaling_list_data_present_flag,
+	amp_enabled_flag,
+	sample_adaptive_offset_enabled_flag,
+	pcm_enabled_flag,
+	pcm_loop_filter_disabled_flag,
+	long_term_ref_pics_present_flag,
+	sps_temporal_mvp_enabled_flag,
+	strong_intra_smoothing_enabled_flag,
+	vui_parameters_present_flag,
+	sps_extension_present_flag,
+	sps_range_extension_flag,
+	transform_skip_rotation_enabled_flag,
+	transform_skip_context_enabled_flag,
+	implicit_rdpcm_enabled_flag,
+	explicit_rdpcm_enabled_flag,
+	extended_precision_processing_flag,
+	intra_smoothing_disabled_flag,
+	high_precision_offsets_enabled_flag,
+	persistent_rice_adaptation_enabled_flag,
+	cabac_bypass_alignment_enabled_flag,
+	sps_scc_extension_flag,
+	sps_curr_pic_ref_enabled_flag,
+	palette_mode_enabled_flag,
+	sps_palette_predictor_initializers_present_flag,
+	intra_boundary_filtering_disabled_flag,
 }
 
-VideoH265ShortTermRefPicSetFlags :: struct {
-	bitfield: u32,
+VideoH265ShortTermRefPicSetFlags :: distinct bit_set[VideoH265ShortTermRefPicSetFlag; u32]
+VideoH265ShortTermRefPicSetFlag :: enum u32 {
+	inter_ref_pic_set_prediction_flag,
+	delta_rps_sign,
 }
 
 VideoH265ShortTermRefPicSet :: struct {
@@ -9616,8 +10246,39 @@ VideoH265SequenceParameterSet :: struct {
 	pPredictorPaletteEntries:                      [^]VideoH265PredictorPaletteEntries,
 }
 
-VideoH265PpsFlags :: struct {
-	bitfield: u32,
+VideoH265PpsFlags :: distinct bit_set[VideoH265PpsFlag; u32]
+VideoH265PpsFlag :: enum u32 {
+	dependent_slice_segments_enabled_flag,
+	output_flag_present_flag,
+	sign_data_hiding_enabled_flag,
+	cabac_init_present_flag,
+	constrained_intra_pred_flag,
+	transform_skip_enabled_flag,
+	cu_qp_delta_enabled_flag,
+	pps_slice_chroma_qp_offsets_present_flag,
+	weighted_pred_flag,
+	weighted_bipred_flag,
+	transquant_bypass_enabled_flag,
+	tiles_enabled_flag,
+	entropy_coding_sync_enabled_flag,
+	uniform_spacing_flag,
+	loop_filter_across_tiles_enabled_flag,
+	pps_loop_filter_across_slices_enabled_flag,
+	deblocking_filter_control_present_flag,
+	deblocking_filter_override_enabled_flag,
+	pps_deblocking_filter_disabled_flag,
+	pps_scaling_list_data_present_flag,
+	lists_modification_present_flag,
+	slice_segment_header_extension_present_flag,
+	pps_extension_present_flag,
+	cross_component_prediction_enabled_flag,
+	chroma_qp_offset_list_enabled_flag,
+	pps_curr_pic_ref_enabled_flag,
+	residual_adaptive_colour_transform_enabled_flag,
+	pps_slice_act_qp_offsets_present_flag,
+	pps_palette_predictor_initializers_present_flag,
+	monochrome_palette_flag,
+	pps_range_extension_flag,
 }
 
 VideoH265PictureParameterSet :: struct {
@@ -9659,8 +10320,12 @@ VideoH265PictureParameterSet :: struct {
 	pPredictorPaletteEntries:                  [^]VideoH265PredictorPaletteEntries,
 }
 
-VideoDecodeH265PictureInfoFlags :: struct {
-	bitfield: u32,
+VideoDecodeH265PictureInfoFlags :: distinct bit_set[VideoDecodeH265PictureInfoFlag; u32]
+VideoDecodeH265PictureInfoFlag :: enum u32 {
+	IrapPicFlag,
+	IdrPicFlag,
+	IsReference,
+	short_term_ref_pic_set_sps_flag,
 }
 
 VideoDecodeH265PictureInfo :: struct {
@@ -9677,8 +10342,10 @@ VideoDecodeH265PictureInfo :: struct {
 	RefPicSetLtCurr:              [VIDEO_DECODE_H265_REF_PIC_SET_LIST_SIZE]u8,
 }
 
-VideoDecodeH265ReferenceInfoFlags :: struct {
-	bitfield: u32,
+VideoDecodeH265ReferenceInfoFlags :: distinct bit_set[VideoDecodeH265ReferenceInfoFlag; u32]
+VideoDecodeH265ReferenceInfoFlag :: enum u32 {
+	used_for_long_term_reference,
+	unused_for_reference,
 }
 
 VideoDecodeH265ReferenceInfo :: struct {
@@ -9707,8 +10374,20 @@ VideoEncodeH265WeightTable :: struct {
 	delta_chroma_offset_l1:         [VIDEO_H265_MAX_NUM_LIST_REF][VIDEO_H265_MAX_CHROMA_PLANES]i8,
 }
 
-VideoEncodeH265SliceSegmentHeaderFlags :: struct {
-	bitfield: u32,
+VideoEncodeH265SliceSegmentHeaderFlags :: distinct bit_set[VideoEncodeH265SliceSegmentHeaderFlag; u32]
+VideoEncodeH265SliceSegmentHeaderFlag :: enum u32 {
+	first_slice_segment_in_pic_flag,
+	dependent_slice_segment_flag,
+	slice_sao_luma_flag,
+	slice_sao_chroma_flag,
+	num_ref_idx_active_override_flag,
+	mvd_l1_zero_flag,
+	cabac_init_flag,
+	cu_chroma_qp_offset_enabled_flag,
+	deblocking_filter_override_flag,
+	slice_deblocking_filter_disabled_flag,
+	collocated_from_l0_flag,
+	slice_loop_filter_across_slices_enabled_flag,
 }
 
 VideoEncodeH265SliceSegmentHeader :: struct {
@@ -9729,8 +10408,10 @@ VideoEncodeH265SliceSegmentHeader :: struct {
 	pWeightTable:           [^]VideoEncodeH265WeightTable,
 }
 
-VideoEncodeH265ReferenceListsInfoFlags :: struct {
-	bitfield: u32,
+VideoEncodeH265ReferenceListsInfoFlags :: distinct bit_set[VideoEncodeH265ReferenceListsInfoFlag; u32]
+VideoEncodeH265ReferenceListsInfoFlag :: enum u32 {
+	ref_pic_list_modification_flag_l0,
+	ref_pic_list_modification_flag_l1,
 }
 
 VideoEncodeH265ReferenceListsInfo :: struct {
@@ -9743,8 +10424,17 @@ VideoEncodeH265ReferenceListsInfo :: struct {
 	list_entry_l1:                [VIDEO_H265_MAX_NUM_LIST_REF]u8,
 }
 
-VideoEncodeH265PictureInfoFlags :: struct {
-	bitfield: u32,
+VideoEncodeH265PictureInfoFlags :: distinct bit_set[VideoEncodeH265PictureInfoFlag; u32]
+VideoEncodeH265PictureInfoFlag :: enum u32 {
+	is_reference,
+	IrapPicFlag,
+	used_for_long_term_reference,
+	discardable_flag,
+	cross_layer_bla_flag,
+	pic_output_flag,
+	no_output_of_prior_pics_flag,
+	short_term_ref_pic_set_sps_flag,
+	slice_temporal_mvp_enabled_flag,
 }
 
 VideoEncodeH265LongTermRefPics :: struct {
@@ -9772,8 +10462,10 @@ VideoEncodeH265PictureInfo :: struct {
 	pLongTermRefPics:           [^]VideoEncodeH265LongTermRefPics,
 }
 
-VideoEncodeH265ReferenceInfoFlags :: struct {
-	bitfield: u32,
+VideoEncodeH265ReferenceInfoFlags :: distinct bit_set[VideoEncodeH265ReferenceInfoFlag; u32]
+VideoEncodeH265ReferenceInfoFlag :: enum u32 {
+	used_for_long_term_reference,
+	unused_for_reference,
 }
 
 VideoEncodeH265ReferenceInfo :: struct {
@@ -10016,6 +10708,8 @@ BindDescriptorSetsInfoKHR                                   :: BindDescriptorSet
 PushConstantsInfoKHR                                        :: PushConstantsInfo
 PushDescriptorSetInfoKHR                                    :: PushDescriptorSetInfo
 PushDescriptorSetWithTemplateInfoKHR                        :: PushDescriptorSetWithTemplateInfo
+AccessFlags3KHR                                             :: Flags64
+AccessFlag3KHR                                              :: Flags64
 PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT          :: PhysicalDeviceTextureCompressionASTCHDRFeatures
 PipelineRobustnessBufferBehaviorEXT                         :: PipelineRobustnessBufferBehavior
 PipelineRobustnessImageBehaviorEXT                          :: PipelineRobustnessImageBehavior
@@ -10114,6 +10808,7 @@ PhysicalDeviceGlobalPriorityQueryFeaturesEXT                :: PhysicalDeviceGlo
 QueueFamilyGlobalPriorityPropertiesEXT                      :: QueueFamilyGlobalPriorityProperties
 PhysicalDeviceSchedulingControlsFlagsARM                    :: Flags64
 PhysicalDeviceSchedulingControlsFlagARM                     :: Flags64
+PhysicalDeviceDepthClampZeroOneFeaturesEXT                  :: PhysicalDeviceDepthClampZeroOneFeaturesKHR
 MemoryDecompressionMethodFlagNV                             :: Flags64
 MemoryDecompressionMethodFlagsNV                            :: Flags64
 PhysicalDevicePipelineProtectedAccessFeaturesEXT            :: PhysicalDevicePipelineProtectedAccessFeatures


### PR DESCRIPTION
This PR updates Vulkan headers and changes how c bit fields are handled in structs. There are roughly three scenarios:

First scenario is if a struct consists only 1 bit fields then it is handled as `bit_set` and `enum`:
```c
typedef struct StdVideoH264PpsFlags {
    uint32_t    transform_8x8_mode_flag : 1;
    uint32_t    redundant_pic_cnt_present_flag : 1;
    uint32_t    constrained_intra_pred_flag : 1;
    uint32_t    deblocking_filter_control_present_flag : 1;
    uint32_t    weighted_pred_flag : 1;
    uint32_t    bottom_field_pic_order_in_frame_present_flag : 1;
    uint32_t    entropy_coding_mode_flag : 1;
    uint32_t    pic_scaling_matrix_present_flag : 1;
} StdVideoH264PpsFlags;
```
generates this:
```odin
VideoH264PpsFlags :: distinct bit_set[VideoH264PpsFlag; u32]
VideoH264PpsFlag :: enum u32 {
	transform_8x8_mode_flag,
	redundant_pic_cnt_present_flag,
	constrained_intra_pred_flag,
	deblocking_filter_control_present_flag,
	weighted_pred_flag,
	bottom_field_pic_order_in_frame_present_flag,
	entropy_coding_mode_flag,
	pic_scaling_matrix_present_flag,
}
```

Second scenario is when a struct consists of only a single bit field set, for example:
```c
typedef struct StdVideoH265HrdFlags {
    uint32_t    nal_hrd_parameters_present_flag : 1;
    uint32_t    vcl_hrd_parameters_present_flag : 1;
    uint32_t    sub_pic_hrd_params_present_flag : 1;
    uint32_t    sub_pic_cpb_params_in_pic_timing_sei_flag : 1;
    uint32_t    fixed_pic_rate_general_flag : 8;
    uint32_t    fixed_pic_rate_within_cvs_flag : 8;
    uint32_t    low_delay_hrd_flag : 8;
} StdVideoH265HrdFlags;
```
generates this:
```odin
VideoH265HrdFlags :: bit_field u32 {
	nal_hrd_parameters_present_flag:           u32 | 1,
	vcl_hrd_parameters_present_flag:           u32 | 1,
	sub_pic_hrd_params_present_flag:           u32 | 1,
	sub_pic_cpb_params_in_pic_timing_sei_flag: u32 | 1,
	fixed_pic_rate_general_flag:               u32 | 8,
	fixed_pic_rate_within_cvs_flag:            u32 | 8,
	low_delay_hrd_flag:                        u32 | 8,
}
```

Third scenario is when struct embeds in itself one or many bit field sets:
```c
typedef struct VkClusterAccelerationStructureBuildTriangleClusterInfoNV {
    uint32_t                                                         clusterID;
    VkClusterAccelerationStructureClusterFlagsNV                     clusterFlags;
    uint32_t                                                         triangleCount:9;
    uint32_t                                                         vertexCount:9;
    uint32_t                                                         positionTruncateBitCount:6;
    uint32_t                                                         indexType:4;
    uint32_t                                                         opacityMicromapIndexType:4;
    VkClusterAccelerationStructureGeometryIndexAndGeometryFlagsNV    baseGeometryIndexAndGeometryFlags;
    uint16_t                                                         indexBufferStride;
    uint16_t                                                         vertexBufferStride;
    uint16_t                                                         geometryIndexAndFlagsBufferStride;
    uint16_t                                                         opacityMicromapIndexBufferStride;
    VkDeviceAddress                                                  indexBuffer;
    VkDeviceAddress                                                  vertexBuffer;
    VkDeviceAddress                                                  geometryIndexAndFlagsBuffer;
    VkDeviceAddress                                                  opacityMicromapArray;
    VkDeviceAddress                                                  opacityMicromapIndexBuffer;
} VkClusterAccelerationStructureBuildTriangleClusterInfoNV;
```
generates this:
```odin
ClusterAccelerationStructureBuildTriangleClusterInfoNV :: struct {
	clusterID: u32,
	clusterFlags: ClusterAccelerationStructureClusterFlagsNV,
	using _: bit_field u32 {
		triangleCount:            u32 | 9,
		vertexCount:              u32 | 9,
		positionTruncateBitCount: u32 | 6,
		indexType:                u32 | 4,
		opacityMicromapIndexType: u32 | 4,
	},
	baseGeometryIndexAndGeometryFlags: ClusterAccelerationStructureGeometryIndexAndGeometryFlagsNV,
	indexBufferStride: u16,
	vertexBufferStride: u16,
	geometryIndexAndFlagsBufferStride: u16,
	opacityMicromapIndexBufferStride: u16,
	indexBuffer: DeviceAddress,
	vertexBuffer: DeviceAddress,
	geometryIndexAndFlagsBuffer: DeviceAddress,
	opacityMicromapArray: DeviceAddress,
	opacityMicromapIndexBuffer: DeviceAddress,
}
```
With multiple field sets:
```c
typedef struct VkAccelerationStructureInstanceKHR {
    VkTransformMatrixKHR          transform;
    uint32_t                      instanceCustomIndex:24;
    uint32_t                      mask:8;
    uint32_t                      instanceShaderBindingTableRecordOffset:24;
    VkGeometryInstanceFlagsKHR    flags:8;
    uint64_t                      accelerationStructureReference;
} VkAccelerationStructureInstanceKHR;
```
generates this:
```odin
AccelerationStructureInstanceKHR :: struct {
	transform: TransformMatrixKHR,
	using _: bit_field u32 {
		instanceCustomIndex: u32 | 24,
		mask:                u32 | 8,
	},
	using _: bit_field u32 {
		instanceShaderBindingTableRecordOffset: u32 | 24,
		flags:              GeometryInstanceFlagKHR | 8,
	},
	accelerationStructureReference: u64,
}
```

where `GeometryInstanceFlagKHR` is:
```odin
Flags :: distinct u32

GeometryInstanceFlagsKHR :: distinct bit_set[GeometryInstanceFlagKHR; Flags]
GeometryInstanceFlagKHR :: enum Flags {
	TRIANGLE_FACING_CULL_DISABLE       = 0,
	TRIANGLE_FLIP_FACING               = 1,
	FORCE_OPAQUE                       = 2,
	FORCE_NO_OPAQUE                    = 3,
	FORCE_OPACITY_MICROMAP_2_STATE_EXT = 4,
	DISABLE_OPACITY_MICROMAPS_EXT      = 5,
	TRIANGLE_FRONT_COUNTERCLOCKWISE    = TRIANGLE_FLIP_FACING,
	TRIANGLE_CULL_DISABLE_NV           = TRIANGLE_FACING_CULL_DISABLE,
	TRIANGLE_FRONT_COUNTERCLOCKWISE_NV = TRIANGLE_FRONT_COUNTERCLOCKWISE,
	FORCE_OPAQUE_NV                    = FORCE_OPAQUE,
	FORCE_NO_OPAQUE_NV                 = FORCE_NO_OPAQUE,
}
```

This compiles and works fine for me but i am not using all of those bit fields in my project.