### PR TITLE
win/sys: Add GetWindowThreadProcessId

### DIFF
--- a/core/sys/windows/user32.odin
+++ b/core/sys/windows/user32.odin
@@ -47,6 +47,8 @@ foreign user32 {
 		lpParam: LPVOID,
 	) -> HWND ---
 
+	GetWindowThreadProcessId :: proc(hwnd: HWND, lpdwProcessId: LPDWORD) -> DWORD ---
+
 	DestroyWindow :: proc(hWnd: HWND) -> BOOL ---
 
 	ShowWindow :: proc(hWnd: HWND, nCmdShow: INT) -> BOOL ---


### PR DESCRIPTION
```
DWORD GetWindowThreadProcessId(
  [in]            HWND    hWnd,
  [out, optional] LPDWORD lpdwProcessId
);
```