### PR TITLE
Add `@(public)`

### DIFF
--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -85,6 +85,8 @@ enum EntityFlag : u64 {
 	EntityFlag_Require = 1ull<<50,
 	EntityFlag_ByPtr   = 1ull<<51, // enforce parameter is passed by pointer
 
+	EntityFlag_ForcePublic = 1ull<<52, // used for passing @(public) to `is_entity_exported`
+
 	EntityFlag_Overridden    = 1ull<<63,
 };
 
@@ -308,7 +310,7 @@ gb_internal bool is_entity_exported(Entity *e, bool allow_builtin = false) {
 	if (e->flags & EntityFlag_NotExported) {
 		return false;
 	}
-	if (e->file != nullptr && (e->file->flags & (AstFile_IsPrivatePkg|AstFile_IsPrivateFile)) != 0) {
+	if (e->file != nullptr && (e->file->flags & (AstFile_IsPrivatePkg|AstFile_IsPrivateFile)) != 0 && (e->flags & EntityFlag_ForcePublic) == 0) {
 		return false;
 	}
 


### PR DESCRIPTION
This PR adds `@(public)`, which can be used to revert `#+private file` and `#+private package` for a single entity.

## Rationale
This makes it possible to export things to the outside of a package, directly from files tagged with for example `#+private file`. But that is not my main concern.

The main thing I'm trying to fix is that I sometimes use `#+private file` at the top of a file within a bigger program. This program is not used as a package by anyone (it's a video game, all of it is a single package). I then use `@(private="package")` to expose a few API functions, from that file, to the rest of the program. In this specific case, when I see it as just a program, and not a package, it is very strange to put `@(private="package")` to make something "less private": What I want to signal is "it's public to the program". There is no "package thinking" going on at all at this point.

With this organizational method I can prefix the "API procs", and make utility procs without any prefixes, with little concern for name collisions etc. It makes my programming more joyful.