### PR TITLE
Fix depth stencil not working on wgpu wasm_js build

### DIFF
--- a/vendor/wgpu/wgpu.js
+++ b/vendor/wgpu/wgpu.js
@@ -528,7 +528,7 @@ class WebGPUInterface {
 			return undefined;
 		}
 
-		const off = this.struct(ptr);
+		const off = this.struct(start);
 
 		return {
 			view:              this.textureViews.get(this.mem.loadPtr(off(4))),


### PR DESCRIPTION
Resolves error shown in browser

Uncaught TypeError: Failed to execute 'beginRenderPass' on 'GPUCommandEncoder': Failed to read the 'depthStencilAttachment' property from 'GPURenderPassDescriptor': Failed to read the 'view' property from 'GPURenderPassDepthStencilAttachment': Required member is undefined.
    at wgpuCommandEncoderBeginRenderPass (wgpu.js:1485:46)