### PR TITLE
Fix linux.rt_sigaction

### DIFF
--- a/core/sys/linux/sys.odin
+++ b/core/sys/linux/sys.odin
@@ -212,7 +212,7 @@ rt_sigreturn :: proc "c" () -> ! {
 /*
 	Alter an action taken by a process.
 */
-rt_sigaction :: proc "contextless" (sig: Signal, sigaction: ^Sig_Action($T), old_sigaction: ^Sig_Action) -> Errno {
+rt_sigaction :: proc "contextless" (sig: Signal, sigaction: ^Sig_Action($T), old_sigaction: ^Sig_Action($U)) -> Errno {
 	// NOTE(jason): It appears that the restorer is required for i386 and amd64
 	when ODIN_ARCH == .i386 || ODIN_ARCH == .amd64 {
 		sigaction.flags += {.RESTORER}


### PR DESCRIPTION
Add missing polymorphic parameter to Sig_Action.

Who did that?

::checks log::

It was me.