### PR TITLE
[core:os/os2] Fix: Correct value cloning in os2._set_env for POSIX

### DIFF
--- a/core/os/os2/env_posix.odin
+++ b/core/os/os2/env_posix.odin
@@ -30,7 +30,7 @@ _set_env :: proc(key, value: string) -> (err: Error) {
 	TEMP_ALLOCATOR_GUARD()
 
 	ckey := strings.clone_to_cstring(key, temp_allocator()) or_return
-	cval := strings.clone_to_cstring(key, temp_allocator()) or_return
+	cval := strings.clone_to_cstring(value, temp_allocator()) or_return
 
 	if posix.setenv(ckey, cval, true) != nil {
 		err = _get_platform_error_from_errno()


### PR DESCRIPTION
The **_set_env** procedure in `core/os/os2/env_posix.odin` was incorrectly cloning the *key* argument for *cval* instead of the *value* argument. This resulted in **set_env** effectively setting the environment variable's value to its own key.

This commit corrects the typo to use the 'value' argument.