### PR TITLE
add quotes for absolute path

### DIFF
--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -603,7 +603,7 @@ try_cross_linking:;
 								// object
 								// dynamic lib
 								// static libs, absolute full path relative to the file in which the lib was imported from
-								lib_str = gb_string_append_fmt(lib_str, " %.*s ", LIT(lib));
+								lib_str = gb_string_append_fmt(lib_str, " \"%.*s\" ", LIT(lib));
 							} else {
 								// dynamic or static system lib, just link regularly searching system library paths
 								lib_str = gb_string_append_fmt(lib_str, " -l%.*s ", LIT(lib));


### PR DESCRIPTION
fix #4598
> cannot build application if path to project folder contains spaces, when using foreign import