### PR TITLE
webgl: add `BlendEquationSeparate` and `GetParameter4i`

### DIFF
--- a/core/sys/wasm/js/odin.js
+++ b/core/sys/wasm/js/odin.js
@@ -402,6 +402,9 @@ class WebGLInterface {
 			BlendEquation: (mode) => {
 				this.ctx.blendEquation(mode);
 			},
+			BlendEquationSeparate: (modeRGB, modeAlpha) => {
+				this.ctx.blendEquationSeparate(modeRGB, modeAlpha);
+			},
 			BlendFunc: (sfactor, dfactor) => {
 				this.ctx.blendFunc(sfactor, dfactor);
 			},
@@ -632,6 +635,13 @@ class WebGLInterface {
 
 			GetParameter: (pname) => {
 				return this.ctx.getParameter(pname);
+			},
+			GetParameter4i: (pname, v0, v1, v2, v3) => {
+				const i4 = this.ctx.getParameter(pname);
+				this.mem.storeI32(v0, i4[0]);
+				this.mem.storeI32(v1, i4[1]);
+				this.mem.storeI32(v2, i4[2]);
+				this.mem.storeI32(v3, i4[3]);
 			},
 			GetProgramParameter: (program, pname) => {
 				return this.ctx.getProgramParameter(this.programs[program], pname)

--- a/vendor/wasm/WebGL/webgl.odin
+++ b/vendor/wasm/WebGL/webgl.odin
@@ -46,16 +46,17 @@ foreign webgl {
 	
 	IsExtensionSupported :: proc(name: string) -> bool ---
 
-	ActiveTexture      :: proc(x: Enum) ---
-	AttachShader       :: proc(program: Program, shader: Shader) ---
-	BindAttribLocation :: proc(program: Program, index: i32, name: string) ---
-	BindBuffer         :: proc(target: Enum, buffer: Buffer) ---
-	BindFramebuffer    :: proc(target: Enum, framebuffer: Framebuffer) ---
-	BindTexture        :: proc(target: Enum, texture: Texture) ---
-	BlendColor         :: proc(red, green, blue, alpha: f32) ---
-	BlendEquation      :: proc(mode: Enum) ---
-	BlendFunc          :: proc(sfactor, dfactor: Enum) ---
-	BlendFuncSeparate  :: proc(srcRGB, dstRGB, srcAlpha, dstAlpha: Enum) ---
+	ActiveTexture         :: proc(x: Enum) ---
+	AttachShader          :: proc(program: Program, shader: Shader) ---
+	BindAttribLocation    :: proc(program: Program, index: i32, name: string) ---
+	BindBuffer            :: proc(target: Enum, buffer: Buffer) ---
+	BindFramebuffer       :: proc(target: Enum, framebuffer: Framebuffer) ---
+	BindTexture           :: proc(target: Enum, texture: Texture) ---
+	BlendColor            :: proc(red, green, blue, alpha: f32) ---
+	BlendEquation         :: proc(mode: Enum) ---
+	BlendEquationSeparate :: proc(modeRGB: Enum, modeAlpha: Enum) ---
+	BlendFunc             :: proc(sfactor, dfactor: Enum) ---
+	BlendFuncSeparate     :: proc(srcRGB, dstRGB, srcAlpha, dstAlpha: Enum) ---
 	
 	BufferData    :: proc(target: Enum, size: int, data: rawptr, usage: Enum) ---
 	BufferSubData :: proc(target: Enum, offset: uintptr, size: int, data: rawptr) ---
@@ -113,6 +114,7 @@ foreign webgl {
 	GetVertexAttribOffset :: proc(index: i32, pname: Enum) -> uintptr ---
 	GetProgramParameter   :: proc(program: Program, pname: Enum) -> i32 ---
 	GetParameter          :: proc(pname: Enum) -> i32 ---
+	GetParameter4i        :: proc(pname: Enum, v0, v1, v2, v4: ^i32) ---
 
 	Hint :: proc(target: Enum, mode: Enum) ---
 	

--- a/vendor/wasm/WebGL/webgl_helpers.odin
+++ b/vendor/wasm/WebGL/webgl_helpers.odin
@@ -29,7 +29,7 @@ CreateProgramFromStrings :: proc(vs_sources, fs_sources: []string) -> (program: 
 	}
 
 	program = CreateProgram()
-	defer if !ok do DeleteProgram(program)
+	defer if !ok { DeleteProgram(program) }
 
 	AttachShader(program, vs)
 	AttachShader(program, fs)


### PR DESCRIPTION
`GetParameter4i` can be used to retrieve the current scissor rect, or the curent viewport, which was previously impossible.

Also adds `BlendEquationSeparate` which seemed to be missing.

Also removes an instance of `do`.