### PR TITLE
fix disposing builder when not created

### DIFF
--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -2185,7 +2185,6 @@ gb_internal void lb_generate_procedure(lbModule *m, lbProcedure *p) {
 		p->is_done = true;
 		m->curr_procedure = nullptr;
 	}
-	lb_end_procedure(p);
 
 	// Add Flags
 	if (p->entity && p->entity->kind == Entity_Procedure && p->entity->Procedure.is_memcpy_like) {

--- a/src/llvm_backend.hpp
+++ b/src/llvm_backend.hpp
@@ -409,7 +409,6 @@ gb_internal LLVMAttributeRef lb_create_enum_attribute_with_type(LLVMContextRef c
 gb_internal void lb_add_proc_attribute_at_index(lbProcedure *p, isize index, char const *name, u64 value);
 gb_internal void lb_add_proc_attribute_at_index(lbProcedure *p, isize index, char const *name);
 gb_internal lbProcedure *lb_create_procedure(lbModule *module, Entity *entity, bool ignore_body=false);
-gb_internal void lb_end_procedure(lbProcedure *p);
 
 
 gb_internal LLVMTypeRef lb_type(lbModule *m, Type *type);

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -783,8 +783,7 @@ gb_internal void lb_end_procedure_body(lbProcedure *p) {
 
 	p->curr_block = nullptr;
 	p->state_flags = 0;
-}
-gb_internal void lb_end_procedure(lbProcedure *p) {
+
 	LLVMDisposeBuilder(p->builder);
 }
 


### PR DESCRIPTION
Fixes #5128

p->builder is created in lb_begin_procedure_body, but that isn't called if there is no body, and we were still calling dispose at that point.

Moved it into lb_end_procedure_body to match.