### PR TITLE
Fix data races in `os2/env_linux.odin`

### DIFF
--- a/core/os/os2/env_linux.odin
+++ b/core/os/os2/env_linux.odin
@@ -126,7 +126,7 @@ _unset_env :: proc(key: string) -> bool {
 		return true
 	}
 
-	// if we got this far, the envrionment variable
+	// if we got this far, the environment variable
 	// existed AND was allocated by us.
 	k_addr, _ := _kv_addr_from_val(v, key)
 	runtime.heap_free(k_addr)

--- a/core/os/os2/env_posix.odin
+++ b/core/os/os2/env_posix.odin
@@ -57,7 +57,7 @@ _clear_env :: proc() {
 }
 
 _environ :: proc(allocator: runtime.Allocator) -> (environ: []string, err: Error) {
-	n := 0	
+	n := 0
 	for entry := posix.environ[0]; entry != nil; n, entry = n+1, posix.environ[n] {}
 
 	r := make([dynamic]string, 0, n, allocator) or_return


### PR DESCRIPTION
Switched to a recursive mutex so that procedures which need to perform lookups can do so while also maintaining the lock across their entire body in order to guarantee atomicity for each environment operation.

While investigating this, I also noticed that there may be an issue with `export_cstring_environment`, which is only privately implemented on Linux and used in `os2/process_linux.odin`. If the environment is exported then another thread clears it or unsets some keys, then the original return value (used in `_process_start`) could hold pointers to invalid memory. I'll have to look into this later and how it's used in `process` to see if the values need to be cloned.