### PR TITLE
Integer Concatenation Operator `##`

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -1627,7 +1627,8 @@ token_precedence :: proc(p: ^Parser, kind: tokenizer.Token_Kind) -> int {
 	case .Mul, .Quo,
 	     .Mod, .Mod_Mod,
 	     .And, .And_Not,
-	     .Shl, .Shr:
+	     .Shl, .Shr,
+	     .Concat:
 		return 7
 	}
 	return 0

--- a/core/odin/tokenizer/token.odin
+++ b/core/odin/tokenizer/token.odin
@@ -64,6 +64,8 @@ Token_Kind :: enum u32 {
 		Shl,      // <<
 		Shr,      // >>
 
+		Concat,   // ##
+
 		Cmp_And,  // &&
 		Cmp_Or,   // ||
 
@@ -80,6 +82,9 @@ Token_Kind :: enum u32 {
 		And_Not_Eq, // &~=
 		Shl_Eq,     // <<=
 		Shr_Eq,     // >>=
+
+		Concat_Eq,  // ##=
+
 		Cmp_And_Eq, // &&=
 		Cmp_Or_Eq,  // ||=
 	B_Assign_Op_End,
@@ -199,6 +204,8 @@ tokens := [Token_Kind.COUNT]string {
 	"<<",
 	">>",
 
+	"##",
+
 	"&&",
 	"||",
 
@@ -215,6 +222,9 @@ tokens := [Token_Kind.COUNT]string {
 	"&~=",
 	"<<=",
 	">>=",
+
+	"##=",
+
 	"&&=",
 	"||=",
 	"",

--- a/core/odin/tokenizer/tokenizer.odin
+++ b/core/odin/tokenizer/tokenizer.odin
@@ -650,7 +650,15 @@ scan :: proc(t: ^Tokenizer) -> Token {
 			}
 		case '#':
 			kind = .Hash
-			if t.ch == '!' {
+
+			if t.ch == '#' {
+				advance_rune(t)
+				kind = .Concat
+				if t.ch == '=' {
+					advance_rune(t)
+					kind = .Concat_Eq
+				}
+			} else if t.ch == '!' {
 				kind = .Comment
 				lit = scan_comment(t)
 			} else if t.ch == '+' {

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -1995,6 +1995,12 @@ gb_internal bool check_binary_op(CheckerContext *c, Operand *o, Token op) {
 			return false;
 		}
 		break;
+	case Token_Concat:
+	case Token_ConcatEq:
+		if (!is_type_integer(type)) {
+			error(op, "Operator '%.*s' is only allowed with integer expressions", LIT(op.string));
+		}
+		break;
 
 	case Token_Add:
 		if (is_type_string(type)) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -3490,6 +3490,7 @@ gb_internal i32 token_precedence(AstFile *f, TokenKind t) {
 	case Token_AndNot:
 	case Token_Shl:
 	case Token_Shr:
+	case Token_Concat:
 		return 7;
 	}
 	return 0;
@@ -3778,6 +3779,7 @@ gb_internal Ast *parse_simple_stmt(AstFile *f, u32 flags) {
 	case Token_AndNotEq:
 	case Token_CmpAndEq:
 	case Token_CmpOrEq:
+	case Token_ConcatEq:
 	{
 		if (f->curr_proc == nullptr) {
 			syntax_error(f->curr_token, "You cannot use a simple statement in the file scope");

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -33,6 +33,7 @@ TOKEN_KIND(Token__OperatorBegin, ""), \
 	TOKEN_KIND(Token_AndNot,   "&~"), \
 	TOKEN_KIND(Token_Shl,      "<<"), \
 	TOKEN_KIND(Token_Shr,      ">>"), \
+	TOKEN_KIND(Token_Concat,   "##"), \
 	TOKEN_KIND(Token_CmpAnd,   "&&"), \
 	TOKEN_KIND(Token_CmpOr,    "||"), \
 \
@@ -49,6 +50,7 @@ TOKEN_KIND(Token__AssignOpBegin, ""), \
 	TOKEN_KIND(Token_AndNotEq, "&~="), \
 	TOKEN_KIND(Token_ShlEq,    "<<="), \
 	TOKEN_KIND(Token_ShrEq,    ">>="), \
+	TOKEN_KIND(Token_ConcatEq, "##="), \
 	TOKEN_KIND(Token_CmpAndEq, "&&="), \
 	TOKEN_KIND(Token_CmpOrEq,  "||="), \
 TOKEN_KIND(Token__AssignOpEnd, ""), \
@@ -937,7 +939,14 @@ gb_internal void tokenizer_get_token(Tokenizer *t, Token *token, int repeat=0) {
 			break;
 		case '#':
 			token->kind = Token_Hash;
-			if (t->curr_rune == '!') {
+			if (t->curr_rune == '#') {
+				advance_to_next_rune(t);
+				token->kind = Token_Concat;
+				if (t->curr_rune == '=') {
+					advance_to_next_rune(t);
+					token->kind = Token_ConcatEq;
+				}
+			} else if (t->curr_rune == '!') {
 				token->kind = Token_Comment;
 				tokenizer_skip_line(t);
 			} else if (t->curr_rune == '+') {


### PR DESCRIPTION
The ability to concatenate two integers.

* `10 ## 20 == 1020`
* `123 ## 456 == 123456`

Implemented as the equivalent of the following code:

```odin
integer_concatenate :: proc(x, y: uint) -> uint {
    pow: uint = 10
    for y >= pow {
        pow *= 10
    }
    return x*pow + y
}
```

Also supports `##=` operator:

```
a ##= b
// equivalent to
a = a ## b
```


Useful for those cases when you need to join two numbers together for those recreational mathematics problems.