### PR TITLE
Fix incorrect CSV reader settings for example, fix typo in docs

### DIFF
--- a/core/encoding/csv/doc.odin
+++ b/core/encoding/csv/doc.odin
@@ -63,8 +63,6 @@ Example:
 	read_csv_from_string :: proc(filename: string) {
 		r: csv.Reader
 		r.trim_leading_space  = true
-		r.reuse_record        = true // Without it you have to delete(record)
-		r.reuse_record_buffer = true // Without it you have to each of the fields within it
 		defer csv.reader_destroy(&r)
 
 		csv_data, ok := os.read_entire_file(filename)

--- a/core/encoding/csv/reader.odin
+++ b/core/encoding/csv/reader.odin
@@ -130,7 +130,7 @@ reader_destroy :: proc(r: ^Reader) {
 	for record, row_idx in csv.iterator_next(&r) { ... }
 
 	TIP: If you process the results within the loop and don't need to own the results,
-	you can set the Reader's `reuse_record` and `reuse_record_reuse_record_buffer` to true;
+	you can set the Reader's `reuse_record` and `reuse_record_buffer` to true;
 	you won't need to delete the record or its fields.
 */
 iterator_next :: proc(r: ^Reader) -> (record: []string, idx: int, err: Error, more: bool) {


### PR DESCRIPTION
- These settings shouldn't be enabled for the `read_csv_from_string` example otherwise you get repeated output since it can't be using the same buffer for every record if you were to try reading them back later.
- Fixed typo in the docs for the `reuse_record_buffer` setting

E.g. for bad output with the original example
```
# test.csv
a,b
1,2
3,4
8,7
```

With the original you'd get
```
ecord 0, field 0: "8"
Record 0, field 1: "7"
Record 1, field 0: "8"
Record 1, field 1: "7"
Record 2, field 0: "8"
Record 2, field 1: "7"
Record 3, field 0: "8"
Record 3, field 1: "7"
```

Meaning it was using the last record written to the internal buffer.