### PR TITLE
Add `~{memory}` clobber to syscall intrinsics for platforms where it was missing

### DIFF
--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -2972,6 +2972,8 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 						constraints = gb_string_appendc(constraints, "}");
 					}
 
+					constraints = gb_string_appendc(constraints, ",~{memory}");
+
 					inline_asm = llvm_get_inline_asm(func_type, make_string_c(asm_string), make_string_c(constraints));
 				}
 				break;
@@ -3034,6 +3036,8 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 						constraints = gb_string_appendc(constraints, "}");
 					}
 
+					constraints = gb_string_appendc(constraints, ",~{memory}");
+
 					inline_asm = llvm_get_inline_asm(func_type, make_string_c(asm_string), make_string_c(constraints));
 				}
 				break;
@@ -3059,6 +3063,8 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 							constraints = gb_string_appendc(constraints, "}");
 						}
 
+						constraints = gb_string_appendc(constraints, ",~{memory}");
+
 						inline_asm = llvm_get_inline_asm(func_type, make_string_c(asm_string), make_string_c(constraints));
 					} else {
 						char asm_string[] = "svc #0";
@@ -3077,6 +3083,8 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 							constraints = gb_string_appendc(constraints, regs[i]);
 							constraints = gb_string_appendc(constraints, "}");
 						}
+
+						constraints = gb_string_appendc(constraints, ",~{memory}");
 
 						inline_asm = llvm_get_inline_asm(func_type, make_string_c(asm_string), make_string_c(constraints));
 					}
@@ -3103,6 +3111,8 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 						constraints = gb_string_appendc(constraints, regs[i]);
 						constraints = gb_string_appendc(constraints, "}");
 					}
+
+					constraints = gb_string_appendc(constraints, ",~{memory}");
 
 					inline_asm = llvm_get_inline_asm(func_type, make_string_c(asm_string), make_string_c(constraints));
 				}


### PR DESCRIPTION
This fixes #4972 and #4588.

As @laytan informs, there is no guarantee that a syscall will not modify memory that it just obtained from the user, or held onto via a previous syscall. Therefore this constraint should be required for all syscalls.

Consider the case (also from @laytan)

```odin
handle := syscall_given_buffer(&buf)
syscall_changes_buffer(handle)
```

Even though there is no user pointer given in the second syscall there is still a possibility that the memory can be modified, thus potentially yielding an unexpected assembly output.

### Tested output on for each added platform:
#### Source
```odin
package main

import "base:intrinsics"

@export
bogus_syscall_test :: proc () {
    intrinsics.syscall(0, 1) // Bogus
}
```

#### LLVM codegen

##### linux_riscv64
```llvm
define dllexport void @bogus_syscall_test(ptr noalias nocapture nonnull readnone %__.context_ptr) local_unnamed_addr {
decls:
  %0 = tail call i64 asm sideeffect "ecall", "={a0},{a7},{a0},~{memory}"(i64 0, i64 1) #18
  ret void
}
```

##### darwin_arm64
```llvm
define dllexport void @bogus_syscall_test(ptr noalias nocapture nonnull readnone %__.context_ptr) local_unnamed_addr {
decls:
  %0 = tail call i64 asm sideeffect "svc #0x80", "={x0},{x16},{x0},~{memory}"(i64 0, i64 1) #17
  ret void
}
```

##### linux_arm64
```llvm
define dllexport void @bogus_syscall_test(ptr noalias nocapture nonnull readnone %__.context_ptr) local_unnamed_addr {
decls:
  %0 = tail call i64 asm sideeffect "svc #0", "={x0},{x8},{x0},~{memory}"(i64 0, i64 1) #16
  ret void
}
```

##### linux_arm32
```llvm
define dllexport void @bogus_syscall_test(ptr noalias nocapture nonnull readnone %__.context_ptr) local_unnamed_addr {
decls:
  %0 = tail call i32 asm sideeffect "svc #0", "={r0},{r7},{r0},~{memory}"(i32 0, i32 1) #19
  ret void
}
```

##### linux_i386
```llvm
define dllexport void @bogus_syscall_test(ptr noalias nocapture nonnull readnone %__.context_ptr) local_unnamed_addr {
decls:
  %0 = tail call i32 asm sideeffect "int $$0x80", "={eax},{eax},{ebx},~{memory}"(i32 0, i32 1) #19
  ret void
}
```

