### PR TITLE
Add bit_set to `core:sys/posix` with all OS types that should be POSIX compliant

### DIFF
--- a/core/sys/posix/posix.odin
+++ b/core/sys/posix/posix.odin
@@ -50,11 +50,12 @@ Unimplemented headers:
 package posix
 
 import "base:intrinsics"
+import "base:runtime"
 
 import "core:c"
 
 result :: enum c.int {
- 	// Use `errno` and `strerror` for more information.
+	// Use `errno` and `strerror` for more information.
 	FAIL = -1,
 	// Operation succeeded.
 	OK = 0,
@@ -71,5 +72,14 @@ when ODIN_OS == .Darwin && ODIN_ARCH == .amd64 {
 } else {
 	@(private)
 	INODE_SUFFIX :: ""
+}
+
+ALL_VALID_OS_TYPES :: bit_set[runtime.Odin_OS_Type] {
+	.Linux,
+	.Darwin,
+	.FreeBSD,
+	.OpenBSD,
+	.NetBSD,
+	.Haiku,
 }
 


### PR DESCRIPTION
I've been writing a library and I needed to conditionally compile a function so if the OS was POSIX I could do a syscall otherwise provide a fallback. 

With this bit_set I could do this:
```odin
when ODIN_OS in posix.ALL_VALID_OS_TYPES {
    my_func :: proc() { /* do something */ }
} else {
    my_func :: proc() { /* do something */ }
}
```