### PR TITLE
Fix `~bit_set[Some_Enum]` altering the enum

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -2599,9 +2599,8 @@ gb_internal ExactValue exact_bit_set_all_set_mask(Type *type) {
 					continue;
 				}
 
-				BigInt shift_amount = f->Constant.value.value_integer;
-				big_int_sub_eq(&shift_amount, &b_lower_base);
-
+				BigInt shift_amount = {};
+				big_int_sub(&shift_amount, &f->Constant.value.value_integer, &b_lower_base);
 
 				BigInt value = {};
 				big_int_shl(&value, &one, &shift_amount);


### PR DESCRIPTION
This was occurring for enums whose minimum values were non-zero. Compiling this instruction would cause the compiler to adjust all of the variants of the enums so that its minimum starts at 0, rather than whatever its minimum was.

For example:
```odin
E :: enum { A = 1, B, C }

slice := []E { .A, .B, .C }
for e in slice do fmt.printfln("%v (%[0]d)", e)
fmt.println()

//set1 := ~bit_set[E]{}
```
With the `~bit_set[E]{}` commented, this outputs:
```
A (1)
B (2)
C (3)
```
as expected. But with that uncommented, this instead outputs:
```
A (0)
B (1)
C (2)
```