### PR TITLE
Correct mipmapFilter field name in wgpu.js

### DIFF
--- a/vendor/wgpu/wgpu.js
+++ b/vendor/wgpu/wgpu.js
@@ -2033,7 +2033,7 @@ class WebGPUInterface {
 						addressModeW:  this.enumeration("AddressMode", off(4)),
 						magFilter:     this.enumeration("FilterMode", off(4)),
 						minFilter:     this.enumeration("FilterMode", off(4)),
-						mipMapFilter:  this.enumeration("MipmapFilterMode", off(4)),
+						mipmapFilter:  this.enumeration("MipmapFilterMode", off(4)),
 						lodMinClamp:   this.mem.loadF32(off(4)),
 						lodMaxClamp:   this.mem.loadF32(off(4)),
 						compare:       this.enumeration("CompareFunction", off(4)),


### PR DESCRIPTION
mipmapFilter is being ignored and defaulting to .Nearest on web platforms due to incorrect capitalization of the field name