### PR TITLE
Fix range check in `core:math/big`'s `int_atoi`

### DIFF
--- a/core/math/big/radix.odin
+++ b/core/math/big/radix.odin
@@ -280,7 +280,7 @@ int_atoi :: proc(res: ^Int, input: string, radix := i8(10), allocator := context
 		}
 
 		pos := ch - '+'
-		if RADIX_TABLE_REVERSE_SIZE <= pos {
+		if RADIX_TABLE_REVERSE_SIZE <= u32(pos) {
 			break
 		}
 		y := RADIX_TABLE_REVERSE[pos]


### PR DESCRIPTION
The check seems to have been assuming that rune comparisons are unsigned, but they're signed. This was causing a bounds check failure for certain input characters (anything with an ASCII value less than '+'/43).

The assertion can be triggered like so:
```go
package mre
import "core:math/big"
main :: proc() {
  i: big.Int
  big.atoi(&i, "(")
}
```

With this change, `int_atoi` will instead return an `Invalid_Argument` error, as one would expect.