### PR TITLE
core/encoding/endian: enumerate platform byte order

### DIFF
--- a/core/encoding/endian/endian.odin
+++ b/core/encoding/endian/endian.odin
@@ -6,6 +6,7 @@ import "core:math/bits"
 Byte_Order :: enum u8 {
 	Little,
 	Big,
+	Platform = Little when ODIN_ENDIAN == .Little else Big,
 }
 
 PLATFORM_BYTE_ORDER :: Byte_Order.Little when ODIN_ENDIAN == .Little else Byte_Order.Big


### PR DESCRIPTION
Enables for
`i, ok := endian.get_u32(a[:], .Platform)`
instead of
`i, ok := endian.get_u32(a[:], endian.PLATFORM_BYTE_ORDER)`,
and due to how `fmt`/`reflect` work,
`fmt.println(endian.Byte_Order.Platform)` will still output/produce `.Little` or `.Big`, which is quite elegant.