### PR TITLE
A few fixes for android

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1574,6 +1574,8 @@ gb_internal void init_android_values(bool with_sdk) {
 
 
 	bc->ODIN_ANDROID_JAR_SIGNER = normalize_path(permanent_allocator(), make_string_c(gb_get_env("ODIN_ANDROID_JAR_SIGNER", permanent_allocator())), NIX_SEPARATOR_STRING);
+	// Strip trailing slash so system() call doesn't fail.
+	bc->ODIN_ANDROID_JAR_SIGNER = substring(bc->ODIN_ANDROID_JAR_SIGNER, 0, bc->ODIN_ANDROID_JAR_SIGNER.len - 1);
 	if (with_sdk) {
 		if (bc->ODIN_ANDROID_SDK.len == 0)  {
 			gb_printf_err("Error: ODIN_ANDROID_SDK not set, which is required for -build-mode:executable for -subtarget:android");

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -554,6 +554,7 @@ struct BuildContext {
 	String ODIN_ANDROID_JAR_SIGNER;
 	String android_keystore;
 	String android_keystore_alias;
+	String android_keystore_password;
 	String android_manifest;
 };
 
@@ -1591,6 +1592,10 @@ gb_internal void init_android_values(bool with_sdk) {
 		}
 		if (bc->android_keystore_alias.len == 0) {
 			gb_printf_err("Error: -android-keystore_alias:<string> has not been set\n");
+			gb_exit(1);
+		}
+		if (bc->android_keystore_password.len == 0) {
+			gb_printf_err("Error: -android-keystore-password:<string> has not been set\n");
 			gb_exit(1);
 		}
 	}

--- a/src/bundle_command.cpp
+++ b/src/bundle_command.cpp
@@ -132,7 +132,7 @@ i32 bundle_android(String original_init_directory) {
 	if (current_directory.len != 0) {
 		bool ok = set_working_directory(init_directory);
 		if (!ok) {
-			gb_printf_err("Error: Unable to currectly set the current working directory to '%.*s'\n", LIT(init_directory));
+			gb_printf_err("Error: Unable to correctly set the current working directory to '%.*s'\n", LIT(init_directory));
 		}
 	}
 
@@ -174,7 +174,8 @@ i32 bundle_android(String original_init_directory) {
 		cmd = gb_string_append_length(cmd, build_context.ODIN_ANDROID_JAR_SIGNER.text, build_context.ODIN_ANDROID_JAR_SIGNER.len);
 		cmd = gb_string_append_fmt(cmd, " -storepass android");
 		if (build_context.android_keystore.len != 0) {
-			String keystore = concatenate_strings(temporary_allocator(), current_directory, build_context.android_keystore);
+			String keystore = normalize_path(temporary_allocator(), build_context.android_keystore, NIX_SEPARATOR_STRING);
+			keystore = substring(keystore, 0, keystore.len - 1);
 			cmd = gb_string_append_fmt(cmd, " -keystore \"%.*s\"", LIT(keystore));
 		}
 		cmd = gb_string_append_fmt(cmd, " \"%.*s.apk-build\"", LIT(output_apk));

--- a/src/bundle_command.cpp
+++ b/src/bundle_command.cpp
@@ -172,7 +172,7 @@ i32 bundle_android(String original_init_directory) {
 		gb_string_clear(cmd);
 
 		cmd = gb_string_append_length(cmd, build_context.ODIN_ANDROID_JAR_SIGNER.text, build_context.ODIN_ANDROID_JAR_SIGNER.len);
-		cmd = gb_string_append_fmt(cmd, " -storepass android");
+		cmd = gb_string_append_fmt(cmd, " -storepass \"%.*s\"", LIT(build_context.android_keystore_password));
 		if (build_context.android_keystore.len != 0) {
 			String keystore = normalize_path(temporary_allocator(), build_context.android_keystore, NIX_SEPARATOR_STRING);
 			keystore = substring(keystore, 0, keystore.len - 1);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -277,6 +277,7 @@ gb_internal void usage(String argv0, String argv1 = {}) {
 	print_usage_line(1, "build             Compiles directory of .odin files, as an executable.");
 	print_usage_line(1, "                  One must contain the program's entry point, all must be in the same package.");
 	print_usage_line(1, "run               Same as 'build', but also then runs the newly compiled executable.");
+	print_usage_line(1, "bundle            Bundles a directory in a specific layout for that platform.");
 	print_usage_line(1, "check             Parses, and type checks a directory of .odin files.");
 	print_usage_line(1, "strip-semicolon   Parses, type checks, and removes unneeded semicolons from the entire program.");
 	print_usage_line(1, "test              Builds and runs procedures with the attribute @(test) in the initial package.");
@@ -411,6 +412,7 @@ enum BuildFlagKind {
 
 	BuildFlag_AndroidKeystore,
 	BuildFlag_AndroidKeystoreAlias,
+	BuildFlag_AndroidKeystorePassword,
 	BuildFlag_AndroidManifest,
 
 	BuildFlag_COUNT,
@@ -631,6 +633,7 @@ gb_internal bool parse_build_flags(Array<String> args) {
 
 	add_flag(&build_flags, BuildFlag_AndroidKeystore,         str_lit("android-keystore"),          BuildFlagParam_String,  Command_bundle_android);
 	add_flag(&build_flags, BuildFlag_AndroidKeystoreAlias,    str_lit("android-keystore-alias"),    BuildFlagParam_String,  Command_bundle_android);
+	add_flag(&build_flags, BuildFlag_AndroidKeystorePassword, str_lit("android-keystore-password"), BuildFlagParam_String,  Command_bundle_android);
 	add_flag(&build_flags, BuildFlag_AndroidManifest,         str_lit("android-manifest"),          BuildFlagParam_String,  Command_bundle_android);
 
 
@@ -1662,6 +1665,11 @@ gb_internal bool parse_build_flags(Array<String> args) {
 						case BuildFlag_AndroidKeystoreAlias:
 							GB_ASSERT(value.kind == ExactValue_String);
 							build_context.android_keystore_alias = value.value_string;
+							break;
+
+						case BuildFlag_AndroidKeystorePassword:
+							GB_ASSERT(value.kind == ExactValue_String);
+							build_context.android_keystore_password = value.value_string;
 							break;
 
 						case BuildFlag_AndroidManifest:

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -81,7 +81,7 @@ String get_working_directory(gbAllocator allocator) {
 	auto buf = array_make<char>(temporary_allocator());
 	size_t size = PATH_MAX;
 
-	char const *cwd;
+	char const *cwd = nullptr;
 	for (; cwd == nullptr; size *= 2) {
 		array_resize(&buf, size);
 


### PR DESCRIPTION
- Fixes a segfault when getting the current working directory on linux
- Strip trailing slashes for jarsigner and the keystore file
- Add `-android-keystore-password`
- Assume `android-keystore` is a relative or absolute path and don't concatenate it with cwd