### PR TITLE
Fix the CI badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
         <img src="https://img.shields.io/discord/568138951836172421?logo=discord">
     </a>
     <a href="https://github.com/odin-lang/odin/actions">
-        <img src="https://github.com/odin-lang/odin/workflows/CI/badge.svg?branch=master&event=push">
+        <img src="https://github.com/odin-lang/odin/actions/workflows/ci.yml/badge.svg?branch=master&event=push">
     </a>
 </p>
 


### PR DESCRIPTION
The CI badge in `README.md` was not displaying the CI status. Caught my eye so I fixed it. The correct URL for the badge requires the file extension (`.yml`) and the path is supposed to be `/actions/workflows` instead of just `/workflows`.

Old: <img src="https://github.com/odin-lang/odin/workflows/CI/badge.svg?branch=master&event=push" />

New: <img src="https://github.com/odin-lang/odin/actions/workflows/ci.yml/badge.svg?branch=master&event=push" />