### PR TITLE
Add missing field in box2d.BodyDef

### DIFF
--- a/vendor/box2d/types.odin
+++ b/vendor/box2d/types.odin
@@ -188,6 +188,10 @@ BodyDef :: struct {
 	// Triggers whenever a shape is add/removed/changed. Default is true.
 	automaticMass: bool,
 
+	// This allows this body to bypass rotational speed limits. Should only be used
+	// for circular objects, like wheels.
+	allowFastRotation: bool,
+
 	// Used internally to detect a valid definition. DO NOT SET.
 	internalValue: i32,
 }


### PR DESCRIPTION
Added missing `allowFastRotation` field to `box2d.BodyDef`.

This field *is* present in the 3.0.0 release upon which Odin's bindings are based, as far as I can tell:
https://github.com/erincatto/box2d/blob/v3.0.0/include/box2d/types.h#L210C1-L210C2

It occupies space that was previously just padding, so it appears we were getting lucky that the struct layout matched up well enough.