### PR TITLE
`vendor:x11/xlib`: add proc binding for SetWindowBorder

### DIFF
--- a/vendor/x11/xlib/xlib_procs.odin
+++ b/vendor/x11/xlib/xlib_procs.odin
@@ -217,6 +217,11 @@ foreign xlib {
 		window:  Window,
 		width:   u32,
 		) ---
+	SetWindowBorder :: proc(
+		display: ^Display,
+		window: Window,
+		pixel: uint,
+		) ---
 	// Window: changing stacking order
 	RaiseWindow :: proc(display: ^Display, window: Window) ---
 	LowerWindow :: proc(display: ^Display, window: Window) ---


### PR DESCRIPTION
This adds a proc binding for the `XSetWindowBorder` function. Tested correct locally in a window manager project.