### PR TITLE
Re-enable static map calls on AMD64 SysV

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1915,12 +1915,6 @@ gb_internal void init_build_context(TargetMetrics *cross_target, Subtarget subta
 	}
 
 
-	// TODO: Static map calls are bugged on `amd64sysv` abi.
-	if (bc->metrics.os != TargetOs_windows && bc->metrics.arch == TargetArch_amd64) {
-		// ENFORCE DYNAMIC MAP CALLS
-		bc->dynamic_map_calls = true;
-	}
-
 	bc->ODIN_VALGRIND_SUPPORT = false;
 	if (build_context.metrics.os != TargetOs_windows) {
 		switch (bc->metrics.arch) {


### PR DESCRIPTION
Closes #3817

Upon an attempt to bisect when this was actually fixed, I could go no further back than when #4440 was merged, as I only have LLVM 19 now, so it's been fixed for a while.