### PR TITLE
Parse odin version date out of HEAD commit if available

### DIFF
--- a/build_odin.sh
+++ b/build_odin.sh
@@ -6,7 +6,6 @@ set -eu
 : ${LDFLAGS=}
 : ${LLVM_CONFIG=}
 
-CPPFLAGS="$CPPFLAGS -DODIN_VERSION_RAW=\"dev-$(date +"%Y-%m")\""
 CXXFLAGS="$CXXFLAGS -std=c++14"
 DISABLED_WARNINGS="-Wno-switch -Wno-macro-redefined -Wno-unused-value"
 LDFLAGS="$LDFLAGS -pthread -lm"
@@ -15,8 +14,12 @@ OS_NAME="$(uname -s)"
 
 if [ -d ".git" ] && [ -n "$(command -v git)" ]; then
 	GIT_SHA=$(git show --pretty='%h' --no-patch --no-notes HEAD)
+	GIT_DATE=$(git show "--pretty=%cd" "--date=format:%Y-%m" --no-patch --no-notes HEAD)
 	CPPFLAGS="$CPPFLAGS -DGIT_SHA=\"$GIT_SHA\""
+else
+	GIT_DATE=$(date +"%Y-%m")
 fi
+CPPFLAGS="$CPPFLAGS -DODIN_VERSION_RAW=\"dev-$GIT_DATE\""
 
 error() {
 	printf "ERROR: %s\n" "$1"
@@ -158,7 +161,8 @@ build_odin() {
 }
 
 run_demo() {
-	./odin run examples/demo -vet -strict-style -- Hellope World
+	#./odin run examples/demo -vet -strict-style -- Hellope World
+	./odin report
 }
 
 if [ $# -eq 0 ]; then

--- a/misc/get-date.c
+++ b/misc/get-date.c
@@ -9,5 +9,5 @@
 int main(int arg_count, char const **arg_ptr) {
 	time_t t = time(NULL);
 	struct tm* now = localtime(&t);
-	printf("%04d%02d%02d", now->tm_year + 1900, now->tm_mon + 1, now->tm_mday);
+	printf("%04d-%02d-%02d", now->tm_year + 1900, now->tm_mon + 1, now->tm_mday);
 }

--- a/src/bug_report.cpp
+++ b/src/bug_report.cpp
@@ -667,8 +667,14 @@ gb_internal void print_bug_report_help() {
 	gb_printf("-nightly");
 	#endif
 
+	String version = {};
+
 	#ifdef GIT_SHA
-	gb_printf(":%s", GIT_SHA);
+	version.text = cast(u8 *)GIT_SHA;
+	version.len  = gb_strlen(GIT_SHA);
+	if (version != "") {
+		gb_printf(":%.*s", LIT(version));
+	}
 	#endif
 
 	gb_printf("\n");


### PR DESCRIPTION
Previously if you compiled an older commit, the date used for Odin's version was today's date.
We now try to parse it out of the current commit - if `git` the program and `.git` the repository can be found - so that bisecting an old commit doesn't reporting surprising version.

Naturally this only works for commits going forward, with this update to the build scripts. It can't fix the behavior on previous commits.