### PR TITLE
core/fmt: add nprint family of procs to get required buffer sizes

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -545,7 +545,7 @@ _nprint_stream_create :: proc "contextless"() -> io.Stream {
 @(require_results)
 nprint :: proc(args: ..any, sep := " ") -> int {
 	stream := _nprint_stream_create()
-	return wprint(stream, ...args, sep = sep, flush = false)
+	return wprint(stream, ..args, sep = sep, flush = false)
 }
 // Returns the number of bytes required to write the arguments using the default print settings with a newline character at the end.
 //
@@ -577,13 +577,13 @@ nprintf :: proc(fmt: string, args: ..any, newline := false) -> int {
 // Returns the number of bytes required to write the arguments according to the specified format string, followed by a newline.
 //
 // Inputs:
-// - format: The format string
+// - fmt: The format string
 // - args: A variadic list of arguments to be formatted
 //
 // Returns: The number of bytes required
 //
 @(require_results)
-nprintfln :: proc(format: string, args: ..any) -> int {
+nprintfln :: proc(fmt: string, args: ..any) -> int {
 	stream := _nprint_stream_create()
 	return wprintfln(stream, fmt, ..args, flush = false)
 }

--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -531,7 +531,7 @@ _nprint_stream_create :: proc "contextless"() -> io.Stream {
 				return io.query_utility({.Write})
 			}
 			return i64(len(p)), nil
-		}
+		},
 	}
 }
 // Returns the number of bytes required to write the arguments using the default print settings.


### PR DESCRIPTION
This pr adds nprint* style procs to fmt to be easily query how many bytes are needed to store the formatted output. This is useful if you want to acquire a buffer with the correct size to use with the bprint* procs.