### PR TITLE
core/sys/wasm/js: add `open` binding to `window.open`

### DIFF
--- a/core/sys/wasm/js/general.odin
+++ b/core/sys/wasm/js/general.odin
@@ -9,4 +9,5 @@ foreign odin_env {
 	abort    :: proc() -> ! ---
 	alert    :: proc(msg: string) ---
 	evaluate :: proc(str: string) ---
+	open     :: proc(url: string, name := "", specs := "") ---
 }

--- a/core/sys/wasm/js/odin.js
+++ b/core/sys/wasm/js/odin.js
@@ -1421,6 +1421,13 @@ function odinSetupDefaultImports(wasmMemoryInterface, consoleElement, memory) {
 			abort: () => { Module.abort() },
 			evaluate: (str_ptr, str_len) => { eval.call(null, wasmMemoryInterface.loadString(str_ptr, str_len)); },
 
+			open: (url_ptr, url_len, name_ptr, name_len, specs_ptr, specs_len) => {
+				const url = wasmMemoryInterface.loadString(url_ptr, url_len);
+				const name = wasmMemoryInterface.loadString(name_ptr, name_len);
+				const specs = wasmMemoryInterface.loadString(specs_ptr, specs_len);
+				window.open(url, name, specs);
+			},
+
 			// return a bigint to be converted to i64
 			time_now: () => BigInt(Date.now()),
 			tick_now: () => performance.now(),


### PR DESCRIPTION
Allows opening windows, useful when you render a link that on click should open a new page.