### PR TITLE
Add `tick_add` proc to `core:time`

### DIFF
--- a/core/time/perf.odin
+++ b/core/time/perf.odin
@@ -18,6 +18,13 @@ tick_now :: proc "contextless" () -> Tick {
 }
 
 /*
+Add duration to a tick.
+*/
+tick_add :: proc "contextless" (t: Tick, d: Duration) -> Tick {
+	return Tick{t._nsec + i64(d)}
+}
+
+/*
 Obtain the difference between ticks.
 */
 tick_diff :: proc "contextless" (start, end: Tick) -> Duration {


### PR DESCRIPTION
Add a `tick_add` proc to `core:time`. This allows a `Tick` to be offset by a `Duration`; useful for calculating deadlines that are based on monotonic time, rather than the clock time.