### PR TITLE
Fill in missing build flags for `core/sys/windows` package

### DIFF
--- a/core/sys/windows/ole32.odin
+++ b/core/sys/windows/ole32.odin
@@ -1,3 +1,4 @@
+#+build windows
 package sys_windows
 
 foreign import "system:Ole32.lib"

--- a/core/sys/windows/types.odin
+++ b/core/sys/windows/types.odin
@@ -1,3 +1,4 @@
+#+build windows
 package sys_windows
 
 import "core:c"


### PR DESCRIPTION
These files are triggering compilation errors on my Linux machine, which are fixed with these build flags.

Thanks for reviewing.