### PR TITLE
Add ODIN_TEST_PLAIN_TEXT

### DIFF
--- a/core/testing/logging.odin
+++ b/core/testing/logging.odin
@@ -17,21 +17,39 @@ import "core:strings"
 import "core:sync/chan"
 import "core:time"
 
-when USING_SHORT_LOGS {
-	Default_Test_Logger_Opts :: runtime.Logger_Options {
-		.Level,
-		.Terminal_Color,
-		.Short_File_Path,
-		.Line,
+when PLAIN_TEXT {
+	when USING_SHORT_LOGS {
+		Default_Test_Logger_Opts :: runtime.Logger_Options {
+			.Level,
+			.Short_File_Path,
+			.Line,
+		}
+	} else {
+		Default_Test_Logger_Opts :: runtime.Logger_Options {
+			.Level,
+			.Short_File_Path,
+			.Line,
+			.Procedure,
+			.Date, .Time,
+		}
 	}
 } else {
-	Default_Test_Logger_Opts :: runtime.Logger_Options {
-		.Level,
-		.Terminal_Color,
-		.Short_File_Path,
-		.Line,
-		.Procedure,
-		.Date, .Time,
+	when USING_SHORT_LOGS {
+		Default_Test_Logger_Opts :: runtime.Logger_Options {
+			.Level,
+			.Terminal_Color,
+			.Short_File_Path,
+			.Line,
+		}
+	} else {
+		Default_Test_Logger_Opts :: runtime.Logger_Options {
+			.Level,
+			.Terminal_Color,
+			.Short_File_Path,
+			.Line,
+			.Procedure,
+			.Date, .Time,
+		}
 	}
 }
 

--- a/core/testing/reporting.odin
+++ b/core/testing/reporting.odin
@@ -18,11 +18,19 @@ import "core:path/filepath"
 import "core:strings"
 
 // Definitions of colors for use in the test runner.
-SGR_RESET   :: ansi.CSI + ansi.RESET           + ansi.SGR
-SGR_READY   :: ansi.CSI + ansi.FG_BRIGHT_BLACK + ansi.SGR
-SGR_RUNNING :: ansi.CSI + ansi.FG_YELLOW       + ansi.SGR
-SGR_SUCCESS :: ansi.CSI + ansi.FG_GREEN        + ansi.SGR
-SGR_FAILED  :: ansi.CSI + ansi.FG_RED          + ansi.SGR
+when PLAIN_TEXT {
+	SGR_RESET   :: ""
+	SGR_READY   :: ""
+	SGR_RUNNING :: ""
+	SGR_SUCCESS :: ""
+	SGR_FAILED  :: ""
+} else {
+	SGR_RESET   :: ansi.CSI + ansi.RESET           + ansi.SGR
+	SGR_READY   :: ansi.CSI + ansi.FG_BRIGHT_BLACK + ansi.SGR
+	SGR_RUNNING :: ansi.CSI + ansi.FG_YELLOW       + ansi.SGR
+	SGR_SUCCESS :: ansi.CSI + ansi.FG_GREEN        + ansi.SGR
+	SGR_FAILED  :: ansi.CSI + ansi.FG_RED          + ansi.SGR
+}
 
 MAX_PROGRESS_WIDTH :: 100
 

--- a/core/testing/runner_windows.odin
+++ b/core/testing/runner_windows.odin
@@ -3,20 +3,34 @@ package testing
 
 import win32 "core:sys/windows"
 
+old_stdout_mode: u32
+old_stderr_mode: u32
+
 console_ansi_init :: proc() {
 	stdout := win32.GetStdHandle(win32.STD_OUTPUT_HANDLE)
 	if stdout != win32.INVALID_HANDLE && stdout != nil {
-		old_console_mode: u32
-		if win32.GetConsoleMode(stdout, &old_console_mode) {
-			win32.SetConsoleMode(stdout, old_console_mode | win32.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+		if win32.GetConsoleMode(stdout, &old_stdout_mode) {
+			win32.SetConsoleMode(stdout, old_stdout_mode | win32.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
 		}
 	}
 
 	stderr := win32.GetStdHandle(win32.STD_ERROR_HANDLE)
 	if stderr != win32.INVALID_HANDLE && stderr != nil {
-		old_console_mode: u32
-		if win32.GetConsoleMode(stderr, &old_console_mode) {
-			win32.SetConsoleMode(stderr, old_console_mode | win32.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+		if win32.GetConsoleMode(stderr, &old_stderr_mode) {
+			win32.SetConsoleMode(stderr, old_stderr_mode | win32.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
 		}
+	}
+}
+
+// Restore the cursor on exit
+console_ansi_fini :: proc() {
+	stdout := win32.GetStdHandle(win32.STD_OUTPUT_HANDLE)
+	if stdout != win32.INVALID_HANDLE && stdout != nil {
+		win32.SetConsoleMode(stdout, old_stdout_mode)
+	}
+
+	stderr := win32.GetStdHandle(win32.STD_ERROR_HANDLE)
+	if stderr != win32.INVALID_HANDLE && stderr != nil {
+		win32.SetConsoleMode(stderr, old_stderr_mode)
 	}
 }


### PR DESCRIPTION
Allow running tests with `-define:ODIN_TEST_PLAIN_TEXT=true`.

This removes all ANSI format codes (and thus `ODIN_TEST_FANCY_OUTPUT`), so the test runner output is more friendly for build output windows in an editor, whose ANSI support may be broken or lacking entirely.

On Windows, we now also restore the console mode so the cursor doesn't disappear after the tests are done.