### PR TITLE
Create() rework; comments tweaks; +hrtfapoapi

### DIFF
--- a/vendor/windows/XAudio2/hrtfapoapi.odin
+++ b/vendor/windows/XAudio2/hrtfapoapi.odin
@@ -1,0 +1,149 @@
+#+build windows
+
+package windows_xaudio2
+
+import win "core:sys/windows"
+
+foreign import hrtf "system:hrtfapo.lib"
+
+HRTF_MAX_GAIN_LIMIT              :: 12.0
+HRTF_MIN_GAIN_LIMIT              :: -96.0
+HRTF_MIN_UNITY_GAIN_DISTANCE     :: 0.05
+HRTF_DEFAULT_UNITY_GAIN_DISTANCE :: 1.0
+HRTF_DEFAULT_CUTOFF_DISTANCE     :: 3.402823466e+38
+
+//! Represents a position in 3D space, using a right-handed coordinate system.
+HrtfPosition :: struct {
+	x: f32,
+	y: f32,
+	z: f32,
+}
+
+//! Indicates the orientation of an HRTF directivity object. This is a row-major 3x3 rotation matrix.
+HrtfOrientation :: struct {
+	element: [9]f32,
+}
+
+//! Indicates one of several stock directivity patterns.
+HrtfDirectivityType :: enum i32 {
+	//! The sound emission is in all directions.
+	OmniDirectional = 0,
+	//! The sound emission is a cardiod shape.
+	Cardioid,
+	//! The sound emission is a cone.
+	Cone,
+}
+
+//! Indicates one of several stock environment types.
+HrtfEnvironment :: enum i32 {
+	//! A small room.
+	Small = 0,
+	//! A medium-sized room.
+	Medium,
+	//! A large enclosed space.
+	Large,
+	//! An outdoor space.
+	Outdoors,
+}
+
+//! Base directivity pattern descriptor. Describes the type of directivity applied to a sound.
+//! The scaling parameter is used to interpolate between directivity behavior and omnidirectional, it determines how much attenuation is applied to the source outside of the directivity pattern and controls how directional the source is.
+HrtfDirectivity :: struct {
+	//! Indicates the type of directivity.
+	type: HrtfDirectivityType,
+	//! A normalized value between zero and one. Specifies the amount of linear interpolation between omnidirectional sound and the full directivity pattern, where 0 is fully omnidirectional and 1 is fully directional.
+	scaling: f32,
+}
+
+//! Describes a cardioid directivity pattern.
+HrtfDirectivityCardioid :: struct {
+	//! Descriptor for the cardioid pattern. The type parameter must be set to HrtfDirectivityType.Cardioid.
+	directivity: HrtfDirectivity,
+	//! Order controls the shape of the cardioid. The higher order the shape, the narrower it is. Must be greater than 0 and less than or equal to 32.
+	order: f32,
+}
+
+//! Describes a cone directivity.
+//! Attenuation is 0 inside the inner cone.
+//! Attenuation is linearly interpolated between the inner cone, which is defined by innerAngle, and the outer cone, which is defined by outerAngle.
+HrtfDirectivityCone :: struct {
+	//! Descriptor for the cone pattern. The type parameter must be set to HrtfDirectivityType.Cone.
+	directivity: HrtfDirectivity,
+	//! Angle, in radians, that defines the inner cone. Must be between 0 and TAU.
+	innerAngle: f32,
+	//! Angle, in radians, that defines the outer cone. Must be between 0 and TAU.
+	outerAngle: f32,
+}
+
+//! Indicates a distance-based decay type applied to a sound.
+HrtfDistanceDecayType :: enum i32 {
+	//! Simulates natural decay with distance, as constrained by minimum and maximum gain distance limits. Drops to silence at rolloff distance.
+	NaturalDecay = 0,
+	//! Used to set up a custom gain curve, within the maximum and minimum gain limit.
+	CustomDecay,
+}
+
+//! Describes a distance-based decay behavior.
+HrtfDistanceDecay :: struct {
+	//! The type of decay behavior, natural or custom.
+	type: HrtfDistanceDecayType,
+	//! The maximum gain limit applied at any distance. Applies to both natural and custom decay. This value is specified in dB, with a range from -96 to 12 inclusive. The default value is 12 dB.
+	maxGain: f32,
+	//! The minimum gain limit applied at any distance. Applies to both natural and custom decay. This value is specified in dB, with a range from -96 to 12 inclusive. The default value is -96 dB.
+	minGain: f32,
+	//! The distance at which the gain is 0dB. Applies to natural decay only. This value is specified in meters, with a range from 0.05 to infinity (max(f32)). The default value is 1 meter.
+	unityGainDistance: f32,
+	//! The distance at which output is silent. Applies to natural decay only. This value is specified in meters, with a range from zero (non-inclusive) to infinity (max(f32)). The default value is infinity.
+	cutoffDistance: f32,
+}
+
+//! Specifies parameters used to initialize HRTF.
+//! Instances of the XAPO interface are created by using the CreateHrtfApo() API:
+//!   ```CreateHrtfApo :: proc(pInit: HrtfApoInit, ppXapo: ^^IXAPO) -> HRESULT```
+HrtfApoInit :: struct {
+	//! The decay type. If you pass in nil, the default value will be used. The default is natural decay.
+	distanceDecay: ^HrtfDistanceDecay,
+	//! The directivity type. If you pass in nil, the default value will be used. The default directivity is omni-directional.
+	directivity: ^HrtfDirectivity,
+}
+
+//! Creates an instance of the XAPO object.
+//! Format requirements:
+//! * Input: mono, 48 kHz, 32-bit float PCM.
+//! * Output: stereo, 48 kHz, 32-bit float PCM.
+//! Audio is processed in blocks of 1024 samples.
+//! Returns:
+//!     S_OK for success, any other value indicates failure.
+//!     Returns E_NOTIMPL on unsupported platforms.
+@(default_calling_convention="system")
+foreign hrtf {
+	CreateHrtfApo :: proc(
+		//! Pointer to an HrtfApoInit struct. Specifies parameters for XAPO interface initialization.
+		#by_ptr init: HrtfApoInit,
+		//! Returns the new instance of the XAPO interface.
+		xApo: ^^IXAPO,
+	) -> HRESULT ---
+}
+
+//! The interface used to set parameters that control how HRTF is applied to a sound.
+IXAPOHrtfParameters_UUID_STRING :: "15B3CD66-E9DE-4464-B6E6-2BC3CF63D455"
+IXAPOHrtfParameters_UUID := &win.IID{0x15B3CD66, 0xE9DE, 0x4464, {0xB6, 0xE6, 0x2B, 0xC3, 0xCF, 0x63, 0xD4, 0x55}}
+IXAPOHrtfParameters :: struct #raw_union {
+	#subtype iunknown: IUnknown,
+	using ixapohrtfparameters_vtable: ^IXAPOHrtfParameters_VTable,
+}
+IXAPOHrtfParameters_VTable :: struct {
+	using iunknown_vtable: IUnknown_VTable,
+
+	// HRTF params
+	//! The position of the sound relative to the listener.
+	SetSourcePosition: proc "system" (this: ^IXAPOHrtfParameters, position: ^HrtfPosition) -> HRESULT,
+	//! The rotation matrix for the source orientation, with respect to the listener's frame of reference (the listener's coordinate system).
+	SetSourceOrientation: proc "system" (this: ^IXAPOHrtfParameters, orientation: ^HrtfOrientation) -> HRESULT,
+	//! The custom direct path gain value for the current source position. Valid only for sounds played with the HrtfDistanceDecayType. Custom decay type.
+	SetSourceGain: proc "system" (this: ^IXAPOHrtfParameters, gain: f32) -> HRESULT,
+
+	// Distance cue params
+	//! Selects the acoustic environment to simulate.
+	SetEnvironment: proc "system" (this: ^IXAPOHrtfParameters, environment: HrtfEnvironment) -> HRESULT,
+}

