### PR TITLE
Add initial support for Objective-C class implementation

### DIFF
--- a/base/intrinsics/intrinsics.odin
+++ b/base/intrinsics/intrinsics.odin
@@ -353,15 +353,18 @@ x86_xgetbv :: proc(cx: u32) -> (eax, edx: u32) ---
 objc_object   :: struct{}
 objc_selector :: struct{}
 objc_class    :: struct{}
+objc_ivar     :: struct{}
+
 objc_id    :: ^objc_object
 objc_SEL   :: ^objc_selector
 objc_Class :: ^objc_class
+objc_Ivar  :: ^objc_ivar
 
 objc_find_selector     :: proc($name: string) -> objc_SEL   ---
 objc_register_selector :: proc($name: string) -> objc_SEL   ---
 objc_find_class        :: proc($name: string) -> objc_Class ---
 objc_register_class    :: proc($name: string) -> objc_Class ---
-
+ivar_get			   :: proc(self: ^$T, $U: typeid) -> ^U ---
 
 valgrind_client_request :: proc(default: uintptr, request: uintptr, a0, a1, a2, a3, a4: uintptr) -> uintptr ---
 

--- a/base/runtime/procs_darwin.odin
+++ b/base/runtime/procs_darwin.odin
@@ -2,21 +2,34 @@
 package runtime
 
 @(priority_index=-1e6)
-foreign import "system:Foundation.framework"
+foreign import ObjC "system:objc"
 
 import "base:intrinsics"
 
-objc_id :: ^intrinsics.objc_object
+objc_id    :: ^intrinsics.objc_object
 objc_Class :: ^intrinsics.objc_class
-objc_SEL :: ^intrinsics.objc_selector
+objc_SEL   :: ^intrinsics.objc_selector
+objc_Ivar  :: ^intrinsics.objc_ivar
+objc_BOOL  :: bool
 
