### PR TITLE
core/sys/wasm/js: improve gamepad API

### DIFF
--- a/core/sys/wasm/js/events.odin
+++ b/core/sys/wasm/js/events.odin
@@ -189,7 +189,7 @@ Key_Location :: enum u8 {
 KEYBOARD_MAX_KEY_SIZE  :: 32
 KEYBOARD_MAX_CODE_SIZE :: 32
 
-GAMEPAD_MAX_ID_SIZE      :: 64
+GAMEPAD_MAX_ID_SIZE      :: 96
 GAMEPAD_MAX_MAPPING_SIZE :: 64
 
 GAMEPAD_MAX_BUTTONS :: 64
@@ -384,7 +384,14 @@ get_gamepad_state :: proc "contextless" (index: int, s: ^Gamepad_State) -> bool 
 	if s == nil {
 		return false
 	}
-	return _get_gamepad_state(index, s)
+
+	if !_get_gamepad_state(index, s) {
+		return false
+	}
+
+	s.id = string(s._id_buf[:s._id_len])
+	s.mapping = string(s._mapping_buf[:s._mapping_len])
+	return true
 }
 
 

--- a/core/sys/wasm/js/odin.js
+++ b/core/sys/wasm/js/odin.js
@@ -1588,10 +1588,24 @@ function odinSetupDefaultImports(wasmMemoryInterface, consoleElement, memory) {
 						}
 					}
 
-					wmi.storeInt(off(W, W), e.gamepad.id.length)
-					wmi.storeInt(off(W, W), e.gamepad.mapping.length)
-					wmi.storeString(off(64, 1), e.gamepad.id);
-					wmi.storeString(off(64, 1), e.gamepad.mapping);
+					let idLength = e.gamepad.id.length;
+					let id = e.gamepad.id;
+					if (idLength > 96) {
+						idLength = 96;
+						id = id.slice(0, 93) + '...';
+					}
+
+					let mappingLength = e.gamepad.mapping.length;
+					let mapping = e.gamepad.mapping;
+					if (mappingLength > 64) {
+						mappingLength = 61;
+						mapping = mapping.slice(0, 61) + '...';
+					}
+
+					wmi.storeInt(off(W, W), idLength);
+					wmi.storeInt(off(W, W), mappingLength);
+					wmi.storeString(off(96, 1), id);
+					wmi.storeString(off(64, 1), mapping);
 				}
 			},
 
@@ -1756,10 +1770,24 @@ function odinSetupDefaultImports(wasmMemoryInterface, consoleElement, memory) {
 						}
 					}
 
-					wmi.storeInt(off(W, W), gamepad.id.length)
-					wmi.storeInt(off(W, W), gamepad.mapping.length)
-					wmi.storeString(off(64, 1), gamepad.id);
-					wmi.storeString(off(64, 1), gamepad.mapping);
+					let idLength = gamepad.id.length;
+					let id = gamepad.id;
+					if (idLength > 96) {
+						idLength = 96;
+						id = id.slice(0, 93) + '...';
+					}
+
+					let mappingLength = gamepad.mapping.length;
+					let mapping = gamepad.mapping;
+					if (mappingLength > 64) {
+						mappingLength = 61;
+						mapping = mapping.slice(0, 61) + '...';
+					}
+
+					wmi.storeInt(off(W, W), idLength);
+					wmi.storeInt(off(W, W), mappingLength);
+					wmi.storeString(off(96, 1), id);
+					wmi.storeString(off(64, 1), mapping);
 
 					return true;
 				}


### PR DESCRIPTION
1. Properly set `id` and `mapping` on the `get_gamepad_state` result
2. Increase `id` limit to 96 bytes, connecting my DualShock 4 made it crash
3. If an `id` or `mapping` is longer than the limits, slice it and add `...`