### PR TITLE
Add linux build tag to core/sys/linux/sys.odin

### DIFF
--- a/core/sys/linux/sys.odin
+++ b/core/sys/linux/sys.odin
@@ -1,3 +1,4 @@
+#+build linux
 #+no-instrumentation
 package linux
 


### PR DESCRIPTION
Allows for importing `core:sys/linux` without build errors on non-linux platforms.