--- a/vendor/windows/XAudio2/xapo.odin
+++ b/vendor/windows/XAudio2/xapo.odin
@@ -1,75 +1,45 @@
 #+build windows
 
 /* NOTES:
-	1.  Definition of terms:
+    1.  Definition of terms:
 	    DSP: Digital Signal Processing.
 
-	    CBR: Constant BitRate -- DSP that consumes a constant number of
-		 input samples to produce an output sample.
-		 For example, a 22kHz to 44kHz resampler is CBR DSP.
-		 Even though the number of input to output samples differ,
-		 the ratio between input to output rate remains constant.
-		 All user-defined XAPOs are assumed to be CBR as
-		 XAudio2 only allows CBR DSP to be added to an effect chain.
+	    CBR: Constant BitRate -- DSP that consumes a constant number of input samples to produce an output sample.
+		 For example, a 22kHz to 44kHz resampler is CBR DSP. Even though the number of input to output samples differ, the ratio between input to output rate remains constant.
+		 All user-defined XAPOs are assumed to be CBR as XAudio2 only allows CBR DSP to be added to an effect chain.
 
 	    XAPO: Cross-platform Audio Processing Object --
-		  a thin wrapper that manages DSP code, allowing it
-		  to be easily plugged into an XAudio2 effect chain.
+		  a thin wrapper that manages DSP code, allowing it to be easily plugged into an XAudio2 effect chain.
 
-	    Frame: A block of samples, one per channel,
-		   to be played simultaneously.
+	    Frame: A block of samples, one per channel, to be played simultaneously.
 		   E.g. a mono stream has one sample per frame.
 
-	    In-Place: Processing such that the input buffer equals the
-		      output buffer (i.e. input data modified directly).
-		      This form of processing is generally more efficient
-		      than using separate memory for input and output.
-		      However, an XAPO may not perform format conversion
-		      when processing in-place.
+	    In-Place: Processing such that the input buffer equals the output buffer (i.e. input data modified directly).
+		      This form of processing is generally more efficient than using separate memory for input and output.
+		      However, an XAPO may not perform format conversion when processing in-place.
 
-	2.  XAPO member variables are divided into three classifications:
-	    Immutable: Set once via IXAPO.Initialize and remain
-		       constant during the lifespan of the XAPO.
+    2.  XAPO member variables are divided into three classifications:
+	    Immutable: Set once via IXAPO.Initialize and remain constant during the lifespan of the XAPO.
 
 	    Locked: May change before the XAPO is locked via
-		    IXAPO.LockForProcess but remain constant
-		    until IXAPO.UnlockForProcess is called.
+		    IXAPO.LockForProcess but remain constant until IXAPO.UnlockForProcess is called.
 
-	    Dynamic: May change from one processing pass to the next,
-		     usually via IXAPOParameters.SetParameters.
-		     XAPOs should assign reasonable defaults to their dynamic
-		     variables during IXAPO.Initialize/LockForProcess so
-		     that calling IXAPOParameters.SetParameters is not
-		     required before processing begins.
+	    Dynamic: May change from one processing pass to the next, usually via IXAPOParameters.SetParameters.
+		     XAPOs should assign reasonable defaults to their dynamic variables during IXAPO.Initialize/LockForProcess so that calling IXAPOParameters.SetParameters is not required before processing begins.
 
-	When implementing an XAPO, determine the type of each variable and
-	initialize them in the appropriate method.  Immutable variables are
-	generally preferable over locked which are preferable over dynamic.
-	That is, one should strive to minimize XAPO state changes for
-	best performance, maintainability, and ease of use.
+	When implementing an XAPO, determine the type of each variable and initialize them in the appropriate method. Immutable variables are generally preferable over locked which are preferable over dynamic.
+	That is, one should strive to minimize XAPO state changes for best performance, maintainability, and ease of use.
 
-	3.  To minimize glitches, the realtime audio processing thread must
-	not block.  XAPO methods called by the realtime thread are commented
-	as non-blocking and therefore should not use blocking synchronization,
-	allocate memory, access the disk, etc.  The XAPO interfaces were
-	designed to allow an effect implementer to move such operations
-	into other methods called on an application controlled thread.
+    3.  To minimize glitches, the realtime audio processing thread must not block. XAPO methods called by the realtime thread are commented as non-blocking and therefore should not use blocking synchronization, allocate memory, access the disk, etc.
+	The XAPO interfaces were designed to allow an effect implementer to move such operations into other methods called on an application controlled thread.
 
-	4.  Extending functionality is accomplished through the addition of new
-	COM interfaces.  For example, if a new member is added to a parameter
-	structure, a new interface using the new structure should be added,
-	leaving the original interface unchanged.
-	This ensures consistent communication between future versions of
-	XAudio2 and various versions of XAPOs that may exist in an application.
+    4.  Extending functionality is accomplished through the addition of new COM interfaces. For example, if a new member is added to a parameter structure, a new interface using the new structure should be added, leaving the original interface unchanged.
+	This ensures consistent communication between future versions of XAudio2 and various versions of XAPOs that may exist in an application.
 
-	5.  All audio data is interleaved in XAudio2.
+    5.  All audio data is interleaved in XAudio2.
 	The default audio format for an effect chain is WAVE_FORMAT_IEEE_FLOAT.
 
-	6.  User-defined XAPOs should assume all input and output buffers are
-	16-byte aligned.
-
-	7.  See XAPOBase.odin for an XAPO base class which provides a default
-	implementation for most of the interface methods defined below.     */
+    6.  User-defined XAPOs should assume all input and output buffers are 16-byte aligned.   */
 
 package windows_xaudio2
 
