### PR TITLE
fix not resolving to alias in a recursive declaration

### DIFF
--- a/src/check_decl.cpp
+++ b/src/check_decl.cpp
@@ -468,6 +468,10 @@ gb_internal void check_type_decl(CheckerContext *ctx, Entity *e, Ast *init_expr,
 	}
 	e->type = named;
 
+	if (!is_distinct) {
+		e->TypeName.is_type_alias = true;
+	}
+
 	check_type_path_push(ctx, e);
 	Type *bt = check_type_expr(ctx, te, named);
 	check_type_path_pop(ctx);
@@ -502,9 +506,9 @@ gb_internal void check_type_decl(CheckerContext *ctx, Entity *e, Ast *init_expr,
 	if (!is_distinct) {
 		e->type = bt;
 		named->Named.base = bt;
-		e->TypeName.is_type_alias = true;
 	}
 
+	e->TypeName.is_type_alias = !is_distinct;
 
 	if (decl->type_expr != nullptr) {
 		Type *t = check_type(ctx, decl->type_expr);


### PR DESCRIPTION
Fixes #5043 

The union variant type was assigned `^Table` instead of the aliassed `^map[string]Type` because we set `is_type_alias = true` after checking the rhs (containing the union to check) of the declaration.