### PR TITLE
Add iterator for `core:text/regex`.

### DIFF
--- a/tests/core/text/regex/test_core_text_regex.odin
+++ b/tests/core/text/regex/test_core_text_regex.odin
@@ -1114,7 +1114,7 @@ iterator_vectors := []Iterator_Test{
 			{pos = {{2,  8},  {3,  4},  {6,  8}}, groups = {"foobar", "o", "ar"}},
 			{pos = {{9, 15}, {10, 11}, {13, 15}}, groups = {"foobar", "o", "ar"}},
 		},
-	}
+	},
 }
 
 @test


### PR DESCRIPTION
Usage:
```odin
haystack := `xxfoobarxfoobarxx`
pattern  := `f(o)ob(ar)`

it := regex.create_iterator(haystack, pattern, {.Global}) or_return
defer regex.destroy(it)

for capture in regex.match(&it) {
	fmt.println(capture)
}
```

Output:
```
Capture{pos = [[2, 8], [3, 4], [6, 8]], groups = ["foobar", "o", "ar"]}
Capture{pos = [[9, 15], [10, 11], [13, 15]], groups = ["foobar", "o", "ar"]}
```