### PR TITLE
Added proc last_index_multi

### DIFF
--- a/core/strings/strings.odin
+++ b/core/strings/strings.odin
@@ -1891,6 +1891,48 @@ index_multi :: proc(s: string, substrs: []string) -> (idx: int, width: int) {
 	return
 }
 /*
+Finds the last occurrence of any substring in `substrs` within `s`
+
+Inputs:
+- s: The string to search in
+- substrs: The substrings to look for
+
+Returns:
+- idx: the index of the last matching substring
+- width: the length of the found substring
+*/
+last_index_multi :: proc(s: string, substrs: []string) -> (idx: int, width: int) {
+	idx = -1
+	if s == "" || len(substrs) <= 0 {
+		return
+	}
+	// disallow "" substr
+	for substr in substrs {
+		if len(substr) == 0 {
+			return
+		}
+	}
+
+	highest_index := -1
+	found := false
+	for substr in substrs {
+        haystack_slice_start := max( 0 , highest_index )
+		haystack := s[haystack_slice_start:]
+		if i := last_index(haystack, substr); i >= 0 {
+			if i + haystack_slice_start > highest_index {
+				highest_index = haystack_slice_start + i
+				width = len(substr)
+				found = true
+			}
+		}
+	}
+
+	if found {
+		idx = highest_index
+	}
+	return
+}
+/*
 Counts the number of non-overlapping occurrences of `substr` in `s`
 
 Inputs:

--- a/tests/core/strings/test_core_strings.odin
+++ b/tests/core/strings/test_core_strings.odin
@@ -60,6 +60,25 @@ test_index_multi_with_empty_string :: proc(t: ^testing.T) {
 	testing.expect_value(t, index, -1)
 }
 
+@test
+test_last_index_multi_overlapping_substrs :: proc(t: ^testing.T) {
+	index, width := strings.last_index_multi("some example text", {"ample", "exam"})
+	testing.expect_value(t, index, 7)
+	testing.expect_value(t, width, 5)
+}
+
+@test
+test_last_index_multi_not_found :: proc(t: ^testing.T) {
+	index, _ := strings.last_index_multi("some example text", {"ey", "tey"})
+	testing.expect_value(t, index, -1)
+}
+
+@test
+test_last_index_multi_with_empty_string :: proc(t: ^testing.T) {
+	index, _ := strings.last_index_multi("some example text", {"ex", ""})
+	testing.expect_value(t, index, -1)
+}
+
 Cut_Test :: struct {
 	input:  string,
 	offset: int,


### PR DESCRIPTION
Added on `core:strings` the procedure `last_index_multi`
following the same conventions that `index_multi` have + tests.