### PR TITLE
Fix a couple bugs in `os2`

### DIFF
--- a/core/os/os2/stat.odin
+++ b/core/os/os2/stat.odin
@@ -24,7 +24,7 @@ File_Info :: struct {
 @(require_results)
 file_info_clone :: proc(fi: File_Info, allocator: runtime.Allocator) -> (cloned: File_Info, err: runtime.Allocator_Error) {
 	cloned = fi
-	cloned.fullpath = strings.clone(fi.fullpath) or_return
+	cloned.fullpath = strings.clone(fi.fullpath, allocator) or_return
 	cloned.name = filepath.base(cloned.fullpath)
 	return
 }

--- a/core/os/os2/user.odin
+++ b/core/os/os2/user.odin
@@ -49,7 +49,7 @@ user_config_dir :: proc(allocator: runtime.Allocator) -> (dir: string, err: Erro
 			dir = concatenate({dir, "/.config"}, allocator) or_return
 		}
 	case: // All other UNIX systems
-		dir = get_env("XDG_CACHE_HOME", allocator)
+		dir = get_env("XDG_CONFIG_HOME", allocator)
 		if dir == "" {
 			dir = get_env("HOME", temp_allocator())
 			if dir == "" {


### PR DESCRIPTION
Fixes a memory leak in `os2.file_info_clone` and a wrong path in `os2.user_config_dir` for the other UNIX-style systems.