### PR TITLE
core/sys/wasm/js: add pointer event info and add charCode to keyboard

### DIFF
--- a/core/sys/wasm/js/events.odin
+++ b/core/sys/wasm/js/events.odin
@@ -239,6 +239,12 @@ Gamepad_State :: struct {
 	_mapping_buf: [GAMEPAD_MAX_MAPPING_SIZE]byte `fmt:"-"`,
 }
 
+Pointer_Type :: enum u8 {
+	Mouse,
+	Pen,
+	Touch,
+}
+
 Event :: struct {
 	kind:                 Event_Kind,
 	target_kind:          Event_Target_Kind,
@@ -275,6 +281,8 @@ Event :: struct {
 
 			repeat: bool,
 
+			char:   rune,
+
 			_key_len:  int                         `fmt:"-"`,
 			_code_len: int                         `fmt:"-"`,
 			_key_buf:  [KEYBOARD_MAX_KEY_SIZE]byte `fmt:"-"`,
@@ -295,6 +303,21 @@ Event :: struct {
 
 			button:  i16,
 			buttons: bit_set[0..<16; u16],
+
+			pointer: struct {
+				altitude_angle:       f64,
+				azimuth_angle:        f64,
+				persistent_device_id: int,
+				pointer_id:           int,
+				width:                int,
+				height:               int,
+				pressure:             f64,
+				tangential_pressure:  f64,
+				tilt:                 [2]f64,
+				twist:                f64,
+				pointer_type:         Pointer_Type,
+				is_primary:           bool,
+			},
 		},
 
 		gamepad: Gamepad_State,

--- a/core/sys/wasm/js/odin.js
+++ b/core/sys/wasm/js/odin.js
@@ -1533,6 +1533,29 @@ function odinSetupDefaultImports(wasmMemoryInterface, consoleElement, memory) {
 
 					wmi.storeI16(off(2), e.button);
 					wmi.storeU16(off(2), e.buttons);
+
+					if (e instanceof PointerEvent) {
+						wmi.storeF64(off(8), e.altitudeAngle);
+						wmi.storeF64(off(8), e.azimuthAngle);
+						wmi.storeInt(off(W), e.persistentDeviceId);
+						wmi.storeInt(off(W), e.pointerId);
+						wmi.storeInt(off(W), e.width);
+						wmi.storeInt(off(W), e.height);
+						wmi.storeF64(off(8), e.pressure);
+						wmi.storeF64(off(8), e.tangentialPressure);
+						wmi.storeF64(off(8), e.tiltX);
+						wmi.storeF64(off(8), e.tiltY);
+						wmi.storeF64(off(8), e.twist);
+						if (e.pointerType == "pen") {
+							wmi.storeU8(off(1), 1);
+						} else if (e.pointerType == "touch") {
+							wmi.storeU8(off(1), 2);
+						} else {
+							wmi.storeU8(off(1), 0);
+						}
+						wmi.storeU8(off(1), !!e.isPrimary);
+					}
+
 				} else if (e instanceof KeyboardEvent) {
 					// Note: those strings are constructed
 					// on the native side from buffers that
@@ -1548,6 +1571,8 @@ function odinSetupDefaultImports(wasmMemoryInterface, consoleElement, memory) {
 					wmi.storeU8(off(1), !!e.metaKey);
 
 					wmi.storeU8(off(1), !!e.repeat);
+
+					wmi.storeI32(off(4), e.charCode);
 
 					wmi.storeInt(off(W, W), e.key.length)
 					wmi.storeInt(off(W, W), e.code.length)


### PR DESCRIPTION
More information on pointer events, and add the charCode to keyboard events (useful with keypress events and doing user text input that way).