### PR TITLE
fixes assigning null as a type if it's an alias but the base type is null

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -1854,7 +1854,10 @@ gb_internal Entity *check_ident(CheckerContext *c, Operand *o, Ast *n, Type *nam
 			o->type = t_invalid;
 		}
 		if (o->type != nullptr && o->type->kind == Type_Named && o->type->Named.type_name->TypeName.is_type_alias) {
-			o->type = base_type(o->type);
+			Type *bt = base_type(o->type);
+			if (bt != nullptr) {
+				o->type = bt;
+			}
 		}
 
 		break;


### PR DESCRIPTION
It's a bit of a band aid fix because the field will get the type of the alias, not the base type, but that was already the case before #5045 so it's forward progression and doesn't seem to break anything.

Closes #5092
Fixes #5061