### PR TITLE
Make build_box2d.sh more flexible

### DIFF
--- a/vendor/box2d/build_box2d.sh
+++ b/vendor/box2d/build_box2d.sh
@@ -4,7 +4,7 @@ set -eu
 VERSION="3.1.0"
 RELEASE="https://github.com/erincatto/box2d/archive/refs/tags/v$VERSION.tar.gz"
 
-cd "$(odin root)"/vendor/box2d
+cd "$(dirname "$0")"
 
 curl -O -L "$RELEASE"
 tar -xzvf "v$VERSION.tar.gz"
@@ -58,7 +58,7 @@ Darwin)
 	*)
 		rm -rf build
 		mkdir build
-		cmake $FLAGS -DCMAKE_OSX_ARCHITECTURES=arm64 -S . -B build
+		cmake $FLAGS -S . -B build
 		cmake --build build
 		cp build/src/libbox2d.a ../lib/box2d_other.a
 		;;
@@ -73,6 +73,7 @@ make -f wasm.Makefile
 if [[ $? -ne 0 ]]; then
 	printf "\e[30;43mwarning:\e[0m Native Box2D libraries were built successfully, the WASM build failed, likely because your default C compiler and/or linker doesn't support WASM, you can set the CC and LD environment variables to point to a compiler and linker that support it\n"
 fi
+make -f wasm.Makefile clean
 set -e
 
 rm -rf "v$VERSION.tar.gz"

--- a/vendor/box2d/wasm.Makefile
+++ b/vendor/box2d/wasm.Makefile
@@ -14,7 +14,7 @@ OBJS      = $(SRCS:.c=.o)
 SYSROOT   = $(shell odin root)/vendor/libc
 CFLAGS    = -Ibox2d-$(VERSION)/include --target=wasm32 -D__EMSCRIPTEN__ -DNDEBUG -O3 --sysroot=$(SYSROOT)
 
-all: lib/box2d_wasm.o lib/box2d_wasm_simd.o clean
+all: lib/box2d_wasm.o lib/box2d_wasm_simd.o
 
 %.o: %.c
 	$(CC) -c $(CFLAGS) -DBOX2D_DISABLE_SIMD $< -o $@


### PR DESCRIPTION
Removed the `odin root` call.
Seperated the clean rule in wasm.Makefile to enable parallel builds.