@@ -77,8 +47,7 @@ import win "core:sys/windows"
 
 //--------------<D-E-F-I-N-I-T-I-O-N-S>-------------------------------------//
 
-// XAPO error codes
-FORMAT_UNSUPPORTED := win.MAKE_HRESULT(win.SEVERITY.ERROR, 0x897, 0x01) // requested audio format unsupported
+FORMAT_UNSUPPORTED := win.MAKE_HRESULT(win.SEVERITY.ERROR, win.FACILITY.XAPO, 0x01) // requested audio format unsupported
 
 // supported number of channels (samples per frame) range
 XAPO_MIN_CHANNELS :: 1
@@ -111,11 +80,11 @@ XAPO_FLAG :: enum u32 {
 
 	// XAPO must be run in-place.  Use this flag only if your DSP implementation cannot process separate input and output buffers.
 	// If set, the following flags must also be set:
-	//     XAPO_FLAG_CHANNELS_MUST_MATCH
-	//     XAPO_FLAG_FRAMERATE_MUST_MATCH
-	//     XAPO_FLAG_BITSPERSAMPLE_MUST_MATCH
-	//     XAPO_FLAG_BUFFERCOUNT_MUST_MATCH
-	//     XAPO_FLAG_INPLACE_SUPPORTED
+	//     CHANNELS_MUST_MATCH
+	//     FRAMERATE_MUST_MATCH
+	//     BITSPERSAMPLE_MUST_MATCH
+	//     BUFFERCOUNT_MUST_MATCH
+	//     INPLACE_SUPPORTED
 	// Multiple input and output buffers may be used with in-place XAPOs, though the input buffer count must equal the output buffer count.
 	// When multiple input/output buffers are used, the XAPO may assume input buffer [N] equals output buffer [N] for in-place processing.
 	INPLACE_REQUIRED = 5,
@@ -139,18 +108,18 @@ XAPO_REGISTRATION_PROPERTIES :: struct #packed {
 	Flags:                XAPO_FLAGS,                                 // XAPO property flags, describes supported input/output configuration
 	MinInputBufferCount:  u32,                                        // minimum number of input buffers required for processing, can be 0
 	MaxInputBufferCount:  u32,                                        // maximum number of input buffers supported for processing, must be >= MinInputBufferCount
-	MinOutputBufferCount: u32,                                        // minimum number of output buffers required for processing, can be 0, must match MinInputBufferCount when XAPO_FLAG_BUFFERCOUNT_MUST_MATCH used
-	MaxOutputBufferCount: u32,                                        // maximum number of output buffers supported for processing, must be >= MinOutputBufferCount, must match MaxInputBufferCount when XAPO_FLAG_BUFFERCOUNT_MUST_MATCH used
+	MinOutputBufferCount: u32,                                        // minimum number of output buffers required for processing, can be 0, must match MinInputBufferCount when XAPO_FLAG.BUFFERCOUNT_MUST_MATCH used
+	MaxOutputBufferCount: u32,                                        // maximum number of output buffers supported for processing, must be >= MinOutputBufferCount, must match MaxInputBufferCount when XAPO_FLAG.BUFFERCOUNT_MUST_MATCH used
 }
 
 // LockForProcess buffer parameters:
 // Defines buffer parameters that remain constant while an XAPO is locked.
