### PR TITLE
Fix futex(8) usage on OpenBSD.

### DIFF
--- a/src/threading.cpp
+++ b/src/threading.cpp
@@ -756,7 +756,7 @@ gb_internal void futex_signal(Futex *f) {
 
 			perror("Futex wake");
 			GB_PANIC("futex wake fail");
-		} else if (ret == 1) {
+		} else {
 			return;
 		}
 	}
@@ -773,7 +773,7 @@ gb_internal void futex_broadcast(Futex *f) {
 
 			perror("Futex wake");
 			GB_PANIC("futex wake fail");
-		} else if (ret == 1) {
+		} else {
 			return;
 		}
 	}
@@ -783,7 +783,7 @@ gb_internal void futex_wait(Futex *f, Footex val) {
 	for (;;) {
 		int ret = futex((volatile uint32_t *)f, FUTEX_WAIT | FUTEX_PRIVATE_FLAG, val, NULL, NULL);
 		if (ret == -1) {
-			if (*f != val) {
+			if (errno == EAGAIN) {
 				return;
 			}
 


### PR DESCRIPTION
When building on OpenBSD-current (what will be 7.7)  Odin compiles, but when using it to build any Odin programs it enters infinite loops calling `futex(8)`. This happens in places like when releasing a mutex and trying to use `futex_signal` or `futex_broadcast` because if there's no waiting thread, the return value is `0`.

`futex_wait` can also be tweaked as per https://man.openbsd.org/futex#ERRORS, when using `FUTEX_WAIT`, the check is performed for the caller and `EAGAIN` is returned if the futex address and val do not match.

I'm working on other diffs to fix linking programs on OpenBSD (have it working, but they are ugly hacks to get the correct linker args), but this PR at least fixes the infinite loop problem.