### PR TITLE
Add `-build-only`, `-keep-test-executable`, delete test executable after running

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -441,6 +441,7 @@ struct BuildContext {
 	String extra_assembler_flags;
 	String microarch;
 	BuildModeKind build_mode;
+	bool   build_only;
 	bool   generate_docs;
 	bool   custom_optimization_level;
 	i32    optimization_level;

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -442,6 +442,7 @@ struct BuildContext {
 	String microarch;
 	BuildModeKind build_mode;
 	bool   build_only;
+	bool   keep_test_executable;
 	bool   generate_docs;
 	bool   custom_optimization_level;
 	i32    optimization_level;


### PR DESCRIPTION
Closes #2035 (the @Kelimion suggestions; we already have `-out` as requested in the original post.)