### PR TITLE
vendor/glfw: fix SetMonitorCallback and MonitorProc type definition

### DIFF
--- a/vendor/glfw/bindings/bindings.odin
+++ b/vendor/glfw/bindings/bindings.odin
@@ -193,7 +193,6 @@ foreign glfw {
 	SetWindowPosCallback          :: proc(window: WindowHandle, cbfun: WindowPosProc)          -> WindowPosProc ---
 	SetFramebufferSizeCallback    :: proc(window: WindowHandle, cbfun: FramebufferSizeProc)    -> FramebufferSizeProc ---
 	SetDropCallback               :: proc(window: WindowHandle, cbfun: DropProc)               -> DropProc ---
-	SetMonitorCallback            :: proc(window: WindowHandle, cbfun: MonitorProc)            -> MonitorProc ---
 	SetWindowMaximizeCallback     :: proc(window: WindowHandle, cbfun: WindowMaximizeProc)     -> WindowMaximizeProc ---
 	SetWindowContentScaleCallback :: proc(window: WindowHandle, cbfun: WindowContentScaleProc) -> WindowContentScaleProc ---
 
@@ -204,7 +203,9 @@ foreign glfw {
 	SetCharCallback        :: proc(window: WindowHandle, cbfun: CharProc)        -> CharProc ---
 	SetCharModsCallback    :: proc(window: WindowHandle, cbfun: CharModsProc)    -> CharModsProc ---
 	SetCursorEnterCallback :: proc(window: WindowHandle, cbfun: CursorEnterProc) -> CursorEnterProc ---
-	SetJoystickCallback    :: proc(cbfun: JoystickProc)    -> JoystickProc ---
+
+	SetMonitorCallback  :: proc(cbfun: MonitorProc)  -> MonitorProc ---
+	SetJoystickCallback :: proc(cbfun: JoystickProc) -> JoystickProc ---
 
 	SetErrorCallback :: proc(cbfun: ErrorProc) -> ErrorProc ---
 

--- a/vendor/glfw/bindings/types.odin
+++ b/vendor/glfw/bindings/types.odin
@@ -48,7 +48,7 @@ WindowMaximizeProc     :: #type proc "c" (window: WindowHandle, iconified: c.int
 WindowContentScaleProc :: #type proc "c" (window: WindowHandle, xscale, yscale: f32)
 FramebufferSizeProc    :: #type proc "c" (window: WindowHandle, width, height: c.int)
 DropProc               :: #type proc "c" (window: WindowHandle, count: c.int, paths: [^]cstring)
-MonitorProc            :: #type proc "c" (window: WindowHandle, event: c.int)
+MonitorProc            :: #type proc "c" (monitor: MonitorHandle, event: c.int)
 
 KeyProc                :: #type proc "c" (window: WindowHandle, key, scancode, action, mods: c.int)
 MouseButtonProc        :: #type proc "c" (window: WindowHandle, button, action, mods: c.int)


### PR DESCRIPTION
SetMonitorCallback does not take a WindowHandle and MonitorProc has a MonitorHandle as the first argument.