-// Used with IXAPO::LockForProcess.
+// Used with IXAPO.LockForProcess.
 // For CBR XAPOs, MaxFrameCount is the only number of frames
-// IXAPO::Process would have to handle for the respective buffer.
+// IXAPO.Process would have to handle for the respective buffer.
 XAPO_LOCKFORPROCESS_BUFFER_PARAMETERS :: struct #packed {
 	pFormat:       ^WAVEFORMATEX,       // buffer audio format
-	MaxFrameCount: u32,                     // maximum number of frames in respective buffer that IXAPO::Process would have to handle, irrespective of dynamic variable settings, can be 0
+	MaxFrameCount: u32,                 // maximum number of frames in respective buffer that IXAPO.Process would have to handle, irrespective of dynamic variable settings, can be 0
 }
 
 // Buffer flags:
@@ -161,31 +130,25 @@ XAPO_LOCKFORPROCESS_BUFFER_PARAMETERS :: struct #packed {
 // If silent, the XAPO may simply set the flag on the output buffer to silent and return, optimizing out the work of processing silent data:  XAPOs that generate silence for any reason may set the buffer's flag accordingly rather than writing out silent frames to the buffer itself.
 // The flags represent what should be assumed is in the respective buffer. The flags may not reflect what is actually stored in memory.
 XAPO_BUFFER_FLAGS :: enum i32 {
-	XAPO_BUFFER_SILENT,        // silent data should be assumed, respective memory may be uninitialized
-	XAPO_BUFFER_VALID,         // arbitrary data should be assumed (may or may not be silent frames), respective memory initialized
+	SILENT,        // silent data should be assumed, respective memory may be uninitialized
+	VALID,         // arbitrary data should be assumed (may or may not be silent frames), respective memory initialized
 }
 
 // Process buffer parameters:
-// Defines buffer parameters that may change from one
-// processing pass to the next.  Used with IXAPO::Process.
-//
+// Defines buffer parameters that may change from one processing pass to the next. Used with IXAPO.Process.
 // Note the byte size of the respective buffer must be at least:
