### PR TITLE
Add missing SEL _cmd argument to objc class_addMethod IMPs

### DIFF
--- a/core/sys/darwin/Foundation/NSApplication.odin
+++ b/core/sys/darwin/Foundation/NSApplication.odin
@@ -256,7 +256,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		return nil
 	}
 	if template.applicationWillFinishLaunching != nil {
-		applicationWillFinishLaunching :: proc "c" (self: id, notification: ^Notification) {
+		applicationWillFinishLaunching :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationWillFinishLaunching(notification)
@@ -264,7 +264,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationWillFinishLaunching:"), auto_cast applicationWillFinishLaunching, "v@:@")
 	}
 	if template.applicationDidFinishLaunching != nil {
-		applicationDidFinishLaunching :: proc "c" (self: id, notification: ^Notification) {
+		applicationDidFinishLaunching :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidFinishLaunching(notification)
@@ -272,7 +272,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationDidFinishLaunching:"), auto_cast applicationDidFinishLaunching, "v@:@")
 	}
 	if template.applicationWillBecomeActive != nil {
-		applicationWillBecomeActive :: proc "c" (self: id, notification: ^Notification) {
+		applicationWillBecomeActive :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationWillBecomeActive(notification)
@@ -280,7 +280,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationWillBecomeActive:"), auto_cast applicationWillBecomeActive, "v@:@")
 	}
 	if template.applicationDidBecomeActive != nil {
-		applicationDidBecomeActive :: proc "c" (self: id, notification: ^Notification) {
+		applicationDidBecomeActive :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidBecomeActive(notification)
@@ -288,7 +288,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationDidBecomeActive:"), auto_cast applicationDidBecomeActive, "v@:@")
 	}
 	if template.applicationWillResignActive != nil {
-		applicationWillResignActive :: proc "c" (self: id, notification: ^Notification) {
+		applicationWillResignActive :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationWillResignActive(notification)
@@ -296,7 +296,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationWillResignActive:"), auto_cast applicationWillResignActive, "v@:@")
 	}
 	if template.applicationDidResignActive != nil {
-		applicationDidResignActive :: proc "c" (self: id, notification: ^Notification) {
+		applicationDidResignActive :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidResignActive(notification)
@@ -304,7 +304,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationDidResignActive:"), auto_cast applicationDidResignActive, "v@:@")
 	}
 	if template.applicationShouldTerminate != nil {
-		applicationShouldTerminate :: proc "c" (self: id, sender: ^Application) -> ApplicationTerminateReply {
+		applicationShouldTerminate :: proc "c" (self: id, cmd: SEL, sender: ^Application) -> ApplicationTerminateReply {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationShouldTerminate(sender)
@@ -312,7 +312,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationShouldTerminate:"), auto_cast applicationShouldTerminate, _UINTEGER_ENCODING+"@:@")
 	}
 	if template.applicationShouldTerminateAfterLastWindowClosed != nil {
-		applicationShouldTerminateAfterLastWindowClosed :: proc "c" (self: id, sender: ^Application) -> BOOL {
+		applicationShouldTerminateAfterLastWindowClosed :: proc "c" (self: id, cmd: SEL, sender: ^Application) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationShouldTerminateAfterLastWindowClosed(sender)
@@ -320,7 +320,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationShouldTerminateAfterLastWindowClosed:"), auto_cast applicationShouldTerminateAfterLastWindowClosed, "B@:@")
 	}
 	if template.applicationWillTerminate != nil {
-		applicationWillTerminate :: proc "c" (self: id, notification: ^Notification) {
+		applicationWillTerminate :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationWillTerminate(notification)
@@ -328,7 +328,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationWillTerminate:"), auto_cast applicationWillTerminate, "v@:@")
 	}
 	if template.applicationWillHide != nil {
-		applicationWillHide :: proc "c" (self: id, notification: ^Notification) {
+		applicationWillHide :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationWillHide(notification)
@@ -336,7 +336,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationWillHide:"), auto_cast applicationWillHide, "v@:@")
 	}
 	if template.applicationDidHide != nil {
-		applicationDidHide :: proc "c" (self: id, notification: ^Notification) {
+		applicationDidHide :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidHide(notification)
@@ -344,7 +344,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationDidHide:"), auto_cast applicationDidHide, "v@:@")
 	}
 	if template.applicationWillUnhide != nil {
-		applicationWillUnhide :: proc "c" (self: id, notification: ^Notification) {
+		applicationWillUnhide :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationWillUnhide(notification)
@@ -352,7 +352,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationWillUnhide:"), auto_cast applicationWillUnhide, "v@:@")
 	}
 	if template.applicationDidUnhide != nil {
-		applicationDidUnhide :: proc "c" (self: id, notification: ^Notification) {
+		applicationDidUnhide :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidUnhide(notification)
@@ -360,7 +360,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationDidUnhide:"), auto_cast applicationDidUnhide, "v@:@")
 	}
 	if template.applicationWillUpdate != nil {
-		applicationWillUpdate :: proc "c" (self: id, notification: ^Notification) {
+		applicationWillUpdate :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationWillUpdate(notification)
@@ -368,7 +368,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationWillUpdate:"), auto_cast applicationWillUpdate, "v@:@")
 	}
 	if template.applicationDidUpdate != nil {
-		applicationDidUpdate :: proc "c" (self: id, notification: ^Notification) {
+		applicationDidUpdate :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidUpdate(notification)
@@ -376,7 +376,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationDidUpdate:"), auto_cast applicationDidUpdate, "v@:@")
 	}
 	if template.applicationShouldHandleReopenHasVisibleWindows != nil {
-		applicationShouldHandleReopenHasVisibleWindows :: proc "c" (self: id, sender: ^Application, flag: BOOL) -> BOOL {
+		applicationShouldHandleReopenHasVisibleWindows :: proc "c" (self: id, cmd: SEL, sender: ^Application, flag: BOOL) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationShouldHandleReopenHasVisibleWindows(sender, flag)
@@ -384,7 +384,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationShouldHandleReopen:hasVisibleWindows:"), auto_cast applicationShouldHandleReopenHasVisibleWindows, "B@:@B")
 	}
 	if template.applicationDockMenu != nil {
-		applicationDockMenu :: proc "c" (self: id, sender: ^Application) -> ^Menu {
+		applicationDockMenu :: proc "c" (self: id, cmd: SEL, sender: ^Application) -> ^Menu {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationDockMenu(sender)
@@ -392,7 +392,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationDockMenu:"), auto_cast applicationDockMenu, "@@:@")
 	}
 	if template.applicationShouldAutomaticallyLocalizeKeyEquivalents != nil {
-		applicationShouldAutomaticallyLocalizeKeyEquivalents :: proc "c" (self: id, application: ^Application) -> BOOL {
+		applicationShouldAutomaticallyLocalizeKeyEquivalents :: proc "c" (self: id, cmd: SEL, application: ^Application) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationShouldAutomaticallyLocalizeKeyEquivalents(application)
@@ -400,7 +400,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationShouldAutomaticallyLocalizeKeyEquivalents:"), auto_cast applicationShouldAutomaticallyLocalizeKeyEquivalents, "B@:@")
 	}
 	if template.applicationWillPresentError != nil {
-		applicationWillPresentError :: proc "c" (self: id, application: ^Application, error: ^Error) -> ^Error {
+		applicationWillPresentError :: proc "c" (self: id, cmd: SEL, application: ^Application, error: ^Error) -> ^Error {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationWillPresentError(application, error)
@@ -408,7 +408,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:willPresentError:"), auto_cast applicationWillPresentError, "@@:@@")
 	}
 	if template.applicationDidChangeScreenParameters != nil {
-		applicationDidChangeScreenParameters :: proc "c" (self: id, notification: ^Notification) {
+		applicationDidChangeScreenParameters :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidChangeScreenParameters(notification)
@@ -416,7 +416,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationDidChangeScreenParameters:"), auto_cast applicationDidChangeScreenParameters, "v@:@")
 	}
 	if template.applicationWillContinueUserActivityWithType != nil {
-		applicationWillContinueUserActivityWithType :: proc "c" (self: id, application: ^Application, userActivityType: ^String) -> BOOL {
+		applicationWillContinueUserActivityWithType :: proc "c" (self: id, cmd: SEL, application: ^Application, userActivityType: ^String) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationWillContinueUserActivityWithType(application, userActivityType)
@@ -424,7 +424,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:willContinueUserActivityWithType:"), auto_cast applicationWillContinueUserActivityWithType, "B@:@@")
 	}
 	if template.applicationContinueUserActivityRestorationHandler != nil {
-		applicationContinueUserActivityRestorationHandler :: proc "c" (self: id, application: ^Application, userActivity: ^UserActivity, restorationHandler: ^Block) -> BOOL {
+		applicationContinueUserActivityRestorationHandler :: proc "c" (self: id, cmd: SEL, application: ^Application, userActivity: ^UserActivity, restorationHandler: ^Block) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationContinueUserActivityRestorationHandler(application, userActivity, restorationHandler)
@@ -432,7 +432,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:continueUserActivity:restorationHandler:"), auto_cast applicationContinueUserActivityRestorationHandler, "B@:@@?")
 	}
 	if template.applicationDidFailToContinueUserActivityWithTypeError != nil {
-		applicationDidFailToContinueUserActivityWithTypeError :: proc "c" (self: id, application: ^Application, userActivityType: ^String, error: ^Error) {
+		applicationDidFailToContinueUserActivityWithTypeError :: proc "c" (self: id, cmd: SEL, application: ^Application, userActivityType: ^String, error: ^Error) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidFailToContinueUserActivityWithTypeError(application, userActivityType, error)
@@ -440,7 +440,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:didFailToContinueUserActivityWithType:error:"), auto_cast applicationDidFailToContinueUserActivityWithTypeError, "v@:@@@")
 	}
 	if template.applicationDidUpdateUserActivity != nil {
-		applicationDidUpdateUserActivity :: proc "c" (self: id, application: ^Application, userActivity: ^UserActivity) {
+		applicationDidUpdateUserActivity :: proc "c" (self: id, cmd: SEL, application: ^Application, userActivity: ^UserActivity) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidUpdateUserActivity(application, userActivity)
@@ -448,7 +448,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:didUpdateUserActivity:"), auto_cast applicationDidUpdateUserActivity, "v@:@@")
 	}
 	if template.applicationDidRegisterForRemoteNotificationsWithDeviceToken != nil {
-		applicationDidRegisterForRemoteNotificationsWithDeviceToken :: proc "c" (self: id, application: ^Application, deviceToken: ^Data) {
+		applicationDidRegisterForRemoteNotificationsWithDeviceToken :: proc "c" (self: id, cmd: SEL, application: ^Application, deviceToken: ^Data) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidRegisterForRemoteNotificationsWithDeviceToken(application, deviceToken)
@@ -456,7 +456,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:didRegisterForRemoteNotificationsWithDeviceToken:"), auto_cast applicationDidRegisterForRemoteNotificationsWithDeviceToken, "v@:@@")
 	}
 	if template.applicationDidFailToRegisterForRemoteNotificationsWithError != nil {
-		applicationDidFailToRegisterForRemoteNotificationsWithError :: proc "c" (self: id, application: ^Application, error: ^Error) {
+		applicationDidFailToRegisterForRemoteNotificationsWithError :: proc "c" (self: id, cmd: SEL, application: ^Application, error: ^Error) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidFailToRegisterForRemoteNotificationsWithError(application, error)
@@ -464,7 +464,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:didFailToRegisterForRemoteNotificationsWithError:"), auto_cast applicationDidFailToRegisterForRemoteNotificationsWithError, "v@:@@")
 	}
 	if template.applicationDidReceiveRemoteNotification != nil {
-		applicationDidReceiveRemoteNotification :: proc "c" (self: id, application: ^Application, userInfo: ^Dictionary) {
+		applicationDidReceiveRemoteNotification :: proc "c" (self: id, cmd: SEL, application: ^Application, userInfo: ^Dictionary) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidReceiveRemoteNotification(application, userInfo)
@@ -472,7 +472,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:didReceiveRemoteNotification:"), auto_cast applicationDidReceiveRemoteNotification, "v@:@@")
 	}
 	// if template.applicationUserDidAcceptCloudKitShareWithMetadata != nil {
-	// 	applicationUserDidAcceptCloudKitShareWithMetadata :: proc "c" (self: id, application: ^Application, metadata: ^CKShareMetadata) {
+	// 	applicationUserDidAcceptCloudKitShareWithMetadata :: proc "c" (self: id, cmd: SEL, application: ^Application, metadata: ^CKShareMetadata) {
 	// 		del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 	// 		context = del._context
 	// 		del.applicationUserDidAcceptCloudKitShareWithMetadata(application, metadata)
@@ -480,7 +480,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 	// 	class_addMethod(class, intrinsics.objc_find_selector("application:userDidAcceptCloudKitShareWithMetadata:"), auto_cast applicationUserDidAcceptCloudKitShareWithMetadata, "v@:@@")
 	// }
 	// if template.applicationHandlerForIntent != nil {
-	// 	applicationHandlerForIntent :: proc "c" (self: id, application: ^Application, intent: ^INIntent) -> id {
+	// 	applicationHandlerForIntent :: proc "c" (self: id, cmd: SEL, application: ^Application, intent: ^INIntent) -> id {
 	// 		del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 	// 		context = del._context
 	// 		return del.applicationHandlerForIntent(application, intent)
@@ -488,7 +488,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 	// 	class_addMethod(class, intrinsics.objc_find_selector("application:handlerForIntent:"), auto_cast applicationHandlerForIntent, "@@:@@")
 	// }
 	if template.applicationOpenURLs != nil {
-		applicationOpenURLs :: proc "c" (self: id, application: ^Application, urls: ^Array) {
+		applicationOpenURLs :: proc "c" (self: id, cmd: SEL, application: ^Application, urls: ^Array) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationOpenURLs(application, urls)
@@ -496,7 +496,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:openURLs:"), auto_cast applicationOpenURLs, "v@:@@")
 	}
 	if template.applicationOpenFile != nil {
-		applicationOpenFile :: proc "c" (self: id, sender: ^Application, filename: ^String) -> BOOL {
+		applicationOpenFile :: proc "c" (self: id, cmd: SEL, sender: ^Application, filename: ^String) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationOpenFile(sender, filename)
@@ -504,7 +504,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:openFile:"), auto_cast applicationOpenFile, "B@:@@")
 	}
 	if template.applicationOpenFileWithoutUI != nil {
-		applicationOpenFileWithoutUI :: proc "c" (self: id, sender: id, filename: ^String) -> BOOL {
+		applicationOpenFileWithoutUI :: proc "c" (self: id, cmd: SEL, sender: id, filename: ^String) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationOpenFileWithoutUI(sender, filename)
@@ -512,7 +512,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:openFileWithoutUI:"), auto_cast applicationOpenFileWithoutUI, "B@:@@")
 	}
 	if template.applicationOpenTempFile != nil {
-		applicationOpenTempFile :: proc "c" (self: id, sender: ^Application, filename: ^String) -> BOOL {
+		applicationOpenTempFile :: proc "c" (self: id, cmd: SEL, sender: ^Application, filename: ^String) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationOpenTempFile(sender, filename)
@@ -520,7 +520,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:openTempFile:"), auto_cast applicationOpenTempFile, "B@:@@")
 	}
 	if template.applicationOpenFiles != nil {
-		applicationOpenFiles :: proc "c" (self: id, sender: ^Application, filenames: ^Array) {
+		applicationOpenFiles :: proc "c" (self: id, cmd: SEL, sender: ^Application, filenames: ^Array) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationOpenFiles(sender, filenames)
@@ -528,7 +528,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:openFiles:"), auto_cast applicationOpenFiles, "v@:@@")
 	}
 	if template.applicationShouldOpenUntitledFile != nil {
-		applicationShouldOpenUntitledFile :: proc "c" (self: id, sender: ^Application) -> BOOL {
+		applicationShouldOpenUntitledFile :: proc "c" (self: id, cmd: SEL, sender: ^Application) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationShouldOpenUntitledFile(sender)
@@ -536,7 +536,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationShouldOpenUntitledFile:"), auto_cast applicationShouldOpenUntitledFile, "B@:@")
 	}
 	if template.applicationOpenUntitledFile != nil {
-		applicationOpenUntitledFile :: proc "c" (self: id, sender: ^Application) -> BOOL {
+		applicationOpenUntitledFile :: proc "c" (self: id, cmd: SEL, sender: ^Application) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationOpenUntitledFile(sender)
@@ -544,7 +544,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationOpenUntitledFile:"), auto_cast applicationOpenUntitledFile, "B@:@")
 	}
 	if template.applicationPrintFile != nil {
-		applicationPrintFile :: proc "c" (self: id, sender: ^Application, filename: ^String) -> BOOL {
+		applicationPrintFile :: proc "c" (self: id, cmd: SEL, sender: ^Application, filename: ^String) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationPrintFile(sender, filename)
@@ -552,7 +552,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:printFile:"), auto_cast applicationPrintFile, "B@:@@")
 	}
 	if template.applicationPrintFilesWithSettingsShowPrintPanels != nil {
-		applicationPrintFilesWithSettingsShowPrintPanels :: proc "c" (self: id, application: ^Application, fileNames: ^Array, printSettings: ^Dictionary, showPrintPanels: BOOL) -> ApplicationPrintReply {
+		applicationPrintFilesWithSettingsShowPrintPanels :: proc "c" (self: id, cmd: SEL, application: ^Application, fileNames: ^Array, printSettings: ^Dictionary, showPrintPanels: BOOL) -> ApplicationPrintReply {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationPrintFilesWithSettingsShowPrintPanels(application, fileNames, printSettings, showPrintPanels)
@@ -560,7 +560,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:printFiles:withSettings:showPrintPanels:"), auto_cast applicationPrintFilesWithSettingsShowPrintPanels, _UINTEGER_ENCODING+"@:@@@B")
 	}
 	if template.applicationSupportsSecureRestorableState != nil {
-		applicationSupportsSecureRestorableState :: proc "c" (self: id, app: ^Application) -> BOOL {
+		applicationSupportsSecureRestorableState :: proc "c" (self: id, cmd: SEL, app: ^Application) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationSupportsSecureRestorableState(app)
@@ -568,7 +568,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationSupportsSecureRestorableState:"), auto_cast applicationSupportsSecureRestorableState, "B@:@")
 	}
 	if template.applicationProtectedDataDidBecomeAvailable != nil {
-		applicationProtectedDataDidBecomeAvailable :: proc "c" (self: id, notification: ^Notification) {
+		applicationProtectedDataDidBecomeAvailable :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationProtectedDataDidBecomeAvailable(notification)
@@ -576,7 +576,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationProtectedDataDidBecomeAvailable:"), auto_cast applicationProtectedDataDidBecomeAvailable, "v@:@")
 	}
 	if template.applicationProtectedDataWillBecomeUnavailable != nil {
-		applicationProtectedDataWillBecomeUnavailable :: proc "c" (self: id, notification: ^Notification) {
+		applicationProtectedDataWillBecomeUnavailable :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationProtectedDataWillBecomeUnavailable(notification)
@@ -584,7 +584,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationProtectedDataWillBecomeUnavailable:"), auto_cast applicationProtectedDataWillBecomeUnavailable, "v@:@")
 	}
 	if template.applicationWillEncodeRestorableState != nil {
-		applicationWillEncodeRestorableState :: proc "c" (self: id, app: ^Application, coder: ^Coder) {
+		applicationWillEncodeRestorableState :: proc "c" (self: id, cmd: SEL, app: ^Application, coder: ^Coder) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationWillEncodeRestorableState(app, coder)
@@ -592,7 +592,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:willEncodeRestorableState:"), auto_cast applicationWillEncodeRestorableState, "v@:@@")
 	}
 	if template.applicationDidDecodeRestorableState != nil {
-		applicationDidDecodeRestorableState :: proc "c" (self: id, app: ^Application, coder: ^Coder) {
+		applicationDidDecodeRestorableState :: proc "c" (self: id, cmd: SEL, app: ^Application, coder: ^Coder) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidDecodeRestorableState(app, coder)
@@ -600,7 +600,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("application:didDecodeRestorableState:"), auto_cast applicationDidDecodeRestorableState, "v@:@@")
 	}
 	if template.applicationDidChangeOcclusionState != nil {
-		applicationDidChangeOcclusionState :: proc "c" (self: id, notification: ^Notification) {
+		applicationDidChangeOcclusionState :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.applicationDidChangeOcclusionState(notification)
@@ -608,7 +608,7 @@ application_delegate_register_and_alloc :: proc(template: ApplicationDelegateTem
 		class_addMethod(class, intrinsics.objc_find_selector("applicationDidChangeOcclusionState:"), auto_cast applicationDidChangeOcclusionState, "v@:@")
 	}
 	if template.applicationDelegateHandlesKey != nil {
-		applicationDelegateHandlesKey :: proc "c" (self: id, sender: ^Application, key: ^String) -> BOOL {
+		applicationDelegateHandlesKey :: proc "c" (self: id, cmd: SEL, sender: ^Application, key: ^String) -> BOOL {
 			del := cast(^_ApplicationDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.applicationDelegateHandlesKey(sender, key)

--- a/core/sys/darwin/Foundation/NSWindow.odin
+++ b/core/sys/darwin/Foundation/NSWindow.odin
@@ -146,7 +146,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		return nil
 	}
 	if template.windowWillPositionSheetUsingRect != nil {
-		windowWillPositionSheetUsingRect :: proc "c" (self: id, window: ^Window, sheet: ^Window, rect: Rect) -> Rect {
+		windowWillPositionSheetUsingRect :: proc "c" (self: id, cmd: SEL, window: ^Window, sheet: ^Window, rect: Rect) -> Rect {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowWillPositionSheetUsingRect(window, sheet, rect)
@@ -154,7 +154,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:willPositionSheet:usingRect:"), auto_cast windowWillPositionSheetUsingRect, _RECT_ENCODING+"@:@@"+_RECT_ENCODING)
 	}
 	if template.windowWillBeginSheet != nil {
-		windowWillBeginSheet :: proc "c" (self: id, notification: ^Notification) {
+		windowWillBeginSheet :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillBeginSheet(notification)
@@ -162,7 +162,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillBeginSheet:"), auto_cast windowWillBeginSheet, "v@:@")
 	}
 	if template.windowDidEndSheet != nil {
-		windowDidEndSheet :: proc "c" (self: id, notification: ^Notification) {
+		windowDidEndSheet :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidEndSheet(notification)
@@ -170,7 +170,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidEndSheet:"), auto_cast windowDidEndSheet, "v@:@")
 	}
 	if template.windowWillResizeToSize != nil {
-		windowWillResizeToSize :: proc "c" (self: id, sender: ^Window, frameSize: Size) -> Size {
+		windowWillResizeToSize :: proc "c" (self: id, cmd: SEL, sender: ^Window, frameSize: Size) -> Size {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowWillResizeToSize(sender, frameSize)
@@ -178,7 +178,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillResize:toSize:"), auto_cast windowWillResizeToSize, _SIZE_ENCODING+"@:@"+_SIZE_ENCODING)
 	}
 	if template.windowDidResize != nil {
-		windowDidResize :: proc "c" (self: id, notification: ^Notification) {
+		windowDidResize :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidResize(notification)
@@ -186,7 +186,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidResize:"), auto_cast windowDidResize, "v@:@")
 	}
 	if template.windowWillStartLiveResize != nil {
-		windowWillStartLiveResize :: proc "c" (self: id, notification: ^Notification) {
+		windowWillStartLiveResize :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillStartLiveResize(notification)
@@ -194,7 +194,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillStartLiveResize:"), auto_cast windowWillStartLiveResize, "v@:@")
 	}
 	if template.windowDidEndLiveResize != nil {
-		windowDidEndLiveResize :: proc "c" (self: id, notification: ^Notification) {
+		windowDidEndLiveResize :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidEndLiveResize(notification)
@@ -202,7 +202,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidEndLiveResize:"), auto_cast windowDidEndLiveResize, "v@:@")
 	}
 	if template.windowWillMiniaturize != nil {
-		windowWillMiniaturize :: proc "c" (self: id, notification: ^Notification) {
+		windowWillMiniaturize :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillMiniaturize(notification)
@@ -210,7 +210,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillMiniaturize:"), auto_cast windowWillMiniaturize, "v@:@")
 	}
 	if template.windowDidMiniaturize != nil {
-		windowDidMiniaturize :: proc "c" (self: id, notification: ^Notification) {
+		windowDidMiniaturize :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidMiniaturize(notification)
@@ -218,7 +218,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidMiniaturize:"), auto_cast windowDidMiniaturize, "v@:@")
 	}
 	if template.windowDidDeminiaturize != nil {
-		windowDidDeminiaturize :: proc "c" (self: id, notification: ^Notification) {
+		windowDidDeminiaturize :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidDeminiaturize(notification)
@@ -226,7 +226,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidDeminiaturize:"), auto_cast windowDidDeminiaturize, "v@:@")
 	}
 	if template.windowWillUseStandardFrameDefaultFrame != nil {
-		windowWillUseStandardFrameDefaultFrame :: proc(self: id, window: ^Window, newFrame: Rect) -> Rect {
+		windowWillUseStandardFrameDefaultFrame :: proc(self: id, cmd: SEL, window: ^Window, newFrame: Rect) -> Rect {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowWillUseStandardFrameDefaultFrame(window, newFrame)
@@ -234,7 +234,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillUseStandardFrame:defaultFrame:"), auto_cast windowWillUseStandardFrameDefaultFrame, _RECT_ENCODING+"@:@"+_RECT_ENCODING)
 	}
 	if template.windowShouldZoomToFrame != nil {
-		windowShouldZoomToFrame :: proc "c" (self: id, window: ^Window, newFrame: Rect) -> BOOL {
+		windowShouldZoomToFrame :: proc "c" (self: id, cmd: SEL, window: ^Window, newFrame: Rect) -> BOOL {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowShouldZoomToFrame(window, newFrame)
@@ -242,7 +242,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowShouldZoom:toFrame:"), auto_cast windowShouldZoomToFrame, "B@:@"+_RECT_ENCODING)
 	}
 	if template.windowWillUseFullScreenContentSize != nil {
-		windowWillUseFullScreenContentSize :: proc "c" (self: id, window: ^Window, proposedSize: Size) -> Size {
+		windowWillUseFullScreenContentSize :: proc "c" (self: id, cmd: SEL, window: ^Window, proposedSize: Size) -> Size {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowWillUseFullScreenContentSize(window, proposedSize)
@@ -250,7 +250,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:willUseFullScreenContentSize:"), auto_cast windowWillUseFullScreenContentSize, _SIZE_ENCODING+"@:@"+_SIZE_ENCODING)
 	}
 	if template.windowWillUseFullScreenPresentationOptions != nil {
-		windowWillUseFullScreenPresentationOptions :: proc(self: id, window: ^Window, proposedOptions: ApplicationPresentationOptions) -> ApplicationPresentationOptions {
+		windowWillUseFullScreenPresentationOptions :: proc(self: id, cmd: SEL, window: ^Window, proposedOptions: ApplicationPresentationOptions) -> ApplicationPresentationOptions {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowWillUseFullScreenPresentationOptions(window, proposedOptions)
@@ -258,7 +258,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:willUseFullScreenPresentationOptions:"), auto_cast windowWillUseFullScreenPresentationOptions, _UINTEGER_ENCODING+"@:@"+_UINTEGER_ENCODING)
 	}
 	if template.windowWillEnterFullScreen != nil {
-		windowWillEnterFullScreen :: proc "c" (self: id, notification: ^Notification) {
+		windowWillEnterFullScreen :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillEnterFullScreen(notification)
@@ -266,7 +266,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillEnterFullScreen:"), auto_cast windowWillEnterFullScreen, "v@:@")
 	}
 	if template.windowDidEnterFullScreen != nil {
-		windowDidEnterFullScreen :: proc "c" (self: id, notification: ^Notification) {
+		windowDidEnterFullScreen :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidEnterFullScreen(notification)
@@ -274,7 +274,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidEnterFullScreen:"), auto_cast windowDidEnterFullScreen, "v@:@")
 	}
 	if template.windowWillExitFullScreen != nil {
-		windowWillExitFullScreen :: proc "c" (self: id, notification: ^Notification) {
+		windowWillExitFullScreen :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillExitFullScreen(notification)
@@ -282,7 +282,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillExitFullScreen:"), auto_cast windowWillExitFullScreen, "v@:@")
 	}
 	if template.windowDidExitFullScreen != nil {
-		windowDidExitFullScreen :: proc "c" (self: id, notification: ^Notification) {
+		windowDidExitFullScreen :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidExitFullScreen(notification)
@@ -290,7 +290,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidExitFullScreen:"), auto_cast windowDidExitFullScreen, "v@:@")
 	}
 	if template.customWindowsToEnterFullScreenForWindow != nil {
-		customWindowsToEnterFullScreenForWindow :: proc "c" (self: id, window: ^Window) -> ^Array {
+		customWindowsToEnterFullScreenForWindow :: proc "c" (self: id, cmd: SEL, window: ^Window) -> ^Array {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.customWindowsToEnterFullScreenForWindow(window)
@@ -298,7 +298,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("customWindowsToEnterFullScreenForWindow:"), auto_cast customWindowsToEnterFullScreenForWindow, "@@:@")
 	}
 	if template.customWindowsToEnterFullScreenForWindowOnScreen != nil {
-		customWindowsToEnterFullScreenForWindowOnScreen :: proc(self: id, window: ^Window, screen: ^Screen) -> ^Array {
+		customWindowsToEnterFullScreenForWindowOnScreen :: proc(self: id, cmd: SEL, window: ^Window, screen: ^Screen) -> ^Array {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.customWindowsToEnterFullScreenForWindowOnScreen(window, screen)
@@ -306,7 +306,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("customWindowsToEnterFullScreenForWindow:onScreen:"), auto_cast customWindowsToEnterFullScreenForWindowOnScreen, "@@:@@")
 	}
 	if template.windowStartCustomAnimationToEnterFullScreenWithDuration != nil {
-		windowStartCustomAnimationToEnterFullScreenWithDuration :: proc "c" (self: id, window: ^Window, duration: TimeInterval) {
+		windowStartCustomAnimationToEnterFullScreenWithDuration :: proc "c" (self: id, cmd: SEL, window: ^Window, duration: TimeInterval) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowStartCustomAnimationToEnterFullScreenWithDuration(window, duration)
@@ -314,7 +314,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:startCustomAnimationToEnterFullScreenWithDuration:"), auto_cast windowStartCustomAnimationToEnterFullScreenWithDuration, "v@:@@")
 	}
 	if template.windowStartCustomAnimationToEnterFullScreenOnScreenWithDuration != nil {
-		windowStartCustomAnimationToEnterFullScreenOnScreenWithDuration :: proc(self: id, window: ^Window, screen: ^Screen, duration: TimeInterval) {
+		windowStartCustomAnimationToEnterFullScreenOnScreenWithDuration :: proc(self: id, cmd: SEL, window: ^Window, screen: ^Screen, duration: TimeInterval) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowStartCustomAnimationToEnterFullScreenOnScreenWithDuration(window, screen, duration)
@@ -322,7 +322,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:startCustomAnimationToEnterFullScreenOnScreen:withDuration:"), auto_cast windowStartCustomAnimationToEnterFullScreenOnScreenWithDuration, "v@:@@d")
 	}
 	if template.windowDidFailToEnterFullScreen != nil {
-		windowDidFailToEnterFullScreen :: proc "c" (self: id, window: ^Window) {
+		windowDidFailToEnterFullScreen :: proc "c" (self: id, cmd: SEL, window: ^Window) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidFailToEnterFullScreen(window)
@@ -330,7 +330,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidFailToEnterFullScreen:"), auto_cast windowDidFailToEnterFullScreen, "v@:@")
 	}
 	if template.customWindowsToExitFullScreenForWindow != nil {
-		customWindowsToExitFullScreenForWindow :: proc "c" (self: id, window: ^Window) -> ^Array {
+		customWindowsToExitFullScreenForWindow :: proc "c" (self: id, cmd: SEL, window: ^Window) -> ^Array {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.customWindowsToExitFullScreenForWindow(window)
@@ -338,7 +338,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("customWindowsToExitFullScreenForWindow:"), auto_cast customWindowsToExitFullScreenForWindow, "@@:@")
 	}
 	if template.windowStartCustomAnimationToExitFullScreenWithDuration != nil {
-		windowStartCustomAnimationToExitFullScreenWithDuration :: proc "c" (self: id, window: ^Window, duration: TimeInterval) {
+		windowStartCustomAnimationToExitFullScreenWithDuration :: proc "c" (self: id, cmd: SEL, window: ^Window, duration: TimeInterval) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowStartCustomAnimationToExitFullScreenWithDuration(window, duration)
@@ -346,7 +346,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:startCustomAnimationToExitFullScreenWithDuration:"), auto_cast windowStartCustomAnimationToExitFullScreenWithDuration, "v@:@d")
 	}
 	if template.windowDidFailToExitFullScreen != nil {
-		windowDidFailToExitFullScreen :: proc "c" (self: id, window: ^Window) {
+		windowDidFailToExitFullScreen :: proc "c" (self: id, cmd: SEL, window: ^Window) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidFailToExitFullScreen(window)
@@ -354,7 +354,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidFailToExitFullScreen:"), auto_cast windowDidFailToExitFullScreen, "v@:@")
 	}
 	if template.windowWillMove != nil {
-		windowWillMove :: proc "c" (self: id, notification: ^Notification) {
+		windowWillMove :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillMove(notification)
@@ -362,7 +362,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillMove:"), auto_cast windowWillMove, "v@:@")
 	}
 	if template.windowDidMove != nil {
-		windowDidMove :: proc "c" (self: id, notification: ^Notification) {
+		windowDidMove :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidMove(notification)
@@ -370,7 +370,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidMove:"), auto_cast windowDidMove, "v@:@")
 	}
 	if template.windowDidChangeScreen != nil {
-		windowDidChangeScreen :: proc "c" (self: id, notification: ^Notification) {
+		windowDidChangeScreen :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidChangeScreen(notification)
@@ -378,7 +378,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidChangeScreen:"), auto_cast windowDidChangeScreen, "v@:@")
 	}
 	if template.windowDidChangeScreenProfile != nil {
-		windowDidChangeScreenProfile :: proc "c" (self: id, notification: ^Notification) {
+		windowDidChangeScreenProfile :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidChangeScreenProfile(notification)
@@ -386,7 +386,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidChangeScreenProfile:"), auto_cast windowDidChangeScreenProfile, "v@:@")
 	}
 	if template.windowDidChangeBackingProperties != nil {
-		windowDidChangeBackingProperties :: proc "c" (self: id, notification: ^Notification) {
+		windowDidChangeBackingProperties :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidChangeBackingProperties(notification)
@@ -394,7 +394,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidChangeBackingProperties:"), auto_cast windowDidChangeBackingProperties, "v@:@")
 	}
 	if template.windowShouldClose != nil {
-		windowShouldClose :: proc "c" (self:id, sender: ^Window) -> BOOL {
+		windowShouldClose :: proc "c" (self:id, cmd: SEL, sender: ^Window) -> BOOL {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowShouldClose(sender)
@@ -402,7 +402,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowShouldClose:"), auto_cast windowShouldClose, "B@:@")
 	}
 	if template.windowWillClose != nil {
-		windowWillClose :: proc "c" (self:id, notification: ^Notification) {
+		windowWillClose :: proc "c" (self:id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillClose(notification)
@@ -410,7 +410,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillClose:"), auto_cast windowWillClose, "v@:@")
 	}
 	if template.windowDidBecomeKey != nil {
-		windowDidBecomeKey :: proc "c" (self: id, notification: ^Notification) {
+		windowDidBecomeKey :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidBecomeKey(notification)
@@ -418,7 +418,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidBecomeKey:"), auto_cast windowDidBecomeKey, "v@:@")
 	}
 	if template.windowDidResignKey != nil {
-		windowDidResignKey :: proc "c" (self: id, notification: ^Notification) {
+		windowDidResignKey :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidResignKey(notification)
@@ -426,7 +426,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidResignKey:"), auto_cast windowDidResignKey, "v@:@")
 	}
 	if template.windowDidBecomeMain != nil {
-		windowDidBecomeMain :: proc "c" (self: id, notification: ^Notification) {
+		windowDidBecomeMain :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidBecomeMain(notification)
@@ -434,7 +434,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidBecomeMain:"), auto_cast windowDidBecomeMain, "v@:@")
 	}
 	if template.windowDidResignMain != nil {
-		windowDidResignMain :: proc "c" (self: id, notification: ^Notification) {
+		windowDidResignMain :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidResignMain(notification)
@@ -442,7 +442,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidResignMain:"), auto_cast windowDidResignMain, "v@:@")
 	}
 	if template.windowWillReturnFieldEditorToObject != nil {
-		windowWillReturnFieldEditorToObject :: proc "c" (self:id, sender: ^Window, client: id) -> id {
+		windowWillReturnFieldEditorToObject :: proc "c" (self:id, cmd: SEL, sender: ^Window, client: id) -> id {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowWillReturnFieldEditorToObject(sender, client)
@@ -450,7 +450,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillReturnFieldEditor:toObject:"), auto_cast windowWillReturnFieldEditorToObject, "@@:@@")
 	}
 	if template.windowDidUpdate != nil {
-		windowDidUpdate :: proc "c" (self: id, notification: ^Notification) {
+		windowDidUpdate :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidUpdate(notification)
@@ -458,7 +458,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidUpdate:"), auto_cast windowDidUpdate, "v@:@")
 	}
 	if template.windowDidExpose != nil {
-		windowDidExpose :: proc "c" (self: id, notification: ^Notification) {
+		windowDidExpose :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidExpose(notification)
@@ -466,7 +466,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidExpose:"), auto_cast windowDidExpose, "v@:@")
 	}
 	if template.windowDidChangeOcclusionState != nil {
-		windowDidChangeOcclusionState :: proc "c" (self: id, notification: ^Notification) {
+		windowDidChangeOcclusionState :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidChangeOcclusionState(notification)
@@ -474,7 +474,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidChangeOcclusionState:"), auto_cast windowDidChangeOcclusionState, "v@:@")
 	}
 	if template.windowShouldDragDocumentWithEventFromWithPasteboard != nil {
-		windowShouldDragDocumentWithEventFromWithPasteboard :: proc "c" (self: id, window: ^Window, event: ^Event, dragImageLocation: Point, pasteboard: ^Pasteboard) -> BOOL {
+		windowShouldDragDocumentWithEventFromWithPasteboard :: proc "c" (self: id, cmd: SEL, window: ^Window, event: ^Event, dragImageLocation: Point, pasteboard: ^Pasteboard) -> BOOL {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowShouldDragDocumentWithEventFromWithPasteboard(window, event, dragImageLocation, pasteboard)
@@ -482,7 +482,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:shouldDragDocumentWithEvent:from:withPasteboard:"), auto_cast windowShouldDragDocumentWithEventFromWithPasteboard, "B@:@@"+_POINT_ENCODING+"@")
 	}
 	if template.windowWillReturnUndoManager != nil {
-		windowWillReturnUndoManager :: proc "c" (self: id, window: ^Window) -> ^UndoManager {
+		windowWillReturnUndoManager :: proc "c" (self: id, cmd: SEL, window: ^Window) -> ^UndoManager {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowWillReturnUndoManager(window)
@@ -490,7 +490,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillReturnUndoManager:"), auto_cast windowWillReturnUndoManager, "@@:@")
 	}
 	if template.windowShouldPopUpDocumentPathMenu != nil {
-		windowShouldPopUpDocumentPathMenu :: proc "c" (self: id, window: ^Window, menu: ^Menu) -> BOOL {
+		windowShouldPopUpDocumentPathMenu :: proc "c" (self: id, cmd: SEL, window: ^Window, menu: ^Menu) -> BOOL {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowShouldPopUpDocumentPathMenu(window, menu)
@@ -498,7 +498,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:shouldPopUpDocumentPathMenu:"), auto_cast windowShouldPopUpDocumentPathMenu, "B@:@@")
 	}
 	if template.windowWillEncodeRestorableState != nil {
-		windowWillEncodeRestorableState :: proc "c" (self: id, window: ^Window, state: ^Coder) {
+		windowWillEncodeRestorableState :: proc "c" (self: id, cmd: SEL, window: ^Window, state: ^Coder) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillEncodeRestorableState(window, state)
@@ -506,7 +506,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:willEncodeRestorableState:"), auto_cast windowWillEncodeRestorableState, "v@:@@")
 	}
 	if template.windowDidEncodeRestorableState != nil {
-		windowDidEncodeRestorableState :: proc "c" (self: id, window: ^Window, state: ^Coder) {
+		windowDidEncodeRestorableState :: proc "c" (self: id, cmd: SEL, window: ^Window, state: ^Coder) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidEncodeRestorableState(window, state)
@@ -514,7 +514,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:didDecodeRestorableState:"), auto_cast windowDidEncodeRestorableState, "v@:@@")
 	}
 	if template.windowWillResizeForVersionBrowserWithMaxPreferredSizeMaxAllowedSize != nil {
-		windowWillResizeForVersionBrowserWithMaxPreferredSizeMaxAllowedSize :: proc "c" (self: id, window: ^Window, maxPreferredFrameSize: Size, maxAllowedFrameSize: Size) -> Size {
+		windowWillResizeForVersionBrowserWithMaxPreferredSizeMaxAllowedSize :: proc "c" (self: id, cmd: SEL, window: ^Window, maxPreferredFrameSize: Size, maxAllowedFrameSize: Size) -> Size {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			return del.windowWillResizeForVersionBrowserWithMaxPreferredSizeMaxAllowedSize(window, maxPreferredFrameSize, maxPreferredFrameSize)
@@ -522,7 +522,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("window:willResizeForVersionBrowserWithMaxPreferredSize:maxAllowedSize:"), auto_cast windowWillResizeForVersionBrowserWithMaxPreferredSizeMaxAllowedSize, _SIZE_ENCODING+"@:@"+_SIZE_ENCODING+_SIZE_ENCODING)
 	}
 	if template.windowWillEnterVersionBrowser != nil {
-		windowWillEnterVersionBrowser :: proc "c" (self: id, notification: ^Notification) {
+		windowWillEnterVersionBrowser :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillEnterVersionBrowser(notification)
@@ -530,7 +530,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillEnterVersionBrowser:"), auto_cast windowWillEnterVersionBrowser, "v@:@")
 	}
 	if template.windowDidEnterVersionBrowser != nil {
-		windowDidEnterVersionBrowser :: proc "c" (self: id, notification: ^Notification) {
+		windowDidEnterVersionBrowser :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidEnterVersionBrowser(notification)
@@ -538,7 +538,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowDidEnterVersionBrowser:"), auto_cast windowDidEnterVersionBrowser, "v@:@")
 	}
 	if template.windowWillExitVersionBrowser != nil {
-		windowWillExitVersionBrowser :: proc "c" (self: id, notification: ^Notification) {
+		windowWillExitVersionBrowser :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowWillExitVersionBrowser(notification)
@@ -546,7 +546,7 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 		class_addMethod(class, intrinsics.objc_find_selector("windowWillExitVersionBrowser:"), auto_cast windowWillExitVersionBrowser, "v@:@")
 	}
 	if template.windowDidExitVersionBrowser != nil {
-		windowDidExitVersionBrowser :: proc "c" (self: id, notification: ^Notification) {
+		windowDidExitVersionBrowser :: proc "c" (self: id, cmd: SEL, notification: ^Notification) {
 			del := cast(^_WindowDelegateInternal)object_getIndexedIvars(self)
 			context = del._context
 			del.windowDidExitVersionBrowser(notification)


### PR DESCRIPTION
When trying to grab the window pointer off the notification in a windowDidBecomeKey implementation, I kept getting segfaults calling notification->object(). The second argument of these needs to be a SEL.

https://developer.apple.com/documentation/objectivec/class_addmethod(_:_:_:_:)?language=objc#Discussion

I imagine existing code is getting by by setting the window information in the delegate's context userdata, which works fine when you only have one window as you can avoid needing to call notification->object(), until you want one delegate assigned to two windows, hard to work around.