### PR TITLE
tests/internal with asan (requiring abi and codegen fixes), and macos -sanitize:address

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,9 @@ jobs:
       fail-fast: false
       matrix:
         # MacOS 13 runs on Intel, 14 runs on ARM
-        os: [macos-13, macos-14]
+        os: [macos-13, macos-14, ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os == 'macos-14' && 'MacOS ARM' || (matrix.os == 'macos-13' && 'MacOS Intel') }} Build, Check, and Test
+    name: ${{ matrix.os == 'macos-14' && 'MacOS ARM' || (matrix.os == 'macos-13' && 'MacOS Intel') || (matrix.os == 'ubuntu-latest' && 'Ubuntu') }} Build, Check, and Test
     timeout-minutes: 15
     steps:
 
@@ -95,52 +95,8 @@ jobs:
           brew update
           brew install llvm@20 wasmtime lua@5.4 lld
 
-      - name: Build Odin
-        run: ./build_odin.sh release
-      - name: Odin version
-        run: ./odin version
-      - name: Odin report
-        run: ./odin report
-      - name: Compile needed Vendor
-        run: |
-          make -C vendor/stb/src
-          make -C vendor/cgltf/src
-          make -C vendor/miniaudio/src
-      - name: Odin check
-        run: ./odin check examples/demo -vet
-      - name: Odin run
-        run: ./odin run examples/demo
-      - name: Odin run -debug
-        run: ./odin run examples/demo -debug
-      - name: Odin check examples/all
-        run: ./odin check examples/all -strict-style -vet -disallow-do
-      - name: Odin check vendor/sdl3
-        run: ./odin check vendor/sdl3  -strict-style -vet -disallow-do -no-entry-point
-      - name: Normal Core library tests
-        run: ./odin test tests/core/normal.odin -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true
-      - name: Optimized Core library tests
-        run: ./odin test tests/core/speed.odin -o:speed -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true
-      - name: Vendor library tests
-        run: ./odin test tests/vendor -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true
-      - name: Internals tests
-        run: ./odin test tests/internal -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true
-      - name: GitHub Issue tests
-        run: |
-          cd tests/issues
-          ./run.sh
-
-      - name: Run demo on WASI WASM32
-        run: |
-          ./odin build examples/demo -target:wasi_wasm32 -vet -strict-style -disallow-do -out:demo
-          wasmtime ./demo.wasm
-        if: matrix.os == 'macos-14'
-
-  build_ubuntu:
-    name: Ubuntu Build, Check, and Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download LLVM
+      - name: Download LLVM (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
@@ -175,30 +131,44 @@ jobs:
       - name: Vendor library tests
         run: ./odin test tests/vendor -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -sanitize:address
       - name: Internals tests
-        run: ./odin test tests/internal -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true
+        run: ./odin test tests/internal -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -sanitize:address
       - name: GitHub Issue tests
         run: |
           cd tests/issues
           ./run.sh
 
+      - name: Run demo on WASI WASM32
+        run: |
+          ./odin build examples/demo -target:wasi_wasm32 -vet -strict-style -disallow-do -out:demo
+          wasmtime ./demo.wasm
+        if: matrix.os == 'macos-14'
+
       - name: Check benchmarks
         run: ./odin check tests/benchmark -vet -strict-style -no-entry-point
       - name: Odin check examples/all for Linux i386
+        if: matrix.os == 'ubuntu-latest'
         run: ./odin check examples/all -vet -strict-style -disallow-do -target:linux_i386
       - name: Odin check examples/all for Linux arm64
+        if: matrix.os == 'ubuntu-latest'
         run: ./odin check examples/all -vet -strict-style -disallow-do -target:linux_arm64
       - name: Odin check examples/all for FreeBSD amd64
+        if: matrix.os == 'ubuntu-latest'
         run: ./odin check examples/all -vet -strict-style -disallow-do -target:freebsd_amd64
       - name: Odin check examples/all for OpenBSD amd64
+        if: matrix.os == 'ubuntu-latest'
         run: ./odin check examples/all -vet -strict-style -disallow-do -target:openbsd_amd64
 
       - name: Odin check vendor/sdl3 for Linux i386
+        if: matrix.os == 'ubuntu-latest'
         run: ./odin check vendor/sdl3 -vet -strict-style -disallow-do -no-entry-point -target:linux_i386
       - name: Odin check vendor/sdl3 for Linux arm64
+        if: matrix.os == 'ubuntu-latest'
         run: ./odin check vendor/sdl3 -vet -strict-style -disallow-do -no-entry-point -target:linux_arm64
       - name: Odin check vendor/sdl3 for FreeBSD amd64
+        if: matrix.os == 'ubuntu-latest'
         run: ./odin check vendor/sdl3 -vet -strict-style -disallow-do -no-entry-point -target:freebsd_amd64
       - name: Odin check vendor/sdl3 for OpenBSD amd64
+        if: matrix.os == 'ubuntu-latest'
         run: ./odin check vendor/sdl3 -vet -strict-style -disallow-do -no-entry-point -target:openbsd_amd64
 
   build_windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,12 +88,14 @@ jobs:
         run: |
           brew update
           brew install llvm@20 lua@5.4 lld
+          echo "$(brew --prefix llvm@20)/bin" >> $GITHUB_PATH
 
       - name: Download LLVM (MacOS ARM)
         if: matrix.os == 'macos-14'
         run: |
           brew update
           brew install llvm@20 wasmtime lua@5.4 lld
+          echo "$(brew --prefix llvm@20)/bin" >> $GITHUB_PATH
 
       - name: Download LLVM (Ubuntu)
         if: matrix.os == 'ubuntu-latest'

--- a/base/runtime/internal.odin
+++ b/base/runtime/internal.odin
@@ -1109,6 +1109,7 @@ __read_bits :: proc "contextless" (dst, src: [^]byte, offset: uintptr, size: uin
 
 when .Address in ODIN_SANITIZER_FLAGS {
 	foreign {
+		@(require)
 		__asan_unpoison_memory_region :: proc "system" (address: rawptr, size: uint) ---
 	}
 }

--- a/src/llvm_abi.cpp
+++ b/src/llvm_abi.cpp
@@ -977,7 +977,7 @@ namespace lbAbiAmd64SysV {
 			return types[0];
 		}
 
-		return LLVMStructTypeInContext(c, types.data, cast(unsigned)types.count, sz == 0);
+		return LLVMStructTypeInContext(c, types.data, cast(unsigned)types.count, false);
 	}
 
 	gb_internal void classify_with(LLVMTypeRef t, Array<RegClass> *cls, i64 ix, i64 off) {
@@ -1231,38 +1231,24 @@ namespace lbAbiArm64 {
 			}
 		} else {
 			i64 size = lb_sizeof(return_type);
-			if (size <= 16) {
-				LLVMTypeRef cast_type = nullptr;
-
-				if (size == 0) {
-					cast_type = LLVMStructTypeInContext(c, nullptr, 0, false);
-				} else if (size <= 8) {
-					cast_type = LLVMIntTypeInContext(c, cast(unsigned)(size*8));
-				} else {
-					unsigned count = cast(unsigned)((size+7)/8);
-
-					LLVMTypeRef llvm_i64 = LLVMIntTypeInContext(c, 64);
-					LLVMTypeRef *types = gb_alloc_array(temporary_allocator(), LLVMTypeRef, count);
-
-					i64 size_copy = size;
-					for (unsigned i = 0; i < count; i++) {
-						if (size_copy >= 8) {
-							types[i] = llvm_i64;
-						} else {
-							types[i] = LLVMIntTypeInContext(c, 8*cast(unsigned)size_copy);
-						}
-						size_copy -= 8;
-					}
-					GB_ASSERT(size_copy <= 0);
-					cast_type = LLVMStructTypeInContext(c, types, count, true);
-				}
-				return lb_arg_type_direct(return_type, cast_type, nullptr, nullptr);
-			} else {
+			if (size > 16) {
 				LB_ABI_MODIFY_RETURN_IF_TUPLE_MACRO();
 
 				LLVMAttributeRef attr = lb_create_enum_attribute_with_type(c, "sret", return_type);
 				return lb_arg_type_indirect(return_type, attr);
 			}
+
+			GB_ASSERT(size <= 16);
+			LLVMTypeRef cast_type = nullptr;
+			if (size == 0) {
+				cast_type = LLVMStructTypeInContext(c, nullptr, 0, false);
+			} else if (size <= 8) {
+				cast_type = LLVMIntTypeInContext(c, cast(unsigned)(size*8));
+			} else {
+				LLVMTypeRef llvm_i64 = LLVMIntTypeInContext(c, 64);
+				cast_type = LLVMArrayType2(llvm_i64, 2);
+			}
+			return lb_arg_type_direct(return_type, cast_type, nullptr, nullptr);
 		}
 	}
     


### PR DESCRIPTION
Started with trying to enable asan in the CI for MacOS, noticed it wasn't enabled on the `tests/internal`
folder, it came up with a couple of issues with the abi/OdinLLVMBuildTransmute that this also solves.

- add @(require) to the asan function called to unpoison locals, I noticed an empty project didn't compile without it
- Looking at clang output for arm64, we should be promoting `{ i64, i32 }` etc. to `{ i64, i64 }`
- after doing the previous point, I noticed this is not handled well in OdinLLVMBuildTransmute
  which was emitting loads and stores into the space of a value that was alignment, asan does not want this,
  looking at clang output again, a memcpy is the appropriate way of handling this.
- Having done this we don't need the hacky "return is packed" set anymore in the amd64 sysv ABI anymore either (Fixes #4553)