### PR TITLE
Change .Multiline regex anchors to match common regex implementations

### DIFF
--- a/core/text/regex/compiler/compiler.odin
+++ b/core/text/regex/compiler/compiler.odin
@@ -467,20 +467,12 @@ compile :: proc(tree: Node, flags: common.Flags) -> (code: Program, class_data: 
 
 	if .No_Capture not_in flags {
 		// `(` <generated code>
-		if pc_open < len(code) && code[pc_open] == Opcode.Multiline_Start_Open {
-			pc_open += 2
-		}
 		inject_at(&code, pc_open, Opcode.Save)
 		inject_at(&code, pc_open + size_of(byte), Opcode(0x00))
 
 		// `)`
-		if code[len(code) - 1] == Opcode.Assert_Multiline_End {
-			inject_at(&code, len(code)-1, Opcode.Save)
-			inject_at(&code, len(code)-1, Opcode(0x01))
-		} else {
-			append(&code, Opcode.Save)
-			append(&code, Opcode(0x01))
-		}
+		append(&code, Opcode.Save)
+		append(&code, Opcode(0x01))
 
 		append(&code, Opcode.Match)
 	} else {

--- a/core/text/regex/compiler/compiler.odin
+++ b/core/text/regex/compiler/compiler.odin
@@ -195,8 +195,12 @@ generate_code :: proc(c: ^Compiler, node: Node) -> (code: Program) {
 
 	case ^Node_Anchor:
 		if .Multiline in c.flags {
-			append(&code, Opcode.Multiline_Open)
-			append(&code, Opcode.Multiline_Close)
+			if specific.start {
+				append(&code, Opcode.Multiline_Start_Open)
+				append(&code, Opcode.Multiline_Start_Close)
+			} else {
+				append(&code, Opcode.Assert_Multiline_End)
+			}
 		} else {
 			if specific.start {
 				append(&code, Opcode.Assert_Start)
@@ -463,11 +467,20 @@ compile :: proc(tree: Node, flags: common.Flags) -> (code: Program, class_data: 
 
 	if .No_Capture not_in flags {
 		// `(` <generated code>
+		if pc_open < len(code) && code[pc_open] == Opcode.Multiline_Start_Open {
+			pc_open += 2
+		}
 		inject_at(&code, pc_open, Opcode.Save)
 		inject_at(&code, pc_open + size_of(byte), Opcode(0x00))
 
 		// `)`
-		append(&code, Opcode.Save); append(&code, Opcode(0x01))
+		if code[len(code) - 1] == Opcode.Assert_Multiline_End {
+			inject_at(&code, len(code)-1, Opcode.Save)
+			inject_at(&code, len(code)-1, Opcode(0x01))
+		} else {
+			append(&code, Opcode.Save)
+			append(&code, Opcode(0x01))
+		}
 
 		append(&code, Opcode.Match)
 	} else {

--- a/core/text/regex/regex.odin
+++ b/core/text/regex/regex.odin
@@ -285,10 +285,6 @@ create_iterator :: proc(
 	flags := flags
 	flags += {.Global} // We're iterating over a string, so the next match could start anywhere
 
-	if .Multiline in flags {
-		return {}, .Unsupported_Flag
-	}
-
 	result.regex         = create(pattern, flags, permanent_allocator, temporary_allocator) or_return
 	result.capture       = preallocate_capture()
 	result.temp          = temporary_allocator

--- a/core/text/regex/virtual_machine/doc.odin
+++ b/core/text/regex/virtual_machine/doc.odin
@@ -171,7 +171,7 @@ For more information, see: https://swtch.com/~rsc/regexp/regexp2.html
 	Be aware, this opcode is not compiled in if the `Multiline` flag is on, as
 	the meaning of `$` changes with that flag.
 
-	(0x15) Assert_Multiline_end
+	(0x15) Assert_Multiline_End
 
 	This opcode is compiled in only when the `Multiline` flag is present, and
 	it replaces the `$` text anchor.

--- a/core/text/regex/virtual_machine/doc.odin
+++ b/core/text/regex/virtual_machine/doc.odin
@@ -178,10 +178,5 @@ For more information, see: https://swtch.com/~rsc/regexp/regexp2.html
 
 	It asserts that either the current thread is on the string
 	boundary, or the thread is on a `\n` or `\r` character.
-	
-	Unlike Multiline_Start_Open and Multiline_Start_Close it does not consume
-	the current character, instead it stops the character from being consumed,
-	potentially allowing the `\n` or `\r` it found to be used for `^` in later
-	matches.
 */
 package regex_vm

--- a/core/text/regex/virtual_machine/doc.odin
+++ b/core/text/regex/virtual_machine/doc.odin
@@ -124,21 +124,21 @@ For more information, see: https://swtch.com/~rsc/regexp/regexp2.html
 
 	A modified version of Assert_Word_Boundary that returns the opposite value.
 
-	(0x0E) Multiline_Open
+	(0x0E) Multiline_Start_Open
 
 	This opcode is compiled in only when the `Multiline` flag is present, and
-	it replaces both `^` and `$` text anchors.
+	it replaces the `^` text anchor.
 
-	It asserts that either the current thread is on one of the string
-	boundaries, or it consumes a `\n` or `\r` character.
+	It asserts that either the current thread is on the string
+	boundary, or it consumes a `\n` or `\r` character.
 
 	If a `\r` character is consumed, the PC will be advanced to the sibling
-	`Multiline_Close` opcode to optionally consume a `\n` character on the next
+	`Multiline_Start_Close` opcode to optionally consume a `\n` character on the next
 	frame.
 
-	(0x0F) Multiline_Close
+	(0x0F) Multiline_Start_Close
 
-	This opcode is always present after `Multiline_Open`.
+	This opcode is always present after `Multiline_Start_Open`.
 
 	It handles consuming the second half of a complete newline, if necessary.
 	For example, Windows newlines are represented by the characters `\r\n`,
@@ -171,5 +171,17 @@ For more information, see: https://swtch.com/~rsc/regexp/regexp2.html
 	Be aware, this opcode is not compiled in if the `Multiline` flag is on, as
 	the meaning of `$` changes with that flag.
 
+	(0x15) Assert_Multiline_end
+
+	This opcode is compiled in only when the `Multiline` flag is present, and
+	it replaces the `$` text anchor.
+
+	It asserts that either the current thread is on the string
+	boundary, or the thread is on a `\n` or `\r` character.
+	
+	Unlike Multiline_Start_Open and Multiline_Start_Close it does not consume
+	the current character, instead it stops the character from being consumed,
+	potentially allowing the `\n` or `\r` it found to be used for `^` in later
+	matches.
 */
 package regex_vm

--- a/core/text/regex/virtual_machine/util.odin
+++ b/core/text/regex/virtual_machine/util.odin
@@ -37,13 +37,14 @@ iterate_opcodes :: proc(iter: ^Opcode_Iterator) -> (opcode: Opcode, pc: int, ok:
 	case .Assert_End:                  iter.pc += size_of(Opcode)
 	case .Assert_Word_Boundary:        iter.pc += size_of(Opcode)
 	case .Assert_Non_Word_Boundary:    iter.pc += size_of(Opcode)
-	case .Multiline_Open:              iter.pc += size_of(Opcode)
-	case .Multiline_Close:             iter.pc += size_of(Opcode)
+	case .Multiline_Start_Open:        iter.pc += size_of(Opcode)
+	case .Multiline_Start_Close:       iter.pc += size_of(Opcode)
 	case .Wait_For_Byte:               iter.pc += size_of(Opcode) + size_of(u8)
 	case .Wait_For_Rune:               iter.pc += size_of(Opcode) + size_of(rune)
 	case .Wait_For_Rune_Class:         iter.pc += size_of(Opcode) + size_of(u8)
 	case .Wait_For_Rune_Class_Negated: iter.pc += size_of(Opcode) + size_of(u8)
 	case .Match_All_And_Escape:        iter.pc += size_of(Opcode)
+	case .Assert_Multiline_End:        iter.pc += size_of(Opcode)
 	case:
 		panic("Invalid opcode found in RegEx program.")
 	}
@@ -53,28 +54,29 @@ iterate_opcodes :: proc(iter: ^Opcode_Iterator) -> (opcode: Opcode, pc: int, ok:
 
 opcode_to_name :: proc(opcode: Opcode) -> (str: string) {
 	switch opcode {
-	case .Match:                       str = "Match"
-	case .Match_And_Exit:              str = "Match_And_Exit"
-	case .Byte:                        str = "Byte"
-	case .Rune:                        str = "Rune"
-	case .Rune_Class:                  str = "Rune_Class"
-	case .Rune_Class_Negated:          str = "Rune_Class_Negated"
-	case .Wildcard:                    str = "Wildcard"
-	case .Jump:                        str = "Jump"
-	case .Split:                       str = "Split"
-	case .Save:                        str = "Save"
-	case .Assert_Start:                str = "Assert_Start"
-	case .Assert_End:                  str = "Assert_End"
-	case .Assert_Word_Boundary:        str = "Assert_Word_Boundary"
-	case .Assert_Non_Word_Boundary:    str = "Assert_Non_Word_Boundary"
-	case .Multiline_Open:              str = "Multiline_Open"
-	case .Multiline_Close:             str = "Multiline_Close"
-	case .Wait_For_Byte:               str = "Wait_For_Byte"
-	case .Wait_For_Rune:               str = "Wait_For_Rune"
-	case .Wait_For_Rune_Class:         str = "Wait_For_Rune_Class"
-	case .Wait_For_Rune_Class_Negated: str = "Wait_For_Rune_Class_Negated"
-	case .Match_All_And_Escape:        str = "Match_All_And_Escape"
-	case:                              str = "<UNKNOWN>"
+	case .Match:                             str = "Match"
+	case .Match_And_Exit:                    str = "Match_And_Exit"
+	case .Byte:                              str = "Byte"
+	case .Rune:                              str = "Rune"
+	case .Rune_Class:                        str = "Rune_Class"
+	case .Rune_Class_Negated:                str = "Rune_Class_Negated"
+	case .Wildcard:                          str = "Wildcard"
+	case .Jump:                              str = "Jump"
+	case .Split:                             str = "Split"
+	case .Save:                              str = "Save"
+	case .Assert_Start:                      str = "Assert_Start"
+	case .Assert_End:                        str = "Assert_End"
+	case .Assert_Word_Boundary:              str = "Assert_Word_Boundary"
+	case .Assert_Non_Word_Boundary:          str = "Assert_Non_Word_Boundary"
+	case .Multiline_Start_Open:              str = "Multiline_Open"
+	case .Multiline_Start_Close:             str = "Multiline_Close"
+	case .Wait_For_Byte:                     str = "Wait_For_Byte"
+	case .Wait_For_Rune:                     str = "Wait_For_Rune"
+	case .Wait_For_Rune_Class:               str = "Wait_For_Rune_Class"
+	case .Wait_For_Rune_Class_Negated:       str = "Wait_For_Rune_Class_Negated"
+	case .Match_All_And_Escape:              str = "Match_All_And_Escape"
+	case .Assert_Multiline_End:              str = "Assert_Multiline_End"
+	case:                                    str = "<UNKNOWN>"
 	}
 
 	return

--- a/core/text/regex/virtual_machine/virtual_machine.odin
+++ b/core/text/regex/virtual_machine/virtual_machine.odin
@@ -47,7 +47,7 @@ Opcode :: enum u8 {
 	Wait_For_Rune_Class               = 0x12, // | u8
 	Wait_For_Rune_Class_Negated       = 0x13, // | u8
 	Match_All_And_Escape              = 0x14, // |
-	Assert_Multiline_End              = 0x15  // |
+	Assert_Multiline_End              = 0x15, // |
 }
 
 Thread :: struct {

--- a/core/text/regex/virtual_machine/virtual_machine.odin
+++ b/core/text/regex/virtual_machine/virtual_machine.odin
@@ -339,14 +339,6 @@ add_thread :: proc(vm: ^Machine, saved: ^[2 * common.MAX_CAPTURE_GROUPS]int, pc:
 }
 
 run :: proc(vm: ^Machine, $UNICODE_MODE: bool) -> (saved: ^[2 * common.MAX_CAPTURE_GROUPS]int, ok: bool) #no_bounds_check {
-	when common.ODIN_DEBUG_REGEX {
-		io.write_string(common.debug_stream, "Whole program::\n")
-		for op in vm.code {
-			io.write_string(common.debug_stream, opcode_to_name(op))
-			io.write_byte(common.debug_stream, '\n')
-		}
-	}
-
 	when UNICODE_MODE {
 		vm.next_rune, vm.next_rune_size = utf8.decode_rune_in_string(vm.memory)
 	} else {

--- a/tests/core/text/regex/test_core_text_regex.odin
+++ b/tests/core/text/regex/test_core_text_regex.odin
@@ -691,11 +691,11 @@ test_case_insensitive :: proc(t: ^testing.T) {
 @test
 test_multiline :: proc(t: ^testing.T) {
 	{
-		EXPR :: `^hellope$world$`
-		check_expression(t, EXPR, "\nhellope\nworld\n", "\nhellope\nworld\n", extra_flags = { .Multiline })
-		check_expression(t, EXPR, "hellope\nworld", "hellope\nworld", extra_flags = { .Multiline })
-		check_expression(t, EXPR, "hellope\rworld", "hellope\rworld", extra_flags = { .Multiline })
-		check_expression(t, EXPR, "hellope\r\nworld", "hellope\r\nworld", extra_flags = { .Multiline })
+		EXPR :: `^hellope$world$` // This should never match
+		check_expression(t, EXPR, "\nhellope\nworld\n", extra_flags = { .Multiline })
+		check_expression(t, EXPR, "hellope\nworld", extra_flags = { .Multiline })
+		check_expression(t, EXPR, "hellope\rworld", extra_flags = { .Multiline })
+		check_expression(t, EXPR, "hellope\r\nworld", extra_flags = { .Multiline })
 	}
 	{
 		EXPR :: `^?.$`
@@ -704,12 +704,12 @@ test_multiline :: proc(t: ^testing.T) {
 	}
 	{
 		EXPR :: `^$`
-		check_expression(t, EXPR, "\n", "\n", extra_flags = { .Multiline })
+		check_expression(t, EXPR, "\n", "", extra_flags = { .Multiline })
 		check_expression(t, EXPR, "", "", extra_flags = { .Multiline })
 	}
 	{
 		EXPR :: `$`
-		check_expression(t, EXPR, "\n", "\n", extra_flags = { .Multiline })
+		check_expression(t, EXPR, "\n", "", extra_flags = { .Multiline })
 		check_expression(t, EXPR, "", "", extra_flags = { .Multiline })
 	}
 }
@@ -1134,4 +1134,18 @@ test_match_iterator :: proc(t: ^testing.T) {
 		}
 		testing.expect_value(t, it.idx, len(test.expected))
 	}
+}
+
+@test
+test_match_iterator_multiline :: proc(t: ^testing.T) {
+	expected_matches := [?]string{"foo1", "foo2", "foo3", "foo4"}
+
+    it, err := regex.create_iterator("foo1\nfoo2\nfoo3\nfoo4", `^foo\d$`, {.Multiline})
+	defer regex.destroy(it)
+
+	testing.expect_value(t, err, nil)
+
+    for match, idx in regex.match(&it) {
+		testing.expect_value(t, match.groups[0], expected_matches[idx])
+    }
 }


### PR DESCRIPTION
Initially, I raised the issue #5017 thinking this was just a problem with the iterator, however after some initial investigation I found that the `^` and `$` anchors when in `.Multiline` mode were including the newline characters in the capture group, which is not the behaviour seen on any of regex101's engines (see images).

So this PR changes the behaviour of `^` and `$` in multiline mode to ensure that newlines are not included in the capture.

To do this I've changed the regex compiler so that Save operations always occur after an opening `Multiline_Start_Open`, and before a `Assert_Multiline_End`. I've added `Assert_Multiline_End` as this requires special behaviour to not progress the string pointer so that one newline can be used by two matches (e.g. `^foo$` on the text `"foo\nfoo"`).

![image](https://github.com/user-attachments/assets/c5910d1f-39f4-4034-8e94-fb51098e2411)
![image](https://github.com/user-attachments/assets/75deb840-712a-44ac-9837-ada6b09d21fe)

@Feoramund your review would be appreciated since you wrote this :)
Closes #5017