### PR TITLE
Enable asan for windows and ubuntu CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,20 +75,13 @@ jobs:
       fail-fast: false
       matrix:
         # MacOS 13 runs on Intel, 14 runs on ARM
-        os: [ubuntu-latest, macos-13, macos-14]
+        os: [macos-13, macos-14]
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os == 'macos-14' && 'MacOS ARM' || (matrix.os == 'macos-13' && 'MacOS Intel' || 'Ubuntu') }} Build, Check, and Test
+    name: ${{ matrix.os == 'macos-14' && 'MacOS ARM' || (matrix.os == 'macos-13' && 'MacOS Intel') }} Build, Check, and Test
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
 
-      - name: Download LLVM (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 20
-          echo "/usr/lib/llvm-20/bin" >> $GITHUB_PATH
+      - uses: actions/checkout@v4
 
       - name: Download LLVM (MacOS Intel)
         if: matrix.os == 'macos-13'
@@ -136,40 +129,77 @@ jobs:
           cd tests/issues
           ./run.sh
 
-      - name: Check benchmarks
-        run: ./odin check tests/benchmark -vet -strict-style -no-entry-point
-      - name: Odin check examples/all for Linux i386
-        run: ./odin check examples/all -vet -strict-style -disallow-do -target:linux_i386
-        if: matrix.os == 'ubuntu-latest'
-      - name: Odin check examples/all for Linux arm64
-        run: ./odin check examples/all -vet -strict-style -disallow-do -target:linux_arm64
-        if: matrix.os == 'ubuntu-latest'
-      - name: Odin check examples/all for FreeBSD amd64
-        run: ./odin check examples/all -vet -strict-style -disallow-do -target:freebsd_amd64
-        if: matrix.os == 'ubuntu-latest'
-      - name: Odin check examples/all for OpenBSD amd64
-        run: ./odin check examples/all -vet -strict-style -disallow-do -target:openbsd_amd64
-        if: matrix.os == 'ubuntu-latest'
-
-      - name: Odin check vendor/sdl3 for Linux i386
-        run: ./odin check vendor/sdl3 -vet -strict-style -disallow-do -no-entry-point -target:linux_i386
-        if: matrix.os == 'ubuntu-latest'
-      - name: Odin check vendor/sdl3 for Linux arm64
-        run: ./odin check vendor/sdl3 -vet -strict-style -disallow-do -no-entry-point -target:linux_arm64
-        if: matrix.os == 'ubuntu-latest'
-      - name: Odin check vendor/sdl3 for FreeBSD amd64
-        run: ./odin check vendor/sdl3 -vet -strict-style -disallow-do -no-entry-point -target:freebsd_amd64
-        if: matrix.os == 'ubuntu-latest'
-      - name: Odin check vendor/sdl3 for OpenBSD amd64
-        run: ./odin check vendor/sdl3 -vet -strict-style -disallow-do -no-entry-point -target:openbsd_amd64
-        if: matrix.os == 'ubuntu-latest'
-
-
       - name: Run demo on WASI WASM32
         run: |
           ./odin build examples/demo -target:wasi_wasm32 -vet -strict-style -disallow-do -out:demo
           wasmtime ./demo.wasm
         if: matrix.os == 'macos-14'
+
+  build_ubuntu:
+    name: Ubuntu Build, Check, and Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download LLVM
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 20
+          echo "/usr/lib/llvm-20/bin" >> $GITHUB_PATH
+
+      - name: Build Odin
+        run: ./build_odin.sh release
+      - name: Odin version
+        run: ./odin version
+      - name: Odin report
+        run: ./odin report
+      - name: Compile needed Vendor
+        run: |
+          make -C vendor/stb/src
+          make -C vendor/cgltf/src
+          make -C vendor/miniaudio/src
+      - name: Odin check
+        run: ./odin check examples/demo -vet
+      - name: Odin run
+        run: ./odin run examples/demo
+      - name: Odin run -debug
+        run: ./odin run examples/demo -debug
+      - name: Odin check examples/all
+        run: ./odin check examples/all -strict-style -vet -disallow-do
+      - name: Odin check vendor/sdl3
+        run: ./odin check vendor/sdl3  -strict-style -vet -disallow-do -no-entry-point
+      - name: Normal Core library tests
+        run: ./odin test tests/core/normal.odin -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -sanitize:address
+      - name: Optimized Core library tests
+        run: ./odin test tests/core/speed.odin -o:speed -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -sanitize:address
+      - name: Vendor library tests
+        run: ./odin test tests/vendor -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -sanitize:address
+      - name: Internals tests
+        run: ./odin test tests/internal -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true
+      - name: GitHub Issue tests
+        run: |
+          cd tests/issues
+          ./run.sh
+
+      - name: Check benchmarks
+        run: ./odin check tests/benchmark -vet -strict-style -no-entry-point
+      - name: Odin check examples/all for Linux i386
+        run: ./odin check examples/all -vet -strict-style -disallow-do -target:linux_i386
+      - name: Odin check examples/all for Linux arm64
+        run: ./odin check examples/all -vet -strict-style -disallow-do -target:linux_arm64
+      - name: Odin check examples/all for FreeBSD amd64
+        run: ./odin check examples/all -vet -strict-style -disallow-do -target:freebsd_amd64
+      - name: Odin check examples/all for OpenBSD amd64
+        run: ./odin check examples/all -vet -strict-style -disallow-do -target:openbsd_amd64
+
+      - name: Odin check vendor/sdl3 for Linux i386
+        run: ./odin check vendor/sdl3 -vet -strict-style -disallow-do -no-entry-point -target:linux_i386
+      - name: Odin check vendor/sdl3 for Linux arm64
+        run: ./odin check vendor/sdl3 -vet -strict-style -disallow-do -no-entry-point -target:linux_arm64
+      - name: Odin check vendor/sdl3 for FreeBSD amd64
+        run: ./odin check vendor/sdl3 -vet -strict-style -disallow-do -no-entry-point -target:freebsd_amd64
+      - name: Odin check vendor/sdl3 for OpenBSD amd64
+        run: ./odin check vendor/sdl3 -vet -strict-style -disallow-do -no-entry-point -target:openbsd_amd64
 
   build_windows:
     name: Windows Build, Check, and Test
@@ -215,23 +245,23 @@ jobs:
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
-          odin test tests/core/normal.odin -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true
+          odin test tests/core/normal.odin -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -sanitize:address
       - name: Optimized core library tests
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
-          odin test tests/core/speed.odin -o:speed -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true
+          odin test tests/core/speed.odin -o:speed -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -sanitize:address
       - name: Vendor library tests
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
           copy vendor\lua\5.4\windows\*.dll .
-          odin test tests/vendor -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true
+          odin test tests/vendor -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -sanitize:address
       - name: Odin internals tests
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
-          odin test tests/internal -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true
+          odin test tests/internal -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -sanitize:address
       - name: Check issues
         shell: cmd
         run: |


### PR DESCRIPTION
Other platforms either do not support asan at all or they fail to link with the asan runtime (and I do not have a machine to figure that stuff out).