### PR TITLE
Fix compiler build error

### DIFF
--- a/src/ptr_map.cpp
+++ b/src/ptr_map.cpp
@@ -15,7 +15,7 @@ static void *const MAP_TOMBSTONE = (void *)~(uintptr)0;
 template <typename K, typename V>
 struct PtrMapEntry {
 	static_assert(sizeof(K) == sizeof(void *), "Key size must be pointer size");
-	
+
 	K key;
 	V value;
 };
@@ -374,7 +374,7 @@ struct PtrMapIterator {
 	}
 
 	bool operator==(PtrMapIterator<K, V> const &other) const noexcept {
-		return this->map == other->map && this->index == other->index;
+		return this->map == other.map && this->index == other.index;
 	}
 
 	operator PtrMapEntry<K, V> *() const {


### PR DESCRIPTION
when I try run `build_odin.sh` on my macbook air I get error:
```
./build_odin.sh
+ clang++ src/main.cpp src/libtommath.cpp -Wno-switch -Wno-macro-redefined -Wno-unused-value '-DODIN_VERSION_RAW="dev-2025-04"' '-DGIT_SHA="19e056a80"' -std=c++14 -I/opt/homebrew/Cellar/llvm/20.1.1/include -std=c++17 -stdlib=libc++ -fno-exceptions -funwind-tables -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -L/opt/homebrew/Cellar/llvm/20.1.1/lib -Wl,-search_paths_first -Wl,-headerpad_max_install_names --sysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -g -pthread -lm -liconv -ldl -framework System -lLLVM -o odin
In file included from src/main.cpp:2:
In file included from src/common.cpp:350:
src/ptr_map.cpp:377:28: error: member reference type 'const PtrMapIterator<K, V>' is not a pointer; did you mean to use '.'?
  377 |                 return this->map == other->map && this->index == other->index;
      |                                     ~~~~~^~
      |                                          .
src/ptr_map.cpp:377:57: error: member reference type 'const PtrMapIterator<K, V>' is not a pointer; did you mean to use '.'?
  377 |                 return this->map == other->map && this->index == other->index;
      |                                                                  ~~~~~^~
      |                                                                       .
2 errors generated.

````