### PR TITLE
make once_do_without_data_contextless actually contextless

### DIFF
--- a/core/sync/extended.odin
+++ b/core/sync/extended.odin
@@ -581,9 +581,9 @@ once_do_without_data :: proc(o: ^Once, fn: proc()) {
 /*
 Call a contextless function with no data once.
 */
-once_do_without_data_contextless :: proc(o: ^Once, fn: proc "contextless" ()) {
+once_do_without_data_contextless :: proc "contextless" (o: ^Once, fn: proc "contextless" ()) {
 	@(cold)
-	do_slow :: proc(o: ^Once, fn: proc "contextless" ()) {
+	do_slow :: proc "contextless" (o: ^Once, fn: proc "contextless" ()) {
 		guard(&o.m)
 		if !o.done {
 			fn()


### PR DESCRIPTION
I was trying to use `sync.Once` and it seems `once_do_without_data_contextless` isn't "contextless" itself which causes the first example below to not compile. The workaround I'm currently using is to force the use of `once_do_with_data_contextless` like in the second example but I included a small change to make the first one also work.

```odin
// FIRST EXAMPLE (DOESN'T COMPILE)
MyData :: struct{
	//...
	foo: int
	//...
}
get_data :: proc "contextless" () -> MyData {
	@static once: sync.Once
	@static data: MyData

	sync.once_do(&once, proc "contextless" (){
		//...
		data.foo = 1234
		//...
	})

	return data
}
```

```odin
// SECOND EXAMPLE (WORKAROUND)
MyData :: struct{
	//...
	foo: int
	//...
}
get_data :: proc "contextless" () -> MyData {
	@static once: sync.Once
	@static data: MyData

	sync.once_do(&once, proc "contextless" (rawptr){
		//...
		data.foo = 1234
		//...
	}, nil)

	return data
}
```
