### PR TITLE
[core:time/timezone] Nanoseconds Not Preserved on Calls to `timezone.datetime_to_tz`

### DIFF
--- a/core/time/timezone/tzdate.odin
+++ b/core/time/timezone/tzdate.odin
@@ -224,7 +224,7 @@ datetime_to_tz :: proc(dt: datetime.DateTime, tz: ^datetime.TZ_Region) -> (out: 
 	record := region_get_nearest(tz, tm) or_return
 
 	secs := time.time_to_unix(tm)
-	adj_time := time.unix(secs + record.utc_offset, 0)
+	adj_time := time.unix(secs + record.utc_offset, i64(dt.nano))
 	adj_dt := time.time_to_datetime(adj_time) or_return
 	adj_dt.tz = tz
 


### PR DESCRIPTION
## Context
Calling `timezone.datetime_to_tz` would cause the loss of nanoseconds with most timezones.

https://godbolt.org/z/KncazTcsE
Not sure why `America/Seattle` works and I didn't dig into it, but with my fix, every timezone carries over the nanoseconds correctly.

## Expected
Nanoseconds are carried over, since timezones wouldn't ever modify them.

## Actual
Nanoseconds are set to `0`.


## Notes
Timezones generated using JS in Firefox:
```js
let values = ""
Intl.supportedValuesOf('timeZone').forEach((timeZone) => { values += `"${timeZone}",` })
console.log(values)
```

---
Odin:    dev-2025-03:a91d528
OS:      Windows 11 Professional (version: 23H2), build 22631.5126
CPU:     AMD Ryzen 7 7700 8-Core Processor
RAM:     64617 MiB
Backend: LLVM 18.1.8