### PR TITLE
Bug/5104

### DIFF
--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -3146,6 +3146,18 @@ gb_internal lbValue lb_emit_comp_against_nil(lbProcedure *p, TokenKind op_kind, 
 			}
 		}
 		break;
+	
+	case Type_SoaPointer:
+		{
+			// NOTE(bill): An SoaPointer is essentially just a pointer for nil comparison
+			lbValue ptr = lb_emit_struct_ev(p, x, 0); // Extract the base pointer component (field 0)
+			if (op_kind == Token_CmpEq) {
+				res.value = LLVMBuildIsNull(p->builder, ptr.value, "");
+			} else if (op_kind == Token_NotEq) {
+				res.value = LLVMBuildIsNotNull(p->builder, ptr.value, "");
+			}
+			return res;
+		}
 
 	case Type_Union:
 		{


### PR DESCRIPTION
This aims to directly resolve this https://github.com/odin-lang/Odin/issues/5104

### Here's a breakdown of the fix:

1. The Problem: The original code crashed the compiler because it didn't know how to handle a comparison between `nil` and a specific type of pointer called an `SoaPointer`. This pointer type arises when you take the address of an element within an SOA (Structure of Arrays) slice or dynamic array, like `&array[1]` in your @Kelimion "5104.odin" example. The relevant compiler function, `lb_emit_comp_against_nil` in `src/llvm_backend_expr.cpp`, lacked instructions for this specific `SoaPointer` type.

2. Understanding `SoaPointer`: Unlike a regular pointer which is just a memory address, an `SoaPointer` in the compiler's LLVM backend is internally represented as a small structure containing two parts:
    - The base memory address of the underlying SOA data.
    - The index of the specific element within that structure.

3. The Correct Fix: The successful fix involved adding a specific case for `Type_SoaPointer` within the switch statement in `lb_emit_comp_against_nil`. Inside this new case, was done the following:
    - Extract the Base Pointer: We used the function `lb_emit_struct_ev(p, x, 0)`. This function correctly extracts the value of the first field (index 0) of the internal structure representing the `SoaPointer (x)`. This first field is the crucial base memory address we needed.
    - Compare the Base Pointer: We then used the standard LLVM comparison instructions `(LLVMBuildIsNull for == nil` or `LLVMBuildIsNotNull for != nil`) on this extracted base pointer.
    - Result: This generated the correct LLVM Intermediate Representation (IR). Instead of trying to compare the whole `SoaPointer` structure to nil, it now correctly compares just the base pointer component of the `SoaPointer` to nil, which is the logically correct operation and something LLVM understands.

In short, the fix teaches the compiler how to properly "unpack" the `SoaPointer` and compare its relevant part (the base address) when checking against nil. 

The `5104.odin` now compiles either `if addr == nil` or `if addr != nil`

`--- CI Simulation Complete on macOS 15.4.1 (24E263) ---`
`./local_ci.sh  42.82s user 15.27s system 136% cpu 42.568 total`