### PR TITLE
Update `linux.Map_Flags_Bits`

### DIFF
--- a/core/sys/linux/bits.odin
+++ b/core/sys/linux/bits.odin
@@ -579,7 +579,7 @@ Inotify_Event_Bits :: enum u32 {
 /*
 	Bits for Mem_Protection bitfield
 */
-Mem_Protection_Bits :: enum{
+Mem_Protection_Bits :: enum {
 	READ      = 0,
 	WRITE     = 1,
 	EXEC      = 2,
@@ -598,7 +598,7 @@ Mem_Protection_Bits :: enum{
 Map_Flags_Bits :: enum {
 	SHARED          = 0,
 	PRIVATE         = 1,
-	SHARED_VALIDATE = 2,
+	DROPPABLE       = 3,
 	FIXED           = 4,
 	ANONYMOUS       = 5,
 	// platform-dependent section start
@@ -618,6 +618,10 @@ Map_Flags_Bits :: enum {
 	FIXED_NOREPLACE = 20,
 	UNINITIALIZED   = 26,
 }
+
+// Not actually flags, but a shift and mask for when HUGETLB is defined
+MAP_HUGE_SHIFT :: 26
+MAP_HUGE_MASK  :: 63
 
 /*
 	Bits for MLock_Flags

--- a/core/sys/linux/types.odin
+++ b/core/sys/linux/types.odin
@@ -371,6 +371,21 @@ Mem_Protection :: bit_set[Mem_Protection_Bits; i32]
 */
 Map_Flags :: bit_set[Map_Flags_Bits; i32]
 
+Map_Shared_Validate :: Map_Flags{.SHARED, .PRIVATE}
+Map_Huge_16KB       :: transmute(Map_Flags)(u32(14) << MAP_HUGE_SHIFT)
+Map_Huge_64KB       :: transmute(Map_Flags)(u32(16) << MAP_HUGE_SHIFT)
+Map_Huge_512KB      :: transmute(Map_Flags)(u32(19) << MAP_HUGE_SHIFT)
+Map_Huge_1MB        :: transmute(Map_Flags)(u32(20) << MAP_HUGE_SHIFT)
+Map_Huge_2MB        :: transmute(Map_Flags)(u32(21) << MAP_HUGE_SHIFT)
+Map_Huge_8MB        :: transmute(Map_Flags)(u32(23) << MAP_HUGE_SHIFT)
+Map_Huge_16MB       :: transmute(Map_Flags)(u32(24) << MAP_HUGE_SHIFT)
+Map_Huge_32MB       :: transmute(Map_Flags)(u32(25) << MAP_HUGE_SHIFT)
+Map_Huge_256MB      :: transmute(Map_Flags)(u32(28) << MAP_HUGE_SHIFT)
+Map_Huge_512MB      :: transmute(Map_Flags)(u32(29) << MAP_HUGE_SHIFT)
+Map_Huge_1GB        :: transmute(Map_Flags)(u32(30) << MAP_HUGE_SHIFT)
+Map_Huge_2GB        :: transmute(Map_Flags)(u32(31) << MAP_HUGE_SHIFT)
+Map_Huge_16GB       :: transmute(Map_Flags)(u32(34) << MAP_HUGE_SHIFT)
+
 /*
 	Flags for mlock(2).
 */


### PR DESCRIPTION
Fixes #5151

- Removes `SHARED_VALIDATE` from the enum and turns it into `Map_Shared_Validate :: Map_Flags{.SHARED, .PRIVATE}` so it has the proper value of 0x03.
- Adds `DROPPABLE`.
- Adds constants `MAP_HUGE_SHIFT` and `MAP_HUGE_MASK`.
- Adds the huge page precomputed constants from `mman.h`, defined as the log2 of the size shifted left by `MAP_HUGE_SHIFT`: 
  Map_Huge_16KB
  Map_Huge_64KB
  Map_Huge_512KB
  Map_Huge_1MB
  Map_Huge_2MB
  Map_Huge_8MB
  Map_Huge_16MB
  Map_Huge_32MB
  Map_Huge_256MB
  Map_Huge_512MB
  Map_Huge_1GB
  Map_Huge_2GB
  Map_Huge_16GB