### PR TITLE
[BREAKING CHANGE] Subtyping based `runtime.Type_Info`

### DIFF
--- a/base/runtime/core.odin
+++ b/base/runtime/core.odin
@@ -63,38 +63,44 @@ Type_Info_Struct_Soa_Kind :: enum u8 {
 
 // Variant Types
 Type_Info_Named :: struct {
+	using info: Type_Info,
 	name: string,
 	base: ^Type_Info,
 	pkg:  string,
 	loc:  ^Source_Code_Location,
 }
-Type_Info_Integer    :: struct {signed: bool, endianness: Platform_Endianness}
-Type_Info_Rune       :: struct {}
-Type_Info_Float      :: struct {endianness: Platform_Endianness}
-Type_Info_Complex    :: struct {}
-Type_Info_Quaternion :: struct {}
-Type_Info_String     :: struct {is_cstring: bool}
-Type_Info_Boolean    :: struct {}
-Type_Info_Any        :: struct {}
-Type_Info_Type_Id    :: struct {}
+Type_Info_Integer    :: struct {using info: Type_Info, signed: bool, endianness: Platform_Endianness}
+Type_Info_Rune       :: struct {using info: Type_Info}
+Type_Info_Float      :: struct {using info: Type_Info, endianness: Platform_Endianness}
+Type_Info_Complex    :: struct {using info: Type_Info}
+Type_Info_Quaternion :: struct {using info: Type_Info}
+Type_Info_String     :: struct {using info: Type_Info, is_cstring: bool}
+Type_Info_Boolean    :: struct {using info: Type_Info}
+Type_Info_Any        :: struct {using info: Type_Info}
+Type_Info_Type_Id    :: struct {using info: Type_Info}
 Type_Info_Pointer :: struct {
+	using info: Type_Info,
 	elem: ^Type_Info, // nil -> rawptr
 }
 Type_Info_Multi_Pointer :: struct {
+	using info: Type_Info,
 	elem: ^Type_Info,
 }
 Type_Info_Procedure :: struct {
+	using info: Type_Info,
 	params:     ^Type_Info, // Type_Info_Parameters
 	results:    ^Type_Info, // Type_Info_Parameters
 	variadic:   bool,
 	convention: Calling_Convention,
 }
 Type_Info_Array :: struct {
+	using info: Type_Info,
 	elem:      ^Type_Info,
 	elem_size: int,
 	count:     int,
 }
 Type_Info_Enumerated_Array :: struct {
+	using info: Type_Info,
 	elem:      ^Type_Info,
 	index:     ^Type_Info,
 	elem_size: int,
@@ -103,12 +109,21 @@ Type_Info_Enumerated_Array :: struct {
 	max_value: Type_Info_Enum_Value,
 	is_sparse: bool,
 }
-Type_Info_Dynamic_Array :: struct {elem: ^Type_Info, elem_size: int}
-Type_Info_Slice         :: struct {elem: ^Type_Info, elem_size: int}
+Type_Info_Dynamic_Array :: struct {
+	using info: Type_Info,
+	elem:      ^Type_Info,
+	elem_size: int,
+}
+Type_Info_Slice         :: struct {
+	using info: Type_Info,
+	elem:      ^Type_Info,
+	elem_size: int,
+}
 
 Type_Info_Parameters :: struct { // Only used for procedures parameters and results
-	types:        []^Type_Info,
-	names:        []string,
+	using info: Type_Info,
+	types: []^Type_Info,
+	names: []string,
 }
 Type_Info_Tuple :: Type_Info_Parameters // Will be removed eventually
 
@@ -121,6 +136,8 @@ Type_Info_Struct_Flag :: enum u8 {
 }
 
 Type_Info_Struct :: struct {
+	using info: Type_Info,
+
 	// Slice these with `field_count`
 	types:   [^]^Type_Info `fmt:"v,field_count"`,
 	names:   [^]string     `fmt:"v,field_count"`,
@@ -130,16 +147,20 @@ Type_Info_Struct :: struct {
 
 	field_count: i32,
 
-	flags: Type_Info_Struct_Flags,
+	struct_flags: Type_Info_Struct_Flags,
 
 	// These are only set iff this structure is an SOA structure
 	soa_kind:      Type_Info_Struct_Soa_Kind,
+	_:             [2]u8,
 	soa_len:       i32,
+	_:             [4]u8,
 	soa_base_type: ^Type_Info,
 
 	equal: Equal_Proc, // set only when the struct has .Comparable set but does not have .Simple_Compare set
 }
 Type_Info_Union :: struct {
+	using info: Type_Info,
+
 	variants:     []^Type_Info,
 	tag_offset:   uintptr,
 	tag_type:     ^Type_Info,
@@ -151,27 +172,32 @@ Type_Info_Union :: struct {
 	shared_nil:   bool,
 }
 Type_Info_Enum :: struct {
+	using info: Type_Info,
 	base:   ^Type_Info,
 	names:  []string,
 	values: []Type_Info_Enum_Value,
 }
 Type_Info_Map :: struct {
+	using info: Type_Info,
 	key:      ^Type_Info,
 	value:    ^Type_Info,
 	map_info: ^Map_Info,
 }
 Type_Info_Bit_Set :: struct {
+	using info: Type_Info,
 	elem:       ^Type_Info,
 	underlying: ^Type_Info, // Possibly nil
 	lower:      i64,
 	upper:      i64,
 }
 Type_Info_Simd_Vector :: struct {
+	using info: Type_Info,
 	elem:       ^Type_Info,
 	elem_size:  int,
 	count:      int,
 }
 Type_Info_Matrix :: struct {
+	using info: Type_Info,
 	elem:         ^Type_Info,
 	elem_size:    int,
 	elem_stride:  int, // elem_stride >= row_count
@@ -184,9 +210,11 @@ Type_Info_Matrix :: struct {
 	},
 }
 Type_Info_Soa_Pointer :: struct {
+	using info: Type_Info,
 	elem: ^Type_Info,
 }
 Type_Info_Bit_Field :: struct {
+	using info: Type_Info,
 	backing_type: ^Type_Info,
 	names:        [^]string     `fmt:"v,field_count"`,
 	types:        [^]^Type_Info `fmt:"v,field_count"`,
@@ -209,33 +237,33 @@ Type_Info :: struct {
 	id:    typeid,
 
 	variant: union {
-		Type_Info_Named,
-		Type_Info_Integer,
-		Type_Info_Rune,
-		Type_Info_Float,
-		Type_Info_Complex,
-		Type_Info_Quaternion,
-		Type_Info_String,
-		Type_Info_Boolean,
-		Type_Info_Any,
-		Type_Info_Type_Id,
-		Type_Info_Pointer,
-		Type_Info_Multi_Pointer,
-		Type_Info_Procedure,
-		Type_Info_Array,
-		Type_Info_Enumerated_Array,
-		Type_Info_Dynamic_Array,
-		Type_Info_Slice,
-		Type_Info_Parameters,
-		Type_Info_Struct,
-		Type_Info_Union,
-		Type_Info_Enum,
-		Type_Info_Map,
-		Type_Info_Bit_Set,
-		Type_Info_Simd_Vector,
-		Type_Info_Matrix,
-		Type_Info_Soa_Pointer,
-		Type_Info_Bit_Field,
+		^Type_Info_Named,
+		^Type_Info_Integer,
+		^Type_Info_Rune,
+		^Type_Info_Float,
+		^Type_Info_Complex,
+		^Type_Info_Quaternion,
+		^Type_Info_String,
+		^Type_Info_Boolean,
+		^Type_Info_Any,
+		^Type_Info_Type_Id,
+		^Type_Info_Pointer,
+		^Type_Info_Multi_Pointer,
+		^Type_Info_Procedure,
+		^Type_Info_Array,
+		^Type_Info_Enumerated_Array,
+		^Type_Info_Dynamic_Array,
+		^Type_Info_Slice,
+		^Type_Info_Parameters,
+		^Type_Info_Struct,
+		^Type_Info_Union,
+		^Type_Info_Enum,
+		^Type_Info_Map,
+		^Type_Info_Bit_Set,
+		^Type_Info_Simd_Vector,
+		^Type_Info_Matrix,
+		^Type_Info_Soa_Pointer,
+		^Type_Info_Bit_Field,
 	},
 }
 
@@ -622,7 +650,7 @@ type_info_base :: proc "contextless" (info: ^Type_Info) -> ^Type_Info {
 	base := info
 	loop: for {
 		#partial switch i in base.variant {
-		case Type_Info_Named: base = i.base
+		case ^Type_Info_Named: base = i.base
 		case: break loop
 		}
 	}
@@ -638,9 +666,9 @@ type_info_core :: proc "contextless" (info: ^Type_Info) -> ^Type_Info {
 	base := info
 	loop: for {
 		#partial switch i in base.variant {
-		case Type_Info_Named:     base = i.base
-		case Type_Info_Enum:      base = i.base
-		case Type_Info_Bit_Field: base = i.backing_type
+		case ^Type_Info_Named:     base = i.base
+		case ^Type_Info_Enum:      base = i.base
+		case ^Type_Info_Bit_Field: base = i.backing_type
 		case: break loop
 		}
 	}

--- a/base/runtime/error_checks.odin
+++ b/base/runtime/error_checks.odin
@@ -191,9 +191,9 @@ when ODIN_NO_RTTI {
 			}
 			ti := type_info_base(type_info_of(id))
 			#partial switch v in ti.variant {
-			case Type_Info_Any:
+			case ^Type_Info_Any:
 				return (^any)(data).id
-			case Type_Info_Union:
+			case ^Type_Info_Union:
 				tag_ptr := uintptr(data) + v.tag_offset
 				idx := 0
 				switch v.tag_type.size {

--- a/base/runtime/print.odin
+++ b/base/runtime/print.odin
@@ -64,7 +64,7 @@ when !ODIN_NO_RTTI {
 		case:
 			ti := type_info_of(x.id)
 			#partial switch v in ti.variant {
-			case Type_Info_Pointer, Type_Info_Multi_Pointer:
+			case ^Type_Info_Pointer, ^Type_Info_Multi_Pointer:
 				print_uintptr((^uintptr)(x.data)^)
 				return
 			}
@@ -270,9 +270,9 @@ print_type :: #force_no_inline proc "contextless" (ti: ^Type_Info) {
 	}
 
 	switch info in ti.variant {
-	case Type_Info_Named:
+	case ^Type_Info_Named:
 		print_string(info.name)
-	case Type_Info_Integer:
+	case ^Type_Info_Integer:
 		switch ti.id {
 		case int:     print_string("int")
 		case uint:    print_string("uint")
@@ -281,50 +281,50 @@ print_type :: #force_no_inline proc "contextless" (ti: ^Type_Info) {
 			print_byte('i' if info.signed else 'u')
 			print_u64(u64(8*ti.size))
 		}
-	case Type_Info_Rune:
+	case ^Type_Info_Rune:
 		print_string("rune")
-	case Type_Info_Float:
+	case ^Type_Info_Float:
 		print_byte('f')
 		print_u64(u64(8*ti.size))
-	case Type_Info_Complex:
+	case ^Type_Info_Complex:
 		print_string("complex")
 		print_u64(u64(8*ti.size))
-	case Type_Info_Quaternion:
+	case ^Type_Info_Quaternion:
 		print_string("quaternion")
 		print_u64(u64(8*ti.size))
-	case Type_Info_String:
+	case ^Type_Info_String:
 		print_string("string")
-	case Type_Info_Boolean:
+	case ^Type_Info_Boolean:
 		switch ti.id {
 		case bool: print_string("bool")
 		case:
 			print_byte('b')
 			print_u64(u64(8*ti.size))
 		}
-	case Type_Info_Any:
+	case ^Type_Info_Any:
 		print_string("any")
-	case Type_Info_Type_Id:
+	case ^Type_Info_Type_Id:
 		print_string("typeid")
 
-	case Type_Info_Pointer:
+	case ^Type_Info_Pointer:
 		if info.elem == nil {
 			print_string("rawptr")
 		} else {
 			print_string("^")
 			print_type(info.elem)
 		}
-	case Type_Info_Multi_Pointer:
+	case ^Type_Info_Multi_Pointer:
 		print_string("[^]")
 		print_type(info.elem)
-	case Type_Info_Soa_Pointer:
+	case ^Type_Info_Soa_Pointer:
 		print_string("#soa ^")
 		print_type(info.elem)
-	case Type_Info_Procedure:
+	case ^Type_Info_Procedure:
 		print_string("proc")
 		if info.params == nil {
 			print_string("()")
 		} else {
-			t := info.params.variant.(Type_Info_Parameters)
+			t := info.params.variant.(^Type_Info_Parameters)
 			print_byte('(')
 			for t, i in t.types {
 				if i > 0 { print_string(", ") }
@@ -336,7 +336,7 @@ print_type :: #force_no_inline proc "contextless" (ti: ^Type_Info) {
 			print_string(" -> ")
 			print_type(info.results)
 		}
-	case Type_Info_Parameters:
+	case ^Type_Info_Parameters:
 		count := len(info.names)
 		if count != 1 { print_byte('(') }
 		for name, i in info.names {
@@ -352,13 +352,13 @@ print_type :: #force_no_inline proc "contextless" (ti: ^Type_Info) {
 		}
 		if count != 1 { print_string(")") }
 
-	case Type_Info_Array:
+	case ^Type_Info_Array:
 		print_byte('[')
 		print_u64(u64(info.count))
 		print_byte(']')
 		print_type(info.elem)
 
-	case Type_Info_Enumerated_Array:
+	case ^Type_Info_Enumerated_Array:
 		if info.is_sparse {
 			print_string("#sparse")
 		}
@@ -368,20 +368,20 @@ print_type :: #force_no_inline proc "contextless" (ti: ^Type_Info) {
 		print_type(info.elem)
 
 
-	case Type_Info_Dynamic_Array:
+	case ^Type_Info_Dynamic_Array:
 		print_string("[dynamic]")
 		print_type(info.elem)
-	case Type_Info_Slice:
+	case ^Type_Info_Slice:
 		print_string("[]")
 		print_type(info.elem)
 
-	case Type_Info_Map:
+	case ^Type_Info_Map:
 		print_string("map[")
 		print_type(info.key)
 		print_byte(']')
 		print_type(info.value)
 
-	case Type_Info_Struct:
+	case ^Type_Info_Struct:
 		switch info.soa_kind {
 		case .None: // Ignore
 		case .Fixed:
@@ -401,10 +401,10 @@ print_type :: #force_no_inline proc "contextless" (ti: ^Type_Info) {
 		}
 
 		print_string("struct ")
-		if .packed    in info.flags { print_string("#packed ") }
-		if .raw_union in info.flags { print_string("#raw_union ") }
-		if .no_copy   in info.flags { print_string("#no_copy ") }
-		if .align in info.flags {
+		if .packed    in info.struct_flags { print_string("#packed ") }
+		if .raw_union in info.struct_flags { print_string("#raw_union ") }
+		if .no_copy   in info.struct_flags { print_string("#no_copy ") }
+		if .align in info.struct_flags {
 			print_string("#align(")
 			print_u64(u64(ti.align))
 			print_string(") ")
@@ -418,7 +418,7 @@ print_type :: #force_no_inline proc "contextless" (ti: ^Type_Info) {
 		}
 		print_byte('}')
 
-	case Type_Info_Union:
+	case ^Type_Info_Union:
 		print_string("union ")
 		if info.custom_align {
 			print_string("#align(")
@@ -435,7 +435,7 @@ print_type :: #force_no_inline proc "contextless" (ti: ^Type_Info) {
 		}
 		print_string("}")
 
-	case Type_Info_Enum:
+	case ^Type_Info_Enum:
 		print_string("enum ")
 		print_type(info.base)
 		print_string(" {")
@@ -445,13 +445,13 @@ print_type :: #force_no_inline proc "contextless" (ti: ^Type_Info) {
 		}
 		print_string("}")
 
-	case Type_Info_Bit_Set:
+	case ^Type_Info_Bit_Set:
 		print_string("bit_set[")
 
 		#partial switch elem in type_info_base(info.elem).variant {
-		case Type_Info_Enum:
+		case ^Type_Info_Enum:
 			print_type(info.elem)
-		case Type_Info_Rune:
+		case ^Type_Info_Rune:
 			print_encoded_rune(rune(info.lower))
 			print_string("..")
 			print_encoded_rune(rune(info.upper))
@@ -466,7 +466,7 @@ print_type :: #force_no_inline proc "contextless" (ti: ^Type_Info) {
 		}
 		print_byte(']')
 
-	case Type_Info_Bit_Field:
+	case ^Type_Info_Bit_Field:
 		print_string("bit_field ")
 		print_type(info.backing_type)
 		print_string(" {")
@@ -481,13 +481,13 @@ print_type :: #force_no_inline proc "contextless" (ti: ^Type_Info) {
 		print_byte('}')
 
 
-	case Type_Info_Simd_Vector:
+	case ^Type_Info_Simd_Vector:
 		print_string("#simd[")
 		print_u64(u64(info.count))
 		print_byte(']')
 		print_type(info.elem)
 		
-	case Type_Info_Matrix:
+	case ^Type_Info_Matrix:
 		print_string("matrix[")
 		print_u64(u64(info.row_count))
 		print_string(", ")

--- a/core/encoding/cbor/tags.odin
+++ b/core/encoding/cbor/tags.odin
@@ -264,17 +264,17 @@ tag_cbor_marshal :: proc(_: ^Tag_Implementation, e: Encoder, v: any) -> Marshal_
 	_encode_u8(e.writer, TAG_CBOR_NR, .Tag) or_return
 	ti := runtime.type_info_base(type_info_of(v.id))
 	#partial switch t in ti.variant {
-	case runtime.Type_Info_String:
+	case ^runtime.Type_Info_String:
 		return marshal_into(e, v)
-	case runtime.Type_Info_Array:
+	case ^runtime.Type_Info_Array:
 		elem_base := reflect.type_info_base(t.elem)
 		if elem_base.id != byte { return .Bad_Tag_Value }
 		return marshal_into(e, v)
-	case runtime.Type_Info_Slice:
+	case ^runtime.Type_Info_Slice:
 		elem_base := reflect.type_info_base(t.elem)
 		if elem_base.id != byte { return .Bad_Tag_Value }
 		return marshal_into(e, v)
-	case runtime.Type_Info_Dynamic_Array:
+	case ^runtime.Type_Info_Dynamic_Array:
 		elem_base := reflect.type_info_base(t.elem)
 		if elem_base.id != byte { return .Bad_Tag_Value }
 		return marshal_into(e, v)
@@ -297,7 +297,7 @@ tag_base64_unmarshal :: proc(_: ^Tag_Implementation, d: Decoder, _: Tag_Number, 
 	defer delete(bytes, context.temp_allocator)
 
 	#partial switch t in ti.variant {
-	case reflect.Type_Info_String:
+	case ^reflect.Type_Info_String:
 
 		if t.is_cstring {
 			length  := base64.decoded_len(bytes)
@@ -313,7 +313,7 @@ tag_base64_unmarshal :: proc(_: ^Tag_Implementation, d: Decoder, _: Tag_Number, 
 
 		return
 
-	case reflect.Type_Info_Slice:
+	case ^reflect.Type_Info_Slice:
 		elem_base := reflect.type_info_base(t.elem)
 
 		if elem_base.id != byte { return _unsupported(v, hdr) }
@@ -322,7 +322,7 @@ tag_base64_unmarshal :: proc(_: ^Tag_Implementation, d: Decoder, _: Tag_Number, 
 		raw^  = base64.decode(bytes) or_return
 		return
 		
-	case reflect.Type_Info_Dynamic_Array:
+	case ^reflect.Type_Info_Dynamic_Array:
 		elem_base := reflect.type_info_base(t.elem)
 
 		if elem_base.id != byte { return _unsupported(v, hdr) }
@@ -336,7 +336,7 @@ tag_base64_unmarshal :: proc(_: ^Tag_Implementation, d: Decoder, _: Tag_Number, 
 		raw.allocator  = context.allocator
 		return
 
-	case reflect.Type_Info_Array:
+	case ^reflect.Type_Info_Array:
 		elem_base := reflect.type_info_base(t.elem)
 
 		if elem_base.id != byte { return _unsupported(v, hdr) }
@@ -366,7 +366,7 @@ tag_base64_marshal :: proc(_: ^Tag_Implementation, e: Encoder, v: any) -> Marsha
 	case [dynamic]byte: bytes = val[:]
 	case:
 		#partial switch t in ti.variant {
-		case runtime.Type_Info_Array:
+		case ^runtime.Type_Info_Array:
 			if t.elem.id != byte { return .Bad_Tag_Value }
 			bytes = ([^]byte)(v.data)[:t.count]
 		case:

--- a/core/encoding/json/marshal.odin
+++ b/core/encoding/json/marshal.odin
@@ -95,10 +95,10 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 	a := any{v.data, ti.id}
 
 	switch info in ti.variant {
-	case runtime.Type_Info_Named:
+	case ^runtime.Type_Info_Named:
 		unreachable()
 
-	case runtime.Type_Info_Integer:
+	case ^runtime.Type_Info_Integer:
 		buf: [40]byte
 		u := cast_any_int_to_u128(a)
 
@@ -120,13 +120,13 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 		io.write_string(w, s) or_return
 
 
-	case runtime.Type_Info_Rune:
+	case ^runtime.Type_Info_Rune:
 		r := a.(rune)
 		io.write_byte(w, '"')                  or_return
 		io.write_escaped_rune(w, r, '"', true) or_return
 		io.write_byte(w, '"')                  or_return
 
-	case runtime.Type_Info_Float:
+	case ^runtime.Type_Info_Float:
 		switch f in a {
 		case f16: io.write_f16(w, f) or_return
 		case f32: io.write_f32(w, f) or_return
@@ -134,7 +134,7 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 		case: return .Unsupported_Type
 		}
 
-	case runtime.Type_Info_Complex:
+	case ^runtime.Type_Info_Complex:
 		r, i: f64
 		switch z in a {
 		case complex32:  r, i = f64(real(z)), f64(imag(z))
@@ -149,16 +149,16 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 		io.write_f64(w, i)       or_return
 		io.write_byte(w, ']')    or_return
 
-	case runtime.Type_Info_Quaternion:
+	case ^runtime.Type_Info_Quaternion:
 		return .Unsupported_Type
 
-	case runtime.Type_Info_String:
+	case ^runtime.Type_Info_String:
 		switch s in a {
 		case string:  io.write_quoted_string(w, s, '"', nil, true)         or_return
 		case cstring: io.write_quoted_string(w, string(s), '"', nil, true) or_return
 		}
 
-	case runtime.Type_Info_Boolean:
+	case ^runtime.Type_Info_Boolean:
 		val: bool
 		switch b in a {
 		case bool: val = bool(b)
@@ -169,37 +169,37 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 		}
 		io.write_string(w, val ? "true" : "false") or_return
 
-	case runtime.Type_Info_Any:
+	case ^runtime.Type_Info_Any:
 		return .Unsupported_Type
 
-	case runtime.Type_Info_Type_Id:
+	case ^runtime.Type_Info_Type_Id:
 		return .Unsupported_Type
 
-	case runtime.Type_Info_Pointer:
+	case ^runtime.Type_Info_Pointer:
 		return .Unsupported_Type
 
-	case runtime.Type_Info_Multi_Pointer:
+	case ^runtime.Type_Info_Multi_Pointer:
 		return .Unsupported_Type
 
-	case runtime.Type_Info_Soa_Pointer:
+	case ^runtime.Type_Info_Soa_Pointer:
 		return .Unsupported_Type
 
-	case runtime.Type_Info_Procedure:
+	case ^runtime.Type_Info_Procedure:
 		return .Unsupported_Type
 
-	case runtime.Type_Info_Parameters:
+	case ^runtime.Type_Info_Parameters:
 		return .Unsupported_Type
 
-	case runtime.Type_Info_Simd_Vector:
+	case ^runtime.Type_Info_Simd_Vector:
 		return .Unsupported_Type
 		
-	case runtime.Type_Info_Matrix:
+	case ^runtime.Type_Info_Matrix:
 		return .Unsupported_Type
 
-	case runtime.Type_Info_Bit_Field:
+	case ^runtime.Type_Info_Bit_Field:
 		return .Unsupported_Type
 
-	case runtime.Type_Info_Array:
+	case ^runtime.Type_Info_Array:
 		opt_write_start(w, opt, '[') or_return
 		for i in 0..<info.count {
 			opt_write_iteration(w, opt, i == 0) or_return
@@ -208,9 +208,9 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 		}
 		opt_write_end(w, opt, ']') or_return
 		
-	case runtime.Type_Info_Enumerated_Array:
+	case ^runtime.Type_Info_Enumerated_Array:
 		index_type := reflect.type_info_base(info.index)
-		enum_type := index_type.variant.(reflect.Type_Info_Enum)
+		enum_type := index_type.variant.(^reflect.Type_Info_Enum)
 
 		opt_write_start(w, opt, '{') or_return
 		for i in 0..<info.count {
@@ -227,7 +227,7 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 		}
 		opt_write_end(w, opt, '}') or_return
 		
-	case runtime.Type_Info_Dynamic_Array:
+	case ^runtime.Type_Info_Dynamic_Array:
 		opt_write_start(w, opt, '[') or_return
 		array := cast(^mem.Raw_Dynamic_Array)v.data
 		for i in 0..<array.len {
@@ -237,7 +237,7 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 		}
 		opt_write_end(w, opt, ']') or_return
 
-	case runtime.Type_Info_Slice:
+	case ^runtime.Type_Info_Slice:
 		opt_write_start(w, opt, '[') or_return
 		slice := cast(^mem.Raw_Slice)v.data
 		for i in 0..<slice.len {
@@ -247,7 +247,7 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 		}
 		opt_write_end(w, opt, ']') or_return
 
-	case runtime.Type_Info_Map:
+	case ^runtime.Type_Info_Map:
 		m := (^mem.Raw_Map)(v.data)
 		opt_write_start(w, opt, '{') or_return
 
@@ -277,13 +277,13 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 						name: string
 
 						#partial switch info in kti.variant {
-						case runtime.Type_Info_String:
+						case ^runtime.Type_Info_String:
 							switch s in ka {
 							case string: name = s
 							case cstring: name = string(s)
 							}
 							opt_write_key(w, opt, name) or_return
-						case runtime.Type_Info_Integer:
+						case ^runtime.Type_Info_Integer:
 							buf: [40]byte
 							u := cast_any_int_to_u128(ka)
 							name = strconv.append_bits_128(buf[:], u, 10, info.signed, 8*kti.size, "0123456789", nil)
@@ -318,7 +318,7 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 						ka  := any{kv.data, kti.id}
 
 						#partial switch info in kti.variant {
-						case runtime.Type_Info_String:
+						case ^runtime.Type_Info_String:
 							switch s in ka {
 							case string: name = s
 							case cstring: name = string(s)
@@ -343,7 +343,7 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 
 		opt_write_end(w, opt, '}') or_return
 
-	case runtime.Type_Info_Struct:
+	case ^runtime.Type_Info_Struct:
 		is_omitempty :: proc(v: any) -> bool {
 			v := v
 			if v == nil {
@@ -351,30 +351,30 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 			}
 			ti := runtime.type_info_core(type_info_of(v.id))
 			#partial switch info in ti.variant {
-			case runtime.Type_Info_String:
+			case ^runtime.Type_Info_String:
 				switch x in v {
 				case string:
 					return x == ""
 				case cstring:
 					return x == nil || x == ""
 				}
-			case runtime.Type_Info_Any:
+			case ^runtime.Type_Info_Any:
 				return v.(any) == nil
-			case runtime.Type_Info_Type_Id:
+			case ^runtime.Type_Info_Type_Id:
 				return v.(typeid) == nil
-			case runtime.Type_Info_Pointer,
-			     runtime.Type_Info_Multi_Pointer,
-			     runtime.Type_Info_Procedure:
+			case ^runtime.Type_Info_Pointer,
+			     ^runtime.Type_Info_Multi_Pointer,
+			     ^runtime.Type_Info_Procedure:
 				return (^rawptr)(v.data)^ == nil
-			case runtime.Type_Info_Dynamic_Array:
+			case ^runtime.Type_Info_Dynamic_Array:
 				return (^runtime.Raw_Dynamic_Array)(v.data).len == 0
-			case runtime.Type_Info_Slice:
+			case ^runtime.Type_Info_Slice:
 				return (^runtime.Raw_Slice)(v.data).len == 0
-			case runtime.Type_Info_Union,
-			     runtime.Type_Info_Bit_Set,
-			     runtime.Type_Info_Soa_Pointer:
+			case ^runtime.Type_Info_Union,
+			     ^runtime.Type_Info_Bit_Set,
+			     ^runtime.Type_Info_Soa_Pointer:
 				return reflect.is_nil(v)
-			case runtime.Type_Info_Map:
+			case ^runtime.Type_Info_Map:
 				return (^runtime.Raw_Map)(v.data).len == 0
 			}
 			return false
@@ -382,7 +382,7 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 
 		marshal_struct_fields :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: Marshal_Error) {
 			ti := runtime.type_info_base(type_info_of(v.id))
-			info := ti.variant.(runtime.Type_Info_Struct)
+			info := ti.variant.(^runtime.Type_Info_Struct)
 			first_iteration := true
 			for name, i in info.names[:info.field_count] {
 				omitempty := false
@@ -432,7 +432,7 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 		marshal_struct_fields(w, v, opt) or_return
 		opt_write_end(w, opt, '}') or_return
 
-	case runtime.Type_Info_Union:
+	case ^runtime.Type_Info_Union:
 		if len(info.variants) == 0 || v.data == nil {
 			io.write_string(w, "null") or_return
 			return nil
@@ -464,7 +464,7 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 		id := info.variants[tag].id
 		return marshal_to_writer(w, any{v.data, id}, opt)
 
-	case runtime.Type_Info_Enum:
+	case ^runtime.Type_Info_Enum:
 		if !opt.use_enum_names || len(info.names) == 0 {
 			return marshal_to_writer(w, any{v.data, info.base.id}, opt)
 		} else {
@@ -476,14 +476,14 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 			}
 		}
 
-	case runtime.Type_Info_Bit_Set:
+	case ^runtime.Type_Info_Bit_Set:
 		is_bit_set_different_endian_to_platform :: proc(ti: ^runtime.Type_Info) -> bool {
 			if ti == nil {
 				return false
 			}
 			t := runtime.type_info_base(ti)
 			#partial switch info in t.variant {
-			case runtime.Type_Info_Integer:
+			case ^runtime.Type_Info_Integer:
 				switch info.endianness {
 				case .Platform: return false
 				case .Little:   return ODIN_ENDIAN != .Little

--- a/core/encoding/json/unmarshal.odin
+++ b/core/encoding/json/unmarshal.odin
@@ -43,7 +43,7 @@ unmarshal_any :: proc(data: []byte, v: any, spec := DEFAULT_SPECIFICATION, alloc
 	}
 	p := make_parser(data, spec, PARSE_INTEGERS, allocator)
 	
-	data := any{(^rawptr)(v.data)^, ti.variant.(reflect.Type_Info_Pointer).elem.id}
+	data := any{(^rawptr)(v.data)^, ti.variant.(^reflect.Type_Info_Pointer).elem.id}
 	if v.data == nil {
 		return .Invalid_Parameter
 	}
@@ -118,7 +118,7 @@ assign_int :: proc(val: any, i: $T) -> bool {
 	case uintptr: dst = uintptr(i)
 	case:
 		ti := type_info_of(v.id)
-		if _, ok := ti.variant.(runtime.Type_Info_Bit_Set); ok {
+		if _, ok := ti.variant.(^runtime.Type_Info_Bit_Set); ok {
 			do_byte_swap := !reflect.bit_set_is_big_endian(v)
 			switch ti.size * 8 {
 			case 0: // no-op.
@@ -202,7 +202,7 @@ unmarshal_string_token :: proc(p: ^Parser, val: any, str: string, ti: ^reflect.T
 	}
 	
 	#partial switch variant in ti.variant {
-	case reflect.Type_Info_Enum:
+	case ^reflect.Type_Info_Enum:
 		for name, i in variant.names {
 			if name == str {
 				assign_int(val, variant.values[i])
@@ -212,7 +212,7 @@ unmarshal_string_token :: proc(p: ^Parser, val: any, str: string, ti: ^reflect.T
 		// TODO(bill): should this be an error or not?
 		return true, nil
 		
-	case reflect.Type_Info_Integer:
+	case ^reflect.Type_Info_Integer:
 		i, pok := strconv.parse_i128(str)
 		if !pok {
 			return false, nil
@@ -223,7 +223,7 @@ unmarshal_string_token :: proc(p: ^Parser, val: any, str: string, ti: ^reflect.T
 		if assign_float(val, i) {
 			return true, nil
 		}
-	case reflect.Type_Info_Float:
+	case ^reflect.Type_Info_Float:
 		f, pok := strconv.parse_f64(str)
 		if !pok {
 			return false, nil
@@ -247,7 +247,7 @@ unmarshal_value :: proc(p: ^Parser, v: any) -> (err: Unmarshal_Error) {
 
 	v := v
 	ti := reflect.type_info_base(type_info_of(v.id))
-	if u, ok := ti.variant.(reflect.Type_Info_Union); ok && token.kind != .Null {
+	if u, ok := ti.variant.(^reflect.Type_Info_Union); ok && token.kind != .Null {
 		// NOTE: If it's a union with only one variant, then treat it as that variant
 		if len(u.variants) == 1 {
 			variant := u.variants[0]
@@ -413,8 +413,8 @@ unmarshal_object :: proc(p: ^Parser, v: any, end_token: Token_Kind) -> (err: Unm
 	ti := reflect.type_info_base(type_info_of(v.id))
 	
 	#partial switch t in ti.variant {
-	case reflect.Type_Info_Struct:
-		if .raw_union in t.flags {
+	case ^reflect.Type_Info_Struct:
+		if .raw_union in t.struct_flags {
 			return UNSUPPORTED_TYPE
 		}
 
@@ -520,7 +520,7 @@ unmarshal_object :: proc(p: ^Parser, v: any, end_token: Token_Kind) -> (err: Unm
 			}
 		}
 		
-	case reflect.Type_Info_Map:
+	case ^reflect.Type_Info_Map:
 		if !reflect.is_string(t.key) && !reflect.is_integer(t.key) {
 			return UNSUPPORTED_TYPE
 		}
@@ -548,14 +548,14 @@ unmarshal_object :: proc(p: ^Parser, v: any, end_token: Token_Kind) -> (err: Unm
 			key_ptr: rawptr
 
 			#partial switch tk in t.key.variant {
-				case runtime.Type_Info_String:			
+				case ^runtime.Type_Info_String:
 					key_ptr = rawptr(&key)
 					key_cstr: cstring
 					if reflect.is_cstring(t.key) {
 						key_cstr = cstring(raw_data(key))
 						key_ptr = &key_cstr
 					}
-				case runtime.Type_Info_Integer:
+				case ^runtime.Type_Info_Integer:
 					i, ok := strconv.parse_i128(key)
 					if !ok	{ return UNSUPPORTED_TYPE }
 					key_ptr = rawptr(&i)
@@ -577,9 +577,9 @@ unmarshal_object :: proc(p: ^Parser, v: any, end_token: Token_Kind) -> (err: Unm
 			}
 		}
 		
-	case reflect.Type_Info_Enumerated_Array:
+	case ^reflect.Type_Info_Enumerated_Array:
 		index_type := reflect.type_info_base(t.index)
-		enum_type := index_type.variant.(reflect.Type_Info_Enum)
+		enum_type := index_type.variant.(^reflect.Type_Info_Enum)
 	
 		enumerated_array_loop: for p.curr_token.kind != end_token {
 			key, _ := parse_object_key(p, p.allocator)
@@ -666,7 +666,7 @@ unmarshal_array :: proc(p: ^Parser, v: any) -> (err: Unmarshal_Error) {
 	length := unmarshal_count_array(p)
 	
 	#partial switch t in ti.variant {
-	case reflect.Type_Info_Slice:	
+	case ^reflect.Type_Info_Slice:
 		raw := (^mem.Raw_Slice)(v.data)
 		data := bytes_make(t.elem.size * int(length), t.elem.align, p.allocator) or_return
 		raw.data = raw_data(data)
@@ -674,7 +674,7 @@ unmarshal_array :: proc(p: ^Parser, v: any) -> (err: Unmarshal_Error) {
 			
 		return assign_array(p, raw.data, t.elem, length)
 		
-	case reflect.Type_Info_Dynamic_Array:
+	case ^reflect.Type_Info_Dynamic_Array:
 		raw := (^mem.Raw_Dynamic_Array)(v.data)
 		data := bytes_make(t.elem.size * int(length), t.elem.align, p.allocator) or_return
 		raw.data = raw_data(data)
@@ -684,7 +684,7 @@ unmarshal_array :: proc(p: ^Parser, v: any) -> (err: Unmarshal_Error) {
 		
 		return assign_array(p, raw.data, t.elem, length)
 		
-	case reflect.Type_Info_Array:
+	case ^reflect.Type_Info_Array:
 		// NOTE(bill): Allow lengths which are less than the dst array
 		if int(length) > t.count {
 			return UNSUPPORTED_TYPE
@@ -692,7 +692,7 @@ unmarshal_array :: proc(p: ^Parser, v: any) -> (err: Unmarshal_Error) {
 		
 		return assign_array(p, v.data, t.elem, length)
 		
-	case reflect.Type_Info_Enumerated_Array:
+	case ^reflect.Type_Info_Enumerated_Array:
 		// NOTE(bill): Allow lengths which are less than the dst array
 		if int(length) > t.count {
 			return UNSUPPORTED_TYPE
@@ -700,7 +700,7 @@ unmarshal_array :: proc(p: ^Parser, v: any) -> (err: Unmarshal_Error) {
 		
 		return assign_array(p, v.data, t.elem, length)
 		
-	case reflect.Type_Info_Complex:
+	case ^reflect.Type_Info_Complex:
 		// NOTE(bill): Allow lengths which are less than the dst array
 		if int(length) > 2 {
 			return UNSUPPORTED_TYPE

--- a/core/flags/internal_assignment.odin
+++ b/core/flags/internal_assignment.odin
@@ -85,7 +85,7 @@ set_odin_flag :: proc(model: ^$T, parser: ^Parser, name: string) -> (error: Erro
 	field, index := get_field_by_name(model, name) or_return
 
 	#partial switch specific_type_info in field.type.variant {
-	case runtime.Type_Info_Boolean:
+	case ^runtime.Type_Info_Boolean:
 		ptr := cast(^bool)(cast(uintptr)model + field.offset)
 		ptr^ = true
 	case:
@@ -111,10 +111,10 @@ set_unix_flag :: proc(model: ^$T, parser: ^Parser, name: string) -> (future_args
 	field, index := get_field_by_name(model, name) or_return
 
 	#partial switch specific_type_info in field.type.variant {
-	case runtime.Type_Info_Boolean:
+	case ^runtime.Type_Info_Boolean:
 		ptr := cast(^bool)(cast(uintptr)model + field.offset)
 		ptr^ = true
-	case runtime.Type_Info_Dynamic_Array:
+	case ^runtime.Type_Info_Dynamic_Array:
 		future_args = 1
 		if tag, ok := reflect.struct_tag_lookup(field.tag, TAG_ARGS); ok {
 			if length, is_variadic := get_struct_subtag(tag, SUBTAG_VARIADIC); is_variadic {
@@ -150,7 +150,7 @@ set_option :: proc(model: ^$T, parser: ^Parser, name, option: string) -> (error:
 
 	// Guard against incorrect syntax.
 	#partial switch specific_type_info in field.type.variant {
-	case runtime.Type_Info_Map:
+	case ^runtime.Type_Info_Map:
 		return Parse_Error {
 			.No_Value,
 			fmt.tprintf("Unable to set `%s` of type %v to `%s`. Are you missing an `=`? The correct format is `map:key=value`.", name, field.type, option),
@@ -181,7 +181,7 @@ set_key_value :: proc(model: ^$T, parser: ^Parser, name, key, value: string) -> 
 	field, index := get_field_by_name(model, name) or_return
 
 	#partial switch specific_type_info in field.type.variant {
-	case runtime.Type_Info_Map:
+	case ^runtime.Type_Info_Map:
 		key := key
 		key_ptr := cast(rawptr)&key
 		key_cstr: cstring

--- a/core/flags/internal_validation.odin
+++ b/core/flags/internal_validation.odin
@@ -19,7 +19,7 @@ validate_structure :: proc(model_type: $T, style: Parsing_Style, loc := #caller_
 	check_fields: for field in reflect.struct_fields_zipped(T) {
 		if style == .Unix {
 			#partial switch specific_type_info in field.type.variant {
-			case runtime.Type_Info_Map:
+			case ^runtime.Type_Info_Map:
 				fmt.panicf("%T.%s is a map type, and these are not supported in UNIX-style parsing mode.",
 					model_type, field.name, loc = loc)
 			}
@@ -61,7 +61,7 @@ validate_structure :: proc(model_type: $T, style: Parsing_Style, loc := #caller_
 
 		if pos_str, has_pos := get_struct_subtag(args_tag, SUBTAG_POS); has_pos {
 			#partial switch specific_type_info in field.type.variant {
-			case runtime.Type_Info_Map:
+			case ^runtime.Type_Info_Map:
 				fmt.panicf("%T.%s has `%s` defined, and this does not make sense on a map type.",
 					model_type, field.name, SUBTAG_POS, loc = loc)
 			}
@@ -85,7 +85,7 @@ validate_structure :: proc(model_type: $T, style: Parsing_Style, loc := #caller_
 			if len(requirement) > 0 {
 				if required_min, required_max, ok = parse_requirements(requirement); ok {
 					#partial switch specific_type_info in field.type.variant {
-					case runtime.Type_Info_Dynamic_Array:
+					case ^runtime.Type_Info_Dynamic_Array:
 						fmt.assertf(required_min != required_max, "%T.%s has `%s` defined as %q, but the minimum and maximum are the same. Increase the maximum by 1 for an exact number of arguments: (%i<%i)",
 							model_type,
 							field.name,
@@ -120,7 +120,7 @@ validate_structure :: proc(model_type: $T, style: Parsing_Style, loc := #caller_
 			}
 
 			#partial switch specific_type_info in field.type.variant {
-			case runtime.Type_Info_Dynamic_Array:
+			case ^runtime.Type_Info_Dynamic_Array:
 				fmt.assertf(style != .Odin,
 					"%T.%s has `%s` defined, but this only makes sense in UNIX-style parsing mode.",
 					model_type, field.name, SUBTAG_VARIADIC, loc = loc)
@@ -132,9 +132,9 @@ validate_structure :: proc(model_type: $T, style: Parsing_Style, loc := #caller_
 
 		allowed_to_define_file_perms: bool = ---
 		#partial switch specific_type_info in field.type.variant {
-		case runtime.Type_Info_Map:
+		case ^runtime.Type_Info_Map:
 			allowed_to_define_file_perms = specific_type_info.value.id == os.Handle
-		case runtime.Type_Info_Dynamic_Array:
+		case ^runtime.Type_Info_Dynamic_Array:
 			allowed_to_define_file_perms = specific_type_info.elem.id == os.Handle
 		case:
 			allowed_to_define_file_perms = field.type.id == os.Handle
@@ -151,7 +151,7 @@ validate_structure :: proc(model_type: $T, style: Parsing_Style, loc := #caller_
 		}
 
 		#partial switch specific_type_info in field.type.variant {
-		case runtime.Type_Info_Map:
+		case ^runtime.Type_Info_Map:
 			fmt.assertf(reflect.is_string(specific_type_info.key), "%T.%s is defined as a map[%T]. Only string types are currently supported as map keys.",
 				model_type,
 				field.name,
@@ -182,7 +182,7 @@ validate_arguments :: proc(model: ^$T, parser: ^Parser) -> Error {
 			is_required = false
 		}
 
-		if _, is_array := field.type.variant.(runtime.Type_Info_Dynamic_Array); is_array && has_requirements {
+		if _, is_array := field.type.variant.(^runtime.Type_Info_Dynamic_Array); is_array && has_requirements {
 			// If it's an array, make sure it meets the required number of arguments.
 			ptr := cast(^runtime.Raw_Dynamic_Array)(cast(uintptr)model + field.offset)
 			if required_min == required_max - 1 && ptr.len != required_min {

--- a/core/flags/usage.odin
+++ b/core/flags/usage.odin
@@ -138,13 +138,13 @@ write_usage :: proc(out: io.Writer, data_type: typeid, program: string = "", sty
 		}
 
 		#partial switch specific_type_info in field.type.variant {
-		case runtime.Type_Info_Map:
+		case ^runtime.Type_Info_Map:
 			flag.type_description = fmt.tprintf("<%v>=<%v>%s",
 				specific_type_info.key.id,
 				specific_type_info.value.id,
 				", required" if flag.is_required else "")
 
-		case runtime.Type_Info_Dynamic_Array:
+		case ^runtime.Type_Info_Dynamic_Array:
 			requirement_spec := describe_array_requirements(flag)
 
 			if flag.is_variadic || flag.name == INTERNAL_VARIADIC_FLAG {

--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -1603,7 +1603,7 @@ enum_value_to_string :: proc(val: any) -> (string, bool) {
 //
 string_to_enum_value :: proc($T: typeid, s: string) -> (T, bool) {
 	ti := runtime.type_info_base(type_info_of(T))
-	if e, ok := ti.variant.(runtime.Type_Info_Enum); ok {
+	if e, ok := ti.variant.(^runtime.Type_Info_Enum); ok {
 		for str, idx in e.names {
 			if s == str {
 				// NOTE(bill): Unsafe cast
@@ -1630,7 +1630,7 @@ fmt_enum :: proc(fi: ^Info, v: any, verb: rune) {
 	type_info := type_info_of(v.id)
 	#partial switch e in type_info.variant {
 	case: fmt_bad_verb(fi, verb)
-	case runtime.Type_Info_Enum:
+	case ^runtime.Type_Info_Enum:
 		switch verb {
 		case: fmt_bad_verb(fi, verb)
 		case 'i', 'd', 'f':
@@ -1670,7 +1670,7 @@ stored_enum_value_to_string :: proc(enum_type: ^runtime.Type_Info, ev: runtime.T
 	ev += runtime.Type_Info_Enum_Value(offset)
 	#partial switch e in et.variant {
 	case: return "", false
-	case runtime.Type_Info_Enum:
+	case ^runtime.Type_Info_Enum:
 		if reflect.is_string(e.base) {
 			for val, idx in e.values {
 				if val == ev {
@@ -1706,7 +1706,7 @@ fmt_bit_set :: proc(fi: ^Info, v: any, name: string = "", verb: rune = 'v') {
 		}
 		t := runtime.type_info_base(ti)
 		#partial switch info in t.variant {
-		case runtime.Type_Info_Integer:
+		case ^runtime.Type_Info_Integer:
 			switch info.endianness {
 			case .Platform: return false
 			case .Little:   return ODIN_ENDIAN != .Little
@@ -1720,12 +1720,12 @@ fmt_bit_set :: proc(fi: ^Info, v: any, name: string = "", verb: rune = 'v') {
 
 	type_info := type_info_of(v.id)
 	#partial switch info in type_info.variant {
-	case runtime.Type_Info_Named:
+	case ^runtime.Type_Info_Named:
 		val := v
 		val.id = info.base.id
 		fmt_bit_set(fi, val, info.name, verb)
 
-	case runtime.Type_Info_Bit_Set:
+	case ^runtime.Type_Info_Bit_Set:
 		bits: u128
 		bit_size := u128(8*type_info.size)
 
@@ -1793,7 +1793,7 @@ fmt_bit_set :: proc(fi: ^Info, v: any, name: string = "", verb: rune = 'v') {
 		io.write_byte(fi.writer, '{', &fi.n)
 		defer io.write_byte(fi.writer, '}', &fi.n)
 
-		e, is_enum := et.variant.(runtime.Type_Info_Enum)
+		e, is_enum := et.variant.(^runtime.Type_Info_Enum)
 		commas := 0
 		loop: for i in 0 ..< bit_size {
 			if bits & (1<<i) == 0 {
@@ -1806,7 +1806,7 @@ fmt_bit_set :: proc(fi: ^Info, v: any, name: string = "", verb: rune = 'v') {
 
 			if is_enum {
 				enum_name: string
-				if ti_named, is_named := info.elem.variant.(runtime.Type_Info_Named); is_named {
+				if ti_named, is_named := info.elem.variant.(^runtime.Type_Info_Named); is_named {
 					enum_name = ti_named.name
 				}
 				for ev, evi in e.values {
@@ -1897,8 +1897,8 @@ fmt_write_array :: proc(fi: ^Info, array_data: rawptr, count: int, elem_size: in
 // Returns: A boolean value indicating whether to continue processing the tag
 //
 @(private)
-handle_tag :: proc(state: ^Info_State, data: rawptr, info: reflect.Type_Info_Struct, idx: int, verb: ^rune, optional_len: ^int, use_nul_termination: ^bool) -> (do_continue: bool) {
-	handle_optional_len :: proc(data: rawptr, info: reflect.Type_Info_Struct, field_name: string, optional_len: ^int) {
+handle_tag :: proc(state: ^Info_State, data: rawptr, info: ^reflect.Type_Info_Struct, idx: int, verb: ^rune, optional_len: ^int, use_nul_termination: ^bool) -> (do_continue: bool) {
+	handle_optional_len :: proc(data: rawptr, info: ^reflect.Type_Info_Struct, field_name: string, optional_len: ^int) {
 		if optional_len == nil {
 			return
 		}
@@ -2001,12 +2001,12 @@ handle_tag :: proc(state: ^Info_State, data: rawptr, info: reflect.Type_Info_Str
 // - info: Type information about the struct
 // - type_name: The name of the type being formatted
 //
-fmt_struct :: proc(fi: ^Info, v: any, the_verb: rune, info: runtime.Type_Info_Struct, type_name: string) {
+fmt_struct :: proc(fi: ^Info, v: any, the_verb: rune, info: ^runtime.Type_Info_Struct, type_name: string) {
 	if the_verb != 'v' && the_verb != 'w' {
 		fmt_bad_verb(fi, the_verb)
 		return
 	}
-	if .raw_union in info.flags {
+	if .raw_union in info.struct_flags {
 		if type_name == "" {
 			io.write_string(fi.writer, "(raw union)", &fi.n)
 		} else {
@@ -2047,7 +2047,7 @@ fmt_struct :: proc(fi: ^Info, v: any, the_verb: rune, info: runtime.Type_Info_St
 		defer fi.indent -= 1
 
 		base_type_name: string
-		if v, ok := info.soa_base_type.variant.(runtime.Type_Info_Named); ok {
+		if v, ok := info.soa_base_type.variant.(^runtime.Type_Info_Named); ok {
 			base_type_name = v.name
 		}
 
@@ -2111,7 +2111,7 @@ fmt_struct :: proc(fi: ^Info, v: any, the_verb: rune, info: runtime.Type_Info_St
 				io.write_string(fi.writer, " = ", &fi.n)
 
 				if info.soa_kind == .Fixed {
-					t := info.types[i].variant.(runtime.Type_Info_Array).elem
+					t := info.types[i].variant.(^runtime.Type_Info_Array).elem
 					t_size := uintptr(t.size)
 					if reflect.is_any(t) {
 						io.write_string(fi.writer, "any{}", &fi.n)
@@ -2120,7 +2120,7 @@ fmt_struct :: proc(fi: ^Info, v: any, the_verb: rune, info: runtime.Type_Info_St
 						fmt_arg(fi, any{data, t.id}, verb)
 					}
 				} else {
-					t := info.types[i].variant.(runtime.Type_Info_Multi_Pointer).elem
+					t := info.types[i].variant.(^runtime.Type_Info_Multi_Pointer).elem
 					t_size := uintptr(t.size)
 					if reflect.is_any(t) {
 						io.write_string(fi.writer, "any{}", &fi.n)
@@ -2293,7 +2293,7 @@ fmt_array :: proc(fi: ^Info, data: rawptr, n: int, elem_size: int, elem: ^reflec
 //
 // NOTE: This procedure supports built-in custom formatters for core library types such as runtime.Source_Code_Location, time.Duration, and time.Time.
 //
-fmt_named :: proc(fi: ^Info, v: any, verb: rune, info: runtime.Type_Info_Named) {
+fmt_named :: proc(fi: ^Info, v: any, verb: rune, info: ^runtime.Type_Info_Named) {
 	write_padded_number :: proc(fi: ^Info, i: i64, width: int) {
 		n := width-1
 		for x := i; x >= 10; x /= 10 {
@@ -2450,26 +2450,26 @@ fmt_named :: proc(fi: ^Info, v: any, verb: rune, info: runtime.Type_Info_Named) 
 	}
 
 	#partial switch b in info.base.variant {
-	case runtime.Type_Info_Struct:
+	case ^runtime.Type_Info_Struct:
 		fmt_struct(fi, v, verb, b, info.name)
-	case runtime.Type_Info_Bit_Field:
+	case ^runtime.Type_Info_Bit_Field:
 		fmt_bit_field(fi, v, verb, b, info.name)
-	case runtime.Type_Info_Bit_Set:
+	case ^runtime.Type_Info_Bit_Set:
 		fmt_bit_set(fi, v, verb = verb)
 	case:
 		if verb == 'w' {
 			#partial switch _ in info.base.variant {
-			case runtime.Type_Info_Array,
-			     runtime.Type_Info_Enumerated_Array,
-			     runtime.Type_Info_Dynamic_Array,
-			     runtime.Type_Info_Slice,
-			     runtime.Type_Info_Struct,
-			     runtime.Type_Info_Enum,
-			     runtime.Type_Info_Map,
-			     runtime.Type_Info_Bit_Set,
-			     runtime.Type_Info_Simd_Vector,
-			     runtime.Type_Info_Matrix,
-			     runtime.Type_Info_Bit_Field:
+			case ^runtime.Type_Info_Array,
+			     ^runtime.Type_Info_Enumerated_Array,
+			     ^runtime.Type_Info_Dynamic_Array,
+			     ^runtime.Type_Info_Slice,
+			     ^runtime.Type_Info_Struct,
+			     ^runtime.Type_Info_Enum,
+			     ^runtime.Type_Info_Map,
+			     ^runtime.Type_Info_Bit_Set,
+			     ^runtime.Type_Info_Simd_Vector,
+			     ^runtime.Type_Info_Matrix,
+			     ^runtime.Type_Info_Bit_Field:
 				io.write_string(fi.writer, info.name, &fi.n)
 			}
 		}
@@ -2485,7 +2485,7 @@ fmt_named :: proc(fi: ^Info, v: any, verb: rune, info: runtime.Type_Info_Named) 
 // - info: The union type information.
 // - type_size: The size of the union type.
 //
-fmt_union :: proc(fi: ^Info, v: any, verb: rune, info: runtime.Type_Info_Union, type_size: int) {
+fmt_union :: proc(fi: ^Info, v: any, verb: rune, info: ^runtime.Type_Info_Union, type_size: int) {
 	if type_size == 0 {
 		io.write_string(fi.writer, "nil", &fi.n)
 		return
@@ -2538,7 +2538,7 @@ fmt_union :: proc(fi: ^Info, v: any, verb: rune, info: runtime.Type_Info_Union, 
 // - verb: The formatting verb rune.
 // - info: A runtime.Type_Info_Matrix struct containing matrix type information.
 //
-fmt_matrix :: proc(fi: ^Info, v: any, verb: rune, info: runtime.Type_Info_Matrix) {
+fmt_matrix :: proc(fi: ^Info, v: any, verb: rune, info: ^runtime.Type_Info_Matrix) {
 	if verb == 'w' {
 		io.write_byte(fi.writer, '{', &fi.n)
 	} else {
@@ -2595,7 +2595,7 @@ fmt_matrix :: proc(fi: ^Info, v: any, verb: rune, info: runtime.Type_Info_Matrix
 	}
 }
 
-fmt_bit_field :: proc(fi: ^Info, v: any, verb: rune, info: runtime.Type_Info_Bit_Field, type_name: string) {
+fmt_bit_field :: proc(fi: ^Info, v: any, verb: rune, info: ^runtime.Type_Info_Bit_Field, type_name: string) {
 	read_bits :: proc(ptr: [^]byte, offset, size: uintptr) -> (res: u64) {
 		for i in 0..<size {
 			j := i+offset
@@ -2608,7 +2608,7 @@ fmt_bit_field :: proc(fi: ^Info, v: any, verb: rune, info: runtime.Type_Info_Bit
 		return
 	}
 
-	handle_bit_field_tag :: proc(data: rawptr, info: reflect.Type_Info_Bit_Field, idx: int, verb: ^rune) -> (do_continue: bool) {
+	handle_bit_field_tag :: proc(data: rawptr, info: ^runtime.Type_Info_Bit_Field, idx: int, verb: ^rune) -> (do_continue: bool) {
 		tag := info.tags[idx]
 		if vt, ok := reflect.struct_tag_lookup(reflect.Struct_Tag(tag), "fmt"); ok {
 			value := strings.trim_space(string(vt))
@@ -2716,21 +2716,21 @@ fmt_value :: proc(fi: ^Info, v: any, verb: rune) {
 
 	type_info := type_info_of(v.id)
 	switch info in type_info.variant {
-	case runtime.Type_Info_Any:        // Ignore
-	case runtime.Type_Info_Parameters: // Ignore
+	case ^runtime.Type_Info_Any:        // Ignore
+	case ^runtime.Type_Info_Parameters: // Ignore
 
-	case runtime.Type_Info_Named:
+	case ^runtime.Type_Info_Named:
 		fmt_named(fi, v, verb, info)
 
-	case runtime.Type_Info_Boolean:    fmt_arg(fi, v, verb)
-	case runtime.Type_Info_Integer:    fmt_arg(fi, v, verb)
-	case runtime.Type_Info_Rune:       fmt_arg(fi, v, verb)
-	case runtime.Type_Info_Float:      fmt_arg(fi, v, verb)
-	case runtime.Type_Info_Complex:    fmt_arg(fi, v, verb)
-	case runtime.Type_Info_Quaternion: fmt_arg(fi, v, verb)
-	case runtime.Type_Info_String:     fmt_arg(fi, v, verb)
+	case ^runtime.Type_Info_Boolean:    fmt_arg(fi, v, verb)
+	case ^runtime.Type_Info_Integer:    fmt_arg(fi, v, verb)
+	case ^runtime.Type_Info_Rune:       fmt_arg(fi, v, verb)
+	case ^runtime.Type_Info_Float:      fmt_arg(fi, v, verb)
+	case ^runtime.Type_Info_Complex:    fmt_arg(fi, v, verb)
+	case ^runtime.Type_Info_Quaternion: fmt_arg(fi, v, verb)
+	case ^runtime.Type_Info_String:     fmt_arg(fi, v, verb)
 
-	case runtime.Type_Info_Pointer:
+	case ^runtime.Type_Info_Pointer:
 		if v.id == typeid_of(^runtime.Type_Info) {
 			reflect.write_type(fi.writer, (^^runtime.Type_Info)(v.data)^, &fi.n)
 		} else {
@@ -2741,10 +2741,10 @@ fmt_value :: proc(fi: ^Info, v: any, verb: rune) {
 				elem := runtime.type_info_base(info.elem)
 				if elem != nil {
 					#partial switch e in elem.variant {
-					case runtime.Type_Info_Array,
-					     runtime.Type_Info_Slice,
-					     runtime.Type_Info_Dynamic_Array,
-					     runtime.Type_Info_Map:
+					case ^runtime.Type_Info_Array,
+					     ^runtime.Type_Info_Slice,
+					     ^runtime.Type_Info_Dynamic_Array,
+					     ^runtime.Type_Info_Map:
 						if ptr == nil {
 							io.write_string(fi.writer, "<nil>", &fi.n)
 							return
@@ -2757,9 +2757,9 @@ fmt_value :: proc(fi: ^Info, v: any, verb: rune) {
 							return
 						}
 
-					case runtime.Type_Info_Struct,
-					     runtime.Type_Info_Union,
-					     runtime.Type_Info_Bit_Field:
+					case ^runtime.Type_Info_Struct,
+					     ^runtime.Type_Info_Union,
+					     ^runtime.Type_Info_Bit_Field:
 						if ptr == nil {
 							io.write_string(fi.writer, "<nil>", &fi.n)
 							return
@@ -2777,11 +2777,11 @@ fmt_value :: proc(fi: ^Info, v: any, verb: rune) {
 			fmt_pointer(fi, ptr, verb)
 		}
 
-	case runtime.Type_Info_Soa_Pointer:
+	case ^runtime.Type_Info_Soa_Pointer:
 		ptr := (^runtime.Raw_Soa_Pointer)(v.data)^
 		fmt_soa_pointer(fi, ptr, verb)
 
-	case runtime.Type_Info_Multi_Pointer:
+	case ^runtime.Type_Info_Multi_Pointer:
 		ptr := (^rawptr)(v.data)^
 		if ptr == nil {
 			io.write_string(fi.writer, "<nil>", &fi.n)
@@ -2803,7 +2803,7 @@ fmt_value :: proc(fi: ^Info, v: any, verb: rune) {
 				}
 
 				#partial switch e in elem.variant {
-				case runtime.Type_Info_Integer:
+				case ^runtime.Type_Info_Integer:
 					switch verb {
 					case 's', 'q':
 						switch elem.id {
@@ -2817,10 +2817,10 @@ fmt_value :: proc(fi: ^Info, v: any, verb: rune) {
 						}
 					}
 
-				case runtime.Type_Info_Array,
-				     runtime.Type_Info_Slice,
-				     runtime.Type_Info_Dynamic_Array,
-				     runtime.Type_Info_Map:
+				case ^runtime.Type_Info_Array,
+				     ^runtime.Type_Info_Slice,
+				     ^runtime.Type_Info_Dynamic_Array,
+				     ^runtime.Type_Info_Map:
 					if fi.indirection_level < 1 {
 						fi.indirection_level += 1
 						defer fi.indirection_level -= 1
@@ -2829,8 +2829,8 @@ fmt_value :: proc(fi: ^Info, v: any, verb: rune) {
 						return
 					}
 
-				case runtime.Type_Info_Struct,
-				     runtime.Type_Info_Union:
+				case ^runtime.Type_Info_Struct,
+				     ^runtime.Type_Info_Union:
 					if fi.indirection_level < 1 {
 						fi.indirection_level += 1
 						defer fi.indirection_level -= 1
@@ -2843,7 +2843,7 @@ fmt_value :: proc(fi: ^Info, v: any, verb: rune) {
 		}
 		fmt_pointer(fi, ptr, verb)
 
-	case runtime.Type_Info_Enumerated_Array:
+	case ^runtime.Type_Info_Enumerated_Array:
 		fi.record_level += 1
 		defer fi.record_level -= 1
 
@@ -2895,7 +2895,7 @@ fmt_value :: proc(fi: ^Info, v: any, verb: rune) {
 			}
 		}
 
-	case runtime.Type_Info_Array:
+	case ^runtime.Type_Info_Array:
 		n := info.count
 		ptr := v.data
 		if ol, ok := fi.optional_len.?; ok {
@@ -2908,7 +2908,7 @@ fmt_value :: proc(fi: ^Info, v: any, verb: rune) {
 		}
 		fmt_array(fi, ptr, n, info.elem_size, info.elem, verb)
 
-	case runtime.Type_Info_Slice:
+	case ^runtime.Type_Info_Slice:
 		slice := cast(^mem.Raw_Slice)v.data
 		n := slice.len
 		ptr := slice.data
@@ -2922,7 +2922,7 @@ fmt_value :: proc(fi: ^Info, v: any, verb: rune) {
 		}
 		fmt_array(fi, ptr, n, info.elem_size, info.elem, verb)
 
-	case runtime.Type_Info_Dynamic_Array:
+	case ^runtime.Type_Info_Dynamic_Array:
 		array := cast(^mem.Raw_Dynamic_Array)v.data
 		n := array.len
 		ptr := array.data
@@ -2936,7 +2936,7 @@ fmt_value :: proc(fi: ^Info, v: any, verb: rune) {
 		}
 		fmt_array(fi, ptr, n, info.elem_size, info.elem, verb)
 
-	case runtime.Type_Info_Simd_Vector:
+	case ^runtime.Type_Info_Simd_Vector:
 		io.write_byte(fi.writer, '<', &fi.n)
 		defer io.write_byte(fi.writer, '>', &fi.n)
 		for i in 0..<info.count {
@@ -2947,7 +2947,7 @@ fmt_value :: proc(fi: ^Info, v: any, verb: rune) {
 		}
 
 
-	case runtime.Type_Info_Map:
+	case ^runtime.Type_Info_Map:
 		switch verb {
 		case:
 			fmt_bad_verb(fi, verb)
@@ -3006,16 +3006,16 @@ fmt_value :: proc(fi: ^Info, v: any, verb: rune) {
 			}
 		}
 
-	case runtime.Type_Info_Struct:
+	case ^runtime.Type_Info_Struct:
 		fmt_struct(fi, v, verb, info, "")
 
-	case runtime.Type_Info_Union:
+	case ^runtime.Type_Info_Union:
 		fmt_union(fi, v, verb, info, type_info.size)
 
-	case runtime.Type_Info_Enum:
+	case ^runtime.Type_Info_Enum:
 		fmt_enum(fi, v, verb)
 
-	case runtime.Type_Info_Procedure:
+	case ^runtime.Type_Info_Procedure:
 		ptr := (^rawptr)(v.data)^
 		if ptr == nil {
 			io.write_string(fi.writer, "nil", &fi.n)
@@ -3025,17 +3025,17 @@ fmt_value :: proc(fi: ^Info, v: any, verb: rune) {
 			fmt_pointer(fi, ptr, 'p')
 		}
 
-	case runtime.Type_Info_Type_Id:
+	case ^runtime.Type_Info_Type_Id:
 		id := (^typeid)(v.data)^
 		reflect.write_typeid(fi.writer, id, &fi.n)
 
-	case runtime.Type_Info_Bit_Set:
+	case ^runtime.Type_Info_Bit_Set:
 		fmt_bit_set(fi, v, verb = verb)
 
-	case runtime.Type_Info_Matrix:
+	case ^runtime.Type_Info_Matrix:
 		fmt_matrix(fi, v, verb, info)
 
-	case runtime.Type_Info_Bit_Field:
+	case ^runtime.Type_Info_Bit_Field:
 		fmt_bit_field(fi, v, verb, info, "")
 	}
 }
@@ -3152,7 +3152,7 @@ fmt_arg :: proc(fi: ^Info, arg: any, verb: rune) {
 	}
 
 	arg_info := type_info_of(arg.id)
-	if info, ok := arg_info.variant.(runtime.Type_Info_Named); ok {
+	if info, ok := arg_info.variant.(^runtime.Type_Info_Named); ok {
 		fmt_named(fi, arg, verb, info)
 		return
 	}

--- a/core/math/rand/rand.odin
+++ b/core/math/rand/rand.odin
@@ -659,7 +659,7 @@ choice_enum :: proc($T: typeid, gen := context.random_generator) -> T where intr
 			return T(i)
 		}
 	} else {
-		values := runtime.type_info_base(type_info_of(T)).variant.(runtime.Type_Info_Enum).values
+		values := runtime.type_info_base(type_info_of(T)).variant.(^runtime.Type_Info_Enum).values
 		return T(choice(values))
 	}
 }

--- a/core/odin/ast/clone.odin
+++ b/core/odin/ast/clone.odin
@@ -81,7 +81,7 @@ clone_node :: proc(node: ^Node) -> ^Node {
 	align := align_of(Node)
 	ti := reflect.union_variant_type_info(node.derived)
 	if ti != nil {
-		elem := ti.variant.(reflect.Type_Info_Pointer).elem
+		elem := ti.variant.(^reflect.Type_Info_Pointer).elem
 		size  = elem.size
 		align = elem.align
 	}

--- a/core/os/errors.odin
+++ b/core/os/errors.odin
@@ -164,7 +164,7 @@ _error_string :: proc "contextless" (e: Platform_Error) -> string where intrinsi
 
 		err := runtime.Type_Info_Enum_Value(e)
 
-		ti := &runtime.type_info_base(type_info_of(Platform_Error)).variant.(runtime.Type_Info_Enum)
+		ti := runtime.type_info_base(type_info_of(Platform_Error)).variant.(^runtime.Type_Info_Enum)
 		if idx, ok := binary_search(ti.values, err); ok {
 			return ti.names[idx]
 		}

--- a/core/os/os2/errors_wasi.odin
+++ b/core/os/os2/errors_wasi.odin
@@ -16,7 +16,7 @@ _error_string :: proc(errno: i32) -> string {
 
 	err := runtime.Type_Info_Enum_Value(e)
 
-	ti := &runtime.type_info_base(type_info_of(wasi.errno_t)).variant.(runtime.Type_Info_Enum)
+	ti := &runtime.type_info_base(type_info_of(wasi.errno_t)).variant.(^runtime.Type_Info_Enum)
 	if idx, ok := slice.binary_search(ti.values, err); ok {
 		return ti.names[idx]
 	}

--- a/core/os/os2/errors_windows.odin
+++ b/core/os/os2/errors_windows.odin
@@ -15,7 +15,7 @@ _error_string :: proc(errno: i32) -> string {
 
 	err := runtime.Type_Info_Enum_Value(e)
 
-	ti := &runtime.type_info_base(type_info_of(win32.System_Error)).variant.(runtime.Type_Info_Enum)
+	ti := &runtime.type_info_base(type_info_of(win32.System_Error)).variant.(^runtime.Type_Info_Enum)
 	if idx, ok := slice.binary_search(ti.values, err); ok {
 		return ti.names[idx]
 	}

--- a/core/reflect/iterator.odin
+++ b/core/reflect/iterator.odin
@@ -10,11 +10,11 @@ iterate_array :: proc(val: any, it: ^int) -> (elem: any, index: int, ok: bool) {
 
 	ti := type_info_base(type_info_of(val.id))
 	#partial switch info in ti.variant {
-	case Type_Info_Pointer:
+	case ^Type_Info_Pointer:
 		if ptr := (^rawptr)(val.data)^; ptr != nil {
 			return iterate_array(any{ptr, info.elem.id}, it)
 		}
-	case Type_Info_Array:
+	case ^Type_Info_Array:
 		if it^ < info.count {
 			elem.data = rawptr(uintptr(val.data) + uintptr(it^ * info.elem_size))
 			elem.id = info.elem.id
@@ -22,7 +22,7 @@ iterate_array :: proc(val: any, it: ^int) -> (elem: any, index: int, ok: bool) {
 			index = it^
 			it^ += 1
 		}
-	case Type_Info_Slice:
+	case ^Type_Info_Slice:
 		array := (^runtime.Raw_Slice)(val.data)
 		if it^ < array.len {
 			elem.data = rawptr(uintptr(array.data) + uintptr(it^ * info.elem_size))
@@ -31,7 +31,7 @@ iterate_array :: proc(val: any, it: ^int) -> (elem: any, index: int, ok: bool) {
 			index = it^
 			it^ += 1
 		}
-	case Type_Info_Dynamic_Array:
+	case ^Type_Info_Dynamic_Array:
 		array := (^runtime.Raw_Dynamic_Array)(val.data)
 		if it^ < array.len {
 			elem.data = rawptr(uintptr(array.data) + uintptr(it^ * info.elem_size))
@@ -52,11 +52,11 @@ iterate_map :: proc(val: any, it: ^int) -> (key, value: any, ok: bool) {
 	}
 	ti := type_info_base(type_info_of(val.id))
 	#partial switch info in ti.variant {
-	case Type_Info_Pointer:
+	case ^Type_Info_Pointer:
 		if ptr := (^rawptr)(val.data)^; ptr != nil {
 			return iterate_map(any{ptr, info.elem.id}, it)
 		}
-	case Type_Info_Map:
+	case ^Type_Info_Map:
 		if info.map_info == nil {
 			break
 		}

--- a/core/reflect/reflect.odin
+++ b/core/reflect/reflect.odin
@@ -76,33 +76,33 @@ type_kind :: proc(T: typeid) -> Type_Kind {
 	ti := type_info_of(T)
 	if ti != nil {
 		switch _ in ti.variant {
-		case Type_Info_Named:            return .Named
-		case Type_Info_Integer:          return .Integer
-		case Type_Info_Rune:             return .Rune
-		case Type_Info_Float:            return .Float
-		case Type_Info_Complex:          return .Complex
-		case Type_Info_Quaternion:       return .Quaternion
-		case Type_Info_String:           return .String
-		case Type_Info_Boolean:          return .Boolean
-		case Type_Info_Any:              return .Any
-		case Type_Info_Type_Id:          return .Type_Id
-		case Type_Info_Pointer:          return .Pointer
-		case Type_Info_Multi_Pointer:    return .Multi_Pointer
-		case Type_Info_Procedure:        return .Procedure
-		case Type_Info_Array:            return .Array
-		case Type_Info_Enumerated_Array: return .Enumerated_Array
-		case Type_Info_Dynamic_Array:    return .Dynamic_Array
-		case Type_Info_Slice:            return .Slice
-		case Type_Info_Parameters:       return .Tuple
-		case Type_Info_Struct:           return .Struct
-		case Type_Info_Union:            return .Union
-		case Type_Info_Enum:             return .Enum
-		case Type_Info_Map:              return .Map
-		case Type_Info_Bit_Set:          return .Bit_Set
-		case Type_Info_Simd_Vector:      return .Simd_Vector
-		case Type_Info_Matrix:           return .Matrix
-		case Type_Info_Soa_Pointer:      return .Soa_Pointer
-		case Type_Info_Bit_Field:        return .Bit_Field
+		case ^Type_Info_Named:            return .Named
+		case ^Type_Info_Integer:          return .Integer
+		case ^Type_Info_Rune:             return .Rune
+		case ^Type_Info_Float:            return .Float
+		case ^Type_Info_Complex:          return .Complex
+		case ^Type_Info_Quaternion:       return .Quaternion
+		case ^Type_Info_String:           return .String
+		case ^Type_Info_Boolean:          return .Boolean
+		case ^Type_Info_Any:              return .Any
+		case ^Type_Info_Type_Id:          return .Type_Id
+		case ^Type_Info_Pointer:          return .Pointer
+		case ^Type_Info_Multi_Pointer:    return .Multi_Pointer
+		case ^Type_Info_Procedure:        return .Procedure
+		case ^Type_Info_Array:            return .Array
+		case ^Type_Info_Enumerated_Array: return .Enumerated_Array
+		case ^Type_Info_Dynamic_Array:    return .Dynamic_Array
+		case ^Type_Info_Slice:            return .Slice
+		case ^Type_Info_Parameters:       return .Tuple
+		case ^Type_Info_Struct:           return .Struct
+		case ^Type_Info_Union:            return .Union
+		case ^Type_Info_Enum:             return .Enum
+		case ^Type_Info_Map:              return .Map
+		case ^Type_Info_Bit_Set:          return .Bit_Set
+		case ^Type_Info_Simd_Vector:      return .Simd_Vector
+		case ^Type_Info_Matrix:           return .Matrix
+		case ^Type_Info_Soa_Pointer:      return .Soa_Pointer
+		case ^Type_Info_Bit_Field:        return .Bit_Field
 		}
 
 	}
@@ -159,23 +159,23 @@ typeid_elem :: proc(id: typeid) -> typeid {
 	bits := 8*ti.size
 
 	#partial switch v in ti.variant {
-	case Type_Info_Complex:
+	case ^Type_Info_Complex:
 		switch bits {
 		case 64:  return f32
 		case 128: return f64
 		}
-	case Type_Info_Quaternion:
+	case ^Type_Info_Quaternion:
 		switch bits {
 		case 128: return f32
 		case 256: return f64
 		}
-	case Type_Info_Pointer:          return v.elem.id
-	case Type_Info_Multi_Pointer:    return v.elem.id
-	case Type_Info_Soa_Pointer:      return v.elem.id
-	case Type_Info_Array:            return v.elem.id
-	case Type_Info_Enumerated_Array: return v.elem.id
-	case Type_Info_Slice:            return v.elem.id
-	case Type_Info_Dynamic_Array:    return v.elem.id
+	case ^Type_Info_Pointer:          return v.elem.id
+	case ^Type_Info_Multi_Pointer:    return v.elem.id
+	case ^Type_Info_Soa_Pointer:      return v.elem.id
+	case ^Type_Info_Array:            return v.elem.id
+	case ^Type_Info_Enumerated_Array: return v.elem.id
+	case ^Type_Info_Slice:            return v.elem.id
+	case ^Type_Info_Dynamic_Array:    return v.elem.id
 	}
 	return id
 }
@@ -233,28 +233,28 @@ length :: proc(val: any) -> int {
 	if val == nil { return 0 }
 
 	#partial switch a in type_info_of(val.id).variant {
-	case Type_Info_Named:
+	case ^Type_Info_Named:
 		return length({val.data, a.base.id})
 
-	case Type_Info_Pointer:
+	case ^Type_Info_Pointer:
 		return length({val.data, a.elem.id})
 
-	case Type_Info_Array:
+	case ^Type_Info_Array:
 		return a.count
 
-	case Type_Info_Enumerated_Array:
+	case ^Type_Info_Enumerated_Array:
 		return a.count
 
-	case Type_Info_Slice:
+	case ^Type_Info_Slice:
 		return (^runtime.Raw_Slice)(val.data).len
 
-	case Type_Info_Dynamic_Array:
+	case ^Type_Info_Dynamic_Array:
 		return (^runtime.Raw_Dynamic_Array)(val.data).len
 
-	case Type_Info_Map:
+	case ^Type_Info_Map:
 		return runtime.map_len((^runtime.Raw_Map)(val.data)^)
 
-	case Type_Info_String:
+	case ^Type_Info_String:
 		if a.is_cstring {
 			return len((^cstring)(val.data)^)
 		} else {
@@ -269,22 +269,22 @@ capacity :: proc(val: any) -> int {
 	if val == nil { return 0 }
 
 	#partial switch a in type_info_of(val.id).variant {
-	case Type_Info_Named:
+	case ^Type_Info_Named:
 		return capacity({val.data, a.base.id})
 
-	case Type_Info_Pointer:
+	case ^Type_Info_Pointer:
 		return capacity({val.data, a.elem.id})
 
-	case Type_Info_Array:
+	case ^Type_Info_Array:
 		return a.count
 
-	case Type_Info_Enumerated_Array:
+	case ^Type_Info_Enumerated_Array:
 		return a.count
 
-	case Type_Info_Dynamic_Array:
+	case ^Type_Info_Dynamic_Array:
 		return (^runtime.Raw_Dynamic_Array)(val.data).cap
 
-	case Type_Info_Map:
+	case ^Type_Info_Map:
 		return runtime.map_cap((^runtime.Raw_Map)(val.data)^)
 	}
 	return 0
@@ -296,50 +296,50 @@ index :: proc(val: any, i: int, loc := #caller_location) -> any {
 	if val == nil { return nil }
 
 	#partial switch a in type_info_of(val.id).variant {
-	case Type_Info_Named:
+	case ^Type_Info_Named:
 		return index({val.data, a.base.id}, i, loc)
 
-	case Type_Info_Pointer:
+	case ^Type_Info_Pointer:
 		ptr := (^rawptr)(val.data)^
 		if ptr == nil {
 			return nil
 		}
 		return index({ptr, a.elem.id}, i, loc)
 
-	case Type_Info_Multi_Pointer:
+	case ^Type_Info_Multi_Pointer:
 		ptr := (^rawptr)(val.data)^
 		if ptr == nil {
 			return nil
 		}
 		return index({ptr, a.elem.id}, i, loc)
 
-	case Type_Info_Array:
+	case ^Type_Info_Array:
 		runtime.bounds_check_error_loc(loc, i, a.count)
 		offset := uintptr(a.elem.size * i)
 		data := rawptr(uintptr(val.data) + offset)
 		return any{data, a.elem.id}
 
-	case Type_Info_Enumerated_Array:
+	case ^Type_Info_Enumerated_Array:
 		runtime.bounds_check_error_loc(loc, i, a.count)
 		offset := uintptr(a.elem.size * i)
 		data := rawptr(uintptr(val.data) + offset)
 		return any{data, a.elem.id}
 
-	case Type_Info_Slice:
+	case ^Type_Info_Slice:
 		raw := (^runtime.Raw_Slice)(val.data)
 		runtime.bounds_check_error_loc(loc, i, raw.len)
 		offset := uintptr(a.elem.size * i)
 		data := rawptr(uintptr(raw.data) + offset)
 		return any{data, a.elem.id}
 
-	case Type_Info_Dynamic_Array:
+	case ^Type_Info_Dynamic_Array:
 		raw := (^runtime.Raw_Dynamic_Array)(val.data)
 		runtime.bounds_check_error_loc(loc, i, raw.len)
 		offset := uintptr(a.elem.size * i)
 		data := rawptr(uintptr(raw.data) + offset)
 		return any{data, a.elem.id}
 
-	case Type_Info_String:
+	case ^Type_Info_String:
 		if a.is_cstring { return nil }
 
 		raw := (^runtime.Raw_String)(val.data)
@@ -355,7 +355,7 @@ index :: proc(val: any, i: int, loc := #caller_location) -> any {
 deref :: proc(val: any) -> any {
 	if val != nil {
 		ti := type_info_base(type_info_of(val.id))
-		if info, ok := ti.variant.(Type_Info_Pointer); ok {
+		if info, ok := ti.variant.(^Type_Info_Pointer); ok {
 			return any{
 				(^rawptr)(val.data)^,
 				info.elem.id,
@@ -384,7 +384,7 @@ Struct_Field :: struct {
 @(require_results)
 struct_field_at :: proc(T: typeid, i: int) -> (field: Struct_Field) {
 	ti := runtime.type_info_base(type_info_of(T))
-	if s, ok := ti.variant.(runtime.Type_Info_Struct); ok {
+	if s, ok := ti.variant.(^runtime.Type_Info_Struct); ok {
 		if 0 <= i && i < int(s.field_count) {
 			field.name     = s.names[i]
 			field.type     = s.types[i]
@@ -399,7 +399,7 @@ struct_field_at :: proc(T: typeid, i: int) -> (field: Struct_Field) {
 @(require_results)
 struct_field_by_name :: proc(T: typeid, name: string) -> (field: Struct_Field) {
 	ti := runtime.type_info_base(type_info_of(T))
-	if s, ok := ti.variant.(runtime.Type_Info_Struct); ok {
+	if s, ok := ti.variant.(^runtime.Type_Info_Struct); ok {
 		for fname, i in s.names[:s.field_count] {
 			if fname == name {
 				field.name     = s.names[i]
@@ -420,7 +420,7 @@ struct_field_value_by_name :: proc(a: any, field: string, allow_using := false) 
 
 	ti := runtime.type_info_base(type_info_of(a.id))
 
-	if s, ok := ti.variant.(runtime.Type_Info_Struct); ok {
+	if s, ok := ti.variant.(^runtime.Type_Info_Struct); ok {
 		for name, i in s.names[:s.field_count] {
 			if name == field {
 				return any{
@@ -456,7 +456,7 @@ struct_field_value :: proc(a: any, field: Struct_Field) -> any {
 @(require_results)
 struct_field_names :: proc(T: typeid) -> []string {
 	ti := runtime.type_info_base(type_info_of(T))
-	if s, ok := ti.variant.(runtime.Type_Info_Struct); ok {
+	if s, ok := ti.variant.(^runtime.Type_Info_Struct); ok {
 		return s.names[:s.field_count]
 	}
 	return nil
@@ -465,7 +465,7 @@ struct_field_names :: proc(T: typeid) -> []string {
 @(require_results)
 struct_field_types :: proc(T: typeid) -> []^Type_Info {
 	ti := runtime.type_info_base(type_info_of(T))
-	if s, ok := ti.variant.(runtime.Type_Info_Struct); ok {
+	if s, ok := ti.variant.(^runtime.Type_Info_Struct); ok {
 		return s.types[:s.field_count]
 	}
 	return nil
@@ -475,7 +475,7 @@ struct_field_types :: proc(T: typeid) -> []^Type_Info {
 @(require_results)
 struct_field_tags :: proc(T: typeid) -> []Struct_Tag {
 	ti := runtime.type_info_base(type_info_of(T))
-	if s, ok := ti.variant.(runtime.Type_Info_Struct); ok {
+	if s, ok := ti.variant.(^runtime.Type_Info_Struct); ok {
 		return transmute([]Struct_Tag)s.tags[:s.field_count]
 	}
 	return nil
@@ -484,7 +484,7 @@ struct_field_tags :: proc(T: typeid) -> []Struct_Tag {
 @(require_results)
 struct_field_offsets :: proc(T: typeid) -> []uintptr {
 	ti := runtime.type_info_base(type_info_of(T))
-	if s, ok := ti.variant.(runtime.Type_Info_Struct); ok {
+	if s, ok := ti.variant.(^runtime.Type_Info_Struct); ok {
 		return s.offsets[:s.field_count]
 	}
 	return nil
@@ -523,7 +523,7 @@ Example:
 @(require_results)
 struct_field_count :: proc(T: typeid, method := Struct_Field_Count_Method.Top_Level) -> (count: int) {
 	ti := runtime.type_info_base(type_info_of(T))
-	if s, ok := ti.variant.(runtime.Type_Info_Struct); ok {
+	if s, ok := ti.variant.(^runtime.Type_Info_Struct); ok {
 		switch method {
 		case .Top_Level:
 			return int(s.field_count)
@@ -551,7 +551,7 @@ struct_field_count :: proc(T: typeid, method := Struct_Field_Count_Method.Top_Le
 @(require_results)
 struct_fields_zipped :: proc(T: typeid) -> (fields: #soa[]Struct_Field) {
 	ti := runtime.type_info_base(type_info_of(T))
-	if s, ok := ti.variant.(runtime.Type_Info_Struct); ok {
+	if s, ok := ti.variant.(^runtime.Type_Info_Struct); ok {
 		return soa_zip(
 			name     = s.names[:s.field_count],
 			type     = s.types[:s.field_count],
@@ -634,7 +634,7 @@ struct_tag_lookup :: proc(tag: Struct_Tag, key: string) -> (value: string, ok: b
 enum_string :: proc(a: any) -> string {
 	if a == nil { return "" }
 	ti := runtime.type_info_base(type_info_of(a.id))
-	if e, ok := ti.variant.(runtime.Type_Info_Enum); ok {
+	if e, ok := ti.variant.(^runtime.Type_Info_Enum); ok {
 		v, _ := as_i64(a)
 		for value, i in e.values {
 			if value == Type_Info_Enum_Value(v) {
@@ -652,7 +652,7 @@ enum_string :: proc(a: any) -> string {
 @(require_results)
 enum_from_name :: proc($Enum_Type: typeid, name: string) -> (value: Enum_Type, ok: bool) {
 	ti := type_info_base(type_info_of(Enum_Type))
-	if eti, eti_ok := ti.variant.(runtime.Type_Info_Enum); eti_ok {
+	if eti, eti_ok := ti.variant.(^runtime.Type_Info_Enum); eti_ok {
 		for value_name, i in eti.names {
 			if value_name != name {
 				continue
@@ -669,7 +669,7 @@ enum_from_name :: proc($Enum_Type: typeid, name: string) -> (value: Enum_Type, o
 @(require_results)
 enum_from_name_any :: proc(Enum_Type: typeid, name: string) -> (value: Type_Info_Enum_Value, ok: bool) {
 	ti := runtime.type_info_base(type_info_of(Enum_Type))
-	if eti, eti_ok := ti.variant.(runtime.Type_Info_Enum); eti_ok {
+	if eti, eti_ok := ti.variant.(^runtime.Type_Info_Enum); eti_ok {
 		for value_name, i in eti.names {
 			if value_name != name {
 				continue
@@ -685,7 +685,7 @@ enum_from_name_any :: proc(Enum_Type: typeid, name: string) -> (value: Type_Info
 @(require_results)
 enum_name_from_value :: proc(value: $Enum_Type) -> (name: string, ok: bool) where intrinsics.type_is_enum(Enum_Type) {
 	ti := type_info_base(type_info_of(Enum_Type))
-	e := ti.variant.(runtime.Type_Info_Enum) or_return
+	e := ti.variant.(^runtime.Type_Info_Enum) or_return
 	if len(e.values) == 0 {
 		return
 	}
@@ -704,7 +704,7 @@ enum_name_from_value_any :: proc(value: any) -> (name: string, ok: bool) {
 		return
 	}
 	ti := type_info_base(type_info_of(value.id))
-	e := ti.variant.(runtime.Type_Info_Enum) or_return
+	e := ti.variant.(^runtime.Type_Info_Enum) or_return
 	if len(e.values) == 0 {
 		return
 	}
@@ -744,7 +744,7 @@ enum_value_has_name :: proc(value: $T) -> bool where intrinsics.type_is_enum(T) 
 @(require_results)
 enum_field_names :: proc(Enum_Type: typeid) -> []string {
 	ti := runtime.type_info_base(type_info_of(Enum_Type))
-	if eti, eti_ok := ti.variant.(runtime.Type_Info_Enum); eti_ok {
+	if eti, eti_ok := ti.variant.(^runtime.Type_Info_Enum); eti_ok {
 		return eti.names
 	}
 	return nil
@@ -752,7 +752,7 @@ enum_field_names :: proc(Enum_Type: typeid) -> []string {
 @(require_results)
 enum_field_values :: proc(Enum_Type: typeid) -> []Type_Info_Enum_Value {
 	ti := runtime.type_info_base(type_info_of(Enum_Type))
-	if eti, eti_ok := ti.variant.(runtime.Type_Info_Enum); eti_ok {
+	if eti, eti_ok := ti.variant.(^runtime.Type_Info_Enum); eti_ok {
 		return eti.values
 	}
 	return nil
@@ -766,7 +766,7 @@ Enum_Field :: struct {
 @(require_results)
 enum_fields_zipped :: proc(Enum_Type: typeid) -> (fields: #soa[]Enum_Field) {
 	ti := runtime.type_info_base(type_info_of(Enum_Type))
-	if eti, eti_ok := ti.variant.(runtime.Type_Info_Enum); eti_ok {
+	if eti, eti_ok := ti.variant.(^runtime.Type_Info_Enum); eti_ok {
 		return soa_zip(name=eti.names, value=eti.values)
 	}
 	return nil
@@ -781,7 +781,7 @@ union_variant_type_info :: proc(a: any) -> ^Type_Info {
 }
 
 @(require_results)
-type_info_union_is_pure_maybe :: proc(info: runtime.Type_Info_Union) -> bool {
+type_info_union_is_pure_maybe :: proc(info: ^runtime.Type_Info_Union) -> bool {
 	return len(info.variants) == 1 && is_pointer_internally(info.variants[0])
 }
 
@@ -790,7 +790,7 @@ union_variant_typeid :: proc(a: any) -> typeid {
 	if a == nil { return nil }
 
 	ti := runtime.type_info_base(type_info_of(a.id))
-	if info, ok := ti.variant.(runtime.Type_Info_Union); ok {
+	if info, ok := ti.variant.(^runtime.Type_Info_Union); ok {
 		if type_info_union_is_pure_maybe(info) {
 			if a.data != nil {
 				return info.variants[0].id
@@ -830,7 +830,7 @@ get_union_variant_raw_tag :: proc(a: any) -> i64 {
 	if a == nil { return -1 }
 
 	ti := runtime.type_info_base(type_info_of(a.id))
-	if info, ok := ti.variant.(runtime.Type_Info_Union); ok {
+	if info, ok := ti.variant.(^runtime.Type_Info_Union); ok {
 		if type_info_union_is_pure_maybe(info) {
 			return 1 if a.data != nil else 0
 		}
@@ -883,7 +883,7 @@ set_union_variant_raw_tag :: proc(a: any, tag: i64) {
 	if a == nil { return }
 
 	ti := runtime.type_info_base(type_info_of(a.id))
-	if info, ok := ti.variant.(runtime.Type_Info_Union); ok {
+	if info, ok := ti.variant.(^runtime.Type_Info_Union); ok {
 		if type_info_union_is_pure_maybe(info) {
 			// Cannot do anything
 			return
@@ -913,7 +913,7 @@ set_union_variant_typeid :: proc(a: any, id: typeid) {
 	if a == nil { return }
 
 	ti := runtime.type_info_base(type_info_of(a.id))
-	if info, ok := ti.variant.(runtime.Type_Info_Union); ok {
+	if info, ok := ti.variant.(^runtime.Type_Info_Union); ok {
 		if type_info_union_is_pure_maybe(info) {
 			// Cannot do anything
 			return
@@ -943,7 +943,7 @@ set_union_variant_type_info :: proc(a: any, tag_ti: ^Type_Info) {
 	if a == nil { return }
 
 	ti := runtime.type_info_base(type_info_of(a.id))
-	if info, ok := ti.variant.(runtime.Type_Info_Union); ok {
+	if info, ok := ti.variant.(^runtime.Type_Info_Union); ok {
 		if type_info_union_is_pure_maybe(info) {
 			// Cannot do anything
 			return
@@ -973,7 +973,7 @@ set_union_value :: proc(dst: any, value: any) -> bool {
 	if dst == nil { return false }
 
 	ti := runtime.type_info_base(type_info_of(dst.id))
-	if info, ok := ti.variant.(runtime.Type_Info_Union); ok {
+	if info, ok := ti.variant.(^runtime.Type_Info_Union); ok {
 		if value.id == nil {
 			intrinsics.mem_zero(dst.data, ti.size)
 			return true
@@ -1012,11 +1012,11 @@ bit_set_is_big_endian :: proc(value: any, loc := #caller_location) -> bool {
 	if value == nil { return ODIN_ENDIAN == .Big }
 	
 	ti := runtime.type_info_base(type_info_of(value.id))
-	if info, ok := ti.variant.(runtime.Type_Info_Bit_Set); ok {
+	if info, ok := ti.variant.(^runtime.Type_Info_Bit_Set); ok {
 		if info.underlying == nil { return ODIN_ENDIAN == .Big }
 
 		underlying_ti := runtime.type_info_base(info.underlying)
-		if underlying_info, uok := underlying_ti.variant.(runtime.Type_Info_Integer); uok {
+		if underlying_info, uok := underlying_ti.variant.(^runtime.Type_Info_Integer); uok {
 			switch underlying_info.endianness {
 			case .Platform: return ODIN_ENDIAN == .Big
 			case .Little:   return false
@@ -1041,7 +1041,7 @@ Bit_Field :: struct {
 @(require_results)
 bit_fields_zipped :: proc(T: typeid) -> (fields: #soa[]Bit_Field) {
 	ti := runtime.type_info_base(type_info_of(T))
-	if s, ok := ti.variant.(runtime.Type_Info_Bit_Field); ok {
+	if s, ok := ti.variant.(^runtime.Type_Info_Bit_Field); ok {
 		return soa_zip(
 			name   = s.names[:s.field_count],
 			type   = s.types[:s.field_count],
@@ -1056,7 +1056,7 @@ bit_fields_zipped :: proc(T: typeid) -> (fields: #soa[]Bit_Field) {
 @(require_results)
 bit_field_names :: proc(T: typeid) -> []string {
 	ti := runtime.type_info_base(type_info_of(T))
-	if s, ok := ti.variant.(runtime.Type_Info_Bit_Field); ok {
+	if s, ok := ti.variant.(^runtime.Type_Info_Bit_Field); ok {
 		return s.names[:s.field_count]
 	}
 	return nil
@@ -1065,7 +1065,7 @@ bit_field_names :: proc(T: typeid) -> []string {
 @(require_results)
 bit_field_types :: proc(T: typeid) -> []^Type_Info {
 	ti := runtime.type_info_base(type_info_of(T))
-	if s, ok := ti.variant.(runtime.Type_Info_Bit_Field); ok {
+	if s, ok := ti.variant.(^runtime.Type_Info_Bit_Field); ok {
 		return s.types[:s.field_count]
 	}
 	return nil
@@ -1074,7 +1074,7 @@ bit_field_types :: proc(T: typeid) -> []^Type_Info {
 @(require_results)
 bit_field_sizes :: proc(T: typeid) -> []uintptr {
 	ti := runtime.type_info_base(type_info_of(T))
-	if s, ok := ti.variant.(runtime.Type_Info_Bit_Field); ok {
+	if s, ok := ti.variant.(^runtime.Type_Info_Bit_Field); ok {
 		return s.bit_sizes[:s.field_count]
 	}
 	return nil
@@ -1083,7 +1083,7 @@ bit_field_sizes :: proc(T: typeid) -> []uintptr {
 @(require_results)
 bit_field_offsets :: proc(T: typeid) -> []uintptr {
 	ti := runtime.type_info_base(type_info_of(T))
-	if s, ok := ti.variant.(runtime.Type_Info_Bit_Field); ok {
+	if s, ok := ti.variant.(^runtime.Type_Info_Bit_Field); ok {
 		return s.bit_offsets[:s.field_count]
 	}
 	return nil
@@ -1092,7 +1092,7 @@ bit_field_offsets :: proc(T: typeid) -> []uintptr {
 @(require_results)
 bit_field_tags :: proc(T: typeid) -> []Struct_Tag {
 	ti := runtime.type_info_base(type_info_of(T))
-	if s, ok := ti.variant.(runtime.Type_Info_Bit_Field); ok {
+	if s, ok := ti.variant.(^runtime.Type_Info_Bit_Field); ok {
 		return transmute([]Struct_Tag)s.tags[:s.field_count]
 	}
 	return nil
@@ -1106,7 +1106,7 @@ as_bool :: proc(a: any) -> (value: bool, valid: bool) {
 	a.id = ti.id
 
 	#partial switch info in ti.variant {
-	case Type_Info_Boolean:
+	case ^Type_Info_Boolean:
 		valid = true
 		switch v in a {
 		case bool: value = v
@@ -1145,7 +1145,7 @@ as_i64 :: proc(a: any) -> (value: i64, valid: bool) {
 	a.id = ti.id
 
 	#partial switch info in ti.variant {
-	case Type_Info_Integer:
+	case ^Type_Info_Integer:
 		valid = true
 		switch v in a {
 		case i8:      value = i64(v)
@@ -1185,12 +1185,12 @@ as_i64 :: proc(a: any) -> (value: i64, valid: bool) {
 		case: valid = false
 		}
 
-	case Type_Info_Rune:
+	case ^Type_Info_Rune:
 		r := a.(rune)
 		value = i64(r)
 		valid = true
 
-	case Type_Info_Float:
+	case ^Type_Info_Float:
 		valid = true
 		switch v in a {
 		case f32:   value = i64(v)
@@ -1202,7 +1202,7 @@ as_i64 :: proc(a: any) -> (value: i64, valid: bool) {
 		case: valid = false
 		}
 
-	case Type_Info_Boolean:
+	case ^Type_Info_Boolean:
 		valid = true
 		switch v in a {
 		case bool: value = i64(v)
@@ -1213,7 +1213,7 @@ as_i64 :: proc(a: any) -> (value: i64, valid: bool) {
 		case: valid = false
 		}
 
-	case Type_Info_Complex:
+	case ^Type_Info_Complex:
 		switch v in a {
 		case complex64:
 			if imag(v) == 0 {
@@ -1227,7 +1227,7 @@ as_i64 :: proc(a: any) -> (value: i64, valid: bool) {
 			}
 		}
 
-	case Type_Info_Quaternion:
+	case ^Type_Info_Quaternion:
 		switch v in a {
 		case quaternion128:
 			if imag(v) == 0 && jmag(v) == 0 && kmag(v) == 0 {
@@ -1253,7 +1253,7 @@ as_u64 :: proc(a: any) -> (value: u64, valid: bool) {
 	a.id = ti.id
 
 	#partial switch info in ti.variant {
-	case Type_Info_Integer:
+	case ^Type_Info_Integer:
 		valid = true
 		switch v in a {
 		case i8:     value = u64(v)
@@ -1293,12 +1293,12 @@ as_u64 :: proc(a: any) -> (value: u64, valid: bool) {
 		case: valid = false
 		}
 
-	case Type_Info_Rune:
+	case ^Type_Info_Rune:
 		r := a.(rune)
 		value = u64(r)
 		valid = true
 
-	case Type_Info_Float:
+	case ^Type_Info_Float:
 		valid = true
 		switch v in a {
 		case f16:   value = u64(v)
@@ -1311,7 +1311,7 @@ as_u64 :: proc(a: any) -> (value: u64, valid: bool) {
 		case: valid = false
 		}
 
-	case Type_Info_Boolean:
+	case ^Type_Info_Boolean:
 		valid = true
 		switch v in a {
 		case bool: value = u64(v)
@@ -1322,7 +1322,7 @@ as_u64 :: proc(a: any) -> (value: u64, valid: bool) {
 		case: valid = false
 		}
 
-	case Type_Info_Complex:
+	case ^Type_Info_Complex:
 		switch v in a {
 		case complex64:
 			if imag(v) == 0 {
@@ -1336,7 +1336,7 @@ as_u64 :: proc(a: any) -> (value: u64, valid: bool) {
 			}
 		}
 
-	case Type_Info_Quaternion:
+	case ^Type_Info_Quaternion:
 		switch v in a {
 		case quaternion128:
 			if imag(v) == 0 && jmag(v) == 0 && kmag(v) == 0 {
@@ -1363,7 +1363,7 @@ as_f64 :: proc(a: any) -> (value: f64, valid: bool) {
 	a.id = ti.id
 
 	#partial switch info in ti.variant {
-	case Type_Info_Integer:
+	case ^Type_Info_Integer:
 		valid = true
 		switch v in a {
 		case i8:    value = f64(v)
@@ -1400,12 +1400,12 @@ as_f64 :: proc(a: any) -> (value: f64, valid: bool) {
 		case: valid = false
 		}
 
-	case Type_Info_Rune:
+	case ^Type_Info_Rune:
 		r := a.(rune)
 		value = f64(i32(r))
 		valid = true
 
-	case Type_Info_Float:
+	case ^Type_Info_Float:
 		valid = true
 		switch v in a {
 		case f16:   value = f64(v)
@@ -1418,7 +1418,7 @@ as_f64 :: proc(a: any) -> (value: f64, valid: bool) {
 		case: valid = false
 		}
 
-	case Type_Info_Boolean:
+	case ^Type_Info_Boolean:
 		valid = true
 		switch v in a {
 		case bool: value = f64(i32(v))
@@ -1429,7 +1429,7 @@ as_f64 :: proc(a: any) -> (value: f64, valid: bool) {
 		case: valid = false
 		}
 
-	case Type_Info_Complex:
+	case ^Type_Info_Complex:
 		switch v in a {
 		case complex64:
 			if imag(v) == 0 {
@@ -1443,7 +1443,7 @@ as_f64 :: proc(a: any) -> (value: f64, valid: bool) {
 			}
 		}
 
-	case Type_Info_Quaternion:
+	case ^Type_Info_Quaternion:
 		switch v in a {
 		case quaternion128:
 			if imag(v) == 0 && jmag(v) == 0 && kmag(v) == 0 {
@@ -1470,7 +1470,7 @@ as_string :: proc(a: any) -> (value: string, valid: bool) {
 	a.id = ti.id
 
 	#partial switch info in ti.variant {
-	case Type_Info_String:
+	case ^Type_Info_String:
 		valid = true
 		switch v in a {
 		case string:  value = v
@@ -1533,11 +1533,11 @@ as_pointer :: proc(a: any) -> (value: rawptr, valid: bool) {
 	a.id = ti.id
 
 	#partial switch info in ti.variant {
-	case Type_Info_Pointer:
+	case ^Type_Info_Pointer:
 		valid = true
 		value = (^rawptr)(a.data)^
 
-	case Type_Info_String:
+	case ^Type_Info_String:
 		valid = true
 		switch v in a {
 		case cstring: value = rawptr(v)
@@ -1557,7 +1557,7 @@ as_raw_data :: proc(a: any) -> (value: rawptr, valid: bool) {
 	a.id = ti.id
 
 	#partial switch info in ti.variant {
-	case Type_Info_String:
+	case ^Type_Info_String:
 		valid = true
 		switch v in a {
 		case string:  value = raw_data(v)
@@ -1565,15 +1565,15 @@ as_raw_data :: proc(a: any) -> (value: rawptr, valid: bool) {
 		case: valid = false
 		}
 
-	case Type_Info_Array:
+	case ^Type_Info_Array:
 		valid = true
 		value = a.data
 
-	case Type_Info_Slice:
+	case ^Type_Info_Slice:
 		valid = true
 		value = (^runtime.Raw_Slice)(a.data).data
 
-	case Type_Info_Dynamic_Array:
+	case ^Type_Info_Dynamic_Array:
 		valid = true
 		value = (^runtime.Raw_Dynamic_Array)(a.data).data
 	}
@@ -1625,38 +1625,38 @@ equal :: proc(a, b: any, including_indirect_array_recursion := false, recursion_
 	t = runtime.type_info_core(t)
 
 	switch v in t.variant {
-	case Type_Info_Named:
+	case ^Type_Info_Named:
 		unreachable()
-	case Type_Info_Parameters:
+	case ^Type_Info_Parameters:
 		unreachable()
-	case Type_Info_Any:
+	case ^Type_Info_Any:
 		if !including_indirect_array_recursion {
 			return false
 		}
 		va := (^any)(a.data)
 		vb := (^any)(b.data)
 		return equal(va, vb, including_indirect_array_recursion, recursion_level+1) 
-	case Type_Info_Map:
+	case ^Type_Info_Map:
 		return false
 	case 
-		Type_Info_Boolean,
-		Type_Info_Integer, 
-		Type_Info_Rune,
-		Type_Info_Float,
-		Type_Info_Complex,
-		Type_Info_Quaternion,
-		Type_Info_Type_Id,
-		Type_Info_Pointer,
-		Type_Info_Multi_Pointer,
-		Type_Info_Procedure,
-		Type_Info_Bit_Set,
-		Type_Info_Enum,
-		Type_Info_Simd_Vector,
-		Type_Info_Soa_Pointer,
-		Type_Info_Matrix:
+		^Type_Info_Boolean,
+		^Type_Info_Integer,
+		^Type_Info_Rune,
+		^Type_Info_Float,
+		^Type_Info_Complex,
+		^Type_Info_Quaternion,
+		^Type_Info_Type_Id,
+		^Type_Info_Pointer,
+		^Type_Info_Multi_Pointer,
+		^Type_Info_Procedure,
+		^Type_Info_Bit_Set,
+		^Type_Info_Enum,
+		^Type_Info_Simd_Vector,
+		^Type_Info_Soa_Pointer,
+		^Type_Info_Matrix:
 		return runtime.memory_compare(a.data, b.data, t.size) == 0
 		
-	case Type_Info_String:
+	case ^Type_Info_String:
 		if v.is_cstring {
 			x := string((^cstring)(a.data)^)
 			y := string((^cstring)(b.data)^)
@@ -1667,7 +1667,7 @@ equal :: proc(a, b: any, including_indirect_array_recursion := false, recursion_
 			return x == y
 		}
 		return true
-	case Type_Info_Array:
+	case ^Type_Info_Array:
 		for i in 0..<v.count {
 			x := rawptr(uintptr(a.data) + uintptr(v.elem_size*i))
 			y := rawptr(uintptr(b.data) + uintptr(v.elem_size*i))
@@ -1676,7 +1676,7 @@ equal :: proc(a, b: any, including_indirect_array_recursion := false, recursion_
 			}
 		}
 		return true
-	case Type_Info_Enumerated_Array:
+	case ^Type_Info_Enumerated_Array:
 		for i in 0..<v.count {
 			x := rawptr(uintptr(a.data) + uintptr(v.elem_size*i))
 			y := rawptr(uintptr(b.data) + uintptr(v.elem_size*i))
@@ -1685,7 +1685,7 @@ equal :: proc(a, b: any, including_indirect_array_recursion := false, recursion_
 			}
 		}
 		return true
-	case Type_Info_Struct:
+	case ^Type_Info_Struct:
 		if v.equal != nil {
 			return v.equal(a.data, b.data)
 		} else {
@@ -1699,12 +1699,12 @@ equal :: proc(a, b: any, including_indirect_array_recursion := false, recursion_
 			}
 			return true
 		}
-	case Type_Info_Union:
+	case ^Type_Info_Union:
 		if v.equal != nil {
 			return v.equal(a.data, b.data)
 		}
 		return false
-	case Type_Info_Slice:
+	case ^Type_Info_Slice:
 		if !including_indirect_array_recursion {
 			return false
 		}
@@ -1724,7 +1724,7 @@ equal :: proc(a, b: any, including_indirect_array_recursion := false, recursion_
 			}	
 		}
 		return true
-	case Type_Info_Dynamic_Array:
+	case ^Type_Info_Dynamic_Array:
 		if !including_indirect_array_recursion {
 			return false
 		}
@@ -1749,7 +1749,7 @@ equal :: proc(a, b: any, including_indirect_array_recursion := false, recursion_
 		}
 		return true
 
-	case Type_Info_Bit_Field:
+	case ^Type_Info_Bit_Field:
 		x, y := a, b
 		x.id = v.backing_type.id
 		y.id = v.backing_type.id

--- a/core/reflect/types.odin
+++ b/core/reflect/types.odin
@@ -19,61 +19,61 @@ are_types_identical :: proc(a, b: ^Type_Info) -> bool {
 	}
 
 	switch x in a.variant {
-	case Type_Info_Named:
-		y := b.variant.(Type_Info_Named) or_return
+	case ^Type_Info_Named:
+		y := b.variant.(^Type_Info_Named) or_return
 		return x.base == y.base
 
-	case Type_Info_Integer:
-		y := b.variant.(Type_Info_Integer) or_return
+	case ^Type_Info_Integer:
+		y := b.variant.(^Type_Info_Integer) or_return
 		return x.signed == y.signed && x.endianness == y.endianness
 
-	case Type_Info_Rune:
-		_, ok := b.variant.(Type_Info_Rune)
+	case ^Type_Info_Rune:
+		_, ok := b.variant.(^Type_Info_Rune)
 		return ok
 
-	case Type_Info_Float:
-		_, ok := b.variant.(Type_Info_Float)
+	case ^Type_Info_Float:
+		_, ok := b.variant.(^Type_Info_Float)
 		return ok
 
-	case Type_Info_Complex:
-		_, ok := b.variant.(Type_Info_Complex)
+	case ^Type_Info_Complex:
+		_, ok := b.variant.(^Type_Info_Complex)
 		return ok
 
-	case Type_Info_Quaternion:
-		_, ok := b.variant.(Type_Info_Quaternion)
+	case ^Type_Info_Quaternion:
+		_, ok := b.variant.(^Type_Info_Quaternion)
 		return ok
 
-	case Type_Info_Type_Id:
-		_, ok := b.variant.(Type_Info_Type_Id)
+	case ^Type_Info_Type_Id:
+		_, ok := b.variant.(^Type_Info_Type_Id)
 		return ok
 
-	case Type_Info_String:
-		_, ok := b.variant.(Type_Info_String)
+	case ^Type_Info_String:
+		_, ok := b.variant.(^Type_Info_String)
 		return ok
 
-	case Type_Info_Boolean:
-		_, ok := b.variant.(Type_Info_Boolean)
+	case ^Type_Info_Boolean:
+		_, ok := b.variant.(^Type_Info_Boolean)
 		return ok
 
-	case Type_Info_Any:
-		_, ok := b.variant.(Type_Info_Any)
+	case ^Type_Info_Any:
+		_, ok := b.variant.(^Type_Info_Any)
 		return ok
 
-	case Type_Info_Pointer:
-		y := b.variant.(Type_Info_Pointer) or_return
+	case ^Type_Info_Pointer:
+		y := b.variant.(^Type_Info_Pointer) or_return
 		return are_types_identical(x.elem, y.elem)
 
-	case Type_Info_Multi_Pointer:
-		y := b.variant.(Type_Info_Multi_Pointer) or_return
+	case ^Type_Info_Multi_Pointer:
+		y := b.variant.(^Type_Info_Multi_Pointer) or_return
 		return are_types_identical(x.elem, y.elem)
 
-	case Type_Info_Soa_Pointer:
-		y := b.variant.(Type_Info_Soa_Pointer) or_return
+	case ^Type_Info_Soa_Pointer:
+		y := b.variant.(^Type_Info_Soa_Pointer) or_return
 		return are_types_identical(x.elem, y.elem)
 
 
-	case Type_Info_Procedure:
-		y := b.variant.(Type_Info_Procedure) or_return
+	case ^Type_Info_Procedure:
+		y := b.variant.(^Type_Info_Procedure) or_return
 		switch {
 		case x.variadic   != y.variadic,
 		     x.convention != y.convention:
@@ -82,27 +82,27 @@ are_types_identical :: proc(a, b: ^Type_Info) -> bool {
 
 		return are_types_identical(x.params, y.params) && are_types_identical(x.results, y.results)
 
-	case Type_Info_Array:
-		y := b.variant.(Type_Info_Array) or_return
+	case ^Type_Info_Array:
+		y := b.variant.(^Type_Info_Array) or_return
 		if x.count != y.count { return false }
 		return are_types_identical(x.elem, y.elem)
 
-	case Type_Info_Enumerated_Array:
-		y := b.variant.(Type_Info_Enumerated_Array) or_return
+	case ^Type_Info_Enumerated_Array:
+		y := b.variant.(^Type_Info_Enumerated_Array) or_return
 		if x.count != y.count { return false }
 		return are_types_identical(x.index, y.index) &&
 		       are_types_identical(x.elem, y.elem)
 
-	case Type_Info_Dynamic_Array:
-		y := b.variant.(Type_Info_Dynamic_Array) or_return
+	case ^Type_Info_Dynamic_Array:
+		y := b.variant.(^Type_Info_Dynamic_Array) or_return
 		return are_types_identical(x.elem, y.elem)
 
-	case Type_Info_Slice:
-		y := b.variant.(Type_Info_Slice) or_return
+	case ^Type_Info_Slice:
+		y := b.variant.(^Type_Info_Slice) or_return
 		return are_types_identical(x.elem, y.elem)
 
-	case Type_Info_Parameters:
-		y := b.variant.(Type_Info_Parameters) or_return
+	case ^Type_Info_Parameters:
+		y := b.variant.(^Type_Info_Parameters) or_return
 		if len(x.types) != len(y.types) { return false }
 		for _, i in x.types {
 			xt, yt := x.types[i], y.types[i]
@@ -112,8 +112,8 @@ are_types_identical :: proc(a, b: ^Type_Info) -> bool {
 		}
 		return true
 
-	case Type_Info_Struct:
-		y := b.variant.(Type_Info_Struct) or_return
+	case ^Type_Info_Struct:
+		y := b.variant.(^Type_Info_Struct) or_return
 		switch {
 		case x.field_count   != y.field_count,
 		     x.flags         != y.flags,
@@ -133,8 +133,8 @@ are_types_identical :: proc(a, b: ^Type_Info) -> bool {
 		}
 		return true
 
-	case Type_Info_Union:
-		y := b.variant.(Type_Info_Union) or_return
+	case ^Type_Info_Union:
+		y := b.variant.(^Type_Info_Union) or_return
 		if len(x.variants) != len(y.variants) { return false }
 
 		for _, i in x.variants {
@@ -143,31 +143,31 @@ are_types_identical :: proc(a, b: ^Type_Info) -> bool {
 		}
 		return true
 
-	case Type_Info_Enum:
+	case ^Type_Info_Enum:
 		// NOTE(bill): Should be handled above
 		return false
 
-	case Type_Info_Map:
-		y := b.variant.(Type_Info_Map) or_return
+	case ^Type_Info_Map:
+		y := b.variant.(^Type_Info_Map) or_return
 		return are_types_identical(x.key, y.key) && are_types_identical(x.value, y.value)
 
-	case Type_Info_Bit_Set:
-		y := b.variant.(Type_Info_Bit_Set) or_return
+	case ^Type_Info_Bit_Set:
+		y := b.variant.(^Type_Info_Bit_Set) or_return
 		return x.elem == y.elem && x.lower == y.lower && x.upper == y.upper
 
-	case Type_Info_Simd_Vector:
-		y := b.variant.(Type_Info_Simd_Vector) or_return
+	case ^Type_Info_Simd_Vector:
+		y := b.variant.(^Type_Info_Simd_Vector) or_return
 		return x.count == y.count && x.elem == y.elem
 		
-	case Type_Info_Matrix:
-		y := b.variant.(Type_Info_Matrix) or_return
+	case ^Type_Info_Matrix:
+		y := b.variant.(^Type_Info_Matrix) or_return
 		if x.row_count != y.row_count { return false }
 		if x.column_count != y.column_count { return false }
 		if x.layout != y.layout { return false }
 		return are_types_identical(x.elem, y.elem)
 
-	case Type_Info_Bit_Field:
-		y := b.variant.(Type_Info_Bit_Field) or_return
+	case ^Type_Info_Bit_Field:
+		y := b.variant.(^Type_Info_Bit_Field) or_return
 		if !are_types_identical(x.backing_type, y.backing_type) { return false }
 		if x.field_count != y.field_count { return false }
 		for _, i in x.names[:x.field_count] {
@@ -191,8 +191,8 @@ are_types_identical :: proc(a, b: ^Type_Info) -> bool {
 is_signed :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
 	#partial switch i in type_info_base(info).variant {
-	case Type_Info_Integer: return i.signed
-	case Type_Info_Float:   return true
+	case ^Type_Info_Integer: return i.signed
+	case ^Type_Info_Float:   return true
 	}
 	return false
 }
@@ -200,8 +200,8 @@ is_signed :: proc(info: ^Type_Info) -> bool {
 is_unsigned :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
 	#partial switch i in type_info_base(info).variant {
-	case Type_Info_Integer: return !i.signed
-	case Type_Info_Float:   return false
+	case ^Type_Info_Integer: return !i.signed
+	case ^Type_Info_Float:   return false
 	}
 	return false
 }
@@ -210,7 +210,7 @@ is_unsigned :: proc(info: ^Type_Info) -> bool {
 is_byte :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
 	#partial switch i in type_info_base(info).variant {
-	case Type_Info_Integer: return info.size == 1
+	case ^Type_Info_Integer: return info.size == 1
 	}
 	return false
 }
@@ -219,83 +219,83 @@ is_byte :: proc(info: ^Type_Info) -> bool {
 @(require_results)
 is_integer :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Integer)
+	_, ok := type_info_base(info).variant.(^Type_Info_Integer)
 	return ok
 }
 @(require_results)
 is_rune :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Rune)
+	_, ok := type_info_base(info).variant.(^Type_Info_Rune)
 	return ok
 }
 @(require_results)
 is_float :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Float)
+	_, ok := type_info_base(info).variant.(^Type_Info_Float)
 	return ok
 }
 @(require_results)
 is_complex :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Complex)
+	_, ok := type_info_base(info).variant.(^Type_Info_Complex)
 	return ok
 }
 @(require_results)
 is_quaternion :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Quaternion)
+	_, ok := type_info_base(info).variant.(^Type_Info_Quaternion)
 	return ok
 }
 @(require_results)
 is_any :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Any)
+	_, ok := type_info_base(info).variant.(^Type_Info_Any)
 	return ok
 }
 @(require_results)
 is_string :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_String)
+	_, ok := type_info_base(info).variant.(^Type_Info_String)
 	return ok
 }
 @(require_results)
 is_cstring :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	v, ok := type_info_base(info).variant.(Type_Info_String)
+	v, ok := type_info_base(info).variant.(^Type_Info_String)
 	return ok && v.is_cstring
 }
 @(require_results)
 is_boolean :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Boolean)
+	_, ok := type_info_base(info).variant.(^Type_Info_Boolean)
 	return ok
 }
 @(require_results)
 is_pointer :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Pointer)
+	_, ok := type_info_base(info).variant.(^Type_Info_Pointer)
 	return ok
 }
 @(require_results)
 is_multi_pointer :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Multi_Pointer)
+	_, ok := type_info_base(info).variant.(^Type_Info_Multi_Pointer)
 	return ok
 }
 @(require_results)
 is_soa_pointer :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Soa_Pointer)
+	_, ok := type_info_base(info).variant.(^Type_Info_Soa_Pointer)
 	return ok
 }
 @(require_results)
 is_pointer_internally :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
 	#partial switch v in info.variant {
-	case Type_Info_Pointer, Type_Info_Multi_Pointer,
-	     Type_Info_Procedure:
+	case ^Type_Info_Pointer, ^Type_Info_Multi_Pointer,
+	     ^Type_Info_Procedure:
 		return true
-	case Type_Info_String:
+	case ^Type_Info_String:
 		return v.is_cstring
 	}
 	return false
@@ -303,85 +303,85 @@ is_pointer_internally :: proc(info: ^Type_Info) -> bool {
 @(require_results)
 is_procedure :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Procedure)
+	_, ok := type_info_base(info).variant.(^Type_Info_Procedure)
 	return ok
 }
 @(require_results)
 is_array :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Array)
+	_, ok := type_info_base(info).variant.(^Type_Info_Array)
 	return ok
 }
 @(require_results)
 is_enumerated_array :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Enumerated_Array)
+	_, ok := type_info_base(info).variant.(^Type_Info_Enumerated_Array)
 	return ok
 }
 @(require_results)
 is_dynamic_array :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Dynamic_Array)
+	_, ok := type_info_base(info).variant.(^Type_Info_Dynamic_Array)
 	return ok
 }
 @(require_results)
 is_dynamic_map :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Map)
+	_, ok := type_info_base(info).variant.(^Type_Info_Map)
 	return ok
 }
 @(require_results)
 is_bit_set :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Bit_Set)
+	_, ok := type_info_base(info).variant.(^Type_Info_Bit_Set)
 	return ok
 }
 @(require_results)
 is_slice :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Slice)
+	_, ok := type_info_base(info).variant.(^Type_Info_Slice)
 	return ok
 }
 @(require_results)
 is_parameters :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Parameters)
+	_, ok := type_info_base(info).variant.(^Type_Info_Parameters)
 	return ok
 }
 @(require_results, deprecated="prefer is_parameters")
 is_tuple :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Parameters)
+	_, ok := type_info_base(info).variant.(^Type_Info_Parameters)
 	return ok
 }
 @(require_results)
 is_struct :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	s, ok := type_info_base(info).variant.(Type_Info_Struct)
-	return ok && .raw_union not_in s.flags
+	s, ok := type_info_base(info).variant.(^Type_Info_Struct)
+	return ok && .raw_union not_in s.struct_flags
 }
 @(require_results)
 is_raw_union :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	s, ok := type_info_base(info).variant.(Type_Info_Struct)
-	return ok && .raw_union in s.flags
+	s, ok := type_info_base(info).variant.(^Type_Info_Struct)
+	return ok && .raw_union in s.struct_flags
 }
 @(require_results)
 is_union :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Union)
+	_, ok := type_info_base(info).variant.(^Type_Info_Union)
 	return ok
 }
 @(require_results)
 is_enum :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Enum)
+	_, ok := type_info_base(info).variant.(^Type_Info_Enum)
 	return ok
 }
 @(require_results)
 is_simd_vector :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Simd_Vector)
+	_, ok := type_info_base(info).variant.(^Type_Info_Simd_Vector)
 	return ok
 }
 
@@ -392,14 +392,14 @@ is_endian_platform :: proc(info: ^Type_Info) -> bool {
 	info := info
 	info = type_info_core(info)
 	#partial switch v in info.variant {
-	case Type_Info_Integer:
+	case ^Type_Info_Integer:
 		return v.endianness == .Platform
-	case Type_Info_Bit_Set:
+	case ^Type_Info_Bit_Set:
 		if v.underlying != nil {
 			return is_endian_platform(v.underlying)
 		}
 		return true
-	case Type_Info_Pointer:
+	case ^Type_Info_Pointer:
 		return true
 	}
 	return false
@@ -411,17 +411,17 @@ is_endian_little :: proc(info: ^Type_Info) -> bool {
 	info := info
 	info = type_info_core(info)
 	#partial switch v in info.variant {
-	case Type_Info_Integer:
+	case ^Type_Info_Integer:
 		if v.endianness == .Platform {
 			return ODIN_ENDIAN == .Little
 		}
 		return v.endianness == .Little
-	case Type_Info_Bit_Set:
+	case ^Type_Info_Bit_Set:
 		if v.underlying != nil {
 			return is_endian_platform(v.underlying)
 		}
 		return ODIN_ENDIAN == .Little
-	case Type_Info_Pointer:
+	case ^Type_Info_Pointer:
 		return ODIN_ENDIAN == .Little
 	}
 	return ODIN_ENDIAN == .Little
@@ -433,17 +433,17 @@ is_endian_big :: proc(info: ^Type_Info) -> bool {
 	info := info
 	info = type_info_core(info)
 	#partial switch v in info.variant {
-	case Type_Info_Integer:
+	case ^Type_Info_Integer:
 		if v.endianness == .Platform {
 			return ODIN_ENDIAN == .Big
 		}
 		return v.endianness == .Big
-	case Type_Info_Bit_Set:
+	case ^Type_Info_Bit_Set:
 		if v.underlying != nil {
 			return is_endian_platform(v.underlying)
 		}
 		return ODIN_ENDIAN == .Big
-	case Type_Info_Pointer:
+	case ^Type_Info_Pointer:
 		return ODIN_ENDIAN == .Big
 	}
 	return ODIN_ENDIAN == .Big
@@ -483,9 +483,9 @@ write_type_writer :: #force_no_inline proc(w: io.Writer, ti: ^Type_Info, n_writt
 	}
 	
 	switch info in ti.variant {
-	case Type_Info_Named:
+	case ^Type_Info_Named:
 		io.write_string(w, info.name, &n) or_return
-	case Type_Info_Integer:
+	case ^Type_Info_Integer:
 		switch ti.id {
 		case int:     io.write_string(w, "int",     &n) or_return
 		case uint:    io.write_string(w, "uint",    &n) or_return
@@ -499,9 +499,9 @@ write_type_writer :: #force_no_inline proc(w: io.Writer, ti: ^Type_Info, n_writt
 			case .Big:    io.write_string(w, "be", &n) or_return
 			}
 		}
-	case Type_Info_Rune:
+	case ^Type_Info_Rune:
 		io.write_string(w, "rune", &n) or_return
-	case Type_Info_Float:
+	case ^Type_Info_Float:
 		io.write_byte(w, 'f', &n)               or_return
 		io.write_i64(w, i64(8*ti.size), 10, &n) or_return
 		switch info.endianness {
@@ -509,50 +509,50 @@ write_type_writer :: #force_no_inline proc(w: io.Writer, ti: ^Type_Info, n_writt
 		case .Little: io.write_string(w, "le", &n) or_return
 		case .Big:    io.write_string(w, "be", &n) or_return
 		}
-	case Type_Info_Complex:
+	case ^Type_Info_Complex:
 		io.write_string(w, "complex", &n)       or_return
 		io.write_i64(w, i64(8*ti.size), 10, &n) or_return
-	case Type_Info_Quaternion:
+	case ^Type_Info_Quaternion:
 		io.write_string(w, "quaternion", &n)    or_return
 		io.write_i64(w, i64(8*ti.size), 10, &n) or_return
-	case Type_Info_String:
+	case ^Type_Info_String:
 		if info.is_cstring {
 			io.write_string(w, "cstring", &n) or_return
 		} else {
 			io.write_string(w, "string", &n)  or_return
 		}
-	case Type_Info_Boolean:
+	case ^Type_Info_Boolean:
 		switch ti.id {
 		case bool: io.write_string(w, "bool", &n) or_return
 		case:
 			io.write_byte(w, 'b', &n)               or_return
 			io.write_i64(w, i64(8*ti.size), 10, &n) or_return
 		}
-	case Type_Info_Any:
+	case ^Type_Info_Any:
 		io.write_string(w, "any", &n) or_return
 
-	case Type_Info_Type_Id:
+	case ^Type_Info_Type_Id:
 		io.write_string(w, "typeid", &n) or_return
 
-	case Type_Info_Pointer:
+	case ^Type_Info_Pointer:
 		if info.elem == nil {
 			io.write_string(w, "rawptr", &n) or_return
 		} else {
 			io.write_string(w, "^", &n) or_return
 			write_type(w, info.elem, &n) or_return
 		}
-	case Type_Info_Multi_Pointer:
+	case ^Type_Info_Multi_Pointer:
 		io.write_string(w, "[^]", &n) or_return
 		write_type(w, info.elem, &n) or_return
-	case Type_Info_Soa_Pointer:
+	case ^Type_Info_Soa_Pointer:
 		io.write_string(w, "#soa ^", &n) or_return
 		write_type(w, info.elem, &n) or_return
-	case Type_Info_Procedure:
+	case ^Type_Info_Procedure:
 		io.write_string(w, "proc", &n) or_return
 		if info.params == nil {
 			io.write_string(w, "()", &n) or_return
 		} else {
-			t := info.params.variant.(Type_Info_Parameters)
+			t := info.params.variant.(^Type_Info_Parameters)
 			io.write_string(w, "(", &n) or_return
 			for t, i in t.types {
 				if i > 0 {
@@ -566,7 +566,7 @@ write_type_writer :: #force_no_inline proc(w: io.Writer, ti: ^Type_Info, n_writt
 			io.write_string(w, " -> ", &n)  or_return
 			write_type(w, info.results, &n) or_return
 		}
-	case Type_Info_Parameters:
+	case ^Type_Info_Parameters:
 		count := len(info.names)
 		if count != 1 { 
 			io.write_string(w, "(", &n) or_return 
@@ -586,13 +586,13 @@ write_type_writer :: #force_no_inline proc(w: io.Writer, ti: ^Type_Info, n_writt
 			io.write_string(w, ")", &n) or_return 
 		}
 
-	case Type_Info_Array:
+	case ^Type_Info_Array:
 		io.write_string(w, "[",              &n) or_return
 		io.write_i64(w, i64(info.count), 10, &n) or_return
 		io.write_string(w, "]",              &n) or_return
 		write_type(w, info.elem,             &n) or_return
 
-	case Type_Info_Enumerated_Array:
+	case ^Type_Info_Enumerated_Array:
 		if info.is_sparse {
 			io.write_string(w, "#sparse", &n) or_return
 		}
@@ -601,20 +601,20 @@ write_type_writer :: #force_no_inline proc(w: io.Writer, ti: ^Type_Info, n_writt
 		io.write_string(w, "]",   &n) or_return
 		write_type(w, info.elem,  &n) or_return
 
-	case Type_Info_Dynamic_Array:
+	case ^Type_Info_Dynamic_Array:
 		io.write_string(w, "[dynamic]", &n) or_return
 		write_type(w, info.elem,        &n) or_return
-	case Type_Info_Slice:
+	case ^Type_Info_Slice:
 		io.write_string(w, "[]", &n) or_return
 		write_type(w, info.elem, &n) or_return
 
-	case Type_Info_Map:
+	case ^Type_Info_Map:
 		io.write_string(w, "map[", &n) or_return
 		write_type(w, info.key,    &n) or_return
 		io.write_byte(w, ']',      &n) or_return
 		write_type(w, info.value,  &n) or_return
 
-	case Type_Info_Struct:
+	case ^Type_Info_Struct:
 		switch info.soa_kind {
 		case .None: // Ignore
 		case .Fixed:
@@ -634,10 +634,10 @@ write_type_writer :: #force_no_inline proc(w: io.Writer, ti: ^Type_Info, n_writt
 		}
 
 		io.write_string(w, "struct ", &n) or_return
-		if .packed    in info.flags { io.write_string(w, "#packed ",    &n) or_return }
-		if .raw_union in info.flags { io.write_string(w, "#raw_union ", &n) or_return }
-		if .no_copy   in info.flags { io.write_string(w, "#no_copy ", &n) or_return }
-		if .align in info.flags {
+		if .packed    in info.struct_flags { io.write_string(w, "#packed ",    &n) or_return }
+		if .raw_union in info.struct_flags { io.write_string(w, "#raw_union ", &n) or_return }
+		if .no_copy   in info.struct_flags { io.write_string(w, "#no_copy ", &n) or_return }
+		if .align in info.struct_flags {
 			io.write_string(w, "#align(",      &n) or_return
 			io.write_i64(w, i64(ti.align), 10, &n) or_return
 			io.write_string(w, ") ",           &n) or_return
@@ -651,7 +651,7 @@ write_type_writer :: #force_no_inline proc(w: io.Writer, ti: ^Type_Info, n_writt
 		}
 		io.write_byte(w, '}', &n) or_return
 
-	case Type_Info_Union:
+	case ^Type_Info_Union:
 		io.write_string(w, "union ", &n) or_return
 		if info.no_nil     { io.write_string(w, "#no_nil ", &n)     or_return }
 		if info.shared_nil { io.write_string(w, "#shared_nil ", &n) or_return }
@@ -667,7 +667,7 @@ write_type_writer :: #force_no_inline proc(w: io.Writer, ti: ^Type_Info, n_writt
 		}
 		io.write_byte(w, '}', &n) or_return
 
-	case Type_Info_Enum:
+	case ^Type_Info_Enum:
 		io.write_string(w, "enum ", &n) or_return
 		write_type(w, info.base, &n) or_return
 		io.write_string(w, " {", &n) or_return
@@ -677,7 +677,7 @@ write_type_writer :: #force_no_inline proc(w: io.Writer, ti: ^Type_Info, n_writt
 		}
 		io.write_byte(w, '}', &n) or_return
 
-	case Type_Info_Bit_Set:
+	case ^Type_Info_Bit_Set:
 		io.write_string(w, "bit_set[", &n) or_return
 		switch {
 		case is_enum(info.elem):
@@ -697,7 +697,7 @@ write_type_writer :: #force_no_inline proc(w: io.Writer, ti: ^Type_Info, n_writt
 		}
 		io.write_byte(w, ']', &n) or_return
 
-	case Type_Info_Bit_Field:
+	case ^Type_Info_Bit_Field:
 		io.write_string(w, "bit_field ", &n) or_return
 		write_type(w, info.backing_type, &n) or_return
 		io.write_string(w, " {",         &n) or_return
@@ -711,13 +711,13 @@ write_type_writer :: #force_no_inline proc(w: io.Writer, ti: ^Type_Info, n_writt
 		}
 		io.write_string(w, "}", &n) or_return
 
-	case Type_Info_Simd_Vector:
+	case ^Type_Info_Simd_Vector:
 		io.write_string(w, "#simd[",         &n) or_return
 		io.write_i64(w, i64(info.count), 10, &n) or_return
 		io.write_byte(w, ']',                &n) or_return
 		write_type(w, info.elem,             &n) or_return
 		
-	case Type_Info_Matrix:
+	case ^Type_Info_Matrix:
 		if info.layout == .Row_Major {
 			io.write_string(w, "#row_major ",   &n) or_return
 		}

--- a/core/slice/map.odin
+++ b/core/slice/map.odin
@@ -52,7 +52,7 @@ map_entry_infos :: proc(m: $M/map[$K]$V, allocator := context.allocator) -> (ent
 	m := m
 	rm := (^runtime.Raw_Map)(&m)
 
-	info := runtime.type_info_base(type_info_of(M)).variant.(runtime.Type_Info_Map)
+	info := runtime.type_info_base(type_info_of(M)).variant.(^runtime.Type_Info_Map)
 	if info.map_info != nil {
 		entries = make(type_of(entries), len(m), allocator) or_return
 

--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -2592,7 +2592,6 @@ gb_internal String lb_filepath_obj_for_module(lbModule *m) {
 	path = gb_string_append_length(path, name.text, name.len);
 
 	{
-
 		GB_ASSERT(m->module_name != nullptr);
 		String s = make_string_c(m->module_name);
 		String prefix = str_lit("odin_package");


### PR DESCRIPTION
Convert the usage of `runtime.Type_Info` from being a union of the variants in-place to based on subtypes in order to minimize memory usage and initialization.

This is a **BREAKING CHANGE** for any code base that uses runtime type information. 

How to fix your code:

* `case runtime.Type_Info_*` -> `case ^runtime.Type_Info_*`
* `x.(runtime.Type_Info_*)` -> `x.(^runtime.Type_Info_*)`
* `info_for_struct.flags` -> `info_for_struct.struct_flags`
