### PR TITLE
Consider custom `#align` when determining union tag size

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -3059,11 +3059,15 @@ gb_internal i64 union_tag_size(Type *u) {
 		compiler_error("how many variants do you have?! %lld", cast(long long)u->Union.variants.count);
 	}
 
-	for_array(i, u->Union.variants) {
-		Type *variant_type = u->Union.variants[i];
-		i64 align = type_align_of(variant_type);
-		if (max_align < align) {
-			max_align = align;
+	if (u->Union.custom_align > 0) {
+		max_align = gb_max(max_align, u->Union.custom_align);
+	} else {
+		for_array(i, u->Union.variants) {
+			Type *variant_type = u->Union.variants[i];
+			i64 align = type_align_of(variant_type);
+			if (max_align < align) {
+				max_align = align;
+			}
 		}
 	}
 


### PR DESCRIPTION
The prior behavior was adjusting the tag size based on the alignment of the types in the union, even when the union has a custom alignment specified with `#align`. This changes the behavior so that a custom alignment, if specified, takes precedence over the alignment of the types.

As an example, prior to these changes this `union` has a tag size of 8 (and thus a total size of 16) because `u64`'s alignment is 8:
```odin
U :: union #align(1) { u64 }
```
After these changes, it will have a tag size of 1 and a total size of 9.

I'm not sure if the original behavior was intended or just an edge case that wasn't considered, but the behavior was surprising to me and the change is simple so I've submitted it here for consideration. It *is* potentially a breaking change for any code that is using a `union` with a custom alignment and also depending on the oversized tag.