### PR TITLE
Use LLVM 20 in shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -4,9 +4,9 @@ pkgs.mkShell {
   nativeBuildInputs = with pkgs; [
     git
     which
-    clang_18
-    llvmPackages_18.llvm
-    llvmPackages_18.bintools
+    clang_20
+    llvmPackages_20.llvm
+    llvmPackages_20.bintools
   ];
   shellHook="CXX=clang++";
 }

--- a/shell.nix
+++ b/shell.nix
@@ -4,9 +4,9 @@ pkgs.mkShell {
   nativeBuildInputs = with pkgs; [
     git
     which
-    clang_17
-    llvmPackages_17.llvm
-    llvmPackages_17.bintools
+    clang_18
+    llvmPackages_18.llvm
+    llvmPackages_18.bintools
   ];
   shellHook="CXX=clang++";
 }


### PR DESCRIPTION
LLVM 17 has some bugs (https://github.com/odin-lang/Odin/issues/4977) and other parts of the project were updated for LLVM 20 last week.