### PR TITLE
Add attribute @(no_sanitize_address)

### DIFF
--- a/src/check_decl.cpp
+++ b/src/check_decl.cpp
@@ -1229,6 +1229,7 @@ gb_internal void check_proc_decl(CheckerContext *ctx, Entity *e, DeclInfo *d) {
 
 	e->Procedure.has_instrumentation = has_instrumentation;
 
+	e->Procedure.no_sanitize_address = ac.no_sanitize_address;
 
 	e->deprecated_message = ac.deprecated_message;
 	e->warning_message = ac.warning_message;

--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -3711,6 +3711,12 @@ gb_internal DECL_ATTRIBUTE_PROC(proc_decl_attribute) {
 		}
 		ac->instrumentation_exit = true;
 		return true;
+	} else if (name == "no_sanitize_address") {
+		if (value != nullptr) {
+			error(value, "'%.*s' expects no parameter", LIT(name));
+		}
+		ac->no_sanitize_address = true;
+		return true;
 	}
 	return false;
 }

--- a/src/checker.hpp
+++ b/src/checker.hpp
@@ -139,6 +139,7 @@ struct AttributeContext {
 	bool    entry_point_only      : 1;
 	bool    instrumentation_enter : 1;
 	bool    instrumentation_exit  : 1;
+	bool    no_sanitize_address   : 1;
 	bool    rodata                : 1;
 	bool    ignore_duplicates     : 1;
 	u32 optimization_mode; // ProcedureOptimizationMode

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -258,6 +258,7 @@ struct Entity {
 			bool    is_memcpy_like             : 1;
 			bool    uses_branch_location       : 1;
 			bool    is_anonymous               : 1;
+			bool    no_sanitize_address        : 1;
 		} Procedure;
 		struct {
 			Array<Entity *> entities;

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -333,7 +333,7 @@ gb_internal lbProcedure *lb_create_procedure(lbModule *m, Entity *entity, bool i
 	}
 
 	if (p->body && entity->pkg && ((entity->pkg->kind == Package_Normal) || (entity->pkg->kind == Package_Init))) {
-		if (build_context.sanitizer_flags & SanitizerFlag_Address) {
+		if (build_context.sanitizer_flags & SanitizerFlag_Address && !entity->Procedure.no_sanitize_address) {
 			lb_add_attribute_to_proc(m, p->value, "sanitize_address");
 		}
 		if (build_context.sanitizer_flags & SanitizerFlag_Memory) {


### PR DESCRIPTION
The purposes of this attribute is to let procedures opt-out of being instrumented with asan. Typically an allocator that includes 'in-band' meta-data will be accessing poisoned values (such as tlsf).

Making asan work with these allocators becomes very challenging so just being to ignore asan within specific allocator procedures makes it easier to reason and removes the need to temporarily poison and unpoison allocator data.