### PR TITLE
vendor/sdl3: fix GetPixelFormatName() returning rawptr instead of cstring

### DIFF
--- a/vendor/sdl3/sdl3_pixels.odin
+++ b/vendor/sdl3/sdl3_pixels.odin
@@ -550,7 +550,7 @@ PixelFormatDetails :: struct {
 
 @(default_calling_convention="c", link_prefix="SDL_")
 foreign lib {
-	GetPixelFormatName     :: proc(format: PixelFormat) -> rawptr ---
+	GetPixelFormatName     :: proc(format: PixelFormat) -> cstring ---
 	GetMasksForPixelFormat :: proc(format: PixelFormat, bpp: ^c.int, Rmask, Gmask, Bmask, Amask: ^Uint32) -> bool ---
 	GetPixelFormatForMasks :: proc(bpp: c.int, Rmask, Gmask, Bmask, Amask: Uint32) -> PixelFormat ---
 	GetPixelFormatDetails  :: proc(format: PixelFormat) -> ^PixelFormatDetails ---


### PR DESCRIPTION
GetPixelFormatName() returns a char * on the C side. The return type seems to have been accidentally swapped to rawptr with the new bindings, since it's a cstring in the SDL2 bindings.