### PR TITLE
Allow intrinsics.type_elem_type(simd_vector) to return the element type.

### DIFF
--- a/core/reflect/reflect.odin
+++ b/core/reflect/reflect.odin
@@ -261,7 +261,11 @@ length :: proc(val: any) -> int {
 		} else {
 			return (^runtime.Raw_String)(val.data).len
 		}
+
+	case Type_Info_Simd_Vector:
+		return a.count
 	}
+
 	return 0
 }
 
@@ -287,7 +291,11 @@ capacity :: proc(val: any) -> int {
 
 	case Type_Info_Map:
 		return runtime.map_cap((^runtime.Raw_Map)(val.data)^)
+
+	case Type_Info_Simd_Vector:
+		return a.count
 	}
+
 	return 0
 }
 

--- a/core/reflect/reflect.odin
+++ b/core/reflect/reflect.odin
@@ -176,6 +176,7 @@ typeid_elem :: proc(id: typeid) -> typeid {
 	case Type_Info_Enumerated_Array: return v.elem.id
 	case Type_Info_Slice:            return v.elem.id
 	case Type_Info_Dynamic_Array:    return v.elem.id
+	case Type_Info_Simd_Vector:      return v.elem.id
 	}
 	return id
 }

--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -5550,6 +5550,7 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 			case Type_EnumeratedArray: operand->type = bt->EnumeratedArray.elem; break;
 			case Type_Slice:           operand->type = bt->Slice.elem;           break;
 			case Type_DynamicArray:    operand->type = bt->DynamicArray.elem;    break;
+			case Type_SimdVector:      operand->type = bt->SimdVector.elem;      break;
 			}
 		}
 		operand->mode = Addressing_Type;


### PR DESCRIPTION
Make `type_elem_type(#simd[4]f32)` return `f32`, same as it would for `[4]f32`.