-//      XAPO_LOCKFORPROCESS_BUFFER_PARAMETERS.MaxFrameCount * XAPO_LOCKFORPROCESS_BUFFER_PARAMETERS.pFormat->nBlockAlign
-//
-// Although the audio format and maximum size of the respective
-// buffer is locked (defined by XAPO_LOCKFORPROCESS_BUFFER_PARAMETERS),
-// the actual memory address of the buffer given is permitted to change
-// from one processing pass to the next.
-//
-// For CBR XAPOs, ValidFrameCount is constant while locked and equals
-// the respective XAPO_LOCKFORPROCESS_BUFFER_PARAMETERS.MaxFrameCount.
+//      XAPO_LOCKFORPROCESS_BUFFER_PARAMETERS.MaxFrameCount * XAPO_LOCKFORPROCESS_BUFFER_PARAMETERS.pFormat.nBlockAlign
+// Although the audio format and maximum size of the respective buffer is locked (defined by XAPO_LOCKFORPROCESS_BUFFER_PARAMETERS), the actual memory address of the buffer given is permitted to change from one processing pass to the next.
+// For CBR XAPOs, ValidFrameCount is constant while locked and equals the respective XAPO_LOCKFORPROCESS_BUFFER_PARAMETERS.MaxFrameCount.
 XAPO_PROCESS_BUFFER_PARAMETERS :: struct #packed {
-	pBuffer:         rawptr,                // audio data buffer, must be non-NULL
+	pBuffer:         rawptr,                // audio data buffer, must be non-nil
 	BufferFlags:     XAPO_BUFFER_FLAGS,     // describes assumed content of pBuffer, does not affect ValidFrameCount
 	ValidFrameCount: u32,                   // number of frames of valid data, must be within respective [0, XAPO_LOCKFORPROCESS_BUFFER_PARAMETERS.MaxFrameCount], always XAPO_LOCKFORPROCESS_BUFFER_PARAMETERS.MaxFrameCount for CBR/user-defined XAPOs, does not affect BufferFlags
 }
 
-XAPOFree :: win.CoTaskMemFree
+// Used by IXAPO methods that must allocate arbitrary sized structures such as WAVEFORMATEX that are subsequently returned to the application.
+XAPOAlloc :: win.CoTaskMemAlloc
+XAPOFree  :: win.CoTaskMemFree
 
 IXAPO_UUID_STRING :: "A410B984-9839-4819-A0BE-2856AE6B3ADB"
 IXAPO_UUID := &win.IID{0xA410B984, 0x9839, 0x4819, {0xA0, 0xBE, 0x28, 0x56, 0xAE, 0x6B, 0x3A, 0xDB}}
