### PR TITLE
[datetime]: Remove the definition of EPOCH

### DIFF
--- a/core/time/datetime/constants.odin
+++ b/core/time/datetime/constants.odin
@@ -5,12 +5,10 @@ Type representing a mononotic day number corresponding to a date.
 
 	Ordinal 1 = Midnight Monday, January 1, 1 A.D. (Gregorian)
 	        |   Midnight Monday, January 3, 1 A.D. (Julian)
+
+Every other ordinal counts days forwards, starting from the above date.
 */
 Ordinal :: i64
-
-/*
-*/
-EPOCH   :: Ordinal(1)
 
 /*
 Minimum valid value for date.

--- a/core/time/datetime/datetime.odin
+++ b/core/time/datetime/datetime.odin
@@ -98,7 +98,7 @@ This procedure takes the value of an ordinal and returns the day of week for
 that ordinal.
 */
 day_of_week :: proc "contextless" (ordinal: Ordinal) -> (day: Weekday) {
-	return Weekday((ordinal - EPOCH + 1) %% 7)
+	return Weekday(ordinal %% 7)
 }
 
 /*
@@ -349,8 +349,7 @@ the result is unspecified.
 unsafe_date_to_ordinal :: proc "contextless" (date: Date) -> (ordinal: Ordinal) {
 	year_minus_one := date.year - 1
 
-	// Day before epoch
-	ordinal = EPOCH - 1
+	ordinal = 0
 
 	// Add non-leap days
 	ordinal += 365 * year_minus_one
@@ -382,17 +381,17 @@ This procedure returns the year and the day of the year of a given ordinal.
 Of the ordinal is outside of its valid range, the result is unspecified.
 */
 unsafe_ordinal_to_year :: proc "contextless" (ordinal: Ordinal) -> (year: i64, day_ordinal: i64) {
-	// Days after epoch
-	d0   := ordinal - EPOCH
+	// Correct for leap year cycle starting at day 1.
+	d0   := ordinal - 1
 
 	// Number of 400-year cycles and remainder
-	n400, d1 := divmod(d0, 146097)
+	n400, d1 := divmod(d0, 365*400 + 100 - 3)
 
 	// Number of 100-year cycles and remainder
-	n100, d2 := divmod(d1, 36524)
+	n100, d2 := divmod(d1, 365*100 + 25 - 1)
 
 	// Number of 4-year cycles and remainder
-	n4,   d3 := divmod(d2, 1461)
+	n4,   d3 := divmod(d2, 365*4 + 1)
 
 	// Number of remaining days
 	n1,   d4 := divmod(d3, 365)


### PR DESCRIPTION

This PR removes the unnecessary declaration and semantically-incorrect usages of EPOCH.

This affects the following places:
- Converting ordinals to year: `day - 1` simply offsets the day count such that the zeroeth day starts at `CE 0001-01-01`, instead of `BCE 0001-12-31`, because the leap year cycle starts one day later than "Ordinal Day 0".
- Weekday calculations: `CE 0001-01-01` is Ordinal Day 1, and is defined as Monday. It follows that the week day number is simply Ordinal Day mod 7.

I have also made a little bit more sense with the constants in `ordinal_to_year`, making it appear more like the number of days 400, 100 and 4 year intervals would have. I made sure I didn't make a mistake by calculating these expressions and comparing the answer to the negative part of the diff.
