### PR TITLE
Use b32 for GLFW functions that return GLFW_TRUE or GLFW_FALSE

### DIFF
--- a/vendor/glfw/bindings/bindings.odin
+++ b/vendor/glfw/bindings/bindings.odin
@@ -163,9 +163,9 @@ foreign glfw {
 	SetJoystickUserPointer :: proc(jid: c.int, pointer: rawptr) ---
 	GetJoystickUserPointer :: proc(jid: c.int) -> rawptr ---
 	JoystickIsGamepad      :: proc(jid: c.int) -> b32 ---
-	UpdateGamepadMappings  :: proc(str: cstring) -> c.int ---
+	UpdateGamepadMappings  :: proc(str: cstring) -> b32 ---
 	GetGamepadName         :: proc(jid: c.int) -> cstring ---
-	GetGamepadState        :: proc(jid: c.int, state: ^GamepadState) -> c.int ---
+	GetGamepadState        :: proc(jid: c.int, state: ^GamepadState) -> b32 ---
 
 	SetClipboardString :: proc(window: WindowHandle, str: cstring) ---
 	
@@ -177,12 +177,12 @@ foreign glfw {
 	MakeContextCurrent :: proc(window: WindowHandle) ---
 	GetCurrentContext  :: proc() -> WindowHandle ---
 	GetProcAddress     :: proc(name: cstring) -> rawptr ---
-	ExtensionSupported :: proc(extension: cstring) -> c.int ---
+	ExtensionSupported :: proc(extension: cstring) -> b32 ---
 
 	VulkanSupported                      :: proc() -> b32 ---
 	GetRequiredInstanceExtensions        :: proc(count: ^u32) -> [^]cstring ---
 	GetInstanceProcAddress               :: proc(instance: vk.Instance, procname: cstring) -> rawptr ---
-	GetPhysicalDevicePresentationSupport :: proc(instance: vk.Instance, device: vk.PhysicalDevice, queuefamily: u32) -> c.int ---
+	GetPhysicalDevicePresentationSupport :: proc(instance: vk.Instance, device: vk.PhysicalDevice, queuefamily: u32) -> b32 ---
 	CreateWindowSurface                  :: proc(instance: vk.Instance, window: WindowHandle, allocator: ^vk.AllocationCallbacks, surface: ^vk.SurfaceKHR) -> vk.Result ---
 	
 	SetWindowIconifyCallback      :: proc(window: WindowHandle, cbfun: WindowIconifyProc)      -> WindowIconifyProc ---


### PR DESCRIPTION
Some GLFW functions that return either `GLFW_TRUE` or `GLFW_FALSE` were defined as returning `c.int`. However, the definitions of `GLFW_TRUE` and `GLFW_FALSE` have been changed to `true` and `false` (instead of 1 and 0) in the Odin bindings.

https://github.com/odin-lang/Odin/blob/0a6dced9daf6baa1b2e81b7d5542899ca6022c7e/vendor/glfw/constants.odin#L12-L14

So, for instance, the C code
```c
glfwGlUpdateGamepadMappings("some string") == GLFW_TRUE
```
does not currently work in Odin as
```odin
glfw.UpdateGamepadMappings("some string") == glfw.TRUE
```

To _fix_ this I redefined the return types of all affected functions as `b32` instead of `c.int`.

Some similar functions like `JoystickIsGamepad` were already defined as returning `b32`.
https://github.com/odin-lang/Odin/blob/0a6dced9daf6baa1b2e81b7d5542899ca6022c7e/vendor/glfw/bindings/bindings.odin#L165

I went through all functions and this should make the definitions consistent.
