### PR TITLE
net: rework errors to be cross-platform

### DIFF
--- a/core/net/common.odin
+++ b/core/net/common.odin
@@ -53,8 +53,6 @@ ODIN_NET_TCP_NODELAY_DEFAULT :: #config(ODIN_NET_TCP_NODELAY_DEFAULT, true)
 Maybe :: runtime.Maybe
 
 Network_Error :: union #shared_nil {
-	General_Error,
-	Platform_Error,
 	Create_Socket_Error,
 	Dial_Error,
 	Listen_Error,
@@ -65,6 +63,7 @@ Network_Error :: union #shared_nil {
 	TCP_Recv_Error,
 	UDP_Recv_Error,
 	Shutdown_Error,
+	Interfaces_Error,
 	Socket_Option_Error,
 	Set_Blocking_Error,
 	Parse_Endpoint_Error,
@@ -74,13 +73,12 @@ Network_Error :: union #shared_nil {
 
 #assert(size_of(Network_Error) == 8)
 
-General_Error :: enum u32 {
-	None = 0,
-	Unable_To_Enumerate_Network_Interfaces = 1,
+Interfaces_Error :: enum u32 {
+	None,
+	Unable_To_Enumerate_Network_Interfaces,
+	Allocation_Failure,
+	Unknown,
 }
-
-// `Platform_Error` is used to wrap errors returned by the different platforms that don't fit a common error.
-Platform_Error :: enum u32 {}
 
 Parse_Endpoint_Error :: enum u32 {
 	None          = 0,

--- a/core/net/errors.odin
+++ b/core/net/errors.odin
@@ -1,0 +1,275 @@
+package net
+
+/*
+Retrieve a platform specific error code, for when the categorized cross-platform errors are not enough.
+
+Platforms specific returns:
+- Darwin:  `posix.Errno`          (`core:sys/posix`)
+- Linux:   `linux.Errno`          (`core:sys/linux`)
+- FreeBSD: `freebsd.Errno`        (`core:sys/freebsd`)
+- Windows: `windows.System_Error` (`core:sys/windows`)
+*/
+@(require_results)
+last_platform_error :: proc() -> i32 {
+	return _last_platform_error()
+}
+
+/*
+Retrieve a stringified version of the last platform error.
+*/
+@(require_results)
+last_platform_error_string :: proc() -> string {
+	return _last_platform_error_string()
+}
+
+set_last_platform_error :: proc(err: i32) {
+	_set_last_platform_error(err)
+}
+
+Create_Socket_Error :: enum i32 {
+	None,
+	// No network connection, or the network stack is not initialized.
+	Network_Unreachable,
+	// Not enough space in internal tables/buffers to create a new socket, or an unsupported protocol is given.
+	Insufficient_Resources,
+	// Invalid/unsupported family or protocol.
+	Invalid_Argument,
+	// The user has no permission to create a socket of this type and/or protocol.
+	Insufficient_Permissions,
+
+	// An error unable to be categorized in above categories, `last_platform_error` may have more info.
+	Unknown,
+}
+
+Dial_Error :: enum i32 {
+	None,
+	// No network connection, or the network stack is not initialized.
+	Network_Unreachable,
+	// Not enough space in internal tables/buffers to create a new socket, or an unsupported protocol is given.
+	Insufficient_Resources,
+	// Invalid endpoint and/or options.	
+	Invalid_Argument,
+	// An attempt was made to connect to a broadcast socket on a socket that doesn't support it.
+	Broadcast_Not_Supported,
+	// The socket is already connected.
+	Already_Connected,
+	// The socket is already in the progress of making a connection.
+	Already_Connecting,
+	// The address is already in use.
+	Address_In_Use,
+	// Could not reach the remote host.
+	Host_Unreachable,
+	// The remote host refused the connection or isn't listening.
+	Refused,
+	// The connection was reset by the remote host.
+	Reset,
+	// Timed out before making a connection.
+	Timeout,
+	// Non-blocking socket that would need to block waiting to connect.
+	Would_Block,
+	// Interrupted by a signal or other method of cancellation like WSACancelBlockingCall on Windows.
+	Interrupted,
+	// Endpoint given without a port, which is required.
+	Port_Required,
+
+	// An error unable to be categorized in above categories, `last_platform_error` may have more info.
+	Unknown,
+}
+
+Bind_Error :: enum i32 {
+	None,
+	// No network connection, or the network stack is not initialized.
+	Network_Unreachable,
+	// Not enough space in internal tables/buffers to create a new socket, or an unsupported protocol is given.
+	Insufficient_Resources,
+	// Invalid socket or endpoint, or invalid combination of the two.
+	Invalid_Argument,
+	// The socket is already bound to an address.
+	Already_Bound,
+	// The address is protected and the current user has insufficient permissions to access it.
+	Insufficient_Permissions_For_Address,
+	// The address is already in use.
+	Address_In_Use,
+
+	// An error unable to be categorized in above categories, `last_platform_error` may have more info.
+	Unknown,
+}
+
+Listen_Error :: enum i32 {
+	None,
+	// No network connection, or the network stack is not initialized.
+	Network_Unreachable,
+	// Not enough space in internal tables/buffers to create a new socket, or an unsupported protocol is given.
+	Insufficient_Resources,
+	// The socket or backlog is invalid.
+	Invalid_Argument,
+	// The socket is valid, but does not support listening.
+	Unsupported_Socket,
+	// The socket is already connected.
+	Already_Connected,
+	// The address is already in use.
+	Address_In_Use,
+
+	// An error unable to be categorized in above categories, `last_platform_error` may have more info.
+	Unknown,
+}
+
+Accept_Error :: enum i32 {
+	None,
+	// No network connection, or the network stack is not initialized.
+	Network_Unreachable,
+	// Not enough space in internal tables/buffers to create a new socket, or an unsupported protocol is given.
+	Insufficient_Resources,
+	// Invalid socket, or options.
+	Invalid_Argument,
+	// The given socket does not support accepting connections.
+	Unsupported_Socket,
+	// accept called on a socket which is not listening.
+	Not_Listening,
+	// A connection arrived but was closed while in the listen queue.
+	Aborted,
+	// Timed out before being able to accept a connection.
+	Timeout,
+	// Non-blocking socket that would need to block waiting for a connection.
+	Would_Block,
+	// Interrupted by a signal or other method of cancellation like WSACancelBlockingCall on Windows.
+	Interrupted,
+
+	// An error unable to be categorized in above categories, `last_platform_error` may have more info.
+	Unknown,
+}
+
+TCP_Recv_Error :: enum i32 {
+	None,
+	// No network connection, or the network stack is not initialized.
+	Network_Unreachable,
+	// Not enough space in internal tables/buffers to create a new socket, or an unsupported protocol is given.
+	Insufficient_Resources,
+	// Invalid socket or buffer given.
+	Invalid_Argument,
+	// The socket is not connected.
+	Not_Connected,
+	// Connection was closed/broken/shutdown while receiving data.
+	Connection_Closed,
+	// Timed out before being able to receive any data.
+	Timeout,
+	// Non-blocking socket that would need to block waiting on data.
+	Would_Block,
+	// Interrupted by a signal or other method of cancellation like WSACancelBlockingCall on Windows.
+	Interrupted,
+
+	// An error unable to be categorized in above categories, `last_platform_error` may have more info.
+	Unknown,
+}
+
+UDP_Recv_Error :: enum i32 {
+	None,
+	// No network connection, or the network stack is not initialized.
+	Network_Unreachable,
+	// Not enough space in internal tables/buffers to create a new socket, or an unsupported protocol is given.
+	Insufficient_Resources,
+	// Invalid socket or buffer given.
+	Invalid_Argument,
+	// "Connection" was refused by remote, or closed/broken/shutdown while receiving data.
+	Connection_Refused,
+	// Timed out before being able to receive any data.
+	Timeout,
+	// Non-blocking socket that would need to block waiting on data.
+	Would_Block,
+	// Interrupted by a signal or other method of cancellation like WSACancelBlockingCall on Windows.
+	Interrupted,
+	// Linux and UDP only: indicates the buffer was too small to receive all data, and the excess is truncated and discarded.
+	Excess_Truncated,
+
+	// An error unable to be categorized in above categories, `last_platform_error` may have more info.
+	Unknown,
+}
+
+TCP_Send_Error :: enum i32 {
+	None,
+	// No network connection, or the network stack is not initialized.
+	Network_Unreachable,
+	// Not enough space in internal tables/buffers to create a new socket, or an unsupported protocol is given.
+	Insufficient_Resources,
+	// Invalid socket or buffer given.
+	Invalid_Argument,
+	// Connection was closed/broken/shutdown while receiving data.
+	Connection_Closed,
+	// The socket is not connected.
+	Not_Connected,
+	// Could not reach the remote host.
+	Host_Unreachable,
+	// Timed out before being able to send any data.
+	Timeout,
+	// Non-blocking socket that would need to block waiting on the remote to be able to receive the data.
+	Would_Block,
+	// Interrupted by a signal or other method of cancellation like WSACancelBlockingCall on Windows.
+	Interrupted,
+
+	// An error unable to be categorized in above categories, `last_platform_error` may have more info.
+	Unknown,
+}
+
+UDP_Send_Error :: enum i32 {
+	None,
+	// No network connection, or the network stack is not initialized.
+	Network_Unreachable,
+	// Not enough space in internal tables/buffers to create a new socket, or an unsupported protocol is given.
+	Insufficient_Resources,
+	// Invalid socket or buffer given.
+	Invalid_Argument,
+	// Could not reach the remote host.
+	Host_Unreachable,
+	// "Connection" was refused by remote, or closed/broken/shutdown while sending data.
+	Connection_Refused,
+	// Timed out before being able to send any data.
+	Timeout,
+	// Non-blocking socket that would need to block waiting on the remote to be able to receive the data.
+	Would_Block,
+	// Interrupted by a signal or other method of cancellation like WSACancelBlockingCall on Windows.
+	Interrupted,
+
+	// An error unable to be categorized in above categories, `last_platform_error` may have more info.
+	Unknown,
+}
+
+Shutdown_Error :: enum i32 {
+	None,
+	// No network connection, or the network stack is not initialized.
+	Network_Unreachable,
+	// Socket is invalid or not connected, or the manner given is invalid.
+	Invalid_Argument,
+	// Connection was closed/aborted/shutdown.
+	Connection_Closed,
+
+	// An error unable to be categorized in above categories, `last_platform_error` may have more info.
+	Unknown,
+}
+
+Socket_Option_Error :: enum i32 {
+	None,
+	// No network connection, or the network stack is not initialized.
+	Network_Unreachable,
+	// Not enough space in internal tables/buffers to create a new socket, or an unsupported protocol is given.
+	Insufficient_Resources,
+	// Socket is invalid, not connected, or the connection has been closed/reset/shutdown.
+	Invalid_Socket,
+	// Unknown or unsupported option for the socket.
+	Invalid_Option,
+	// Invalid level or value.
+	Invalid_Value,
+
+	// An error unable to be categorized in above categories, `last_platform_error` may have more info.
+	Unknown,
+}
+
+Set_Blocking_Error :: enum i32 {
+	None,
+	// No network connection, or the network stack is not initialized.
+	Network_Unreachable,
+	// Socket is invalid.
+	Invalid_Argument,
+
+	// An error unable to be categorized in above categories, `last_platform_error` may have more info.
+	Unknown,
+}

--- a/core/net/errors_darwin.odin
+++ b/core/net/errors_darwin.odin
@@ -20,192 +20,232 @@ package net
 		Feoramund:       FreeBSD platform code
 */
 
-import "core:c"
+import "core:reflect"
 import "core:sys/posix"
 
-@(private)
-ESHUTDOWN :: 58
-
-Create_Socket_Error :: enum c.int {
-	None                                 = 0,
-	Family_Not_Supported_For_This_Socket = c.int(posix.EAFNOSUPPORT),
-	No_Socket_Descriptors_Available      = c.int(posix.EMFILE),
-	No_Buffer_Space_Available            = c.int(posix.ENOBUFS),
-	No_Memory_Available                  = c.int(posix.ENOMEM),
-	Protocol_Unsupported_By_System       = c.int(posix.EPROTONOSUPPORT),
-	Wrong_Protocol_For_Socket            = c.int(posix.EPROTONOSUPPORT),
-	Family_And_Socket_Type_Mismatch      = c.int(posix.EPROTONOSUPPORT),
+_last_platform_error :: proc() -> i32 {
+	return i32(posix.errno())
 }
 
-Dial_Error :: enum c.int {
-	None                      = 0,
-	Port_Required             = -1, // Attempted to dial an endpointing without a port being set.
-
-	Address_In_Use            = c.int(posix.EADDRINUSE),
-	In_Progress               = c.int(posix.EINPROGRESS),
-	Cannot_Use_Any_Address    = c.int(posix.EADDRNOTAVAIL),
-	Wrong_Family_For_Socket   = c.int(posix.EAFNOSUPPORT),
-	Refused                   = c.int(posix.ECONNREFUSED),
-	Is_Listening_Socket       = c.int(posix.EACCES),
-	Already_Connected         = c.int(posix.EISCONN),
-	Network_Unreachable       = c.int(posix.ENETUNREACH),  // Device is offline
-	Host_Unreachable          = c.int(posix.EHOSTUNREACH), // Remote host cannot be reached
-	No_Buffer_Space_Available = c.int(posix.ENOBUFS),
-	Not_Socket                = c.int(posix.ENOTSOCK),
-	Timeout                   = c.int(posix.ETIMEDOUT),
-
-	// TODO: we may need special handling for this; maybe make a socket a struct with metadata?
-	Would_Block               = c.int(posix.EWOULDBLOCK), 
+_last_platform_error_string :: proc() -> string {
+	description, _ := reflect.enum_name_from_value(posix.errno())
+	return description
 }
 
-Bind_Error :: enum c.int {
-	None                         = 0,
-	Privileged_Port_Without_Root = -1, // Attempted to bind to a port less than 1024 without root access.
-
-	Address_In_Use          = c.int(posix.EADDRINUSE),    // Another application is currently bound to this endpoint.
-	Given_Nonlocal_Address  = c.int(posix.EADDRNOTAVAIL), // The address is not a local address on this machine.
-	Broadcast_Disabled      = c.int(posix.EACCES),        // To bind a UDP socket to the broadcast address, the appropriate socket option must be set.
-	Address_Family_Mismatch = c.int(posix.EFAULT),        // The address family of the address does not match that of the socket.
-	Already_Bound           = c.int(posix.EINVAL),        // The socket is already bound to an address.
-	No_Ports_Available      = c.int(posix.ENOBUFS),       // There are not enough ephemeral ports available.
+_set_last_platform_error :: proc(err: i32) {
+	posix.errno(posix.Errno(err))
 }
 
-Listen_Error :: enum c.int {
-	None                                    = 0,
-	Address_In_Use                          = c.int(posix.EADDRINUSE),
-	Already_Connected                       = c.int(posix.EISCONN),
-	No_Socket_Descriptors_Available         = c.int(posix.EMFILE),
-	No_Buffer_Space_Available               = c.int(posix.ENOBUFS),
-	Nonlocal_Address                        = c.int(posix.EADDRNOTAVAIL),
-	Not_Socket                              = c.int(posix.ENOTSOCK),
-	Listening_Not_Supported_For_This_Socket = c.int(posix.EOPNOTSUPP),
+_create_socket_error :: proc() -> Create_Socket_Error {
+	#partial switch posix.errno() {
+	case .EMFILE, .ENOBUFS, .ENOMEM, .EPROTONOSUPPORT, .EISCONN, .ENFILE:
+		return .Insufficient_Resources
+	case .EAFNOSUPPORT, .EPROTOTYPE:
+		return .Invalid_Argument
+	case .EACCES:
+		return .Insufficient_Permissions
+	case:
+		return .Unknown
+	}
 }
 
-Accept_Error :: enum c.int {
-	None                                              = 0,
-	// TODO(tetra): Is this error actually possible here? Or is like Linux, in which case we can remove it.
-	Reset                                             = c.int(posix.ECONNRESET), 
-	Not_Listening                                     = c.int(posix.EINVAL),
-	No_Socket_Descriptors_Available_For_Client_Socket = c.int(posix.EMFILE),
-	No_Buffer_Space_Available                         = c.int(posix.ENOBUFS),
-	Not_Socket                                        = c.int(posix.ENOTSOCK),
-	Not_Connection_Oriented_Socket                    = c.int(posix.EOPNOTSUPP),
-
-	// TODO: we may need special handling for this; maybe make a socket a struct with metadata?
-	Would_Block                                       = c.int(posix.EWOULDBLOCK), 
+_dial_error :: proc() -> Dial_Error {
+	#partial switch posix.errno() {
+	case .ENOBUFS:
+		return .Insufficient_Resources
+	case .EAFNOSUPPORT, .EBADF, .EFAULT, .EINVAL, .ENOTSOCK, .EPROTOTYPE, .EADDRNOTAVAIL:
+		return .Invalid_Argument
+	case .EISCONN:
+		return .Already_Connected
+	case .EALREADY:
+		return .Already_Connecting
+	case .EADDRINUSE:
+		return .Address_In_Use
+	case .ENETDOWN:
+		return .Network_Unreachable
+	case .EHOSTUNREACH:
+		return .Host_Unreachable
+	case .ECONNREFUSED:
+		return .Refused
+	case .ECONNRESET:
+		return .Reset
+	case .ETIMEDOUT:
+		return .Timeout
+	case .EINPROGRESS:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case .EACCES:
+		return .Broadcast_Not_Supported
+	case:
+		return .Unknown
+	}
 }
 
-TCP_Recv_Error :: enum c.int {
-	None              = 0,
-	Shutdown          = ESHUTDOWN,
-	Not_Connected     = c.int(posix.ENOTCONN),
-
-	// TODO(tetra): Is this error actually possible here?
-	Connection_Broken = c.int(posix.ENETRESET),
-	Not_Socket        = c.int(posix.ENOTSOCK),
-	Aborted           = c.int(posix.ECONNABORTED),
-
-	// TODO(tetra): Determine when this is different from the syscall returning n=0 and maybe normalize them?
-	Connection_Closed = c.int(posix.ECONNRESET),
-	Offline           = c.int(posix.ENETDOWN),
-	Host_Unreachable  = c.int(posix.EHOSTUNREACH),
-	Interrupted       = c.int(posix.EINTR),
-
-	// NOTE: No, really. Presumably this means something different for nonblocking sockets...
-	Timeout           = c.int(posix.EWOULDBLOCK),
+_bind_error :: proc() -> Bind_Error {
+	#partial switch posix.errno() {
+	case .EADDRNOTAVAIL, .EAFNOSUPPORT, .EBADF, .EDESTADDRREQ, .EFAULT, .ENOTSOCK, .EOPNOTSUPP:
+		return .Invalid_Argument
+	case .EINVAL:
+		return .Already_Bound
+	case .EACCES:
+		return .Insufficient_Permissions_For_Address
+	case .EADDRINUSE:
+		return .Address_In_Use
+	case:
+		return .Unknown
+	}
 }
 
-UDP_Recv_Error :: enum c.int {
-	None             = 0,
-	Buffer_Too_Small = c.int(posix.EMSGSIZE), // The buffer is too small to fit the entire message, and the message was truncated. When this happens, the rest of message is lost.
-	Not_Socket       = c.int(posix.ENOTSOCK), // The so-called socket is not an open socket.
-	Not_Descriptor   = c.int(posix.EBADF),    // The so-called socket is, in fact, not even a valid descriptor.
-	Bad_Buffer       = c.int(posix.EFAULT),   // The buffer did not point to a valid location in memory.
-	Interrupted      = c.int(posix.EINTR),    // A signal occurred before any data was transmitted. See signal(7).
-
-	// The send timeout duration passed before all data was sent. See Socket_Option.Send_Timeout.
-	// NOTE: No, really. Presumably this means something different for nonblocking sockets...
-	Timeout          = c.int(posix.EWOULDBLOCK), 
-	Socket_Not_Bound = c.int(posix.EINVAL), // The socket must be bound for this operation, but isn't.
+_listen_error :: proc() -> Listen_Error {
+	#partial switch posix.errno() {
+	case .EBADF, .ENOTSOCK:
+		return .Invalid_Argument
+	case .EDESTADDRREQ, .EOPNOTSUPP:
+		return .Unsupported_Socket
+	case .EINVAL:
+		return .Already_Connected
+	case:
+		return .Unknown
+	}
 }
 
-TCP_Send_Error :: enum c.int {
-	None                      = 0,
-
-	Aborted                   = c.int(posix.ECONNABORTED), 
-	Connection_Closed         = c.int(posix.ECONNRESET),
-	Not_Connected             = c.int(posix.ENOTCONN),
-	Shutdown                  = ESHUTDOWN,
-
-	// The send queue was full.
-	// This is usually a transient issue.
-	//
-	// This also shouldn't normally happen on Linux, as data is dropped if it
-	// doesn't fit in the send queue.
-	No_Buffer_Space_Available = c.int(posix.ENOBUFS),
-	Offline                   = c.int(posix.ENETDOWN),
-	Host_Unreachable          = c.int(posix.EHOSTUNREACH),
-	Interrupted               = c.int(posix.EINTR), // A signal occurred before any data was transmitted. See signal(7).
-
-	// NOTE: No, really. Presumably this means something different for nonblocking sockets...
-	// The send timeout duration passed before all data was sent. See Socket_Option.Send_Timeout.
-	Timeout                   = c.int(posix.EWOULDBLOCK), 
-	Not_Socket                = c.int(posix.ENOTSOCK), // The so-called socket is not an open socket.
+_accept_error :: proc() -> Accept_Error {
+	#partial switch posix.errno() {
+	case .EMFILE, .ENFILE, .ENOMEM:
+		return .Insufficient_Resources
+	case .EBADF, .ENOTSOCK, .EFAULT:
+		return .Invalid_Argument
+	case .EOPNOTSUPP:
+		return .Unsupported_Socket
+	case .ECONNABORTED:
+		return .Aborted
+	case .EWOULDBLOCK:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
 }
 
-// TODO
-UDP_Send_Error :: enum c.int {
-	None                        = 0,
-	Message_Too_Long            = c.int(posix.EMSGSIZE), // The message is larger than the maximum UDP packet size. No data was sent.
-
-	// TODO: not sure what the exact circumstances for this is yet
-	Network_Unreachable         = c.int(posix.ENETUNREACH),
-	No_Outbound_Ports_Available = c.int(posix.EAGAIN),   // There are no more emphemeral outbound ports available to bind the socket to, in order to send.
-
-	// The send timeout duration passed before all data was sent. See Socket_Option.Send_Timeout.
-	// NOTE: No, really. Presumably this means something different for nonblocking sockets...
-	Timeout                     = c.int(posix.EWOULDBLOCK), 
-	Not_Socket                  = c.int(posix.ENOTSOCK), // The so-called socket is not an open socket.
-	Not_Descriptor              = c.int(posix.EBADF),    // The so-called socket is, in fact, not even a valid descriptor.
-	Bad_Buffer                  = c.int(posix.EFAULT),   // The buffer did not point to a valid location in memory.
-	Interrupted                 = c.int(posix.EINTR),    // A signal occurred before any data was transmitted. See signal(7).
-
-	// The send queue was full.
-	// This is usually a transient issue.
-	//
-	// This also shouldn't normally happen on Linux, as data is dropped if it
-	// doesn't fit in the send queue.
-	No_Buffer_Space_Available   = c.int(posix.ENOBUFS),
-	No_Memory_Available         = c.int(posix.ENOMEM),   // No memory was available to properly manage the send queue.
+_tcp_recv_error :: proc() -> TCP_Recv_Error {
+	#partial switch posix.errno() {
+	case .EBADF, .EFAULT, .EINVAL, .ENOTSOCK, .EOPNOTSUPP:
+		return .Invalid_Argument
+	case .ENOBUFS:
+		return .Insufficient_Resources
+	case .ENOTCONN:
+		return .Not_Connected
+	case .ECONNRESET:
+		return .Connection_Closed
+	case .ETIMEDOUT:
+		return .Timeout
+	case .EAGAIN:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
 }
 
-Shutdown_Manner :: enum c.int {
-	Receive = c.int(posix.SHUT_RD),
-	Send    = c.int(posix.SHUT_WR),
-	Both    = c.int(posix.SHUT_RDWR),
+_udp_recv_error :: proc() -> UDP_Recv_Error {
+	#partial switch posix.errno() {
+	case .EBADF, .EFAULT, .EINVAL, .ENOTSOCK, .EOPNOTSUPP, .EMSGSIZE:
+		return .Invalid_Argument
+	case .ENOBUFS, .ENOMEM:
+		return .Insufficient_Resources
+	case .ECONNRESET, .ENOTCONN:
+		return .Connection_Refused
+	case .ETIMEDOUT:
+		return .Timeout
+	case .EAGAIN:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
 }
 
-Shutdown_Error :: enum c.int {
-	None           = 0,
-	Aborted        = c.int(posix.ECONNABORTED),
-	Reset          = c.int(posix.ECONNRESET),
-	Offline        = c.int(posix.ENETDOWN),
-	Not_Connected  = c.int(posix.ENOTCONN),
-	Not_Socket     = c.int(posix.ENOTSOCK),
-	Invalid_Manner = c.int(posix.EINVAL),
+_tcp_send_error :: proc() -> TCP_Send_Error {
+	#partial switch posix.errno() {
+	case .EACCES, .EBADF, .EFAULT, .EMSGSIZE, .ENOTSOCK, .EOPNOTSUPP:
+		return .Invalid_Argument
+	case .ENOBUFS:
+		return .Insufficient_Resources
+	case .ECONNRESET, .EPIPE:
+		return .Connection_Closed
+	case .ENOTCONN:
+		return .Not_Connected
+	case .EHOSTUNREACH:
+		return .Host_Unreachable
+	case .ENETDOWN, .ENETUNREACH:
+		return .Network_Unreachable
+	case .ETIMEDOUT:
+		return .Timeout
+	case .EAGAIN:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
 }
 
-Socket_Option_Error :: enum c.int {
-	None                       = 0,
-	Offline                    = c.int(posix.ENETDOWN),
-	Timeout_When_Keepalive_Set = c.int(posix.ENETRESET),
-	Invalid_Option_For_Socket  = c.int(posix.ENOPROTOOPT),
-	Reset_When_Keepalive_Set   = c.int(posix.ENOTCONN),
-	Not_Socket                 = c.int(posix.ENOTSOCK),
+_udp_send_error :: proc() -> UDP_Send_Error {
+	#partial switch posix.errno() {
+	case .EACCES, .EBADF, .EFAULT, .EMSGSIZE, .ENOTSOCK, .EOPNOTSUPP, .EAFNOSUPPORT, .EDESTADDRREQ:
+		return .Invalid_Argument
+	case .ENOBUFS, .ENOMEM:
+		return .Insufficient_Resources
+	case .ECONNRESET, .EPIPE:
+		return .Connection_Refused
+	case .EHOSTUNREACH:
+		return .Host_Unreachable
+	case .ENETDOWN, .ENETUNREACH:
+		return .Network_Unreachable
+	case .ETIMEDOUT:
+		return .Timeout
+	case .EAGAIN:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
 }
 
-Set_Blocking_Error :: enum c.int {
-	None = 0,
+_shutdown_error :: proc() -> Shutdown_Error {
+	#partial switch posix.errno() {
+	case .EBADF, .EINVAL, .ENOTSOCK, .ENOTCONN:
+		return .Invalid_Argument
+	case:
+		return .Unknown
+	}
+}
 
-	// TODO: Add errors for `set_blocking`
+_socket_option_error :: proc() -> Socket_Option_Error {
+	#partial switch posix.errno() {
+	case .ENOBUFS:
+		return .Insufficient_Resources
+	case .EBADF, .ENOTSOCK, .EISCONN:
+		return .Invalid_Socket
+	case .EINVAL, .ENOPROTOOPT:
+		return .Invalid_Option
+	case .EFAULT, .EDOM:
+		return .Invalid_Value
+	case:
+		return .Unknown
+	}
+}
+
+_set_blocking_error :: proc() -> Set_Blocking_Error {
+	#partial switch posix.errno() {
+	case .EBADF:
+		return .Invalid_Argument
+	case:
+		return .Unknown
+	}
 }

--- a/core/net/errors_freebsd.odin
+++ b/core/net/errors_freebsd.odin
@@ -20,198 +20,267 @@ package net
 		Feoramund:       FreeBSD platform code
 */
 
-import "core:c"
+import "core:reflect"
 import "core:sys/freebsd"
 
-Create_Socket_Error :: enum c.int {
-	None                                 = 0,
-	Access_Denied                        = cast(c.int)freebsd.Errno.EACCES,
-	Family_Not_Supported_For_This_Socket = cast(c.int)freebsd.Errno.EAFNOSUPPORT,
-	Full_Per_Process_Descriptor_Table    = cast(c.int)freebsd.Errno.EMFILE,
-	Full_System_File_Table               = cast(c.int)freebsd.Errno.ENFILE,
-	No_Buffer_Space_Available            = cast(c.int)freebsd.Errno.ENOBUFS,
-	Insufficient_Permission              = cast(c.int)freebsd.Errno.EPERM,
-	Protocol_Unsupported_In_Family       = cast(c.int)freebsd.Errno.EPROTONOSUPPORT,
-	Socket_Type_Unsupported_By_Protocol  = cast(c.int)freebsd.Errno.EPROTOTYPE,
+@(private="file", thread_local)
+_last_error: freebsd.Errno
+
+_last_platform_error :: proc() -> i32 {
+	return i32(_last_error)
 }
 
-Dial_Error :: enum c.int {
-	None                        = 0,
-	Port_Required               = -1,
-	Not_Descriptor              = cast(c.int)freebsd.Errno.EBADF,
-	Invalid_Namelen             = cast(c.int)freebsd.Errno.EINVAL,
-	Not_Socket                  = cast(c.int)freebsd.Errno.ENOTSOCK,
-	Address_Unavailable         = cast(c.int)freebsd.Errno.EADDRNOTAVAIL,
-	Wrong_Family_For_Socket     = cast(c.int)freebsd.Errno.EAFNOSUPPORT,
-	Already_Connected           = cast(c.int)freebsd.Errno.EISCONN,
-	Timeout                     = cast(c.int)freebsd.Errno.ETIMEDOUT,
-	Refused_By_Remote_Host      = cast(c.int)freebsd.Errno.ECONNREFUSED,
-	// `Refused` alias for `core:net` tests.
-	// The above default name `Refused_By_Remote_Host` is more explicit.
-	Refused                     = Refused_By_Remote_Host,
-	Reset_By_Remote_Host        = cast(c.int)freebsd.Errno.ECONNRESET,
-	Network_Unreachable         = cast(c.int)freebsd.Errno.ENETUNREACH,
-	Host_Unreachable            = cast(c.int)freebsd.Errno.EHOSTUNREACH,
-	Address_In_Use              = cast(c.int)freebsd.Errno.EADDRINUSE,
-	Invalid_Address_Space       = cast(c.int)freebsd.Errno.EFAULT,
-	In_Progress                 = cast(c.int)freebsd.Errno.EINPROGRESS,
-	Interrupted_By_Signal       = cast(c.int)freebsd.Errno.EINTR,
-	Previous_Attempt_Incomplete = cast(c.int)freebsd.Errno.EALREADY,
-	Broadcast_Unavailable       = cast(c.int)freebsd.Errno.EACCES,
-	Auto_Port_Unavailable       = cast(c.int)freebsd.Errno.EAGAIN,
-
-	// NOTE: There are additional connect() error possibilities, but they are
-	// strictly for addresses in the UNIX domain.
+_last_platform_error_string :: proc() -> string {
+	description, _ := reflect.enum_name_from_value(_last_error)
+	return description
 }
 
-Bind_Error :: enum c.int {
-	None                         = 0,
-	Kernel_Resources_Unavailable = cast(c.int)freebsd.Errno.EAGAIN,
-	Not_Descriptor               = cast(c.int)freebsd.Errno.EBADF,
-
-	// NOTE: bind() can also return EINVAL if the underlying `addrlen` is an
-	// invalid length for the address family. This shouldn't happen for the net
-	// package, but it's worth noting.
-	Already_Bound                = cast(c.int)freebsd.Errno.EINVAL,
-	Not_Socket                   = cast(c.int)freebsd.Errno.ENOTSOCK,
-	Given_Nonlocal_Address       = cast(c.int)freebsd.Errno.EADDRNOTAVAIL,
-	Address_In_Use               = cast(c.int)freebsd.Errno.EADDRINUSE,
-	Address_Family_Mismatch      = cast(c.int)freebsd.Errno.EAFNOSUPPORT,
-	Protected_Address            = cast(c.int)freebsd.Errno.EACCES,
-	Invalid_Address_Space        = cast(c.int)freebsd.Errno.EFAULT,
-
-	// NOTE: There are additional bind() error possibilities, but they are
-	// strictly for addresses in the UNIX domain.
+_set_last_platform_error :: proc(err: i32) {
+	_last_error = freebsd.Errno(err)
 }
 
-Listen_Error :: enum c.int {
-	None                                    = 0,
-	Not_Descriptor                          = cast(c.int)freebsd.Errno.EBADF,
-	Socket_Not_Bound                        = cast(c.int)freebsd.Errno.EDESTADDRREQ,
-	Already_Connected                       = cast(c.int)freebsd.Errno.EINVAL,
-	Not_Socket                              = cast(c.int)freebsd.Errno.ENOTSOCK,
-	Listening_Not_Supported_For_This_Socket = cast(c.int)freebsd.Errno.EOPNOTSUPP,
+_create_socket_error :: proc(errno: freebsd.Errno) -> Create_Socket_Error {
+	assert(errno != nil)
+	_last_error = errno
+
+	#partial switch errno {
+	case .EMFILE, .ENFILE, .ENOBUFS, .EPROTONOSUPPORT:
+		return .Insufficient_Resources
+	case .EAFNOSUPPORT, .EPROTOTYPE:
+		return .Invalid_Argument
+	case .EACCES, .EPERM:
+		return .Insufficient_Permissions
+	case:
+		return .Unknown
+	}
 }
 
-Accept_Error :: enum c.int {
-	None                              = 0,
-	Not_Descriptor                    = cast(c.int)freebsd.Errno.EBADF,
-	Interrupted                       = cast(c.int)freebsd.Errno.EINTR,
-	Full_Per_Process_Descriptor_Table = cast(c.int)freebsd.Errno.EMFILE,
-	Full_System_File_Table            = cast(c.int)freebsd.Errno.ENFILE,
-	Not_Socket                        = cast(c.int)freebsd.Errno.ENOTSOCK,
-	Listen_Not_Called_On_Socket_Yet   = cast(c.int)freebsd.Errno.EINVAL,
-	Address_Not_Writable              = cast(c.int)freebsd.Errno.EFAULT,
+_dial_error :: proc(errno: freebsd.Errno) -> Dial_Error {
+	assert(errno != nil)
+	_last_error = errno
 
-	// NOTE: This is the same as EWOULDBLOCK.
-	No_Connections_Available          = cast(c.int)freebsd.Errno.EAGAIN,
-	// `Would_Block` alias for `core:net` tests.
-	Would_Block                       = cast(c.int)freebsd.Errno.EAGAIN,
-
-	New_Connection_Aborted            = cast(c.int)freebsd.Errno.ECONNABORTED,
+	#partial switch errno {
+	case .EBADF, .EINVAL, .ENOTSOCK, .EADDRNOTAVAIL, .EAFNOSUPPORT, .EFAULT, .EAGAIN:
+		return .Invalid_Argument
+	case .EISCONN:
+		return .Already_Connected
+	case .EALREADY:
+		return .Already_Connecting
+	case .EADDRINUSE:
+		return .Address_In_Use
+	case .ENETUNREACH:
+		return .Network_Unreachable
+	case .EHOSTUNREACH:
+		return .Host_Unreachable
+	case .ECONNREFUSED:
+		return .Refused
+	case .ECONNRESET:
+		return .Reset
+	case .ETIMEDOUT:
+		return .Timeout
+	case .EINPROGRESS:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case .EACCES:
+		return .Broadcast_Not_Supported
+	case:
+		return .Unknown
+	}
 }
 
-TCP_Recv_Error :: enum c.int {
-	None                                 = 0,
-	Not_Descriptor                       = cast(c.int)freebsd.Errno.EBADF,
-	Connection_Closed                    = cast(c.int)freebsd.Errno.ECONNRESET,
-	Not_Connected                        = cast(c.int)freebsd.Errno.ENOTCONN,
-	Not_Socket                           = cast(c.int)freebsd.Errno.ENOTSOCK,
+_bind_error :: proc(errno: freebsd.Errno) -> Bind_Error {
+	assert(errno != nil)
+	_last_error = errno
 
-	// NOTE(Feoramund): The next two errors are only relevant for recvmsg(),
-	// but I'm including them for completeness's sake.
-	Full_Table_And_Pending_Data          = cast(c.int)freebsd.Errno.EMFILE,
-	Invalid_Message_Size                 = cast(c.int)freebsd.Errno.EMSGSIZE,
-
-	Timeout                              = cast(c.int)freebsd.Errno.EAGAIN,
-	Interrupted_By_Signal                = cast(c.int)freebsd.Errno.EINTR,
-	Buffer_Pointer_Outside_Address_Space = cast(c.int)freebsd.Errno.EFAULT,
+	#partial switch errno {
+	case .EAGAIN, .ENOTSOCK, .EADDRNOTAVAIL, .EAFNOSUPPORT, .EFAULT:
+		return .Insufficient_Resources
+	case .EBADF:
+		return .Invalid_Argument
+	case .EINVAL:
+		return .Already_Bound
+	case .EACCES:
+		return .Insufficient_Permissions_For_Address
+	case .EADDRINUSE:
+		return .Address_In_Use
+	case:
+		return .Unknown
+	}
 }
 
-UDP_Recv_Error :: enum c.int {
-	None                                 = 0,
-	Not_Descriptor                       = cast(c.int)freebsd.Errno.EBADF,
-	Connection_Closed                    = cast(c.int)freebsd.Errno.ECONNRESET,
-	Not_Connected                        = cast(c.int)freebsd.Errno.ENOTCONN,
-	Not_Socket                           = cast(c.int)freebsd.Errno.ENOTSOCK,
+_listen_error :: proc(errno: freebsd.Errno) -> Listen_Error {
+	assert(errno != nil)
+	_last_error = errno
 
-	// NOTE(Feoramund): The next two errors are only relevant for recvmsg(),
-	// but I'm including them for completeness's sake.
-	Full_Table_And_Data_Discarded        = cast(c.int)freebsd.Errno.EMFILE,
-	Invalid_Message_Size                 = cast(c.int)freebsd.Errno.EMSGSIZE,
-
-	Timeout                              = cast(c.int)freebsd.Errno.EAGAIN,
-	Interrupted_By_Signal                = cast(c.int)freebsd.Errno.EINTR,
-	Buffer_Pointer_Outside_Address_Space = cast(c.int)freebsd.Errno.EFAULT,
+	#partial switch errno {
+	case .EBADF, .ENOTSOCK:
+		return .Invalid_Argument
+	case .EDESTADDRREQ, .EOPNOTSUPP:
+		return .Unsupported_Socket
+	case .EINVAL:
+		return .Already_Connected
+	case:
+		return .Unknown
+	}
 }
 
-TCP_Send_Error :: enum c.int {
-	None                              = 0,
-	Connection_Closed                 = cast(c.int)freebsd.Errno.ECONNRESET,
-	Not_Descriptor                    = cast(c.int)freebsd.Errno.EBADF,
-	Broadcast_Status_Mismatch         = cast(c.int)freebsd.Errno.EACCES,
-	Not_Connected                     = cast(c.int)freebsd.Errno.ENOTCONN,
-	Not_Socket                        = cast(c.int)freebsd.Errno.ENOTSOCK,
-	Argument_In_Invalid_Address_Space = cast(c.int)freebsd.Errno.EFAULT,
+_accept_error :: proc(errno: freebsd.Errno) -> Accept_Error {
+	assert(errno != nil)
+	_last_error = errno
 
-	Message_Size_Breaks_Atomicity     = cast(c.int)freebsd.Errno.EMSGSIZE,
-
-	/* The socket is marked non-blocking, or MSG_DONTWAIT is
-	   specified, and the requested operation would block. */
-	Would_Block                       = cast(c.int)freebsd.Errno.EAGAIN,
-
-	/* NOTE: This error arises for two distinct reasons:
-
-	   1. The system was unable to allocate an internal buffer.
-	      The operation may succeed when buffers become available.
-
-	   2. The output queue for a network interface was full.
-	      This generally indicates that the interface has stopped
-	      sending, but may be caused by transient congestion.
-	*/
-	No_Buffer_Space_Available         = cast(c.int)freebsd.Errno.ENOBUFS,
-
-	Host_Unreachable                  = cast(c.int)freebsd.Errno.EHOSTUNREACH,
-	Already_Connected                 = cast(c.int)freebsd.Errno.EISCONN,
-	ICMP_Unreachable                  = cast(c.int)freebsd.Errno.ECONNREFUSED,
-	Host_Down                         = cast(c.int)freebsd.Errno.EHOSTDOWN,
-	Network_Down                      = cast(c.int)freebsd.Errno.ENETDOWN,
-	Jailed_Socket_Tried_To_Escape     = cast(c.int)freebsd.Errno.EADDRNOTAVAIL,
-	Cannot_Send_More_Data             = cast(c.int)freebsd.Errno.EPIPE,
+	#partial switch errno {
+	case .EMFILE, .ENFILE:
+		return .Insufficient_Resources
+	case .EBADF, .ENOTSOCK, .EFAULT:
+		return .Invalid_Argument
+	case .EINVAL:
+		return .Not_Listening
+	case .ECONNABORTED:
+		return .Aborted
+	case .EWOULDBLOCK:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
 }
 
-// NOTE(Feoramund): The same as TCP errors go, as far as I'm aware.
-UDP_Send_Error :: distinct TCP_Send_Error
+_tcp_recv_error :: proc(errno: freebsd.Errno) -> TCP_Recv_Error {
+	assert(errno != nil)
+	_last_error = errno
 
-Shutdown_Manner :: enum c.int {
-	Receive = cast(c.int)freebsd.Shutdown_Method.RD,
-	Send    = cast(c.int)freebsd.Shutdown_Method.WR,
-	Both    = cast(c.int)freebsd.Shutdown_Method.RDWR,
+	#partial switch errno {
+	case .EBADF, .ENOTSOCK, .EFAULT:
+		return .Invalid_Argument
+	case .ENOTCONN:
+		return .Not_Connected
+	case .ECONNRESET:
+		return .Connection_Closed
+	case .ETIMEDOUT:
+		return .Timeout
+	case .EAGAIN:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
 }
 
-Shutdown_Error :: enum c.int {
-	None           = 0,
-	Not_Descriptor = cast(c.int)freebsd.Errno.EBADF,
-	Invalid_Manner = cast(c.int)freebsd.Errno.EINVAL,
-	Not_Connected  = cast(c.int)freebsd.Errno.ENOTCONN,
-	Not_Socket     = cast(c.int)freebsd.Errno.ENOTSOCK,
+_udp_recv_error :: proc(errno: freebsd.Errno) -> UDP_Recv_Error {
+	assert(errno != nil)
+	_last_error = errno
+
+	#partial switch errno {
+	case .EBADF, .ENOTSOCK, .EFAULT:
+		return .Invalid_Argument
+	case .ECONNRESET, .ENOTCONN:
+		return .Connection_Refused
+	case .ETIMEDOUT:
+		return .Timeout
+	case .EAGAIN:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
 }
 
-Socket_Option_Error :: enum c.int {
-	None                              = 0,
-	Value_Out_Of_Range                = -1,
-	Not_Descriptor                    = cast(c.int)freebsd.Errno.EBADF,
-	Not_Socket                        = cast(c.int)freebsd.Errno.ENOTSOCK,
-	Unknown_Option_For_Level          = cast(c.int)freebsd.Errno.ENOPROTOOPT,
-	Argument_In_Invalid_Address_Space = cast(c.int)freebsd.Errno.EFAULT,
-	// This error can arise for many different reasons.
-	Invalid_Value                     = cast(c.int)freebsd.Errno.EINVAL,
-	System_Memory_Allocation_Failed   = cast(c.int)freebsd.Errno.ENOMEM,
-	Insufficient_System_Resources     = cast(c.int)freebsd.Errno.ENOBUFS,
+_tcp_send_error :: proc(errno: freebsd.Errno) -> TCP_Send_Error {
+	assert(errno != nil)
+	_last_error = errno
+
+	#partial switch errno {
+	case .EBADF, .EACCES, .ENOTSOCK, .EFAULT, .EMSGSIZE:
+		return .Invalid_Argument
+	case .ENOBUFS:
+		return .Insufficient_Resources
+	case .ECONNRESET, .EPIPE:
+		return .Connection_Closed
+	case .ENOTCONN:
+		return .Not_Connected
+	case .EHOSTUNREACH:
+		return .Host_Unreachable
+	case .EHOSTDOWN:
+		return .Host_Unreachable
+	case .ENETDOWN:
+		return .Network_Unreachable
+	case .EAGAIN:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
 }
 
-Set_Blocking_Error :: enum c.int {
-	None             = 0,
-	Not_Descriptor   = cast(c.int)freebsd.Errno.EBADF,
-	Wrong_Descriptor = cast(c.int)freebsd.Errno.ENOTTY,
+_udp_send_error :: proc(errno: freebsd.Errno) -> UDP_Send_Error {
+	assert(errno != nil)
+	_last_error = errno
+
+	#partial switch errno {
+	case .EBADF, .EACCES, .ENOTSOCK, .EFAULT, .EMSGSIZE:
+		return .Invalid_Argument
+	case .ENOBUFS:
+		return .Insufficient_Resources
+	case .ECONNRESET, .EPIPE:
+		return .Connection_Refused
+	case .EHOSTUNREACH:
+		return .Host_Unreachable
+	case .EHOSTDOWN:
+		return .Host_Unreachable
+	case .ENETDOWN:
+		return .Network_Unreachable
+	case .EAGAIN:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
+}
+
+_shutdown_error :: proc(errno: freebsd.Errno) -> Shutdown_Error {
+	assert(errno != nil)
+	_last_error = errno
+
+	#partial switch errno {
+	case .EBADF, .EINVAL, .ENOTSOCK, .ENOTCONN:
+		return .Invalid_Argument
+	case:
+		return .Unknown
+	}
+}
+
+_socket_option_error :: proc(errno: freebsd.Errno) -> Socket_Option_Error {
+	assert(errno != nil)
+	_last_error = errno
+
+	#partial switch errno {
+	case .ENOMEM, .ENOBUFS:
+		return .Insufficient_Resources
+	case .EBADF, .ENOTSOCK:
+		return .Invalid_Socket
+	case .ENOPROTOOPT:
+		return .Invalid_Option
+	case .EINVAL, .EFAULT:
+		return .Invalid_Value
+	case:
+		return .Unknown
+	}
+}
+
+_set_blocking_error :: proc(errno: freebsd.Errno) -> Set_Blocking_Error {
+	assert(errno != nil)
+	_last_error = errno
+
+	#partial switch errno {
+	case .EBADF, .ENOTTY:
+		return .Invalid_Argument
+	case:
+		return .Unknown
+	}
 }

--- a/core/net/errors_linux.odin
+++ b/core/net/errors_linux.odin
@@ -21,181 +21,269 @@ package net
 		Feoramund:       FreeBSD platform code
 */
 
-import "core:c"
+import "core:reflect"
 import "core:sys/linux"
 
-Create_Socket_Error :: enum c.int {
-	None                                 = 0,
-	Family_Not_Supported_For_This_Socket = c.int(linux.Errno.EAFNOSUPPORT),
-	No_Socket_Descriptors_Available      = c.int(linux.Errno.EMFILE),
-	No_Buffer_Space_Available            = c.int(linux.Errno.ENOBUFS),
-	No_Memory_Available_Available        = c.int(linux.Errno.ENOMEM),
-	Protocol_Unsupported_By_System       = c.int(linux.Errno.EPROTONOSUPPORT),
-	Wrong_Protocol_For_Socket            = c.int(linux.Errno.EPROTONOSUPPORT),
-	Family_And_Socket_Type_Mismatch      = c.int(linux.Errno.EPROTONOSUPPORT),
+@(private="file", thread_local)
+_last_error: linux.Errno
+
+_last_platform_error :: proc() -> i32 {
+	return i32(_last_error)
 }
 
-Dial_Error :: enum c.int {
-	None                      = 0,
-	Port_Required             = -1,
-
-	Address_In_Use            = c.int(linux.Errno.EADDRINUSE),
-	In_Progress               = c.int(linux.Errno.EINPROGRESS),
-	Cannot_Use_Any_Address    = c.int(linux.Errno.EADDRNOTAVAIL),
-	Wrong_Family_For_Socket   = c.int(linux.Errno.EAFNOSUPPORT),
-	Refused                   = c.int(linux.Errno.ECONNREFUSED),
-	Is_Listening_Socket       = c.int(linux.Errno.EACCES),
-	Already_Connected         = c.int(linux.Errno.EISCONN),
-	Network_Unreachable       = c.int(linux.Errno.ENETUNREACH), // Device is offline
-	Host_Unreachable          = c.int(linux.Errno.EHOSTUNREACH), // Remote host cannot be reached
-	No_Buffer_Space_Available = c.int(linux.Errno.ENOBUFS),
-	Not_Socket                = c.int(linux.Errno.ENOTSOCK),
-	Timeout                   = c.int(linux.Errno.ETIMEDOUT),
-
-	// TODO: we may need special handling for this; maybe make a socket a struct with metadata?
-	Would_Block               = c.int(linux.Errno.EWOULDBLOCK), 
+_last_platform_error_string :: proc() -> string {
+	description, _ := reflect.enum_name_from_value(_last_error)
+	return description
 }
 
-Bind_Error :: enum c.int {
-	None                    = 0,
-	Address_In_Use          = c.int(linux.Errno.EADDRINUSE),    // Another application is currently bound to this endpoint.
-	Given_Nonlocal_Address  = c.int(linux.Errno.EADDRNOTAVAIL), // The address is not a local address on this machine.
-	Broadcast_Disabled      = c.int(linux.Errno.EACCES),        // To bind a UDP socket to the broadcast address, the appropriate socket option must be set.
-	Address_Family_Mismatch = c.int(linux.Errno.EFAULT),        // The address family of the address does not match that of the socket.
-	Already_Bound           = c.int(linux.Errno.EINVAL),        // The socket is already bound to an address.
-	No_Ports_Available      = c.int(linux.Errno.ENOBUFS),       // There are not enough ephemeral ports available.
+_set_last_platform_error :: proc(err: i32) {
+	_last_error = linux.Errno(err)
 }
 
-Listen_Error :: enum c.int {
-	None                                    = 0,
-	Address_In_Use                          = c.int(linux.Errno.EADDRINUSE),
-	Already_Connected                       = c.int(linux.Errno.EISCONN),
-	No_Socket_Descriptors_Available         = c.int(linux.Errno.EMFILE),
-	No_Buffer_Space_Available               = c.int(linux.Errno.ENOBUFS),
-	Nonlocal_Address                        = c.int(linux.Errno.EADDRNOTAVAIL),
-	Not_Socket                              = c.int(linux.Errno.ENOTSOCK),
-	Listening_Not_Supported_For_This_Socket = c.int(linux.Errno.EOPNOTSUPP),
+_create_socket_error :: proc(errno: linux.Errno) -> Create_Socket_Error {
+	assert(errno != nil)
+	_last_error = errno
+
+	#partial switch errno {
+	case .EMFILE, .ENFILE, .ENOBUFS, .EPROTONOSUPPORT:
+		return .Insufficient_Resources
+	case .EAFNOSUPPORT, .EPROTOTYPE:
+		return .Invalid_Argument
+	case .EACCES, .EPERM:
+		return .Insufficient_Permissions
+	case:
+		return .Unknown
+	}
 }
 
-Accept_Error :: enum c.int {
-	None                                              = 0,
-	Not_Listening                                     = c.int(linux.Errno.EINVAL),
-	No_Socket_Descriptors_Available_For_Client_Socket = c.int(linux.Errno.EMFILE),
-	No_Buffer_Space_Available                         = c.int(linux.Errno.ENOBUFS),
-	Not_Socket                                        = c.int(linux.Errno.ENOTSOCK),
-	Not_Connection_Oriented_Socket                    = c.int(linux.Errno.EOPNOTSUPP),
+_dial_error :: proc(errno: linux.Errno) -> Dial_Error {
+	assert(errno != nil)
+	_last_error = errno
 
-	// TODO: we may need special handling for this; maybe make a socket a struct with metadata?
-	Would_Block                                       = c.int(linux.Errno.EWOULDBLOCK),
+	#partial switch errno {
+	case .EAGAIN:
+		return .Insufficient_Resources
+	case .EBADF, .EINVAL, .ENOTSOCK, .EADDRNOTAVAIL, .EAFNOSUPPORT, .EFAULT:
+		return .Invalid_Argument
+	case .EISCONN:
+		return .Already_Connected
+	case .EALREADY:
+		return .Already_Connecting
+	case .EADDRINUSE:
+		return .Address_In_Use
+	case .ENETUNREACH:
+		return .Network_Unreachable
+	case .EHOSTUNREACH:
+		return .Host_Unreachable
+	case .ECONNREFUSED:
+		return .Refused
+	case .ECONNRESET:
+		return .Reset
+	case .ETIMEDOUT:
+		return .Timeout
+	case .EINPROGRESS:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case .EACCES:
+		return .Broadcast_Not_Supported
+	case:
+		return .Unknown
+	}
 }
 
-TCP_Recv_Error :: enum c.int {
-	None              = 0,
-	Shutdown          = c.int(linux.Errno.ESHUTDOWN),
-	Not_Connected     = c.int(linux.Errno.ENOTCONN),
-	Connection_Broken = c.int(linux.Errno.ENETRESET),
-	Not_Socket        = c.int(linux.Errno.ENOTSOCK),
-	Aborted           = c.int(linux.Errno.ECONNABORTED),
+_bind_error :: proc(errno: linux.Errno) -> Bind_Error {
+	assert(errno != nil)
+	_last_error = errno
 
-	// TODO(tetra): Determine when this is different from the syscall returning n=0 and maybe normalize them?
-	Connection_Closed = c.int(linux.Errno.ECONNRESET), 
-	Offline           = c.int(linux.Errno.ENETDOWN),
-	Host_Unreachable  = c.int(linux.Errno.EHOSTUNREACH),
-	Interrupted       = c.int(linux.Errno.EINTR),
-	Timeout           = c.int(linux.Errno.EWOULDBLOCK), // NOTE: No, really. Presumably this means something different for nonblocking sockets...
+	#partial switch errno {
+	case .EAGAIN, .ENOTSOCK, .EADDRNOTAVAIL, .EAFNOSUPPORT, .EFAULT:
+		return .Insufficient_Resources
+	case .EINVAL:
+		return .Already_Bound
+	case .EBADF:
+		return .Invalid_Argument
+	case .EACCES:
+		return .Insufficient_Permissions_For_Address
+	case .EADDRINUSE:
+		return .Address_In_Use
+	case:
+		return .Unknown
+	}
 }
 
-UDP_Recv_Error :: enum c.int {
-	None             = 0,
+_listen_error :: proc(errno: linux.Errno) -> Listen_Error {
+	assert(errno != nil)
+	_last_error = errno
 
-	Buffer_Too_Small = c.int(linux.Errno.EMSGSIZE), // The buffer is too small to fit the entire message, and the message was truncated. When this happens, the rest of message is lost.
-	Not_Socket       = c.int(linux.Errno.ENOTSOCK), // The so-called socket is not an open socket.
-	Not_Descriptor   = c.int(linux.Errno.EBADF),    // The so-called socket is, in fact, not even a valid descriptor.
-	Bad_Buffer       = c.int(linux.Errno.EFAULT),   // The buffer did not point to a valid location in memory.
-	Interrupted      = c.int(linux.Errno.EINTR),    // A signal occurred before any data was transmitted. See signal(7).
-
-	// The send timeout duration passed before all data was received. See Socket_Option.Receive_Timeout.
-	// NOTE: No, really. Presumably this means something different for nonblocking sockets...
-	Timeout          = c.int(linux.Errno.EWOULDBLOCK), 
-	Socket_Not_Bound = c.int(linux.Errno.EINVAL), // The socket must be bound for this operation, but isn't.
+	#partial switch errno {
+	case .EBADF, .ENOTSOCK:
+		return .Invalid_Argument
+	case .EDESTADDRREQ, .EOPNOTSUPP:
+		return .Unsupported_Socket
+	case .EINVAL:
+		return .Already_Connected
+	case:
+		return .Unknown
+	}
 }
 
-TCP_Send_Error :: enum c.int {
-	None                      = 0,
-	Aborted                   = c.int(linux.Errno.ECONNABORTED), 
-	Connection_Closed         = c.int(linux.Errno.ECONNRESET),
-	Not_Connected             = c.int(linux.Errno.ENOTCONN),
-	Shutdown                  = c.int(linux.Errno.ESHUTDOWN),
+_accept_error :: proc(errno: linux.Errno) -> Accept_Error {
+	assert(errno != nil)
+	_last_error = errno
 
-	// The send queue was full.
-	// This is usually a transient issue.
-	//
-	// This also shouldn't normally happen on Linux, as data is dropped if it
-	// doesn't fit in the send queue.
-	No_Buffer_Space_Available = c.int(linux.Errno.ENOBUFS),
-	Offline                   = c.int(linux.Errno.ENETDOWN),
-	Host_Unreachable          = c.int(linux.Errno.EHOSTUNREACH),
-	Interrupted               = c.int(linux.Errno.EINTR),        // A signal occurred before any data was transmitted. See signal(7).
-	Timeout                   = c.int(linux.Errno.EWOULDBLOCK),  // The send timeout duration passed before all data was sent. See Socket_Option.Send_Timeout.
-	Not_Socket                = c.int(linux.Errno.ENOTSOCK),     // The so-called socket is not an open socket.
+	#partial switch errno {
+	case .EMFILE, .ENFILE, .ENOBUFS, .ENOMEM:
+		return .Insufficient_Resources
+	case .EBADF, .ENOTSOCK, .EFAULT:
+		return .Invalid_Argument
+	case .EINVAL:
+		return .Not_Listening
+	case .ECONNABORTED:
+		return .Aborted
+	case .EWOULDBLOCK:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
 }
 
-// TODO
-UDP_Send_Error :: enum c.int {
-	None                        = 0,
-	Message_Too_Long            = c.int(linux.Errno.EMSGSIZE), // The message is larger than the maximum UDP packet size. No data was sent.
+_tcp_recv_error :: proc(errno: linux.Errno) -> TCP_Recv_Error {
+	assert(errno != nil)
+	_last_error = errno
 
-	// TODO: not sure what the exact circumstances for this is yet
-	Network_Unreachable         = c.int(linux.Errno.ENETUNREACH), 
-	No_Outbound_Ports_Available = c.int(linux.Errno.EAGAIN),      // There are no more emphemeral outbound ports available to bind the socket to, in order to send.
-
-	// The send timeout duration passed before all data was sent. See Socket_Option.Send_Timeout.
-	// NOTE: No, really. Presumably this means something different for nonblocking sockets...
-	Timeout                     = c.int(linux.Errno.EWOULDBLOCK), 
-	Not_Socket                  = c.int(linux.Errno.ENOTSOCK), // The so-called socket is not an open socket.
-	Not_Descriptor              = c.int(linux.Errno.EBADF),    // The so-called socket is, in fact, not even a valid descriptor.
-	Bad_Buffer                  = c.int(linux.Errno.EFAULT),   // The buffer did not point to a valid location in memory.
-	Interrupted                 = c.int(linux.Errno.EINTR),    // A signal occurred before any data was transmitted. See signal(7).
-
-	// The send queue was full.
-	// This is usually a transient issue.
-	//
-	// This also shouldn't normally happen on Linux, as data is dropped if it
-	// doesn't fit in the send queue.
-	No_Buffer_Space_Available   = c.int(linux.Errno.ENOBUFS),
-	No_Memory_Available         = c.int(linux.Errno.ENOMEM), // No memory was available to properly manage the send queue.
+	#partial switch errno {
+	case .EBADF, .ENOTSOCK, .EFAULT:
+		return .Invalid_Argument
+	case .ENOTCONN:
+		return .Not_Connected
+	case .ECONNREFUSED:
+		return .Connection_Closed
+	case .ETIMEDOUT:
+		return .Timeout
+	case .EAGAIN:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
 }
 
-// TODO(flysand): slight regression
-Shutdown_Manner :: enum c.int {
-	Receive = c.int(linux.Shutdown_How.RD),
-	Send    = c.int(linux.Shutdown_How.WR),
-	Both    = c.int(linux.Shutdown_How.RDWR),
+_udp_recv_error :: proc(errno: linux.Errno) -> UDP_Recv_Error {
+	assert(errno != nil)
+	_last_error = errno
+
+	#partial switch errno {
+	case .EBADF, .ENOTSOCK, .EFAULT:
+		return .Invalid_Argument
+	case .ECONNREFUSED, .ENOTCONN:
+		return .Connection_Refused
+	case .ETIMEDOUT:
+		return .Timeout
+	case .EAGAIN:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
 }
 
-Shutdown_Error :: enum c.int {
-	None           = 0,
-	Aborted        = c.int(linux.Errno.ECONNABORTED),
-	Reset          = c.int(linux.Errno.ECONNRESET),
-	Offline        = c.int(linux.Errno.ENETDOWN),
-	Not_Connected  = c.int(linux.Errno.ENOTCONN),
-	Not_Socket     = c.int(linux.Errno.ENOTSOCK),
-	Invalid_Manner = c.int(linux.Errno.EINVAL),
+_tcp_send_error :: proc(errno: linux.Errno) -> TCP_Send_Error {
+	assert(errno != nil)
+	_last_error = errno
+
+	#partial switch errno {
+	case .EBADF, .EACCES, .ENOTSOCK, .EFAULT, .EMSGSIZE, .EDESTADDRREQ, .EINVAL, .EISCONN, .EOPNOTSUPP:
+		return .Invalid_Argument
+	case .ENOBUFS, .ENOMEM:
+		return .Insufficient_Resources
+	case .ECONNRESET, .EPIPE:
+		return .Connection_Closed
+	case .ENOTCONN:
+		return .Not_Connected
+	case .EHOSTUNREACH:
+		return .Host_Unreachable
+	case .EHOSTDOWN:
+		return .Host_Unreachable
+	case .ENETDOWN:
+		return .Network_Unreachable
+	case .EAGAIN:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
 }
 
-Socket_Option_Error :: enum c.int {
-	None                       = 0,
-	Offline                    = c.int(linux.Errno.ENETDOWN),
-	Timeout_When_Keepalive_Set = c.int(linux.Errno.ENETRESET),
-	Invalid_Option_For_Socket  = c.int(linux.Errno.ENOPROTOOPT),
-	Reset_When_Keepalive_Set   = c.int(linux.Errno.ENOTCONN),
-	Not_Socket                 = c.int(linux.Errno.ENOTSOCK),
+_udp_send_error :: proc(errno: linux.Errno) -> UDP_Send_Error {
+	assert(errno != nil)
+	_last_error = errno
+
+	#partial switch errno {
+	case .EBADF, .EACCES, .ENOTSOCK, .EFAULT, .EMSGSIZE, .EDESTADDRREQ, .EINVAL, .EISCONN, .EOPNOTSUPP:
+		return .Invalid_Argument
+	case .ENOBUFS, .ENOMEM:
+		return .Insufficient_Resources
+	case .ECONNRESET, .EPIPE:
+		return .Connection_Refused
+	case .EHOSTUNREACH:
+		return .Host_Unreachable
+	case .EHOSTDOWN:
+		return .Host_Unreachable
+	case .ENETDOWN:
+		return .Network_Unreachable
+	case .EAGAIN:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
 }
 
-Set_Blocking_Error :: enum c.int {
-	None = 0,
+_shutdown_error :: proc(errno: linux.Errno) -> Shutdown_Error {
+	assert(errno != nil)
+	_last_error = errno
 
-	// TODO: add errors occuring on followig calls:
-	// flags, _ := linux.Errno.fcntl(sd, linux.Errno.F_GETFL, 0)
-	// linux.Errno.fcntl(sd, linux.Errno.F_SETFL, flags | int(linux.Errno.O_NONBLOCK))
+	#partial switch errno {
+	case .EBADF, .EINVAL, .ENOTSOCK, .ENOTCONN:
+		return .Invalid_Argument
+	case:
+		return .Unknown
+	}
+}
+
+_socket_option_error :: proc(errno: linux.Errno) -> Socket_Option_Error {
+	assert(errno != nil)
+	_last_error = errno
+
+	#partial switch errno {
+	case .ENOMEM, .ENOBUFS:
+		return .Insufficient_Resources
+	case .EBADF, .ENOTSOCK:
+		return .Invalid_Socket
+	case .ENOPROTOOPT, .EINVAL:
+		return .Invalid_Option
+	case .EFAULT, .EDOM:
+		return .Invalid_Value
+	case:
+		return .Unknown
+	}
+}
+
+_set_blocking_error :: proc(errno: linux.Errno) -> Set_Blocking_Error {
+	assert(errno != nil)
+	_last_error = errno
+
+	#partial switch errno {
+	case .EBADF:
+		return .Invalid_Argument
+	case:
+		return .Unknown
+	}
 }

--- a/core/net/errors_others.odin
+++ b/core/net/errors_others.odin
@@ -1,0 +1,20 @@
+#+build !darwin
+#+build !linux
+#+build !freebsd
+#+build !windows
+package net
+
+@(private="file", thread_local)
+_last_error: i32
+
+_last_platform_error :: proc() -> i32 {
+	return _last_error
+}
+
+_last_platform_error_string :: proc() -> string {
+	return ""
+}
+
+_set_last_platform_error :: proc(err: i32) {
+	_last_error = err
+}

--- a/core/net/errors_windows.odin
+++ b/core/net/errors_windows.odin
@@ -20,250 +20,242 @@ package net
 		Feoramund:       FreeBSD platform code
 */
 
-import "core:c"
+import     "core:reflect"
 import win "core:sys/windows"
 
-Create_Socket_Error :: enum c.int {
-	None                                 = 0,
-	Network_Subsystem_Failure            = win.WSAENETDOWN,
-	Family_Not_Supported_For_This_Socket = win.WSAEAFNOSUPPORT,
-	No_Socket_Descriptors_Available      = win.WSAEMFILE,
-	No_Buffer_Space_Available            = win.WSAENOBUFS,
-	Protocol_Unsupported_By_System       = win.WSAEPROTONOSUPPORT,
-	Wrong_Protocol_For_Socket            = win.WSAEPROTOTYPE,
-	Family_And_Socket_Type_Mismatch      = win.WSAESOCKTNOSUPPORT,
+_last_platform_error :: proc() -> i32 {
+	return i32(win.WSAGetLastError())
 }
 
-Dial_Error :: enum c.int {
-	None                      = 0,
-	Port_Required             = -1,
-	Address_In_Use            = win.WSAEADDRINUSE,
-	In_Progress               = win.WSAEALREADY,
-	Cannot_Use_Any_Address    = win.WSAEADDRNOTAVAIL,
-	Wrong_Family_For_Socket   = win.WSAEAFNOSUPPORT,
-	Refused                   = win.WSAECONNREFUSED,
-	Is_Listening_Socket       = win.WSAEINVAL,
-	Already_Connected         = win.WSAEISCONN,
-	Network_Unreachable       = win.WSAENETUNREACH,  // Device is offline
-	Host_Unreachable          = win.WSAEHOSTUNREACH, // Remote host cannot be reached
-	No_Buffer_Space_Available = win.WSAENOBUFS,
-	Not_Socket                = win.WSAENOTSOCK,
-	Timeout                   = win.WSAETIMEDOUT,
-	Would_Block               = win.WSAEWOULDBLOCK,  // TODO: we may need special handling for this; maybe make a socket a struct with metadata?
+_last_platform_error_string :: proc() -> string {
+	description, _ := reflect.enum_name_from_value(win.System_Error(win.WSAGetLastError()))
+	return description
 }
 
-Bind_Error :: enum c.int {
-	None                    = 0,
-	Address_In_Use          = win.WSAEADDRINUSE,    // Another application is currently bound to this endpoint.
-	Given_Nonlocal_Address  = win.WSAEADDRNOTAVAIL, // The address is not a local address on this machine.
-	Broadcast_Disabled      = win.WSAEACCES,        // To bind a UDP socket to the broadcast address, the appropriate socket option must be set.
-	Address_Family_Mismatch = win.WSAEFAULT,        // The address family of the address does not match that of the socket.
-	Already_Bound           = win.WSAEINVAL,        // The socket is already bound to an address.
-	No_Ports_Available      = win.WSAENOBUFS,       // There are not enough ephemeral ports available.
+_set_last_platform_error :: proc(err: i32) {
+	win.WSASetLastError(err)
 }
 
-Listen_Error :: enum c.int {
-	None                                    = 0,
-	Address_In_Use                          = win.WSAEADDRINUSE,
-	Already_Connected                       = win.WSAEISCONN,
-	No_Socket_Descriptors_Available         = win.WSAEMFILE,
-	No_Buffer_Space_Available               = win.WSAENOBUFS,
-	Nonlocal_Address                        = win.WSAEADDRNOTAVAIL,
-	Not_Socket                              = win.WSAENOTSOCK,
-	Listening_Not_Supported_For_This_Socket = win.WSAEOPNOTSUPP,
+_create_socket_error :: proc() -> Create_Socket_Error {
+	#partial switch win.System_Error(win.WSAGetLastError()) {
+	case .WSANOTINITIALISED, .WSAENETDOWN, .WSAEINVALIDPROVIDER, .WSAEINVALIDPROCTABLE, .WSAEPROVIDERFAILEDINIT:
+		return .Network_Unreachable
+	case .WSAEAFNOSUPPORT, .WSAEINPROGRESS, .WSAEINVAL, .WSAEPROTOTYPE, .WSAESOCKTNOSUPPORT:
+		return .Invalid_Argument
+	case .WSAEMFILE, .WSAENOBUFS, .WSAEPROTONOSUPPORT:
+		return .Insufficient_Resources
+	case:
+		return .Unknown
+	}
 }
 
-Accept_Error :: enum c.int {
-	None                                              = 0,
-	Not_Listening                                     = win.WSAEINVAL,
-	No_Socket_Descriptors_Available_For_Client_Socket = win.WSAEMFILE,
-	No_Buffer_Space_Available                         = win.WSAENOBUFS,
-	Not_Socket                                        = win.WSAENOTSOCK,
-	Not_Connection_Oriented_Socket                    = win.WSAEOPNOTSUPP,
-
-	// TODO: we may need special handling for this; maybe make a socket a struct with metadata?
-	Would_Block                                       = win.WSAEWOULDBLOCK, 
+_dial_error :: proc() -> Dial_Error {
+	#partial switch win.System_Error(win.WSAGetLastError()) {
+	case .WSANOTINITIALISED, .WSAENETDOWN:
+		return .Network_Unreachable
+	case .WSAEADDRINUSE:
+		return .Address_In_Use
+	case .WSAEINTR:
+		return .Interrupted
+	case .WSAEWOULDBLOCK:
+		return .Would_Block
+	case .WSAEALREADY:
+		return .Already_Connecting
+	case .WSAEADDRNOTAVAIL, .WSAEAFNOSUPPORT, .WSAEFAULT, .WSAENOTSOCK, .WSAEINPROGRESS, .WSAEINVAL:
+		return .Invalid_Argument
+	case .WSAECONNREFUSED:
+		return .Refused
+	case .WSAEISCONN:
+		return .Already_Connected
+	case .WSAEHOSTUNREACH:
+		return .Host_Unreachable
+	case .WSAENOBUFS:
+		return .Insufficient_Resources
+	case .WSAETIMEDOUT:
+		return .Timeout
+	case .WSAEACCES:
+		return .Broadcast_Not_Supported
+	case:
+		return .Unknown
+	}
 }
 
-TCP_Recv_Error :: enum c.int {
-	None                      = 0,
-	Network_Subsystem_Failure = win.WSAENETDOWN,
-	Not_Connected             = win.WSAENOTCONN,
-	Bad_Buffer                = win.WSAEFAULT,
-	Keepalive_Failure         = win.WSAENETRESET,
-	Not_Socket                = win.WSAENOTSOCK,
-	Shutdown                  = win.WSAESHUTDOWN,
-	Would_Block               = win.WSAEWOULDBLOCK,
-	Aborted                   = win.WSAECONNABORTED, 
-	Timeout                   = win.WSAETIMEDOUT,
-
-	// TODO(tetra): Determine when this is different from the syscall returning n=0 and maybe normalize them?
-	Connection_Closed         = win.WSAECONNRESET, 
-
-	// TODO: verify can actually happen
-	Host_Unreachable          = win.WSAEHOSTUNREACH,
+_bind_error :: proc() -> Bind_Error {
+	#partial switch win.System_Error(win.WSAGetLastError()) {
+	case .WSANOTINITIALISED, .WSAENETDOWN:
+		return .Network_Unreachable
+	case .WSAEADDRINUSE:
+		return .Address_In_Use
+	case .WSAEADDRNOTAVAIL, .WSAEFAULT, .WSAEINPROGRESS, .WSAEACCES, .WSAEINVAL, .WSAENOTSOCK:
+		return .Invalid_Argument
+	case:
+		return .Unknown
+	}
 }
 
-UDP_Recv_Error :: enum c.int {
-	None                      = 0,
-	Network_Subsystem_Failure = win.WSAENETDOWN,
-	Aborted                   = win.WSAECONNABORTED,
-	Buffer_Too_Small          = win.WSAEMSGSIZE,     // The buffer is too small to fit the entire message, and the message was truncated. When this happens, the rest of message is lost.
-	Remote_Not_Listening      = win.WSAECONNRESET,   // The machine at the remote endpoint doesn't have the given port open to receiving UDP data.
-	Shutdown                  = win.WSAESHUTDOWN,
-	Broadcast_Disabled        = win.WSAEACCES,       // A broadcast address was specified, but the .Broadcast socket option isn't set.
-	Bad_Buffer                = win.WSAEFAULT,
-	No_Buffer_Space_Available = win.WSAENOBUFS,
-	Not_Socket                = win.WSAENOTSOCK,     // The socket is not valid socket handle.
-	Would_Block               = win.WSAEWOULDBLOCK,
-	Host_Unreachable          = win.WSAEHOSTUNREACH, // The remote host cannot be reached from this host at this time.
-	Offline                   = win.WSAENETUNREACH,  // The network cannot be reached from this host at this time.
-	Timeout                   = win.WSAETIMEDOUT,
-
-	// TODO: can this actually happen? The socket isn't bound; an unknown flag specified; or MSG_OOB specified with SO_OOBINLINE enabled.
-	Incorrectly_Configured    = win.WSAEINVAL, 
-	TTL_Expired               = win.WSAENETRESET,    // The message took more hops than was allowed (the Time To Live) to reach the remote endpoint.
+_listen_error :: proc() -> Listen_Error {
+	#partial switch win.System_Error(win.WSAGetLastError()) {
+	case .WSANOTINITIALISED, .WSAENETDOWN:
+		return .Network_Unreachable
+	case .WSAEMFILE, .WSAENOBUFS:
+		return .Insufficient_Resources
+	case .WSAEADDRINUSE:
+		return .Address_In_Use
+	case .WSAEINPROGRESS, .WSAENOTSOCK:
+		return .Invalid_Argument
+	case .WSAEISCONN:
+		return .Already_Connected
+	case .WSAEOPNOTSUPP, .WSAEINVAL:
+		return .Unsupported_Socket
+	case:
+		return .Unknown
+	}
 }
 
-// TODO: consider merging some errors to make handling them easier
-// TODO: verify once more what errors to actually expose
-TCP_Send_Error :: enum c.int {
-	None                      = 0,
-	
-	Aborted                   = win.WSAECONNABORTED, 
-	Not_Connected             = win.WSAENOTCONN,
-	Shutdown                  = win.WSAESHUTDOWN,
-	Connection_Closed         = win.WSAECONNRESET,
-	No_Buffer_Space_Available = win.WSAENOBUFS,
-	Network_Subsystem_Failure = win.WSAENETDOWN,
-	Host_Unreachable          = win.WSAEHOSTUNREACH,
-	Would_Block               = win.WSAEWOULDBLOCK,
-
-	// TODO: verify possible, as not mentioned in docs
-	Offline                   = win.WSAENETUNREACH,  
-	Timeout                   = win.WSAETIMEDOUT,
-
-	// A broadcast address was specified, but the .Broadcast socket option isn't set.
-	Broadcast_Disabled        = win.WSAEACCES,
-	Bad_Buffer                = win.WSAEFAULT,
-
-	// Connection is broken due to keepalive activity detecting a failure during the operation.
-	Keepalive_Failure         = win.WSAENETRESET, // TODO: not functionally different from Reset; merge?
-	Not_Socket                = win.WSAENOTSOCK,  // The so-called socket is not an open socket.
+_accept_error :: proc() -> Accept_Error {
+	#partial switch win.System_Error(win.WSAGetLastError()) {
+	case .WSANOTINITIALISED, .WSAENETDOWN:
+		return .Network_Unreachable
+	case .WSAEMFILE, .WSAENOBUFS:
+		return .Insufficient_Resources
+	case .WSAECONNRESET:
+		return .Aborted
+	case .WSAEFAULT, .WSAEINPROGRESS, .WSAENOTSOCK:
+		return .Invalid_Argument
+	case .WSAEINTR:
+		return .Interrupted
+	case .WSAEINVAL:
+		return .Not_Listening
+	case .WSAEWOULDBLOCK:
+		return .Would_Block
+	case .WSAEOPNOTSUPP:
+		return .Unsupported_Socket
+	case:
+		return .Unknown
+	}
 }
 
-UDP_Send_Error :: enum c.int {
-	None                      = 0,
-	Network_Subsystem_Failure = win.WSAENETDOWN,
-
-	Aborted                   = win.WSAECONNABORTED,
-	Message_Too_Long          = win.WSAEMSGSIZE, 	 // The message is larger than the maximum UDP packet size.
-	Remote_Not_Listening      = win.WSAECONNRESET,   // The machine at the remote endpoint doesn't have the given port open to receiving UDP data.
-	Shutdown                  = win.WSAESHUTDOWN,    // A broadcast address was specified, but the .Broadcast socket option isn't set.
-	Broadcast_Disabled        = win.WSAEACCES,
-	Bad_Buffer                = win.WSAEFAULT,       // Connection is broken due to keepalive activity detecting a failure during the operation.
-
-	// TODO: not functionally different from Reset; merge?
-	Keepalive_Failure         = win.WSAENETRESET, 
-	No_Buffer_Space_Available = win.WSAENOBUFS,
-	Not_Socket                = win.WSAENOTSOCK,     // The socket is not valid socket handle.
-
-	// This socket is unidirectional and cannot be used to send any data.
-	// TODO: verify possible; decide whether to keep if not
-	Receive_Only                         = win.WSAEOPNOTSUPP,
-	Would_Block                          = win.WSAEWOULDBLOCK,
-	Host_Unreachable                     = win.WSAEHOSTUNREACH,  // The remote host cannot be reached from this host at this time.
-	Cannot_Use_Any_Address               = win.WSAEADDRNOTAVAIL, // Attempt to send to the Any address.
-	Family_Not_Supported_For_This_Socket = win.WSAEAFNOSUPPORT,  // The address is of an incorrect address family for this socket.
-	Offline                              = win.WSAENETUNREACH,   // The network cannot be reached from this host at this time.
-	Timeout                              = win.WSAETIMEDOUT,
+_tcp_recv_error :: proc() -> TCP_Recv_Error {
+	#partial switch win.System_Error(win.WSAGetLastError()) {
+	case .WSANOTINITIALISED, .WSAENETDOWN:
+		return .Network_Unreachable
+	case .WSAEFAULT, .WSAEINPROGRESS, .WSAENOTSOCK, .WSAEMSGSIZE, .WSAEINVAL, .WSAEOPNOTSUPP:
+		return .Invalid_Argument
+	case .WSAENOTCONN:
+		return .Not_Connected
+	case .WSAEINTR:
+		return .Interrupted
+	case .WSAENETRESET, .WSAESHUTDOWN, .WSAECONNABORTED, .WSAECONNRESET:
+		return .Connection_Closed
+	case .WSAEWOULDBLOCK:
+		return .Would_Block
+	case .WSAETIMEDOUT:
+		return .Timeout
+	case:
+		return .Unknown
+	}
 }
 
-Shutdown_Manner :: enum c.int {
-	Receive = win.SD_RECEIVE,
-	Send    = win.SD_SEND,
-	Both    = win.SD_BOTH,
+_udp_recv_error :: proc() -> UDP_Recv_Error {
+	#partial switch win.System_Error(win.WSAGetLastError()) {
+	case .WSANOTINITIALISED, .WSAENETDOWN:
+		return .Network_Unreachable
+	case .WSAEFAULT, .WSAEINPROGRESS, .WSAEINVAL, .WSAEISCONN, .WSAENOTSOCK, .WSAEOPNOTSUPP, .WSAEMSGSIZE:
+		return .Invalid_Argument
+	case .WSAEINTR:
+		return .Interrupted
+	case .WSAENETRESET, .WSAESHUTDOWN, .WSAECONNRESET:
+		return .Connection_Refused
+	case .WSAEWOULDBLOCK:
+		return .Would_Block
+	case .WSAETIMEDOUT:
+		return .Timeout
+	case:
+		return .Unknown
+	}
 }
 
-Shutdown_Error :: enum c.int {
-	None           = 0,
-	Aborted        = win.WSAECONNABORTED,
-	Reset          = win.WSAECONNRESET,
-	Offline        = win.WSAENETDOWN,
-	Not_Connected  = win.WSAENOTCONN,
-	Not_Socket     = win.WSAENOTSOCK,
-	Invalid_Manner = win.WSAEINVAL,
+_tcp_send_error :: proc() -> TCP_Send_Error {
+	#partial switch win.System_Error(win.WSAGetLastError()) {
+	case .WSANOTINITIALISED, .WSAENETDOWN:
+		return .Network_Unreachable
+	case .WSAENOBUFS:
+		return .Insufficient_Resources
+	case .WSAEACCES, .WSAEINPROGRESS, .WSAEFAULT, .WSAENOTSOCK, .WSAEOPNOTSUPP, .WSAEMSGSIZE, .WSAEINVAL:
+		return .Invalid_Argument
+	case .WSAEINTR:
+		return .Interrupted
+	case .WSAENETRESET, .WSAESHUTDOWN, .WSAECONNABORTED, .WSAECONNRESET:
+		return .Connection_Closed
+	case .WSAENOTCONN:
+		return .Not_Connected
+	case .WSAEWOULDBLOCK:
+		return .Would_Block
+	case .WSAETIMEDOUT:
+		return .Timeout
+	case .WSAEHOSTUNREACH:
+		return .Host_Unreachable
+	case:
+		return .Unknown
+	}
 }
 
-Socket_Option :: enum c.int {
-	// bool: Whether the address that this socket is bound to can be reused by other sockets.
-	//       This allows you to bypass the cooldown period if a program dies while the socket is bound.
-	Reuse_Address             = win.SO_REUSEADDR,
-
-	// bool: Whether other programs will be inhibited from binding the same endpoint as this socket.
-	Exclusive_Addr_Use        = win.SO_EXCLUSIVEADDRUSE,
-
-	// bool: When true, keepalive packets will be automatically be sent for this connection. TODO: verify this understanding
-	Keep_Alive                = win.SO_KEEPALIVE, 
-
-	// bool: When true, client connections will immediately be sent a TCP/IP RST response, rather than being accepted.
-	Conditional_Accept        = win.SO_CONDITIONAL_ACCEPT,
-
-	// bool: If true, when the socket is closed, but data is still waiting to be sent, discard that data.
-	Dont_Linger               = win.SO_DONTLINGER,
-
-	// bool: When true, 'out-of-band' data sent over the socket will be read by a normal net.recv() call, the same as normal 'in-band' data.
-	Out_Of_Bounds_Data_Inline = win.SO_OOBINLINE,   
-
-	// bool: When true, disables send-coalescing, therefore reducing latency.
-	TCP_Nodelay               = win.TCP_NODELAY, 
-
-	// win.LINGER: Customizes how long (if at all) the socket will remain open when there
-	// is some remaining data waiting to be sent, and net.close() is called.
-	Linger                    = win.SO_LINGER, 
-
-	// win.DWORD: The size, in bytes, of the OS-managed receive-buffer for this socket.
-	Receive_Buffer_Size       = win.SO_RCVBUF, 
-
-	// win.DWORD: The size, in bytes, of the OS-managed send-buffer for this socket.
-	Send_Buffer_Size          = win.SO_SNDBUF,
-
-	// win.DWORD: For blocking sockets, the time in milliseconds to wait for incoming data to be received, before giving up and returning .Timeout.
-	//            For non-blocking sockets, ignored.
-	//            Use a value of zero to potentially wait forever.
-	Receive_Timeout           = win.SO_RCVTIMEO,
-
-	// win.DWORD: For blocking sockets, the time in milliseconds to wait for outgoing data to be sent, before giving up and returning .Timeout.
-	//            For non-blocking sockets, ignored.
-	//            Use a value of zero to potentially wait forever.
-	Send_Timeout              = win.SO_SNDTIMEO,
-
-	// bool: Allow sending to, receiving from, and binding to, a broadcast address.
-	Broadcast                 = win.SO_BROADCAST, 
+_udp_send_error :: proc() -> UDP_Send_Error {
+	#partial switch win.System_Error(win.WSAGetLastError()) {
+	case .WSANOTINITIALISED, .WSAENETDOWN, .WSAENETUNREACH:
+		return .Network_Unreachable
+	case .WSAENOBUFS:
+		return .Insufficient_Resources
+	case .WSAEACCES, .WSAEINVAL, .WSAEINPROGRESS, .WSAEFAULT, .WSAENOTCONN, .WSAENOTSOCK, .WSAEOPNOTSUPP, .WSAEADDRNOTAVAIL, .WSAEAFNOSUPPORT, .WSAEDESTADDRREQ:
+		return .Invalid_Argument
+	case .WSAEINTR:
+		return .Interrupted
+	case .WSAENETRESET, .WSAESHUTDOWN, .WSAECONNRESET:
+		return .Connection_Refused
+	case .WSAEWOULDBLOCK:
+		return .Would_Block
+	case .WSAETIMEDOUT:
+		return .Timeout
+	case:
+		return .Unknown
+	}
 }
 
-Socket_Option_Error :: enum c.int {
-	None                               = 0,
-	Linger_Only_Supports_Whole_Seconds = 1,
-
-	// The given value is too big or small to be given to the OS.
-	Value_Out_Of_Range, 
-
-	Network_Subsystem_Failure          = win.WSAENETDOWN,
-	Timeout_When_Keepalive_Set         = win.WSAENETRESET,
-	Invalid_Option_For_Socket          = win.WSAENOPROTOOPT,
-	Reset_When_Keepalive_Set           = win.WSAENOTCONN,
-	Not_Socket                         = win.WSAENOTSOCK,
+_shutdown_error :: proc() -> Shutdown_Error {
+	#partial switch win.System_Error(win.WSAGetLastError()) {
+	case .WSAENETDOWN, .WSANOTINITIALISED:
+		return .Network_Unreachable
+	case .WSAECONNABORTED, .WSAECONNRESET:
+		return .Connection_Closed
+	case .WSAEINPROGRESS, .WSAEINVAL, .WSAENOTCONN, .WSAENOTSOCK:
+		return .Invalid_Argument
+	case:
+		return .Unknown
+	}
 }
 
-Set_Blocking_Error :: enum c.int {
-	None = 0,
+_socket_option_error :: proc() -> Socket_Option_Error {
+	#partial switch win.System_Error(win.WSAGetLastError()) {
+	case .WSAENETDOWN, .WSANOTINITIALISED:
+		return .Network_Unreachable
+	case .WSAEFAULT, .WSAEINVAL:
+		return .Invalid_Value
+	case .WSAENETRESET, .WSAENOTCONN, .WSAENOTSOCK:
+		return .Invalid_Socket
+	case .WSAENOPROTOOPT:
+		return .Invalid_Option
+	case:
+		return .Unknown
+	}
+}
 
-	Network_Subsystem_Failure          = win.WSAENETDOWN,
-	Blocking_Call_In_Progress          = win.WSAEINPROGRESS,
-	Not_Socket                         = win.WSAENOTSOCK,
-
-	// TODO: are those errors possible?
-	Network_Subsystem_Not_Initialized  = win.WSAENOTINITIALISED,
-	Invalid_Argument_Pointer           = win.WSAEFAULT,
+_set_blocking_error :: proc() -> Set_Blocking_Error {
+	#partial switch win.System_Error(win.WSAGetLastError()) {
+	case .WSAENETDOWN, .WSANOTINITIALISED:
+		return .Network_Unreachable
+	case .WSAEINPROGRESS, .WSAENOTSOCK, .WSAEFAULT:
+		return .Invalid_Argument
+	case:
+		return .Unknown
+	}
 }

--- a/core/net/interface.odin
+++ b/core/net/interface.odin
@@ -27,7 +27,7 @@ MAX_INTERFACE_ENUMERATION_TRIES :: 3
 /*
 	`enumerate_interfaces` retrieves a list of network interfaces with their associated properties.
 */
-enumerate_interfaces :: proc(allocator := context.allocator) -> (interfaces: []Network_Interface, err: Network_Error) {
+enumerate_interfaces :: proc(allocator := context.allocator) -> (interfaces: []Network_Interface, err: Interfaces_Error) {
 	return _enumerate_interfaces(allocator)
 }
 

--- a/core/net/interface_darwin.odin
+++ b/core/net/interface_darwin.odin
@@ -26,7 +26,7 @@ import "core:sys/posix"
 foreign import lib "system:System.framework"
 
 @(private)
-_enumerate_interfaces :: proc(allocator := context.allocator) -> (interfaces: []Network_Interface, err: Network_Error) {
+_enumerate_interfaces :: proc(allocator := context.allocator) -> (interfaces: []Network_Interface, err: Interfaces_Error) {
 	context.allocator = allocator
 
 	head: ^ifaddrs
@@ -47,7 +47,7 @@ _enumerate_interfaces :: proc(allocator := context.allocator) -> (interfaces: []
 			iface.adapter_name = key_ptr^
 		}
 		if mem_err != nil {
-			return {}, .Unable_To_Enumerate_Network_Interfaces
+			return {}, .Allocation_Failure
 		}
 
 		address: Address

--- a/core/net/interface_freebsd.odin
+++ b/core/net/interface_freebsd.odin
@@ -25,7 +25,7 @@ import "core:strings"
 import "core:sys/freebsd"
 
 @(private)
-_enumerate_interfaces :: proc(allocator := context.allocator) -> (interfaces: []Network_Interface, err: Network_Error) {
+_enumerate_interfaces :: proc(allocator := context.allocator) -> (interfaces: []Network_Interface, err: Interfaces_Error) {
 	// This is a simplified implementation of `getifaddrs` from the FreeBSD
 	// libc using only Odin and syscalls.
 	context.allocator = allocator
@@ -50,7 +50,7 @@ _enumerate_interfaces :: proc(allocator := context.allocator) -> (interfaces: []
 	// Allocate and get the entries.
 	buf, alloc_err := make([]byte, needed)
 	if alloc_err != nil {
-		return nil, .Unable_To_Enumerate_Network_Interfaces
+		return nil, .Allocation_Failure
 	}
 	defer delete(buf)
 

--- a/core/net/interface_linux.odin
+++ b/core/net/interface_linux.odin
@@ -30,7 +30,7 @@ package net
 // NOTE(flysand): https://man7.org/linux/man-pages/man7/netlink.7.html
 // apparently musl libc uses this to enumerate network interfaces
 @(private)
-_enumerate_interfaces :: proc(allocator := context.allocator) -> (interfaces: []Network_Interface, err: Network_Error) {
+_enumerate_interfaces :: proc(allocator := context.allocator) -> (interfaces: []Network_Interface, err: Interfaces_Error) {
 	context.allocator = allocator
 
 	// head: ^os.ifaddrs

--- a/core/sys/windows/ws2_32.odin
+++ b/core/sys/windows/ws2_32.odin
@@ -91,6 +91,7 @@ foreign ws2_32 {
 	WSACleanup :: proc() -> c_int ---
 	// [MS-Docs](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsagetlasterror)
 	WSAGetLastError :: proc() -> c_int ---
+	WSASetLastError :: proc(err: c_int) ---
 	// [MS-Docs](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsapoll)
 	WSAPoll :: proc(fdArray: ^WSA_POLLFD, fds: c_ulong, timeout: c_int) -> c_int ---
 	// [MS-Docs](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsaduplicatesocketw)

--- a/tests/core/net/test_core_net_freebsd.odin
+++ b/tests/core/net/test_core_net_freebsd.odin
@@ -17,9 +17,6 @@ import "core:net"
 import "core:time"
 import "core:testing"
 
-ENDPOINT_DUPLICATE_BINDING := net.Endpoint{net.IP4_Address{127, 0, 0, 1}, 11000}
-ENDPOINT_EPIPE_TEST        := net.Endpoint{net.IP4_Address{127, 0, 0, 1}, 11001}
-
 @test
 test_duplicate_binding :: proc(t: ^testing.T) {
 	// FreeBSD has the capacity to permit multiple processes and sockets to
@@ -35,8 +32,13 @@ test_duplicate_binding :: proc(t: ^testing.T) {
 	if !testing.expect_value(t, err_set1, nil) {
 		return
 	}
-	err_bind1 := net.bind(tcp_socket1, ENDPOINT_DUPLICATE_BINDING)
+	err_bind1 := net.bind(tcp_socket1, {net.IP4_Loopback, 0})
 	if !testing.expect_value(t, err_bind1, nil) {
+		return
+	}
+
+	ep, err_bound := net.bound_endpoint(tcp_socket1)
+	if !testing.expect_value(t, err_bound, nil) {
 		return
 	}
 
@@ -50,7 +52,7 @@ test_duplicate_binding :: proc(t: ^testing.T) {
 	if !testing.expect_value(t, err_set2, nil) {
 		return
 	}
-	err_bind2 := net.bind(tcp_socket2, ENDPOINT_DUPLICATE_BINDING)
+	err_bind2 := net.bind(tcp_socket2, ep)
 	if !testing.expect_value(t, err_bind2, nil) {
 		return
 	}
@@ -60,13 +62,18 @@ test_duplicate_binding :: proc(t: ^testing.T) {
 test_sigpipe_bypass :: proc(t: ^testing.T) {
 	// If the internals aren't working as expected, this test will fail by raising SIGPIPE.
 
-	server_socket, listen_err := net.listen_tcp(ENDPOINT_EPIPE_TEST)
+	server_socket, listen_err := net.listen_tcp({net.IP4_Loopback, 0})
 	if !testing.expect_value(t, listen_err, nil) {
 		return
 	}
 	defer net.close(server_socket)
 
-	client_socket, dial_err := net.dial_tcp(ENDPOINT_EPIPE_TEST)
+	ep, bound_err := net.bound_endpoint(server_socket)
+	if !testing.expect_value(t, bound_err, nil) {
+		return
+	}
+
+	client_socket, dial_err := net.dial_tcp(ep)
 	if !testing.expect_value(t, dial_err, nil) {
 		return
 	}
@@ -80,7 +87,7 @@ test_sigpipe_bypass :: proc(t: ^testing.T) {
 
 	data := "Hellope!"
 	bytes_written, err_send := net.send(client_socket, transmute([]u8)data)
-	if !testing.expect_value(t, err_send, net.TCP_Send_Error.Cannot_Send_More_Data) {
+	if !testing.expect_value(t, err_send, net.TCP_Send_Error.Connection_Closed) {
 		return
 	}
 	if !testing.expect_value(t, bytes_written, 0) {


### PR DESCRIPTION
Also fixes some platform inconsistencies I came across.

Errors were not cross-platform, discussed with @Kelimion for a proper solution and we came up with this.

For an example, here is TCP_Send_Error, where I pulled all possible definitions, this is problematic because you can't handle them in a cross-platform manner:
```odin
// All targets define:
Connection_Closed
Not_Connected
No_Buffer_Space_Available
Host_Unreachable
Not_Socket
// Darwin & Linux & Windows define:
Aborted
Shutdown
Offline
Timeout
// Darwin & Linux define:
Interrupted
// Windows defines:
Network_Subsystem_Failure
Broadcast_Disabled
Bad_Buffer
Keepalive_Failure
// FreeBSD & Windows defines:
Would_Block
// FreeBSD defines:
Not_Descriptor
Broadcast_Status_Mismatch
Argument_In_Invalid_Address_Space
Message_Size_Breaks_Atomicity
Already_Connected
ICMP_Unreachable
Host_Down
Network_Down
Jailed_Socket_Tried_To_Escape
Cannot_Send_More_Data
```

Now they are mapped into common categories, and you can still get at the detailed platform error code using the `last_platform_error()` functions if you need it in situations where the categories aren't enough.