### PR TITLE
vendor:wasm/WebGL: Fix incorrect parameter types

### DIFF
--- a/vendor/wasm/WebGL/webgl.odin
+++ b/vendor/wasm/WebGL/webgl.odin
@@ -61,10 +61,10 @@ foreign webgl {
 	BufferData    :: proc(target: Enum, size: int, data: rawptr, usage: Enum) ---
 	BufferSubData :: proc(target: Enum, offset: uintptr, size: int, data: rawptr) ---
 
-	Clear         :: proc(bits: Enum) ---
+	Clear         :: proc(bits: u32) ---
 	ClearColor    :: proc(r, g, b, a: f32) ---
-	ClearDepth    :: proc(x: Enum) ---
-	ClearStencil  :: proc(x: Enum) ---
+	ClearDepth    :: proc(x: f32) ---
+	ClearStencil  :: proc(x: int) ---
 	ColorMask     :: proc(r, g, b, a: bool) ---
 	CompileShader :: proc(shader: Shader) ---
 	

--- a/vendor/wasm/WebGL/webgl.odin
+++ b/vendor/wasm/WebGL/webgl.odin
@@ -64,7 +64,7 @@ foreign webgl {
 	Clear         :: proc(bits: u32) ---
 	ClearColor    :: proc(r, g, b, a: f32) ---
 	ClearDepth    :: proc(x: f32) ---
-	ClearStencil  :: proc(x: int) ---
+	ClearStencil  :: proc(x: i32) ---
 	ColorMask     :: proc(r, g, b, a: bool) ---
 	CompileShader :: proc(shader: Shader) ---
 	


### PR DESCRIPTION
I was playing with WebGL today, noticed there were some errant Enums.