-foreign Foundation {
-	objc_lookUpClass :: proc "c" (name: cstring) -> objc_Class ---
+
+objc_IMP :: proc "c" (object: objc_id, sel: objc_SEL, #c_vararg args: ..any) -> objc_id
+
+foreign ObjC {
 	sel_registerName :: proc "c" (name: cstring) -> objc_SEL ---
-	objc_allocateClassPair :: proc "c" (superclass: objc_Class, name: cstring, extraBytes: uint) -> objc_Class ---
 
 	objc_msgSend        :: proc "c" (self: objc_id, op: objc_SEL, #c_vararg args: ..any) ---
 	objc_msgSend_fpret  :: proc "c" (self: objc_id, op: objc_SEL, #c_vararg args: ..any) -> f64 ---
 	objc_msgSend_fp2ret :: proc "c" (self: objc_id, op: objc_SEL, #c_vararg args: ..any) -> complex128 ---
 	objc_msgSend_stret  :: proc "c" (self: objc_id, op: objc_SEL, #c_vararg args: ..any) ---
+
+	objc_lookUpClass          :: proc "c" (name: cstring) -> objc_Class ---
+	objc_allocateClassPair    :: proc "c" (superclass: objc_Class, name: cstring, extraBytes: uint) -> objc_Class ---
+	objc_registerClassPair    :: proc "c" (cls : objc_Class) ---
+	class_addMethod           :: proc "c" (cls: objc_Class, name: objc_SEL, imp: objc_IMP, types: cstring) -> objc_BOOL ---
+	class_addIvar             :: proc "c" (cls: objc_Class, name: cstring, size: uint, alignment: u8, types: cstring) -> objc_BOOL ---
+	class_getInstanceVariable :: proc "c" (cls : objc_Class, name: cstring) -> objc_Ivar ---
+	class_getInstanceSize     :: proc "c" (cls : objc_Class) -> uint ---
+	ivar_getOffset            :: proc "c" (v: objc_Ivar) -> uintptr ---
 }
+

--- a/src/checker.hpp
+++ b/src/checker.hpp
@@ -148,8 +148,12 @@ struct AttributeContext {
 
 	String  objc_class;
 	String  objc_name;
-	bool    objc_is_class_method;
+    String  objc_selector;
 	Type *  objc_type;
+    Type *  objc_superclass;
+    Type *  objc_ivar;
+	bool    objc_is_class_method   : 1;
+    bool    objc_is_implementation : 1;     // This struct or proc provides a class/method implementation, not a binding to an existing type.
 
 	String require_target_feature; // required by the target micro-architecture
 	String enable_target_feature;  // will be enabled for the procedure only
@@ -365,6 +369,11 @@ struct ObjcMsgData {
 	Type *proc_type;
 };
 
+struct ObjcMethodData {
+    AttributeContext ac;
+    Entity *proc_entity;
+};
+
 enum LoadFileTier {
 	LoadFileTier_Invalid,
 	LoadFileTier_Exists,
@@ -478,6 +487,12 @@ struct CheckerInfo {
 
 	BlockingMutex objc_types_mutex;
 	PtrMap<Ast *, ObjcMsgData> objc_msgSend_types;
+
+    MPSCQueue<Entity *> objc_class_implementations;
+
+    BlockingMutex objc_method_mutex;
+    PtrMap<Type *, Array<ObjcMethodData>> objc_method_implementations;
+
 
 	BlockingMutex load_file_mutex;
 	StringMap<LoadFileCache *> load_file_cache;

--- a/src/checker_builtin_procs.hpp
+++ b/src/checker_builtin_procs.hpp
@@ -331,6 +331,7 @@ BuiltinProc__type_end,
 	BuiltinProc_objc_find_class,
 	BuiltinProc_objc_register_selector,
 	BuiltinProc_objc_register_class,
+    BuiltinProc_objc_ivar_get,
 
 	BuiltinProc_constant_utf16_cstring,
 
@@ -673,6 +674,7 @@ gb_global BuiltinProc builtin_procs[BuiltinProc_COUNT] = {
 	{STR_LIT("objc_find_class"),        1, false, Expr_Expr, BuiltinProcPkg_intrinsics},
 	{STR_LIT("objc_register_selector"), 1, false, Expr_Expr, BuiltinProcPkg_intrinsics, false, true},
 	{STR_LIT("objc_register_class"),    1, false, Expr_Expr, BuiltinProcPkg_intrinsics, false, true},
+    {STR_LIT("ivar_get"),               2, false, Expr_Expr, BuiltinProcPkg_intrinsics, false, true},
 
 	{STR_LIT("constant_utf16_cstring"), 1, false, Expr_Expr, BuiltinProcPkg_intrinsics},
 

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -235,6 +235,9 @@ struct Entity {
 			Type * type_parameter_specialization;
 			String ir_mangled_name;
 			bool   is_type_alias;
+            bool   objc_is_implementation;
+            Type*  objc_superclass;
+            Type*  objc_ivar;
 			String objc_class_name;
 			TypeNameObjCMetadata *objc_metadata;
 		} TypeName;

--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -1173,6 +1173,332 @@ gb_internal lbProcedure *lb_create_objc_names(lbModule *main_module) {
 	return p;
 }
 
+// TODO(harold): Move this out of here and into a more suitable place.
+// TODO(harold): Should not take an allocator, but always use temp, as we return string literals as well.
+String lb_get_objc_type_encoding(Type *t, gbAllocator allocator, isize pointer_depth = 0) {
+    // NOTE(harold): See https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html#//apple_ref/doc/uid/TP40008048-CH100
+
+    // NOTE(harold): Darwin targets are always 64-bit. Should we drop this and assume "q" always?
+    #define INT_SIZE_ENCODING (build_context.metrics.ptr_size == 4 ? "i" : "q")
+    switch (t->kind) {
+    case Type_Basic: {
+        switch (t->Basic.kind) {
+        case Basic_Invalid:
+            return str_lit("?");
+
+        case Basic_llvm_bool:
+        case Basic_bool:
+        case Basic_b8:
+            return str_lit("B");
+
+        case Basic_b16:
+            return str_lit("C");
+        case Basic_b32:
+            return str_lit("I");
+        case Basic_b64:
+            return str_lit("q");
+        case Basic_i8:
+            return str_lit("c");
+        case Basic_u8:
+            return str_lit("C");
+        case Basic_i16:
+        case Basic_i16le:
+        case Basic_i16be:
+            return str_lit("s");
+        case Basic_u16:
+        case Basic_u16le:
+        case Basic_u16be:
+            return str_lit("S");
+        case Basic_i32:
+        case Basic_i32le:
+        case Basic_i32be:
+            return str_lit("i");
+        case Basic_u32le:
+        case Basic_u32:
+        case Basic_u32be:
+            return str_lit("I");
+        case Basic_i64:
+        case Basic_i64le:
+        case Basic_i64be:
+            return str_lit("q");
+        case Basic_u64:
+        case Basic_u64le:
+        case Basic_u64be:
+            return str_lit("Q");
+        case Basic_i128:
+        case Basic_i128le:
+        case Basic_i128be:
+            return str_lit("t");
+        case Basic_u128:
+        case Basic_u128le:
+        case Basic_u128be:
+            return str_lit("T");
+        case Basic_rune:
+            return str_lit("I");
+        case Basic_f16:
+        case Basic_f16le:
+        case Basic_f16be:
+            return str_lit("s");    // @harold: Closest we've got?
+        case Basic_f32:
+        case Basic_f32le:
+        case Basic_f32be:
+            return str_lit("f");
+        case Basic_f64:
+        case Basic_f64le:
+        case Basic_f64be:
+            return str_lit("d");
+
+        // TODO(harold) These:
+        case Basic_complex32:
+        case Basic_complex64:
+        case Basic_complex128:
+        case Basic_quaternion64:
+        case Basic_quaternion128:
+        case Basic_quaternion256:
+                return str_lit("?");
+
+        case Basic_int:
+            return str_lit(INT_SIZE_ENCODING);
+        case Basic_uint:
+            return build_context.metrics.ptr_size == 4 ? str_lit("I") : str_lit("Q");
+        case Basic_uintptr:
+        case Basic_rawptr:
+            return str_lit("^v");
+
+        case Basic_string:
+            return build_context.metrics.ptr_size == 4 ? str_lit("{string=*i}") : str_lit("{string=*q}");
+
+        case Basic_cstring: return str_lit("*");
+        case Basic_any:     return str_lit("{any=^v^v");  // rawptr + ^Type_Info
+
+        case Basic_typeid:
+            GB_ASSERT(t->Basic.size == 8);
+            return str_lit("q");
+
+        // Untyped types
+        case Basic_UntypedBool:
+        case Basic_UntypedInteger:
+        case Basic_UntypedFloat:
+        case Basic_UntypedComplex:
+        case Basic_UntypedQuaternion:
+        case Basic_UntypedString:
+        case Basic_UntypedRune:
+        case Basic_UntypedNil:
+        case Basic_UntypedUninit:
+            GB_PANIC("Untyped types cannot be @encoded()");
+            return str_lit("?");
+        }
+        break;
+    }
+
+    case Type_Named:
+    case Type_Struct:
+    case Type_Union: {
+        Type* base = t;
+        if (base->kind == Type_Named) {
+            base = base_type(base);
+            if(base->kind != Type_Struct && base->kind != Type_Union) {
+                return lb_get_objc_type_encoding(base, allocator, pointer_depth);
+            }
+        }
+
+        const bool is_union = base->kind == Type_Union;
+        if (!is_union) {
+            // Check for objc_SEL
+            if (internal_check_is_assignable_to(base, t_objc_SEL)) {
+                return str_lit(":");
+            }
+
+            // Check for objc_Class
+            if (internal_check_is_assignable_to(base, t_objc_SEL)) {
+                return str_lit("#");
+            }
+
+            // Treat struct as an Objective-C Class?
+            if (has_type_got_objc_class_attribute(base) && pointer_depth == 0) {
+                return str_lit("#");
+            }
+        }
+
+        if (is_type_objc_object(base)) {
+            return str_lit("@");
+        }
+
+
+        gbString s = gb_string_make_reserve(allocator, 16);
+        s = gb_string_append_length(s, is_union ? "(" :"{", 1);
+        if (t->kind == Type_Named) {
+            s = gb_string_append_length(s, t->Named.name.text, t->Named.name.len);
+        }
+
+        // Write fields
+        if (pointer_depth < 2) {
+            s = gb_string_append_length(s, "=", 1);
+
+            if (!is_union) {
+                for( auto& f : t->Struct.fields ) {
+                    String field_type = lb_get_objc_type_encoding(f->type, allocator, pointer_depth);
+                    s = gb_string_append_length(s, field_type.text, field_type.len);
+                }
+            } else {
+                // #TODO(harold): Encode fields
+            }
+        }
+
+        s = gb_string_append_length(s, is_union ? ")" :"}", 1);
+
+        return make_string_c(s);
+    }
+
+    case Type_Generic:
+        GB_PANIC("Generic types cannot be @encoded()");
+        return str_lit("?");
+
+    case Type_Pointer: {
+        String pointee = lb_get_objc_type_encoding(t->Pointer.elem, allocator, pointer_depth +1);
+        // Special case for Objective-C Objects
+        if (pointer_depth == 0 && pointee == "@") {
+            return pointee;
+        }
+
+        return concatenate_strings(allocator, str_lit("^"), pointee);
+    }
+
+    case Type_MultiPointer:
+        return concatenate_strings(allocator, str_lit("^"), lb_get_objc_type_encoding(t->Pointer.elem, allocator, pointer_depth +1));
+
+    case Type_Array: {
+        String type_str = lb_get_objc_type_encoding(t->Array.elem, allocator, pointer_depth);
+
+        gbString s = gb_string_make_reserve(allocator, type_str.len + 8);
+        s = gb_string_append_fmt(s, "[%lld%s]", t->Array.count, type_str.text);
+        return make_string_c(s);
+    }
+
+    case Type_EnumeratedArray: {
+        String type_str = lb_get_objc_type_encoding(t->EnumeratedArray.elem, allocator, pointer_depth);
+
+        gbString s = gb_string_make_reserve(allocator, type_str.len + 8);
+        s = gb_string_append_fmt(s, "[%lld%s]", t->EnumeratedArray.count, type_str.text);
+        return make_string_c(s);
+    }
+
+    case Type_Slice: {
+        String type_str = lb_get_objc_type_encoding(t->Slice.elem, allocator, pointer_depth);
+        gbString s = gb_string_make_reserve(allocator, type_str.len + 8);
+        s = gb_string_append_fmt(s, "{slice=^%s%s}", type_str, INT_SIZE_ENCODING);
+        return make_string_c(s);
+    }
+
+    case Type_DynamicArray: {
+        String type_str = lb_get_objc_type_encoding(t->DynamicArray.elem, allocator, pointer_depth);
+        gbString s = gb_string_make_reserve(allocator, type_str.len + 8);
+        s = gb_string_append_fmt(s, "{dynamic=^%s%s%sAllocator={?^v}}", type_str, INT_SIZE_ENCODING, INT_SIZE_ENCODING);
+        return make_string_c(s);
+    }
+
+    case Type_Map:
+        return str_lit("{^v^v{Allocator=?^v}}");
+    case Type_Enum:
+        return lb_get_objc_type_encoding(t->Enum.base_type, allocator, pointer_depth);
+    case Type_Tuple:
+        // NOTE(harold): Is this allowed here?
+        return str_lit("?");
+    case Type_Proc:
+        return str_lit("?");
+    case Type_BitSet:
+        return lb_get_objc_type_encoding(t->BitSet.underlying, allocator, pointer_depth);
+    case Type_SimdVector:
+        break;
+    case Type_Matrix:
+        break;
+    case Type_BitField:
+        return lb_get_objc_type_encoding(t->BitField.backing_type, allocator, pointer_depth);
+    case Type_SoaPointer: {
+        gbString s = gb_string_make_reserve(allocator, 8);
+        s = gb_string_append_fmt(s, "{=^v%s}", INT_SIZE_ENCODING);
+        return make_string_c(s);
+    }
+
+    } // End switch t->kind
+    #undef INT_SIZE_ENCODING
+
+    GB_PANIC("Unreachable");
+}
+
+struct lbObjCGlobalClass {
+    lbObjCGlobal g;
+    lbValue      class_value;    // Local registered class value
+};
+
+gb_internal void lb_register_objc_thing(
+    StringSet &handled,
+    lbModule *m,
+    Array<lbValue> &args,
+    Array<lbObjCGlobalClass> &class_impls,
+    StringMap<lbObjCGlobalClass> &class_map,
+    lbProcedure *p,
+    lbObjCGlobal const &g,
+    char const *call
+) {
+    if (string_set_update(&handled, g.name)) {
+        return;
+    }
+
+    lbAddr addr = {};
+    lbValue *found = string_map_get(&m->members, g.global_name);
+    if (found) {
+        addr = lb_addr(*found);
+    } else {
+        lbValue v = {};
+        LLVMTypeRef t = lb_type(m, g.type);
+        v.value = LLVMAddGlobal(m->mod, t, g.global_name);
+        v.type = alloc_type_pointer(g.type);
+        addr = lb_addr(v);
+        LLVMSetInitializer(v.value, LLVMConstNull(t));
+    }
+
+    lbValue class_ptr{};
+    lbValue class_name = lb_const_value(m, t_cstring, exact_value_string(g.name));
+
+    // If this class requires an implementation, save it for registration below.
+    if (g.class_impl_type != nullptr) {
+
+        // Make sure the superclass has been initialized before us
+        lbValue superclass_value{};
+
+        auto& tn = g.class_impl_type->Named.type_name->TypeName;
+        Type *superclass = tn.objc_superclass;
+        if (superclass != nullptr) {
+            auto& superclass_global = string_map_must_get(&class_map, superclass->Named.type_name->TypeName.objc_class_name);
+            lb_register_objc_thing(handled, m, args, class_impls, class_map, p, superclass_global.g, call);
+            GB_ASSERT(superclass_global.class_value.value);
+
+            superclass_value = superclass_global.class_value;
+        }
+
+        args.count = 3;
+        args[0] = superclass == nullptr ? lb_const_nil(m, t_objc_Class) : superclass_value;
+        args[1] = class_name;
+        args[2] = lb_const_int(m, t_uint, 0);
+        class_ptr = lb_emit_runtime_call(p, "objc_allocateClassPair", args);
+
+        array_add(&class_impls, lbObjCGlobalClass{g, class_ptr});
+    }
+    else {
+        args.count = 1;
+        args[0] = class_name;
+        class_ptr = lb_emit_runtime_call(p, call, args);
+    }
+
+    lb_addr_store(p, addr, class_ptr);
+
+    lbObjCGlobalClass* class_global = string_map_get(&class_map, g.name);
+    if (class_global != nullptr) {
+        class_global->class_value = class_ptr;
+    }
+}
+
 gb_internal void lb_finalize_objc_names(lbGenerator *gen, lbProcedure *p) {
 	if (p == nullptr) {
 		return;
@@ -1186,39 +1512,238 @@ gb_internal void lb_finalize_objc_names(lbGenerator *gen, lbProcedure *p) {
 	string_set_init(&handled);
 	defer (string_set_destroy(&handled));
 
-	auto args = array_make<lbValue>(temporary_allocator(), 1);
+	auto args        = array_make<lbValue>(temporary_allocator(), 3, 8);
+    auto class_impls = array_make<lbObjCGlobalClass>(temporary_allocator(), 0, 16);
 
-	LLVMSetLinkage(p->value, LLVMInternalLinkage);
-	lb_begin_procedure_body(p);
+    // Ensure classes that have been implicitly referenced through
+    // the objc_superclass attribute have a global variable available for them.
+    TypeSet class_set{};
+    type_set_init(&class_set, gen->objc_classes.count+16);
+    defer (type_set_destroy(&class_set));
 
-	auto register_thing = [&handled, &m, &args](lbProcedure *p, lbObjCGlobal const &g, char const *call) {
-		if (!string_set_update(&handled, g.name)) {
-			lbAddr addr = {};
-			lbValue *found = string_map_get(&m->members, g.global_name);
-			if (found) {
-				addr = lb_addr(*found);
-			} else {
-				lbValue v = {};
-				LLVMTypeRef t = lb_type(m, g.type);
-				v.value = LLVMAddGlobal(m->mod, t, g.global_name);
-				v.type = alloc_type_pointer(g.type);
-				addr = lb_addr(v);
-				LLVMSetInitializer(v.value, LLVMConstNull(t));
-			}
+    auto referenced_classes = array_make<lbObjCGlobal>(temporary_allocator());
+    for (lbObjCGlobal g = {}; mpsc_dequeue(&gen->objc_classes, &g); /**/) {
+        array_add( &referenced_classes, g);
 
-			args[0] = lb_const_value(m, t_cstring, exact_value_string(g.name));
-			lbValue ptr = lb_emit_runtime_call(p, call, args);
-			lb_addr_store(p, addr, ptr);
-		}
-	};
+        Type *cls = g.class_impl_type;
+        while (cls) {
+            if (type_set_update(&class_set, cls)) {
+                break;
+            }
+            GB_ASSERT(cls->kind == Type_Named);
 
-	for (lbObjCGlobal g = {}; mpsc_dequeue(&gen->objc_classes, &g); /**/) {
-		register_thing(p, g, "objc_lookUpClass");
-	}
+            cls = cls->Named.type_name->TypeName.objc_superclass;
+        }
+    }
 
-	for (lbObjCGlobal g = {}; mpsc_dequeue(&gen->objc_selectors, &g); /**/) {
-		register_thing(p, g, "sel_registerName");
-	}
+    for (auto pair : class_set) {
+        auto& tn = pair.type->Named.type_name->TypeName;
+        Type *class_impl = !tn.objc_is_implementation ? nullptr : pair.type;
+        lb_handle_objc_find_or_register_class(p, tn.objc_class_name, class_impl);
+    }
+    for (lbObjCGlobal g = {}; mpsc_dequeue(&gen->objc_classes, &g); /**/) {
+        array_add( &referenced_classes, g );
+    }
+
+    // Add all class globals to a map so that we can look them up dynamically
+    // in order to resolve out-of-order because classes that are being implemented
+    // need their superclasses to have been registered before them.
+    StringMap<lbObjCGlobalClass> global_class_map{};
+    string_map_init(&global_class_map, (usize)gen->objc_classes.count);
+    defer (string_map_destroy(&global_class_map));
+
+    for (lbObjCGlobal g :referenced_classes) {
+        string_map_set(&global_class_map, g.name, lbObjCGlobalClass{g});
+    }
+
+    LLVMSetLinkage(p->value, LLVMInternalLinkage);
+    lb_begin_procedure_body(p);
+
+    // Register class globals, gathering classes that must be implemented
+    for (auto& kv : global_class_map) {
+        lb_register_objc_thing(handled, m, args, class_impls, global_class_map, p, kv.value.g, "objc_lookUpClass");
+    }
+
+    // Prefetch selectors for implemented methods so that they can also be registered.
+    for (const auto& cd : class_impls) {
+        auto& g = cd.g;
+        Type *class_type = g.class_impl_type;
+
+        Array<ObjcMethodData>* methods = map_get(&m->info->objc_method_implementations, class_type);
+        if (!methods) {
+            continue;
+        }
+
+        for (const ObjcMethodData& md : *methods) {
+            lb_handle_objc_find_or_register_selector(p, md.ac.objc_selector);
+        }
+    }
+
+    // Now we can register all referenced selectors
+    for (lbObjCGlobal g = {}; mpsc_dequeue(&gen->objc_selectors, &g); /**/) {
+        lb_register_objc_thing(handled, m, args, class_impls, global_class_map, p, g, "sel_registerName");
+    }
+
+
+    // Emit method wrapper implementations and registration
+    auto wrapper_args = array_make<Type *>(temporary_allocator(), 2, 8);
+
+    for (const auto& cd : class_impls) {
+        auto& g = cd.g;
+        Type *class_type = g.class_impl_type;
+
+        Array<ObjcMethodData>* methods = map_get(&m->info->objc_method_implementations, class_type);
+        if (!methods) {
+            continue;
+        }
+
+        Type *class_ptr_type = alloc_type_pointer(class_type);
+        lbValue class_value = cd.class_value;
+
+        for (const ObjcMethodData& md : *methods) {
+            GB_ASSERT( md.proc_entity->kind == Entity_Procedure);
+            Type *method_type = md.proc_entity->type;
+
+            String proc_name = make_string_c("__$objc_method::");
+            proc_name = concatenate_strings(temporary_allocator(), proc_name, g.name);
+            proc_name = concatenate_strings(temporary_allocator(), proc_name, str_lit("::"));
+            proc_name = concatenate_strings( permanent_allocator(), proc_name, md.ac.objc_name);
+
+            wrapper_args.count = 2;
+            wrapper_args[0] = md.ac.objc_is_class_method ? t_objc_Class : class_ptr_type;
+            wrapper_args[1] = t_objc_SEL;
+
+            auto method_param_count  = (isize)method_type->Proc.param_count;
+            i32  method_param_offset = 0;
+
+            // TODO(harold): Need to make sure (at checker stage) that the non-class method has the self parameter already.
+            //               (Maybe this is already accounted for?.)
+            if (!md.ac.objc_is_class_method) {
+                GB_ASSERT(method_param_count >= 1);
+                method_param_count -= 1;
+                method_param_offset = 1;
+            }
+
+            for (i32 i = 0; i < method_param_count; i++) {
+                array_add(&wrapper_args, method_type->Proc.params->Tuple.variables[method_param_offset+i]->type);
+            }
+
+            Type *wrapper_args_tuple = alloc_type_tuple_from_field_types(wrapper_args.data, wrapper_args.count, false, true);
+            Type *wrapper_proc_type = alloc_type_proc(nullptr, wrapper_args_tuple, (isize)wrapper_args_tuple->Tuple.variables.count, nullptr, 0, false, ProcCC_CDecl);
+
+            lbProcedure *wrapper_proc = lb_create_dummy_procedure(m, proc_name, wrapper_proc_type);
+            lb_add_attribute_to_proc(wrapper_proc->module, wrapper_proc->value, "nounwind");
+
+            // Emit the wrapper
+            LLVMSetLinkage(wrapper_proc->value, LLVMExternalLinkage);
+            lb_begin_procedure_body(wrapper_proc);
+            {
+                auto method_call_args = array_make<lbValue>(temporary_allocator(), method_param_count + (isize)method_param_offset);
+
+                if (!md.ac.objc_is_class_method) {
+                    method_call_args[0] = lbValue {
+                        wrapper_proc->raw_input_parameters[0],
+                        class_ptr_type,
+                    };
+                }
+
+                for (isize i = 0; i < method_param_count; i++) {
+                    method_call_args[i+method_param_offset] = lbValue {
+                        wrapper_proc->raw_input_parameters[i+2],
+                        method_type->Proc.params->Tuple.variables[i+method_param_offset]->type,
+                    };
+                }
+                lbValue method_proc_value = lb_find_procedure_value_from_entity(m, md.proc_entity);
+
+                // Call real procedure for method from here, passing the parameters expected, if any.
+                lb_emit_call(wrapper_proc, method_proc_value, method_call_args);
+            }
+            lb_end_procedure_body(wrapper_proc);
+
+
+            // Add the method to the class
+            String method_encoding = str_lit("v");
+            // TODO (harold): Checker must ensure that objc_methods have a single return value or none!
+            GB_ASSERT(method_type->Proc.result_count <= 1);
+            if (method_type->Proc.result_count != 0) {
+                method_encoding = lb_get_objc_type_encoding(method_type->Proc.results->Tuple.variables[0]->type, temporary_allocator());
+            }
+
+            if (!md.ac.objc_is_class_method) {
+                method_encoding = concatenate_strings(temporary_allocator(), method_encoding, str_lit("@:"));
+            } else {
+                method_encoding = concatenate_strings(temporary_allocator(), method_encoding, str_lit("#:"));
+            }
+
+            for (i32 i = method_param_offset; i < method_param_count; i++) {
+                Type *param_type = method_type->Proc.params->Tuple.variables[i]->type;
+                String param_encoding = lb_get_objc_type_encoding(param_type, temporary_allocator());
+
+                method_encoding = concatenate_strings(temporary_allocator(), method_encoding, param_encoding);
+            }
+
+            // Emit method registration
+            lbAddr* sel_address = string_map_get(&m->objc_selectors, md.ac.objc_selector);
+            GB_ASSERT(sel_address);
+            lbValue selector_value = lb_addr_load(p, *sel_address);
+
+            args.count = 4;
+            args[0] = class_value;    // Class
+            args[1] = selector_value; // SEL
+            args[2] = lbValue { wrapper_proc->value, wrapper_proc->type };
+            args[3] = lb_const_value(m, t_cstring, exact_value_string(method_encoding));
+
+            // TODO(harold): Emit check BOOL result and panic if false.
+            lb_emit_runtime_call(p, "class_addMethod", args);
+
+        } // End methods
+
+        // Add ivar if we have one
+        Type *ivar_type = class_type->Named.type_name->TypeName.objc_ivar;
+        if (ivar_type != nullptr) {
+            // Register a single ivar for this class
+            Type *ivar_base = ivar_type->Named.base;
+            // TODO(harold): No idea if I can use this, but I assume so?
+            const i64 size      = ivar_base->cached_size;
+            const i64 alignment = ivar_base->cached_align;
+            // TODO(harold): Checker: Alignment must be compatible with ivar rules. Or we should increase the alignment if needed.
+
+            String ivar_name  = str_lit("__$ivar");
+            String ivar_types = str_lit("{= }");
+            args.count = 5;
+            args[0] = class_value;
+            args[1] = lb_const_value(m, t_cstring, exact_value_string(ivar_name));
+            args[2] = lb_const_value(m, t_uint, exact_value_u64((u64)size));
+            args[3] = lb_const_value(m, t_u8, exact_value_u64((u64)alignment));
+            args[4] = lb_const_value(m, t_cstring, exact_value_string(ivar_types));
+            lb_emit_runtime_call(p, "class_addIvar", args);
+        }
+
+        // Complete the class registration
+        args.count = 1;
+        args[0] = class_value;
+        lb_emit_runtime_call(p, "objc_registerClassPair", args);
+
+        // If we have an ivar, store its offset globally for an intrinsic
+        // TODO(harold): Only do this for types that had ivar_get calls registered!
+        if (ivar_type != nullptr) {
+            args.count = 2;
+            args[0] = class_value;
+            args[1] = lb_const_value(m, t_cstring, exact_value_string(str_lit("__$ivar")));
+            lbValue ivar = lb_emit_runtime_call(p, "class_getInstanceVariable", args);
+
+            args.count = 1;
+            args[0] = ivar;
+            lbValue ivar_offset     = lb_emit_runtime_call(p, "ivar_getOffset", args);
+            lbValue ivar_offset_u32 = lb_emit_conv(p, ivar_offset, t_u32);
+
+            String class_name = class_type->Named.type_name->TypeName.objc_class_name;
+            // TODO(harold): Oops! This is wrong, that map is there to prevent re-entry.
+            //               Simply emit from referred ivars. For now use a single module only.
+            lbAddr ivar_addr = string_map_must_get(&m->objc_ivars, class_name);
+            lb_addr_store(p, ivar_addr, ivar_offset_u32);
+        }
+    }
 
 	lb_end_procedure_body(p);
 }

--- a/src/llvm_backend.hpp
+++ b/src/llvm_backend.hpp
@@ -196,6 +196,7 @@ struct lbModule {
 
 	StringMap<lbAddr> objc_classes;
 	StringMap<lbAddr> objc_selectors;
+    StringMap<lbAddr> objc_ivars;
 
 	PtrMap<u64/*type hash*/, lbAddr> map_cell_info_map; // address of runtime.Map_Info
 	PtrMap<u64/*type hash*/, lbAddr> map_info_map;      // address of runtime.Map_Cell_Info
@@ -219,6 +220,7 @@ struct lbObjCGlobal {
 	gbString  global_name;
 	String    name;
 	Type *    type;
+    Type *    class_impl_type;  // This is set when the class has the objc_implement attribute set to true.
 };
 
 struct lbGenerator : LinkerData {
@@ -240,6 +242,7 @@ struct lbGenerator : LinkerData {
 	MPSCQueue<lbEntityCorrection> entities_to_correct_linkage;
 	MPSCQueue<lbObjCGlobal> objc_selectors;
 	MPSCQueue<lbObjCGlobal> objc_classes;
+    MPSCQueue<lbObjCGlobal> objc_ivars;
 };
 
 

--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -101,6 +101,7 @@ gb_internal void lb_init_module(lbModule *m, Checker *c) {
 
 	string_map_init(&m->objc_classes);
 	string_map_init(&m->objc_selectors);
+    string_map_init(&m->objc_ivars);
 
 	map_init(&m->map_info_map, 0);
 	map_init(&m->map_cell_info_map, 0);
@@ -173,6 +174,7 @@ gb_internal bool lb_init_generator(lbGenerator *gen, Checker *c) {
 	mpsc_init(&gen->entities_to_correct_linkage, heap_allocator());
 	mpsc_init(&gen->objc_selectors, heap_allocator());
 	mpsc_init(&gen->objc_classes, heap_allocator());
+    mpsc_init(&gen->objc_ivars, heap_allocator());
 
 	return true;
 }

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -3290,6 +3290,7 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 	case BuiltinProc_objc_find_class:        return lb_handle_objc_find_class(p, expr);
 	case BuiltinProc_objc_register_selector: return lb_handle_objc_register_selector(p, expr);
 	case BuiltinProc_objc_register_class:    return lb_handle_objc_register_class(p, expr);
+    case BuiltinProc_objc_ivar_get:          return lb_handle_objc_ivar_get(p, expr);
 
 
 	case BuiltinProc_constant_utf16_cstring:

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -729,10 +729,12 @@ gb_global Type *t_map_set_proc = nullptr;
 gb_global Type *t_objc_object   = nullptr;
 gb_global Type *t_objc_selector = nullptr;
 gb_global Type *t_objc_class    = nullptr;
+gb_global Type *t_objc_ivar     = nullptr;
 
 gb_global Type *t_objc_id    = nullptr;
 gb_global Type *t_objc_SEL   = nullptr;
 gb_global Type *t_objc_Class = nullptr;
+gb_global Type *t_objc_Ivar  = nullptr;
 
 enum OdinAtomicMemoryOrder : i32 {
 	OdinAtomicMemoryOrder_relaxed = 0, // unordered


### PR DESCRIPTION
# Add support for Objective-C class implementation

The purpose of this work is to add full Odin-native support for creating Objective-C classes, not just consuming them.
Doing so without modifying syntax, only leveraging attributes and new compiler intrinsics. I also attempt to leverage existing attributes and augment them when necessarry to add the desired new functionality.

This facilitates creating new classes where needed, for things like delegates, event handlers, etc. without ugly runtime workarounds, or leaving Odin to provide it in a different language.

This PR has the following requirements:

- Automatically register user-made classes with the Objective-C runtime at startup
- Allow specifying a superclass
- Allow association with a single type that would serve as a singular Ivar that is added to the new Objective-C class
- Allow specifying a selector name manually to be used with the implemented class
- Provide an easy way to get the ivar value for an Objective-C class.

What it does not aim to do (at least not this PR):
- Add new syntax
- Register associated protocols with a class.
- Force protocol conformance or register protocols during class generation. Supports for things like [conformsToProtocol](https://developer.apple.com/documentation/objectivec/nsobject-swift.class/conforms(to:)?language=objc) won't be available.
- Attempt to automatically propagate the Odin state (context) into the Objective-C runtime flow.

### Requirements
- [x] Implement `@objc_implement` attribute for structs
- [x] Implement `@objc_superclass` attribute for procs
    - [x] Disallow superclass cycles
    - [x] Ensure sane ordering during generation so that superclasses get generated first
- [x] Implement `@objc_ivar` attribute
- [ ] Limit generating the global ivar offset to intrinsic usage?
- [x] Implement `@objc_selector` attribute

- [ ] Apply a legitimate strategy for export/linkage
    - [ ] If the `@export` attribute is applied to an Objective-C class, then all methods are exported. Currently all are exported unconditionally (`@export` is implied)

- [ ] Checker:
    - [x] Basic preliminary checks
    - [ ] Proper checks specification
    - [ ] Proper checks applied across all changes
- [ ] Proper, understandable error messages
- [ ] Resolve all pending TODOs

### State and discussion
At the time of this writing the full example below works as all the main requirements have been implemented. It will only work with a single module as there's still issues with the changes. Due to lack of experience with the codebase there needs to be some guidance from the team to get this to a proper shippable state.

I'd like to get feedback on attribute and intrinsic naming in addition to the code changes itself.


### Practical Explanation & Usage

Creating a new Objective-C class looks like it does when consuming an existing one, except we add the `@objc_implement` attribute:
```odin
@(objc_class="HBAppDelegate", objc_implement)
HBAppDelegate :: struct {
    using _: NSF.Object,
    using _: NS.ApplicationDelegate,
}
```

Typically you also want to specify a super/base class as well:
```odin
@(objc_class="HBAppDelegate", objc_implement, objc_superclass=NS.Object)
HBAppDelegate :: struct { ...
```

Finally you may want to associate a type to serve as the class' Ivar:
```odin
@(objc_class="HBAppDelegate", objc_implement, objc_superclass=NS.Object, objc_ivar=HBAppDelegateT)
HBAppDelegate :: struct {
    using _: NSF.Object,
    using _: NS.ApplicationDelegate,
}

// This serves as the only Ivar for HBAppDelegate, it's just a regular struct. 
HBAppDelegateT :: struct {
    ctx: runtime.Context,
    // ...
}
```

You can add methods to it the same way you do when consuming existing Objective-C methods, simply add the same `@objc_implement` attribute:
```odin
@(objc_type=HBAppDelegate, objc_implement, objc_name="alloc", objc_is_class_method=true)
HBAppDelegate_alloc :: proc "c" () -> ^HBAppDelegate {
    return msgSend(^HBAppDelegate, HBAppDelegate, "alloc")
}
```

The compiler will generate a hidden function that conforms to the signature that the Objective-C runtime expects, which simply forwards the call to our method `proc`:
```odin
__$objc_method::MyFoo::alloc :: proc "c" ( self: objc_id, _cmd: objc_SEL ) -> ^HBAppDelegate {
    return HBAppDelegate_alloc()
}
```

Any arguments will be forwarded:
```odin
@(objc_type=HBAppDelegate, objc_implement, objc_name="initWithContext")
HBAppDelegate_initWithContext :: proc "c" ( self: ^HBAppDelegate, ctx: runtime.Context ) -> ^HBAppDelegate {
    s := intrinsics.ivar_get(self, HBAppDelegateT)
    s.ctx = ctx

    return self
}

// Generates:
__$objc_method::MyFoo::alloc :: proc "c" ( self: objc_id, _cmd: objc_SEL, ctx: runtime.Context ) -> ^HBAppDelegate {
    return HBAppDelegate_initWithContext(self, ctx)
}
```

Notice the use of the new intrinsic `intrinsics.ivar_get`. This intrinsic will obtain a pointer to the Type's data of the Ivar from an instance, if one is associated with the class. This is implemented by recording the offset to the ivar at startup, then it simply offsets from the instance pointer during the call to the intrinsic.

You can also specify the selector name to be used for a method. By default the value of `@objc_name` will be used, if one is not specified. But there will be many cases when you may want to specify one manually, as it is when implementing a protocol. Specify it via the `@objc_selector` attribute:

```odin
@(objc_type=HBAppDelegate, objc_implement, objc_name="applicationWillFinishLaunching", objc_selector="applicationWillFinishLaunching:")
HBAppDelegate_applicationWillFinishLaunching :: #force_inline proc "c" (self: ^HBAppDelegate, notification: ^NS.Notification) {
...
}

@(objc_type=HBAppDelegate, objc_implement, objc_name="applicationDidFinishLaunching", objc_selector="applicationDidFinishLaunching:")
HBAppDelegate_applicationDidFinishLaunching :: #force_inline proc "c" (self: ^HBAppDelegate, notification: ^NS.Notification) {
...
}
```

Full working example of an `NSAppDelegate` (partially) implemented in Odin:

```odin
package objcsandbox

import "base:intrinsics"
import "base:runtime"
import "core:log"
import NSF "libs:darwodin/Foundation"
import NS  "libs:darwodin/AppKit"

msgSend  :: intrinsics.objc_send
ivar_get :: intrinsics.ivar_get


main :: proc() {
    context.logger = log.create_console_logger()

    app := NS.Application.sharedApplication()
    app->setActivationPolicy(.Regular)
    app->activate()
    app->setDelegate(HBAppDelegate.alloc()->initWithContext(context))
    app->run()
}

State :: enum {
    Initializing,
    Launching,
    FinishedLaunching,
}
HBAppDelegateT :: struct {
    ctx:   runtime.Context,
    state: State,
}

@(objc_class="HBAppDelegate", objc_superclass=NSF.Object, objc_implement, objc_ivar=HBAppDelegateT)
HBAppDelegate :: struct {
    using _: NSF.Object,
    using _: NS.ApplicationDelegate,
}

@private
get_self :: #force_inline proc "c" ( self: ^HBAppDelegate ) -> ^HBAppDelegateT {
    return ivar_get(self, HBAppDelegateT)
}

@(objc_type=HBAppDelegate, objc_implement, objc_name="alloc", objc_is_class_method=true)
HBAppDelegate_alloc :: proc "c" () -> ^HBAppDelegate {
    return msgSend(^HBAppDelegate, HBAppDelegate, "alloc")
}

@(objc_type=HBAppDelegate, objc_implement, objc_name="initWithContext")
HBAppDelegate_initWithContext :: proc "c" ( self: ^HBAppDelegate, ctx: runtime.Context ) -> ^HBAppDelegate {
    s := get_self(self)
    s.ctx = ctx

    return self
}

@(objc_type=HBAppDelegate, objc_implement, objc_name="applicationWillFinishLaunching", objc_selector="applicationWillFinishLaunching:")
HBAppDelegate_applicationWillFinishLaunching :: #force_inline proc "c" (self: ^HBAppDelegate, notification: ^NSF.Notification) {
    s := get_self(self)
    context = s.ctx
    log.infof("applicationWillFinishLaunching: %v -> %v", s.state, State.Launching)
    s.state = .Launching
}

@(objc_type=HBAppDelegate, objc_implement, objc_name="applicationDidFinishLaunching", objc_selector="applicationDidFinishLaunching:")
HBAppDelegate_applicationDidFinishLaunching :: #force_inline proc "c" (self: ^HBAppDelegate, notification: ^NSF.Notification) {
    s := get_self(self)
    context = s.ctx
    log.infof("applicationDidFinishLaunching: %v -> %v", s.state, State.FinishedLaunching)
    s.state = .FinishedLaunching
}
```

