### PR TITLE
Remove Type_Info_Tuple

### DIFF
--- a/base/runtime/core.odin
+++ b/base/runtime/core.odin
@@ -110,7 +110,6 @@ Type_Info_Parameters :: struct { // Only used for procedures parameters and resu
 	types:        []^Type_Info,
 	names:        []string,
 }
-Type_Info_Tuple :: Type_Info_Parameters // Will be removed eventually
 
 Type_Info_Struct_Flags :: distinct bit_set[Type_Info_Struct_Flag; u8]
 Type_Info_Struct_Flag :: enum u8 {

--- a/core/odin/doc-format/doc_format.odin
+++ b/core/odin/doc-format/doc_format.odin
@@ -180,7 +180,7 @@ Type_Kind :: enum u32le {
 	Struct                 = 10,
 	Union                  = 11,
 	Enum                   = 12,
-	Tuple                  = 13,
+	Parameters             = 13,
 	Proc                   = 14,
 	Bit_Set                = 15,
 	Simd_Vector            = 16,
@@ -256,10 +256,10 @@ Type :: struct {
 	types: Array(Type_Index),
 
 	// Used by:
-	// .Named  - 1 field for the definition
-	// .Struct - fields
-	// .Enum   - fields
-	// .Tuple  - parameters (procedures only)
+	// .Named       - 1 field for the definition
+	// .Struct      - fields
+	// .Enum        - fields
+	// .Parameters  - parameters (procedures only)
 	entities: Array(Entity_Index),
 
 	// Used By: .Struct, .Union

--- a/core/reflect/reflect.odin
+++ b/core/reflect/reflect.odin
@@ -24,7 +24,6 @@ Type_Info_Enumerated_Array       :: runtime.Type_Info_Enumerated_Array
 Type_Info_Dynamic_Array          :: runtime.Type_Info_Dynamic_Array
 Type_Info_Slice                  :: runtime.Type_Info_Slice
 Type_Info_Parameters             :: runtime.Type_Info_Parameters
-Type_Info_Tuple                  :: runtime.Type_Info_Parameters
 Type_Info_Struct                 :: runtime.Type_Info_Struct
 Type_Info_Union                  :: runtime.Type_Info_Union
 Type_Info_Enum                   :: runtime.Type_Info_Enum
@@ -58,7 +57,7 @@ Type_Kind :: enum {
 	Enumerated_Array,
 	Dynamic_Array,
 	Slice,
-	Tuple,
+	Parameters,
 	Struct,
 	Union,
 	Enum,
@@ -93,7 +92,7 @@ type_kind :: proc(T: typeid) -> Type_Kind {
 		case Type_Info_Enumerated_Array: return .Enumerated_Array
 		case Type_Info_Dynamic_Array:    return .Dynamic_Array
 		case Type_Info_Slice:            return .Slice
-		case Type_Info_Parameters:       return .Tuple
+		case Type_Info_Parameters:       return .Parameters
 		case Type_Info_Struct:           return .Struct
 		case Type_Info_Union:            return .Union
 		case Type_Info_Enum:             return .Enum

--- a/core/reflect/types.odin
+++ b/core/reflect/types.odin
@@ -348,12 +348,6 @@ is_parameters :: proc(info: ^Type_Info) -> bool {
 	_, ok := type_info_base(info).variant.(Type_Info_Parameters)
 	return ok
 }
-@(require_results, deprecated="prefer is_parameters")
-is_tuple :: proc(info: ^Type_Info) -> bool {
-	if info == nil { return false }
-	_, ok := type_info_base(info).variant.(Type_Info_Parameters)
-	return ok
-}
 @(require_results)
 is_struct :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }


### PR DESCRIPTION
It's been deprecated for 2 years. Use `Type_Info_Parameters`. May need to update the documentation generator as well.