### PR TITLE
Fix printing of `bit_set[Enum]` when `min(Enum) != 0`

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -1802,11 +1802,8 @@ fmt_bit_set :: proc(fi: ^Info, v: any, name: string = "", verb: rune = 'v') {
 
 		e, is_enum := et.variant.(runtime.Type_Info_Enum)
 		commas := 0
-		loop: for i in 0 ..< bit_size {
-			if bits & (1<<i) == 0 {
-				continue loop
-			}
-
+		loop: for i in transmute(bit_set[0..<128])bits {
+			i := i64(i) + info.lower
 			if commas > 0 {
 				io.write_string(fi.writer, ", ", &fi.n)
 			}
@@ -1829,8 +1826,7 @@ fmt_bit_set :: proc(fi: ^Info, v: any, name: string = "", verb: rune = 'v') {
 					}
 				}
 			}
-			v := i64(i) + info.lower
-			io.write_i64(fi.writer, v, 10, &fi.n)
+			io.write_i64(fi.writer, i, 10, &fi.n)
 			commas += 1
 		}
 	}


### PR DESCRIPTION
The lower bound of the `bit_set` was only being applied *after* searching for a matching enum value, so values wouldn't match correctly if the minimum value of the enum wasn't 0.

Not directly related, but also changed the `for` loop to use a `bit_set` instead of testing each index.

Example:
```odin
package main
import "core:fmt"

Direction :: enum u8 {
    North = 1,
    South,
    East,
    West,
}

main :: proc() {
	neighbors := bit_set[Direction] {.North, .South}
	fmt.println(neighbors)
}
```
Before:
```
bit_set[Direction]{1, North}
```
After:
```
bit_set[Direction]{North, South}
```