### PR TITLE
Use the proper size for SizeOfStruct to make resolving of procedure names work

### DIFF
--- a/core/debug/trace/trace_windows.odin
+++ b/core/debug/trace/trace_windows.odin
@@ -49,7 +49,9 @@ _resolve :: proc(ctx: ^Context, frame: Frame, allocator: runtime.Allocator) -> (
 
 	data: [size_of(win32.SYMBOL_INFOW) + size_of([256]win32.WCHAR)]byte
 	symbol := (^win32.SYMBOL_INFOW)(&data[0])
-	symbol.SizeOfStruct = size_of(symbol)
+	// The value of SizeOfStruct must be the size of the whole struct,
+	// not just the size of the pointer
+	symbol.SizeOfStruct = size_of(symbol^)
 	symbol.MaxNameLen = 255
 	if win32.SymFromAddrW(ctx.impl.hProcess, win32.DWORD64(frame), &{}, symbol) {
 		fl.procedure, _ = win32.wstring_to_utf8(&symbol.Name[0], -1, allocator)


### PR DESCRIPTION
This fixes name resolution for procedures in windows, when creating a stack trace.

Background:
I've been trying to build a tracking allocator that stores a stack trace in addition to the source location, because there seem to be a few procedures that don't forward the location, which makes the tracking allocator show the location inside the stdlib.
While that might be technically correct, it doesn't help when trying to find out where that function actually got called.

After implementing a prototype I noticed that, while I now got all the source locations from the stack trace, the procedure names were missing and after some debugging I saw that the function was failing with the error code 87 (ERROR_INVALID_PARAMETER) realized that the wrong size is set on the struct.