### PR TITLE
Fix linking of programs on OpenBSD

### DIFF
--- a/base/runtime/os_specific_bsd.odin
+++ b/base/runtime/os_specific_bsd.odin
@@ -9,7 +9,7 @@ foreign libc {
 	@(link_name="write")
 	_unix_write :: proc(fd: i32, buf: rawptr, size: int) -> int ---
 
-	when ODIN_OS == .NetBSD {
+	when ODIN_OS == .NetBSD || ODIN_OS == .OpenBSD {
 		@(link_name="__errno") __error :: proc() -> ^i32 ---
 	} else {
 		__error :: proc() -> ^i32 ---

--- a/core/os/os_openbsd.odin
+++ b/core/os/os_openbsd.odin
@@ -343,7 +343,7 @@ AT_REMOVEDIR        :: 0x08
 
 @(default_calling_convention="c")
 foreign libc {
-	@(link_name="__error")        __error              :: proc() -> ^c.int ---
+	@(link_name="__errno")        __error              :: proc() -> ^c.int ---
 
 	@(link_name="fork")           _unix_fork           :: proc() -> pid_t ---
 	@(link_name="getthrid")       _unix_getthrid       :: proc() -> int ---

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -701,6 +701,13 @@ gb_internal i32 linker_stage(LinkerData *gen) {
 					// This points the linker to where the entry point is
 					link_settings = gb_string_appendc(link_settings, "-e _main ");
 				}
+			} else if (build_context.metrics.os == TargetOs_openbsd) {
+				// OpenBSD ports install shared libraries in /usr/local/lib. Also, we must explicitly link libpthread.
+				platform_lib_str = gb_string_appendc(platform_lib_str, "-lpthread -Wl,-L/usr/local/lib ");
+				// Until the LLVM back-end can be adapted to emit endbr64 instructions on amd64, we
+				// need to pass -z nobtcfi in order to allow the resulting program to run under
+				// OpenBSD 7.4 and newer. Once support is added at compile time, this can be dropped.
+				platform_lib_str = gb_string_appendc(platform_lib_str, "-Wl,-z,nobtcfi ");
 			}
 
 			if (!build_context.no_rpath) {


### PR DESCRIPTION
This is a continuation of my work to get Odin working again on OpenBSD (see also #4927).

This is the simplest way I found to fix linking on OpenBSD. It resolves a few items at once but breaking them out doesn't seem prudent as alone they don't result in a working Odin linking stage.

1. The `__errno` libc symbol needed fixing.
2. OpenBSD puts ports in `/usr/local/lib` and we need to request the linker to look there. This allows Odin examples, like those for SDL2, to properly link and run.
3. pthreads need to be explicitly linked in
4. Since OpenBSD 7.4, the system enforces indirect branch targets on hardware platforms that support it. Until someone can fix up the use of the LLVM backend on OpenBSD to properly emit the target instructions (e.g. `endbr64` on amd64), a special linker arg is needed to opt-out of enforcement in the resulting program.

OpenBSD is transitioning the base LLVM from v16 to v19 soon, but for now anyone testing this needs to install a supported LLVM from ports and invoke the build like:

```
$ LD_LIBRARY_PATH=$(llvm-config-19 --libdir) LLVM_CONFIG=llvm-config-19 ./build_odin.sh
```

Once the base LLVM is updated to a supported version, the `LD_LIBRARY_PATH` dance shouldn't be needed. In the meantime, if someone creates an Odin port, we can have it depend on LLVM from ports patch it Odin in our tree to find libLLVM properly. (Unless someone seeing this PR knows a simple way to do this 😄.)