@@ -214,11 +177,11 @@ IXAPO_VTable :: struct {
 	  // PARAMETERS:
 	  //  pOutputFormat          - [in]  output format known to be supported
 	  //  pRequestedInputFormat  - [in]  input format to examine
-	  //  ppSupportedInputFormat - [out] receives pointer to nearest input format supported if not NULL and input/output configuration unsupported, use XAPOFree to free structure, left untouched on any failure except XAPO_E_FORMAT_UNSUPPORTED
+	  //  ppSupportedInputFormat - [out] receives pointer to nearest input format supported if not nil and input/output configuration unsupported, use XAPOFree to free structure, left untouched on any failure except FORMAT_UNSUPPORTED
 	  // RETURN VALUE:
 	  //  COM error code, including:
 	  //    S_OK                      - input/output configuration supported, ppSupportedInputFormat left untouched
-	  //    FORMAT_UNSUPPORTED        - input/output configuration unsupported, ppSupportedInputFormat receives pointer to nearest input format supported if not NULL
+	  //    FORMAT_UNSUPPORTED        - input/output configuration unsupported, ppSupportedInputFormat receives pointer to nearest input format supported if not nil
 	  //    E_INVALIDARG              - either audio format invalid, ppSupportedInputFormat left untouched
 	IsInputFormatSupported: proc "system" (this: ^IXAPO, pOutputFormat: ^WAVEFORMATEX, pRequestedInputFormat: ^WAVEFORMATEX, ppSupportedInputFormat: ^^WAVEFORMATEX) -> HRESULT,
 
@@ -232,11 +195,11 @@ IXAPO_VTable :: struct {
 	  // PARAMETERS:
 	  //  pInputFormat            - [in]  input format known to be supported
 	  //  pRequestedOutputFormat  - [in]  output format to examine
-	  //  ppSupportedOutputFormat - [out] receives pointer to nearest output format supported if not NULL and input/output configuration unsupported, use XAPOFree to free structure, left untouched on any failure except XAPO_E_FORMAT_UNSUPPORTED
+	  //  ppSupportedOutputFormat - [out] receives pointer to nearest output format supported if not nil and input/output configuration unsupported, use XAPOFree to free structure, left untouched on any failure except FORMAT_UNSUPPORTED
 	  // RETURN VALUE:
 	  //  COM error code, including:
 	  //    S_OK                      - input/output configuration supported, ppSupportedOutputFormat left untouched
-	  //    FORMAT_UNSUPPORTED        - input/output configuration unsupported, ppSupportedOutputFormat receives pointer to nearest output format supported if not NULL
+	  //    FORMAT_UNSUPPORTED        - input/output configuration unsupported, ppSupportedOutputFormat receives pointer to nearest output format supported if not nil
 	  //    E_INVALIDARG              - either audio format invalid, ppSupportedOutputFormat left untouched
 	IsOutputFormatSupported: proc "system" (this: ^IXAPO, pInputFormat: ^WAVEFORMATEX, pRequestedOutputFormat: ^WAVEFORMATEX, ppSupportedOutputFormat: ^^WAVEFORMATEX) -> HRESULT,
 
@@ -246,10 +209,10 @@ IXAPO_VTable :: struct {
 	  //  The contents of pData are defined by the XAPO.
 	  //  Immutable variables (constant during the lifespan of the XAPO) should be set once via this method.
 	  //  Once initialized, an XAPO cannot be initialized again.
-	  //  An XAPO should be initialized before passing it to XAudio2 as part of an effect chain.  XAudio2 will not call this method; it exists for future content-driven initialization.
+	  //  An XAPO should be initialized before passing it to XAudio2 as part of an effect chain. XAudio2 will not call this method; it exists for future content-driven initialization.
 	  // PARAMETERS:
-	  //  pData        - [in] effect-specific initialization parameters, may be NULL if DataByteSize == 0
-	  //  DataByteSize - [in] size of pData in bytes, may be 0 if pData is NULL
+	  //  pData        - [in] effect-specific initialization parameters, may be nil if DataByteSize == 0
+	  //  DataByteSize - [in] size of pData in bytes, may be 0 if pData is nil
 	  // RETURN VALUE:
 	  //  COM error code
 	Initialize: proc "system" (this: ^IXAPO, pData: rawptr, DataByteSize: u32) -> HRESULT,
@@ -279,9 +242,9 @@ IXAPO_VTable :: struct {
 	  //  Once locked, an XAPO cannot be locked again until UnLockForProcess is called.
 	  // PARAMETERS:
 	  //  InputLockedParameterCount  - [in] number of input buffers, must be within [XAPO_REGISTRATION_PROPERTIES.MinInputBufferCount, XAPO_REGISTRATION_PROPERTIES.MaxInputBufferCount]
-	  //  pInputLockedParameters     - [in] array of input locked buffer parameter structures, may be NULL if InputLockedParameterCount == 0, otherwise must have InputLockedParameterCount elements
-	  //  OutputLockedParameterCount - [in] number of output buffers, must be within [XAPO_REGISTRATION_PROPERTIES.MinOutputBufferCount, XAPO_REGISTRATION_PROPERTIES.MaxOutputBufferCount], must match InputLockedParameterCount when XAPO_FLAG_BUFFERCOUNT_MUST_MATCH used
-	  //  pOutputLockedParameters    - [in] array of output locked buffer parameter structures, may be NULL if OutputLockedParameterCount == 0, otherwise must have OutputLockedParameterCount elements
+	  //  pInputLockedParameters     - [in] array of input locked buffer parameter structures, may be nil if InputLockedParameterCount == 0, otherwise must have InputLockedParameterCount elements
+	  //  OutputLockedParameterCount - [in] number of output buffers, must be within [XAPO_REGISTRATION_PROPERTIES.MinOutputBufferCount, XAPO_REGISTRATION_PROPERTIES.MaxOutputBufferCount], must match InputLockedParameterCount when XAPO_FLAG.BUFFERCOUNT_MUST_MATCH used
+	  //  pOutputLockedParameters    - [in] array of output locked buffer parameter structures, may be nil if OutputLockedParameterCount == 0, otherwise must have OutputLockedParameterCount elements
 	  // RETURN VALUE:
 	  //  COM error code
 	LockForProcess: proc "system" (this: ^IXAPO, InputLockedParameterCount: u32, pInputLockedParameters: [^]XAPO_LOCKFORPROCESS_BUFFER_PARAMETERS, OutputLockedParameterCount: u32, pOutputLockedParameters: [^]XAPO_LOCKFORPROCESS_BUFFER_PARAMETERS) -> HRESULT,
@@ -303,16 +266,16 @@ IXAPO_VTable :: struct {
 	  //  ppInputProcessParameters will not necessarily be the same as ppOutputProcessParameters for in-place processing, rather the pBuffer members of each will point to the same memory.
 	  //  Multiple input/output buffers may be used with in-place XAPOs, though the input buffer count must equal the output buffer count.
 	  //  When multiple input/output buffers are used with in-place XAPOs, the XAPO may assume input buffer [N] equals output buffer [N].
-	  //  When IsEnabled is FALSE, the XAPO should process thru. Thru processing means an XAPO should not apply its normal processing to the given input/output buffers during Process.
-	  //  It should instead pass data from input to output with as little modification possible.  Effects that perform format conversion should continue to do so.
+	  //  When IsEnabled is false, the XAPO should process thru. Thru processing means an XAPO should not apply its normal processing to the given input/output buffers during Process.
+	  //  It should instead pass data from input to output with as little modification possible. Effects that perform format conversion should continue to do so.
 	  //  The effect must ensure transitions between normal and thru processing do not introduce discontinuities into the signal.
 	  //  XAudio2 calls this method only if the XAPO is locked. This method should not block as it is called from the realtime thread.
 	  // PARAMETERS:
 	  //  InputProcessParameterCount  - [in]     number of input buffers, matches respective InputLockedParameterCount parameter given to LockForProcess
-	  //  pInputProcessParameters     - [in]     array of input process buffer parameter structures, may be NULL if InputProcessParameterCount == 0, otherwise must have InputProcessParameterCount elements
+	  //  pInputProcessParameters     - [in]     array of input process buffer parameter structures, may be nil if InputProcessParameterCount == 0, otherwise must have InputProcessParameterCount elements
 	  //  OutputProcessParameterCount - [in]     number of output buffers, matches respective OutputLockedParameterCount parameter given to LockForProcess
-	  //  pOutputProcessParameters    - [in/out] array of output process buffer parameter structures, may be NULL if OutputProcessParameterCount == 0, otherwise must have OutputProcessParameterCount elements
-	  //  IsEnabled                   - [in]     TRUE to process normally, FALSE to process thru
+	  //  pOutputProcessParameters    - [in/out] array of output process buffer parameter structures, may be nil if OutputProcessParameterCount == 0, otherwise must have OutputProcessParameterCount elements
+	  //  IsEnabled                   - [in]     true to process normally, false to process thru
 	  // RETURN VALUE:
 	  //  void
 	Process: proc "system" (this: ^IXAPO, InputProcessParameterCount: u32, pInputProcessParameters: [^]XAPO_PROCESS_BUFFER_PARAMETERS, OutputProcessParameterCount: u32, pOutputProcessParameters: [^]XAPO_PROCESS_BUFFER_PARAMETERS, IsEnabled: b32),
@@ -358,7 +321,7 @@ IXAPOParameters_VTable :: struct {
 	  //  This method may only be called on the realtime thread; no synchronization between it and IXAPO.Process is necessary.
 	  //  This method should not block as it is called from the realtime thread.
 	  // PARAMETERS:
-	  //  pParameters       - [in] effect-specific parameter block, must be != NULL
+	  //  pParameters       - [in] effect-specific parameter block, must be != nil
 	  //  ParameterByteSize - [in] size of pParameters in bytes, must be > 0
 	  // RETURN VALUE:
 	  //  void
@@ -369,7 +332,7 @@ IXAPOParameters_VTable :: struct {
 	  // REMARKS:
 	  //  Unlike SetParameters, XAudio2 does not call this method on the realtime thread.  Thus, the XAPO must protect variables shared with SetParameters/Process using appropriate synchronization.
 	  // PARAMETERS:
-	  //  pParameters       - [out] receives effect-specific parameter block, must be != NULL
+	  //  pParameters       - [out] receives effect-specific parameter block, must be != nil
 	  //  ParameterByteSize - [in]  size of pParameters in bytes, must be > 0
 	  // RETURN VALUE:
 	  //  void

--- a/vendor/windows/XAudio2/xapofx.odin
+++ b/vendor/windows/XAudio2/xapofx.odin
@@ -132,7 +132,7 @@ FXECHO_PARAMETERS :: struct #packed {
 @(default_calling_convention="cdecl")
 foreign xa2 {
 	// creates instance of requested XAPO, use Release to free instance
-    	//  pInitData        - [in] effect-specific initialization parameters, may be NULL if InitDataByteSize == 0
-    	//  InitDataByteSize - [in] size of pInitData in bytes, may be 0 if pInitData is NULL
+    	//  pInitData        - [in] effect-specific initialization parameters, may be nil if InitDataByteSize == 0
+    	//  InitDataByteSize - [in] size of pInitData in bytes, may be 0 if pInitData is nil
 	CreateFX :: proc(clsid: win.REFCLSID, pEffect: ^^IUnknown, pInitDat: rawptr = nil, InitDataByteSize: u32 = 0) -> HRESULT ---
 }

--- a/vendor/windows/XAudio2/xaudio2fx.odin
+++ b/vendor/windows/XAudio2/xaudio2fx.odin
@@ -243,13 +243,13 @@ ReverbConvertI3DL2ToNative :: proc "contextless" (pI3DL2: ^REVERB_I3DL2_PARAMETE
 
 	if pI3DL2.DecayHFRatio >= 1.0 {
 		index := i32(-4.0 * math.log10_f32(pI3DL2.DecayHFRatio))
-		if index < -8 do index = -8
+		if index < -8 {index = -8}
 		pNative.LowEQGain  = byte((index < 0) ? index + 8 : 8)
 		pNative.HighEQGain = 8
 		pNative.DecayTime  = pI3DL2.DecayTime * pI3DL2.DecayHFRatio
 	} else {
 		index := i32(4.0 * math.log10_f32(pI3DL2.DecayHFRatio))
-		if index < -8 do index = -8
+		if index < -8 {index = -8}
 		pNative.LowEQGain  = 8
 		pNative.HighEQGain = byte((index < 0) ? index + 8 : 8)
 		pNative.DecayTime  = pI3DL2.DecayTime

--- a/vendor/windows/XAudio2/xaudio2fx.odin
+++ b/vendor/windows/XAudio2/xaudio2fx.odin
@@ -10,8 +10,7 @@ foreign import xa2 "system:xaudio2.lib"
  *
  * Effect creation functions.
  *
- * On Xbox the application can link with the debug library to use the debug
- * functionality.
+ * On Xbox the application can link with the debug library to use the debug functionality.
  *
  **************************************************************************/
 
@@ -32,9 +31,9 @@ foreign xa2 {
 // The user is responsible for allocating pPeakLevels, pRMSLevels, and initializing ChannelCount accordingly.
 // The volume meter does not support SetEffectParameters().
 VOLUMEMETER_LEVELS :: struct #packed {
-	pPeakLevels:  [^]f32 `fmt:"v,ChannelCount"`, // Peak levels table: receives maximum absolute level for each channel over a processing pass, may be NULL if pRMSLevls != NULL, otherwise must have at least ChannelCount elements.
-	pRMSLevels:   [^]f32 `fmt:"v,ChannelCount"`, // Root mean square levels table: receives RMS level for each channel over a processing pass, may be NULL if pPeakLevels != NULL, otherwise must have at least ChannelCount elements.
-	ChannelCount: u32,                           // Number of channels being processed by the volume meter APO
+	pPeakLevels:  [^]f32 `fmt:"v,ChannelCount"`,   // Peak levels table: receives maximum absolute level for each channel over a processing pass, may be nil if pRMSLevls != nil, otherwise must have at least ChannelCount elements.
+	pRMSLevels:   [^]f32 `fmt:"v,ChannelCount"`,   // Root mean square levels table: receives RMS level for each channel over a processing pass, may be nil if pPeakLevels != nil, otherwise must have at least ChannelCount elements.
+	ChannelCount: u32, 	                           // Number of channels being processed by the volume meter APO
 }
 
 /**************************************************************************
@@ -87,7 +86,7 @@ REVERB_PARAMETERS :: struct #packed {
 	Density:         f32,         // [0, 100] (percentage)
 	RoomSize:        f32,         // [1, 100] in feet
 	// component control
-	DisableLateField: b32,        // TRUE to disable late field reflections
+	DisableLateField: b32,        // true to disable late field reflections
 }
 
 // Maximum, minimum and default values for the parameters above
@@ -244,13 +243,13 @@ ReverbConvertI3DL2ToNative :: proc "contextless" (pI3DL2: ^REVERB_I3DL2_PARAMETE
 
 	if pI3DL2.DecayHFRatio >= 1.0 {
 		index := i32(-4.0 * math.log10_f32(pI3DL2.DecayHFRatio))
-		if index < -8 { index = -8 }
+		if index < -8 do index = -8
 		pNative.LowEQGain  = byte((index < 0) ? index + 8 : 8)
 		pNative.HighEQGain = 8
 		pNative.DecayTime  = pI3DL2.DecayTime * pI3DL2.DecayHFRatio
 	} else {
 		index := i32(4.0 * math.log10_f32(pI3DL2.DecayHFRatio))
-		if index < -8 { index = -8 }
+		if index < -8 do index = -8
 		pNative.LowEQGain  = 8
 		pNative.HighEQGain = byte((index < 0) ? index + 8 : 8)
 		pNative.DecayTime  = pI3DL2.DecayTime


### PR DESCRIPTION
Create() proc in xaudio2.odin replaced by a lib binding one that works.
Added hrtfapoapi.h binding.
Comments throughout the files tweaked.
Some format helpers for multipointer arrays.
Some changes from stuff now in "core:sys/windows".