### PR TITLE
New core library: core:algorithm/fenwick_tree 

### DIFF
--- a/core/algorithm/fenwick_tree/fenwick_tree.odin
+++ b/core/algorithm/fenwick_tree/fenwick_tree.odin
@@ -1,9 +1,13 @@
 // This package implements fenwick tree operations over a slice
 package algorithm_fenwick_tree
 
+import "base:intrinsics"
+
 // Reference(s): https://cp-algorithms.com/data_structures/fenwick.html
 
-init :: proc(tree: $S/[]$E) {
+init :: proc(tree: $S/[]$E)
+	where intrinsics.type_is_numeric(E) {
+
 	n := len(tree)
 	for i := 0; i < n; i += 1 {
         r := i | (i + 1)
@@ -13,23 +17,30 @@ init :: proc(tree: $S/[]$E) {
 	}
 }
 
-add :: proc(tree: $S/[]$E, #any_int p: int, v: E) {
-	p += 1;
+add :: proc(tree: $S/[]$E, #any_int p: int, v: E)
+	where intrinsics.type_is_numeric(E) {
+
+	x := p + 1
 	for p <= len(tree) {
-		tree[p - 1] += v;
-		p += p & -p;	
+		tree[x - 1] += v
+		x += x & -x;
 	}
 }
 
-sum :: proc(tree: $S/[]$E, #any_int r: int) {
+sum :: proc(tree: $S/[]$E, #any_int r: int) -> E
+	where intrinsics.type_is_numeric(E) {
+
 	sum := 0
-	for r > 0 {
+	ptr := r
+	for ptr > 0 {
 		sum += tree[r - 1]
-		r -= r & -r;
+		ptr -= ptr & -ptr
 	}
 	return sum
 }
 
-range_sum :: proc(tree: $S/[]$E, #any_int l: int, #any_int r: int) {
+range_sum :: proc(tree: $S/[]$E, #any_int l: int, #any_int r: int) -> E
+	where intrinsics.type_is_numeric(E) {
+
 	return sum(tree, r) - sum(tree, l)
 }

--- a/core/algorithm/fenwick_tree/fenwick_tree.odin
+++ b/core/algorithm/fenwick_tree/fenwick_tree.odin
@@ -1,11 +1,20 @@
 // This package implements fenwick tree operations over a slice
 package algorithm_fenwick_tree
 
-import "base:intrinsics"
+// Reference(s): https://cp-algorithms.com/data_structures/fenwick.html
 
-add :: proc(tree: $Slice_Type/[]$Elem_Type, p: int, v: Elem_Type)
-	where intrinsics.type_is_unsigned(Elem_Type) {
+init_from_slice :: proc(tree: $S/[]$E, src: $A/[]E) {
+	n := len(tree)
+	for i := 0; i < n; i += 1 {
+        tree[i] += src[i]
+        r := i | (i + 1)
+        if r < n {
+        	tree[r] += tree[i]
+        }
+	}
+}
 
+add :: proc(tree: $S/[]$E, #any_int p: int, v: E) {
 	p += 1;
 	for p <= len(tree) {
 		tree[p - 1] += v;
@@ -13,9 +22,7 @@ add :: proc(tree: $Slice_Type/[]$Elem_Type, p: int, v: Elem_Type)
 	}
 }
 
-sum :: proc(tree: $Slice_Type/[]$Elem_Type, r: int) 
-	where intrinsics.type_is_unsigned(Elem_Type) {
-
+sum :: proc(tree: $S/[]$E, #any_int r: int) {
 	sum := 0
 	for r > 0 {
 		sum += tree[r - 1]
@@ -24,9 +31,6 @@ sum :: proc(tree: $Slice_Type/[]$Elem_Type, r: int)
 	return sum
 }
 
-range_sum :: proc(tree: $Slice_Type/[]$Elem_Type, l: int, r: int)
-	where intrinsics.type_is_unsigned(Elem_Type) {
-
+range_sum :: proc(tree: $S/[]$E, #any_int l: int, #any_int r: int) {
 	return sum(tree, r) - sum(tree, l)
 }
-

--- a/core/algorithm/fenwick_tree/fenwick_tree.odin
+++ b/core/algorithm/fenwick_tree/fenwick_tree.odin
@@ -1,0 +1,24 @@
+// This package implements fenwick tree operations over a slice
+package algorithm_fenwick_tree
+
+add :: proc(tree: $Slice_Type/[]$Elem_Type, p: int, v: Elem_Type)  {
+	p += 1;
+	for p <= len(tree) {
+		tree[p - 1] += v;
+		p += p & -p;	
+	}
+}
+
+sum :: proc(tree: $Slice_Type/[]$Elem_Type, r: int)  {
+	sum := 0
+	for r > 0 {
+		sum += tree[r - 1]
+		r -= r & -r;
+	}
+	return sum
+}
+
+range_sum :: proc(tree: $Slice_Type/[]$Elem_Type, l: int, r: int)  {
+	return sum(tree, r) - sum(tree, l)
+}
+

--- a/core/algorithm/fenwick_tree/fenwick_tree.odin
+++ b/core/algorithm/fenwick_tree/fenwick_tree.odin
@@ -3,10 +3,9 @@ package algorithm_fenwick_tree
 
 // Reference(s): https://cp-algorithms.com/data_structures/fenwick.html
 
-init_from_slice :: proc(tree: $S/[]$E, src: $A/[]E) {
+init :: proc(tree: $S/[]$E) {
 	n := len(tree)
 	for i := 0; i < n; i += 1 {
-        tree[i] += src[i]
         r := i | (i + 1)
         if r < n {
         	tree[r] += tree[i]

--- a/core/algorithm/fenwick_tree/fenwick_tree.odin
+++ b/core/algorithm/fenwick_tree/fenwick_tree.odin
@@ -1,7 +1,11 @@
 // This package implements fenwick tree operations over a slice
 package algorithm_fenwick_tree
 
-add :: proc(tree: $Slice_Type/[]$Elem_Type, p: int, v: Elem_Type)  {
+import "base:intrinsics"
+
+add :: proc(tree: $Slice_Type/[]$Elem_Type, p: int, v: Elem_Type)
+	where intrinsics.type_is_unsigned(Elem_Type) {
+
 	p += 1;
 	for p <= len(tree) {
 		tree[p - 1] += v;
@@ -9,7 +13,9 @@ add :: proc(tree: $Slice_Type/[]$Elem_Type, p: int, v: Elem_Type)  {
 	}
 }
 
-sum :: proc(tree: $Slice_Type/[]$Elem_Type, r: int)  {
+sum :: proc(tree: $Slice_Type/[]$Elem_Type, r: int) 
+	where intrinsics.type_is_unsigned(Elem_Type) {
+
 	sum := 0
 	for r > 0 {
 		sum += tree[r - 1]
@@ -18,7 +24,9 @@ sum :: proc(tree: $Slice_Type/[]$Elem_Type, r: int)  {
 	return sum
 }
 
-range_sum :: proc(tree: $Slice_Type/[]$Elem_Type, l: int, r: int)  {
+range_sum :: proc(tree: $Slice_Type/[]$Elem_Type, l: int, r: int)
+	where intrinsics.type_is_unsigned(Elem_Type) {
+
 	return sum(tree, r) - sum(tree, l)
 }
 

--- a/tests/core/algorithm/test_core_fenwick_tree.odin
+++ b/tests/core/algorithm/test_core_fenwick_tree.odin
@@ -1,1 +1,11 @@
 package test_core_algorithm
+
+import "core:testing"
+import "core:algorithm/fenwick_tree"
+
+@(test)
+test_fenwick_tree :: proc(t: ^testing.T) {
+	tree := []int{1,2,3,4,5}
+	fenwick_tree.init(tree)
+
+}

--- a/tests/core/algorithm/test_core_fenwick_tree.odin
+++ b/tests/core/algorithm/test_core_fenwick_tree.odin
@@ -1,0 +1,1 @@
+package test_core_algorithm

--- a/tests/core/algorithm/test_core_fenwick_tree.odin
+++ b/tests/core/algorithm/test_core_fenwick_tree.odin
@@ -5,7 +5,14 @@ import "core:algorithm/fenwick_tree"
 
 @(test)
 test_fenwick_tree :: proc(t: ^testing.T) {
-	tree := []int{1,2,3,4,5}
+	tree := []int{3,1,4,1,5,9}
 	fenwick_tree.init(tree)
-
+	testing.expect_value(t, fenwick_tree.sum(tree, 3), 8)
+	testing.expect_value(t, fenwick_tree.range_sum(tree, 0, 4), 9)
+	fenwick_tree.add(tree, 2, 6)
+	testing.expect_value(t, fenwick_tree.sum(tree, 4), 15)
+	testing.expect_value(t, fenwick_tree.range_sum(tree, 2, 5), 16)
+	fenwick_tree.add(tree, 5, -4)
+	testing.expect_value(t, fenwick_tree.sum(tree, 6), 25)
+	testing.expect_value(t, fenwick_tree.range_sum(tree, 1, 3), 11)
 }


### PR DESCRIPTION
Implements a set of procedures to operate on a slice as a fenwick tree:

- init(slice): in place convert a slice to a fenwick tree
- add(slice, idx, value): add value to the position element
- sum(slice, r) -> V: sum [0,r)
- range_sum(slice, l, r) -> V: sum [l,r) 

Fenwick trees are commonly used in competitive programming problems but also has applications in domains relevant to Odin i.e. game dev and image processing.