### PR TITLE
[vendor:SDL/ttf] - GPUAtlasDrawSequence multipointer from pointer

### DIFF
--- a/vendor/sdl3/ttf/sdl3_ttf.odin
+++ b/vendor/sdl3/ttf/sdl3_ttf.odin
@@ -98,7 +98,7 @@ GPUAtlasDrawSequence :: struct {
 	atlas_texture: ^SDL.GPUTexture,
 	xy, uv:        [^]SDL.FPoint,
 	num_vertices:  c.int,
-	indices:       ^c.int,
+	indices:       [^]c.int,
 	num_indices:   c.int,
 	image_type:    ImageType,
 	next:          ^GPUAtlasDrawSequence,

--- a/vendor/sdl3/ttf/sdl3_ttf.odin
+++ b/vendor/sdl3/ttf/sdl3_ttf.odin
@@ -96,7 +96,7 @@ ImageType :: enum c.int {
 
 GPUAtlasDrawSequence :: struct {
 	atlas_texture: ^SDL.GPUTexture,
-	xy, uv:        ^SDL.FPoint,
+	xy, uv:        [^]SDL.FPoint,
 	num_vertices:  c.int,
 	indices:       ^c.int,
 	num_indices:   c.int,


### PR DESCRIPTION
changes the `xy`,  `uv`, and `indices` fields of `GPUAtlasDrawSequence` to multipointers to match the intended usage

API description:
<https://wiki.libsdl.org/SDL3_ttf/TTF_GPUAtlasDrawSequence>