### PR TITLE
Remove unneeded slicing in `strings.clone`

### DIFF
--- a/core/strings/strings.odin
+++ b/core/strings/strings.odin
@@ -25,7 +25,7 @@ Returns:
 clone :: proc(s: string, allocator := context.allocator, loc := #caller_location) -> (res: string, err: mem.Allocator_Error) #optional_allocator_error {
 	c := make([]byte, len(s), allocator, loc) or_return
 	copy(c, s)
-	return string(c[:len(s)]), nil
+	return string(c), nil
 }
 /*
 Clones a string safely (returns early with an allocation error on failure)


### PR DESCRIPTION
Unless I'm mistaken, there should be no need to slice a newly allocated byte slice by its exact length for a regular `string`. (This differs from `clone_from_bytes` which appends a null byte and does need to re-slice `c` according to its API description.)