### PR TITLE
Added simple test coverage overview

### DIFF
--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Normal Core library tests
         run: |
           ./odin build tests/core/normal.odin -build-mode:test -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
-          kcov kcov-out ./tests .
+          kcov kcov-out ./core .
 
       - name: Optimized Core library tests
         run: |

--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Normal Core library tests
         run: |
           ./odin build tests/core/normal.odin -build-mode:test -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
-          kcov kcov-out ./core .
+          kcov kcov-out ./normal .
 
       - name: Optimized Core library tests
         run: |

--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -30,8 +30,7 @@ jobs:
       - name: Normal Core library tests
         run: |
           ./odin build tests/core/normal.odin -build-mode:test -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
-          ls -al
-          kcov kcov-out ./normal .
+          kcov kcov-out ./normal.bin .
 
       - name: Optimized Core library tests
         run: |

--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -29,17 +29,19 @@ jobs:
 
       - name: Normal Core library tests
         run: |
-          ./odin build tests/core/normal.odin -build-mode:test -o:none -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
+          ./odin build tests/core/normal.odin -build-mode:test -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
           kcov --exclude-path=tests kcov-out ./normal.bin .
 
-      - name: Optimized Core library tests
-        run: |
-          ./odin build tests/core/speed.odin -build-mode:test -o:none -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
-          kcov --exclude-path=tests kcov-out ./speed.bin .
+      # Not sure if they are relevant? /aj
+      #
+      #- name: Optimized Core library tests
+      #  run: |
+      #    ./odin build tests/core/speed.odin -build-mode:test -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
+      #    kcov --exclude-path=tests kcov-out ./speed.bin .
 
       - name: Internals tests
         run: |
-          ./odin build tests/internal -build-mode:test -debug -o:none -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
+          ./odin build tests/internal -build-mode:test -debug -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
           kcov --exclude-path=tests kcov-out ./internal .
 
       - name: Report

--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -29,17 +29,17 @@ jobs:
 
       - name: Normal Core library tests
         run: |
-          ./odin build tests/core/normal.odin -build-mode:test -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
+          ./odin build tests/core/normal.odin -build-mode:test -o:none -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
           kcov --exclude-path=tests kcov-out ./normal.bin .
 
       - name: Optimized Core library tests
         run: |
-          ./odin build tests/core/speed.odin -build-mode:test -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
+          ./odin build tests/core/speed.odin -build-mode:test -o:none -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
           kcov --exclude-path=tests kcov-out ./speed.bin .
 
       - name: Internals tests
         run: |
-          ./odin build tests/internal -build-mode:test -debug -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
+          ./odin build tests/internal -build-mode:test -debug -o:none -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
           kcov --exclude-path=tests kcov-out ./internal .
 
       - name: Report

--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -14,7 +14,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install kcov
 
-      - name: Download LLVM (Linux)
+      - name: Download LLVM
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
@@ -30,17 +30,20 @@ jobs:
       - name: Normal Core library tests
         run: |
           ./odin build tests/core/normal.odin -build-mode:test -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
-          kcov kcov-out ./normal.bin .
+          kcov kcov-out-normal ./normal.bin .
 
       - name: Optimized Core library tests
         run: |
           ./odin build tests/core/speed.odin -build-mode:test -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
+          kcov kcov-out-speed ./speed.bin .
 
       - name: Internals tests
         run: |
           ./odin build tests/internal -build-mode:test -debug -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
+          kcov kcov-out-internal ./internal .
 
       - name: Report
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: bash <(curl -s https://codecov.io/bash) -s kcov-out
+        run: |
+          bash <(curl -s https://codecov.io/bash) -s kcov-out-*

--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -32,12 +32,10 @@ jobs:
           ./odin build tests/core/normal.odin -build-mode:test -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
           kcov --exclude-path=tests kcov-out ./normal.bin .
 
-      # Not sure if they are relevant? /aj
-      #
-      #- name: Optimized Core library tests
-      #  run: |
-      #    ./odin build tests/core/speed.odin -build-mode:test -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
-      #    kcov --exclude-path=tests kcov-out ./speed.bin .
+      - name: Optimized Core library tests
+        run: |
+          ./odin build tests/core/speed.odin -build-mode:test -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
+          kcov --exclude-path=tests kcov-out ./speed.bin .
 
       - name: Internals tests
         run: |

--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Normal Core library tests
         run: |
           ./odin build tests/core/normal.odin -build-mode:test -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
+          ls -al
           kcov kcov-out ./normal .
 
       - name: Optimized Core library tests

--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -1,0 +1,46 @@
+name: Test Coverage
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build_linux_amd64:
+    runs-on: ubuntu-latest
+    name: Linux AMD64 Test Coverage
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kcov
+        run: |
+          sudo apt-get update
+          sudo apt-get install kcov
+
+      - name: Download LLVM (Linux)
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 18
+          echo "/usr/lib/llvm-18/bin" >> $GITHUB_PATH
+
+      - name: Build Odin
+        run: ./build_odin.sh release
+
+      - name: Odin version
+        run: ./odin version
+
+      - name: Normal Core library tests
+        run: |
+          ./odin build tests/core/normal.odin -build-mode:test -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
+          kcov kcov-out ./tests .
+
+      - name: Optimized Core library tests
+        run: |
+          ./odin build tests/core/speed.odin -build-mode:test -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
+
+      - name: Internals tests
+        run: |
+          ./odin build tests/internal -build-mode:test -debug -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
+
+      - name: Report
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: bash <(curl -s https://codecov.io/bash) -s kcov-out

--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -30,20 +30,20 @@ jobs:
       - name: Normal Core library tests
         run: |
           ./odin build tests/core/normal.odin -build-mode:test -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
-          kcov kcov-out-normal ./normal.bin .
+          kcov --exclude-path=tests kcov-out ./normal.bin .
 
       - name: Optimized Core library tests
         run: |
           ./odin build tests/core/speed.odin -build-mode:test -debug -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
-          kcov kcov-out-speed ./speed.bin .
+          kcov --exclude-path=tests kcov-out ./speed.bin .
 
       - name: Internals tests
         run: |
           ./odin build tests/internal -build-mode:test -debug -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -target:linux_amd64
-          kcov kcov-out-internal ./internal .
+          kcov --exclude-path=tests kcov-out ./internal .
 
       - name: Report
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
-          bash <(curl -s https://codecov.io/bash) -s kcov-out-*
+          bash <(curl -s https://codecov.io/bash) -s kcov-out

--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -3,7 +3,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build_linux_amd64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Linux AMD64 Test Coverage
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
Added [kcov](https://github.com/SimonKagstrom/kcov) to the build pipeline and upload the result to [codecov.io](https://codecov.io/) for easy visualization of the test coverage in Odin.

You can find the results here: https://app.codecov.io/gh/andreas-jonsson/Odin/

_Consider this more of a demo then something that should be merged as is._