### PR TITLE
Add NSWindow sizing and ordering functions

### DIFF
--- a/core/sys/darwin/Foundation/NSImage.odin
+++ b/core/sys/darwin/Foundation/NSImage.odin
@@ -1,0 +1,4 @@
+package objc_Foundation
+
+@(objc_class="NSImage")
+Image :: struct {using _: Object}

--- a/core/sys/darwin/Foundation/NSWindow.odin
+++ b/core/sys/darwin/Foundation/NSWindow.odin
@@ -645,18 +645,209 @@ Window_contentView :: proc "c" (self: ^Window) -> ^View {
 Window_setContentView :: proc "c" (self: ^Window, content_view: ^View) {
 	msgSend(nil, self, "setContentView:", content_view)
 }
-@(objc_type=Window, objc_name="contentLayoutRect")
-Window_contentLayoutRect :: proc "c" (self: ^Window) -> Rect {
-	return msgSend(Rect, self, "contentLayoutRect")
-}
+
+// Sizing Windows
 @(objc_type=Window, objc_name="frame")
 Window_frame :: proc "c" (self: ^Window) -> Rect {
 	return msgSend(Rect, self, "frame")
 }
-@(objc_type=Window, objc_name="setFrame")
-Window_setFrame :: proc "c" (self: ^Window, frame: Rect) {
-	msgSend(nil, self, "setFrame:", frame)
+@(objc_type=Window, objc_name="setFrameOrigin")
+Window_setFrameOrigin :: proc "c" (self: ^Window, point: Point) {
+	msgSend(nil, self, "setFrameOrigin:", point)
 }
+@(objc_type=Window, objc_name="setFrameTopLeftPoint")
+Window_setFrameTopLeftPoint :: proc "c" (self: ^Window, point: Point) {
+	msgSend(nil, self, "setFrameTopLeftPoint:", point)
+}
+@(objc_type=Window, objc_name="constrainFrameRectToScreen")
+Window_constrainFrameRectToScreen :: proc "c" (self: ^Window, frame: Rect, screen: ^Screen) -> Rect {
+	return msgSend(Rect, self, "constrainFrameRect:toScreen:", frame, screen)
+}
+@(objc_type=Window, objc_name="cascadeTopLeftFromPoint")
+Window_cascadeTopLeftFromPoint :: proc "c" (self: ^Window, point: Point) -> Point {
+	return msgSend(Point, self, "cascadeTopLeftFromPoint:", point)
+}
+@(objc_type=Window, objc_name="setFrameDisplay")
+Window_setFrameDisplay :: proc "c" (self: ^Window, frame: Rect, display: BOOL) {
+	msgSend(nil, self, "setFrame:display:", frame, display)
+}
+@(objc_type=Window, objc_name="setFrameDisplayAnimate")
+Window_setFrameDisplayAnimate :: proc "c" (self: ^Window, frame: Rect, display: BOOL, animate: BOOL) {
+	msgSend(nil, self, "setFrame:display:animate:", frame, display)
+}
+@(objc_type=Window, objc_name="animationResizeTime")
+Window_animationResizeTime :: proc "c" (self: ^Window, new_frame: Rect) -> TimeInterval {
+	return msgSend(TimeInterval, self, "animationResizeTime:", new_frame)
+}
+@(objc_type=Window, objc_name="aspectRatio")
+Window_aspectRatio :: proc "c" (self: ^Window) -> Size {
+	return msgSend(Size, self, "aspectRatio")
+}
+@(objc_type=Window, objc_name="setAspectRatio")
+Window_setAspectRatio :: proc "c" (self: ^Window, ratio: Size) {
+	msgSend(nil, self, "setAspectRatio:", ratio)
+}
+@(objc_type=Window, objc_name="minSize")
+Window_minSize :: proc "c" (self: ^Window) -> Size {
+	return msgSend(Size, self, "minSize")
+}
+@(objc_type=Window, objc_name="setMinSize")
+Window_setMinSize :: proc "c" (self: ^Window, size: Size) {
+	msgSend(nil, self, "setMinSize:", size)
+}
+@(objc_type=Window, objc_name="maxSize")
+Window_maxSize :: proc "c" (self: ^Window) -> Size {
+	return msgSend(Size, self, "maxSize")
+}
+@(objc_type=Window, objc_name="setMaxSize")
+Window_setMaxSize :: proc "c" (self: ^Window, size: Size) {
+	msgSend(nil, self, "setMaxSize:", size)
+}
+@(objc_type=Window, objc_name="isZoomed")
+Window_isZoomed :: proc "c" (self: ^Window) -> BOOL {
+	return msgSend(BOOL, self, "isZoomed")
+}
+@(objc_type=Window, objc_name="performZoom")
+Window_performZoom :: proc "c" (self: ^Window, sender: id) {
+	msgSend(nil, self, "performZoom:", sender)
+}
+@(objc_type=Window, objc_name="zoom")
+Window_zoom :: proc "c" (self: ^Window, sender: id) {
+	msgSend(nil, self, "zoom:", sender)
+}
+@(objc_type=Window, objc_name="resizeFlags")
+Window_resizeFlags :: proc "c" (self: ^Window) -> EventModifierFlags {
+	return msgSend(EventModifierFlags, self, "resizeFlags")
+}
+@(objc_type=Window, objc_name="resizeIncrements")
+Window_resizeIncrements :: proc "c" (self: ^Window) -> Size {
+	return msgSend(Size, self, "resizeIncrements")
+}
+@(objc_type=Window, objc_name="setResizeIncrements")
+Window_setResizeIncrements :: proc "c" (self: ^Window, increment: Size) {
+	msgSend(nil, self, "setResizeIncrements:", increment)
+}
+@(objc_type=Window, objc_name="preservesContentDuringLiveResize")
+Window_preservesContentDuringLiveResize :: proc "c" (self: ^Window) -> BOOL {
+	return msgSend(BOOL, self, "preservesContentDuringLiveResize")
+}
+@(objc_type=Window, objc_name="setPreservesContentDuringLiveResize")
+Window_setPreservesContentDuringLiveResize :: proc "c" (self: ^Window, preserve: BOOL) {
+	msgSend(nil, self, "setPreservesContentDuringLiveResize:", preserve)
+}
+@(objc_type=Window, objc_name="inLiveResize")
+Window_inLiveResize :: proc "c" (self: ^Window) -> BOOL {
+	return msgSend(BOOL, self, "inLiveResize")
+}
+
+// Sizing Content
+@(objc_type=Window, objc_name="contentAspectRatio")
+Window_contentAspectRatio :: proc "c" (self: ^Window) -> Size {
+	return msgSend(Size, self, "contentAspectRatio")
+}
+@(objc_type=Window, objc_name="setContentAspectRatio")
+Window_setContentAspectRatio :: proc "c" (self: ^Window, ratio: Size) {
+	msgSend(nil, self, "setContentAspectRatio:", ratio)
+}
+@(objc_type=Window, objc_name="contentMinSize")
+Window_contentMinSize :: proc "c" (self: ^Window) -> Size {
+	return msgSend(Size, self, "contentMinSize")
+}
+@(objc_type=Window, objc_name="setContentMinSize")
+Window_setContentMinSize :: proc "c" (self: ^Window, size: Size) {
+	msgSend(nil, self, "setContentMinSize:", size)
+}
+@(objc_type=Window, objc_name="setContentSize")
+Window_setContentSize :: proc "c" (self: ^Window, size: Size) {
+	msgSend(nil, self, "setContentSize:", size)
+}
+@(objc_type=Window, objc_name="contentMaxSize")
+Window_contentMaxSize :: proc "c" (self: ^Window) -> Size {
+	return msgSend(Size, self, "contentMaxSize")
+}
+@(objc_type=Window, objc_name="setContentMaxSize")
+Window_setContentMaxSize :: proc "c" (self: ^Window, size: Size) {
+	msgSend(nil, self, "setContentMaxSize:", size)
+}
+@(objc_type=Window, objc_name="contentResizeIncrements")
+Window_contentResizeIncrements :: proc "c" (self: ^Window) -> Size {
+	return msgSend(Size, self, "contentResizeIncrements")
+}
+@(objc_type=Window, objc_name="setContentResizeIncrements")
+Window_setContentResizeIncrements :: proc "c" (self: ^Window, increment: Size) {
+	msgSend(nil, self, "setContentResizeIncrements:", increment)
+}
+@(objc_type=Window, objc_name="contentLayoutGuide")
+Window_contentLayoutGuide :: proc "c" (self: ^Window) -> id {
+	return msgSend(id, self, "contentLayoutGuide")
+}
+@(objc_type=Window, objc_name="contentLayoutRect")
+Window_contentLayoutRect :: proc "c" (self: ^Window) -> Rect {
+	return msgSend(Rect, self, "contentLayoutRect")
+}
+@(objc_type=Window, objc_name="maxFullScreenContentSize")
+Window_maxFullScreenContentSize :: proc "c" (self: ^Window) -> Size {
+	return msgSend(Size, self, "maxFullScreenContentSize")
+}
+@(objc_type=Window, objc_name="setMaxFullScreenContentSize")
+Window_setMaxFullScreenContentSize :: proc "c" (self: ^Window, size: Size) {
+	msgSend(nil, self, "setMaxFullScreenContentSize:", size)
+}
+@(objc_type=Window, objc_name="minFullScreenContentSize")
+Window_minFullScreenContentSize :: proc "c" (self: ^Window) -> Size {
+	return msgSend(Size, self, "minFullScreenContentSize")
+}
+@(objc_type=Window, objc_name="setMinFullScreenContentSize")
+Window_setMinFullScreenContentSize :: proc "c" (self: ^Window, size: Size) {
+	msgSend(nil, self, "setMinFullScreenContentSize:", size)
+}
+
+// Managing Window Layers
+@(objc_type=Window, objc_name="orderOut")
+Window_orderOut :: proc "c" (self: ^Window, sender: id) {
+	msgSend(nil, self, "orderOut:", sender)
+}
+@(objc_type=Window, objc_name="orderBack")
+Window_orderBack :: proc "c" (self: ^Window, sender: id) {
+	msgSend(nil, self, "orderBack:", sender)
+}
+@(objc_type=Window, objc_name="orderFront")
+Window_orderFront :: proc "c" (self: ^Window, sender: id) {
+	msgSend(nil, self, "orderFront:", sender)
+}
+@(objc_type=Window, objc_name="orderFrontRegardless")
+Window_orderFrontRegardless :: proc "c" (self: ^Window) {
+	msgSend(nil, self, "orderFrontRegardless")
+}
+WindowOrderingMode :: enum Integer {
+	Above =  1,
+	Out   =  0,
+	Below = -1,
+}
+@(objc_type=Window, objc_name="orderWindowRelativeTo")
+Window_orderWindowRelativeTo :: proc "c" (self: ^Window, place: WindowOrderingMode, other_win: Integer) {
+	msgSend(nil, self, "orderWindow:relativeTo:", place, other_win)
+}
+WindowLevel :: Integer
+NormalWindowLevel     :: 0
+FloatingWindowLevel   :: 3
+SubmenuWindowLevel    :: 3
+TornOffWindowLevel    :: 3
+ModalPanelWindowLevel :: 8
+DockWindowLevel       :: 20 // Deprecated
+MainMenuLevel         :: 24
+StatusLevel           :: 25
+PopUpMenuLevel        :: 101
+ScreenSaverLevel      :: 1000
+@(objc_type=Window, objc_name="level")
+Window_level :: proc "c" (self: ^Window) -> WindowLevel {
+	return msgSend(WindowLevel, self, "level")
+}
+@(objc_type=Window, objc_name="setLevel")
+Window_setLevel :: proc "c" (self: ^Window, level: WindowLevel) {
+	msgSend(nil, self, "setLevel:", level)
+}
+
 @(objc_type=Window, objc_name="opaque")
 Window_opaque :: proc "c" (self: ^Window) -> BOOL {
 	return msgSend(BOOL, self, "opaque")
@@ -757,17 +948,9 @@ Window_hasTitleBar :: proc "c" (self: ^Window) -> BOOL {
 Window_orderedIndex :: proc "c" (self: ^Window) -> Integer {
 	return msgSend(Integer, self, "orderedIndex")
 }
-@(objc_type=Window, objc_name="setMinSize")
-Window_setMinSize :: proc "c" (self: ^Window, size: Size) {
-	msgSend(nil, self, "setMinSize:", size)
-}
 @(objc_type=Window, objc_name="setTitleVisibility")
 Window_setTitleVisibility :: proc "c" (self: ^Window, visibility: Window_Title_Visibility) {
 	msgSend(nil, self, "setTitleVisibility:", visibility)
-}
-@(objc_type=Window, objc_name="performZoom")
-Window_performZoom :: proc "c" (self: ^Window) {
-	msgSend(nil, self, "performZoom:", self)
 }
 @(objc_type=Window, objc_name="setFrameAutosaveName")
 NSWindow_setFrameAutosaveName :: proc "c" (self: ^Window, name: ^String) {

--- a/core/sys/darwin/Foundation/NSWindow.odin
+++ b/core/sys/darwin/Foundation/NSWindow.odin
@@ -848,6 +848,200 @@ Window_setLevel :: proc "c" (self: ^Window, level: WindowLevel) {
 	msgSend(nil, self, "setLevel:", level)
 }
 
+// Managing Key Status
+@(objc_type=Window, objc_name="isKeyWindow")
+Window_isKeyWindow :: proc "c" (self: ^Window) -> BOOL {
+	return msgSend(BOOL, self, "isKeyWindow")
+}
+@(objc_type=Window, objc_name="canBecomeKeyWindow")
+Window_canBecomeKeyWindow :: proc "c" (self: ^Window) -> BOOL {
+	return msgSend(BOOL, self, "canBecomeKeyWindow")
+}
+@(objc_type=Window, objc_name="makeKeyWindow")
+Window_makeKeyWindow :: proc "c" (self: ^Window) {
+	msgSend(nil, self, "makeKeyWindow")
+}
+@(objc_type=Window, objc_name="makeKeyAndOrderFront")
+Window_makeKeyAndOrderFront :: proc "c" (self: ^Window, sender: id) {
+	msgSend(nil, self, "makeKeyAndOrderFront:", sender)
+}
+
+// Managing Main Status
+@(objc_type=Window, objc_name="isMainWindow")
+Window_isMainWindow :: proc "c" (self: ^Window) -> BOOL {
+	return msgSend(BOOL, self, "isMainWindow")
+}
+@(objc_type=Window, objc_name="canBecomeMainWindow")
+Window_canBecomeMainWindow :: proc "c" (self: ^Window) -> BOOL {
+	return msgSend(BOOL, self, "canBecomeMainWindow")
+}
+@(objc_type=Window, objc_name="makeMainWindow")
+Window_makeMainWindow :: proc "c" (self: ^Window) {
+	msgSend(nil, self, "makeMainWindow")
+}
+
+// Managing Toolbars
+@(objc_type=Window, objc_name="toolbar")
+Window_toolbar :: proc "c" (self: ^Window) -> ^Toolbar {
+	return msgSend(^Toolbar, self, "toolbar")
+}
+@(objc_type=Window, objc_name="setToolbar")
+Window_setToolbar :: proc "c" (self: ^Window, toolbar: ^Toolbar) {
+	msgSend(nil, self, "setToolbar:", toolbar)
+}
+@(objc_type=Window, objc_name="toggleToolbarShown")
+Window_toggleToolbarShown :: proc "c" (self: ^Window, sender: id) {
+	msgSend(nil, self, "toggleToolbarShown:", sender)
+}
+@(objc_type=Window, objc_name="runToolbarCustomizationPalette")
+Window_runToolbarCustomizationPalette :: proc "c" (self: ^Window, sender: id) {
+	msgSend(nil, self, "runToolbarCustomizationPalette:", sender)
+}
+
+// Managing Attached Windows
+@(objc_type=Window, objc_name="childWindows")
+Window_childWindows :: proc "c" (self: ^Window) -> ^Array {
+	return msgSend(^Array, self, "childWindows")
+}
+@(objc_type=Window, objc_name="addChildWindowOrdered")
+Window_addChildWindowOrdered :: proc "c" (self: ^Window, child: ^Window, place: WindowOrderingMode) {
+	msgSend(nil, self, "addChildWindow:ordered:", child, place)
+}
+@(objc_type=Window, objc_name="removeChildWindow")
+Window_removeChildWindow :: proc "c" (self: ^Window, child: ^Window) {
+	msgSend(nil, self, "removeChildWindow:", child)
+}
+@(objc_type=Window, objc_name="parentWindow")
+Window_parentWindow :: proc "c" (self: ^Window) -> ^Window {
+	return msgSend(^Window, self, "parentWindow")
+}
+// There is a setter for parentWindow, but omitting due to the documentation:
+// This property should be set from a subclass when it is overridden by a subclass’s implementation. It should not be set otherwise.
+
+// Managing Titles
+@(objc_type=Window, objc_name="title")
+Window_title :: proc "c" (self: ^Window) -> ^String {
+	return msgSend(^String, self, "title")
+}
+@(objc_type=Window, objc_name="setTitle")
+Window_setTitle :: proc "c" (self: ^Window, title: ^String) {
+	msgSend(nil, self, "setTitle:", title)
+}
+@(objc_type=Window, objc_name="subtitle")
+Window_subtitle :: proc "c" (self: ^Window) -> ^String {
+	return msgSend(^String, self, "subtitle")
+}
+@(objc_type=Window, objc_name="setSubtitle")
+Window_setSubtitle :: proc "c" (self: ^Window, subtitle: ^String) {
+	msgSend(nil, self, "setSubtitle:", subtitle)
+}
+WindowTitleVisibility :: enum Integer {
+	Visible = 0,
+	Hidden  = 1,
+}
+@(objc_type=Window, objc_name="titleVisibility")
+Window_titleVisibility :: proc "c" (self: ^Window) -> WindowTitleVisibility {
+	return msgSend(WindowTitleVisibility, self, "titleVisibility")
+}
+@(objc_type=Window, objc_name="setTitleVisibility")
+Window_setTitleVisibility :: proc "c" (self: ^Window, visibility: WindowTitleVisibility) {
+	msgSend(nil, self, "setTitleVisibility:", visibility)
+}
+@(objc_type=Window, objc_name="setTitleWithRepresentedFilename")
+Window_setTitleWithRepresentedFilename :: proc "c" (self: ^Window, filename: ^String) {
+	msgSend(nil, self, "setTitleWithRepresentedFilename:", filename)
+}
+@(objc_type=Window, objc_name="representedFilename")
+Window_representedFilename :: proc "c" (self: ^Window) -> ^String {
+	return msgSend(^String, self, "representedFilename")
+}
+@(objc_type=Window, objc_name="setRepresentedFilename")
+Window_setRepresentedFilename :: proc "c" (self: ^Window, filename: ^String) {
+	msgSend(nil, self, "setRepresentedFilename:", filename)
+}
+@(objc_type=Window, objc_name="representedURL")
+Window_representedURL :: proc "c" (self: ^Window) -> ^URL {
+	return msgSend(^URL, self, "representedURL")
+}
+@(objc_type=Window, objc_name="setRepresentedURL")
+Window_setRepresentedURL :: proc "c" (self: ^Window, url: ^URL) {
+	msgSend(nil, self, "setRepresentedURL:", url)
+}
+
+// Moving Windows
+@(objc_type=Window, objc_name="isMovableByWindowBackground")
+Window_isMovableByWindowBackground :: proc "c" (self: ^Window) -> BOOL {
+	return msgSend(BOOL, self, "isMovableByWindowBackground")
+}
+@(objc_type=Window, objc_name="setMovableByWindowBackground")
+Window_setMovableByWindowBackground :: proc "c" (self: ^Window, movable: BOOL) {
+	msgSend(nil, self, "setMovableByWindowBackground:", movable)
+}
+@(objc_type=Window, objc_name="isMovable")
+Window_isMovable :: proc "c" (self: ^Window) -> BOOL {
+	return msgSend(BOOL, self, "isMovable")
+}
+@(objc_type=Window, objc_name="setMovable")
+Window_setMovable :: proc "c" (self: ^Window, movable: BOOL) {
+	msgSend(nil, self, "setMovable:", movable)
+}
+@(objc_type=Window, objc_name="center")
+Window_center :: proc "c" (self: ^Window) {
+	msgSend(nil, self, "center")
+}
+
+// Closing Windows
+@(objc_type=Window, objc_name="performClose")
+Window_performClose :: proc "c" (self: ^Window, sender: id) {
+	msgSend(nil, self, "performClose:", sender)
+}
+@(objc_type=Window, objc_name="close")
+Window_close :: proc "c" (self: ^Window) {
+	msgSend(nil, self, "close")
+}
+@(objc_type=Window, objc_name="isReleasedWhenClosed")
+Window_isReleasedWhenClosed :: proc "c" (self: ^Window) -> BOOL {
+	return msgSend(BOOL, self, "isReleasedWhenClosed")
+}
+@(objc_type=Window, objc_name="setReleasedWhenClosed")
+Window_setReleasedWhenClosed :: proc "c" (self: ^Window, release: BOOL) {
+	msgSend(BOOL, self, "setReleasedWhenClosed:", release)
+}
+
+// Minimizing Windows
+@(objc_type=Window, objc_name="isMiniaturized")
+Window_isMiniaturized :: proc "c" (self: ^Window) -> BOOL {
+	return msgSend(BOOL, self, "isMiniaturized")
+}
+@(objc_type=Window, objc_name="performMiniaturize")
+Window_performMiniaturize :: proc "c" (self: ^Window, sender: id) {
+	msgSend(nil, self, "performMiniaturize:", sender)
+}
+@(objc_type=Window, objc_name="miniaturize")
+Window_miniaturize :: proc "c" (self: ^Window, sender: id) {
+	msgSend(nil, self, "miniaturize:", sender)
+}
+@(objc_type=Window, objc_name="deminiaturize")
+Window_deminiaturize :: proc "c" (self: ^Window, sender: id) {
+	msgSend(nil, self, "deminiaturize:", sender)
+}
+@(objc_type=Window, objc_name="miniwindowImage")
+Window_miniwindowImage :: proc "c" (self: ^Window) -> ^Image {
+	return msgSend(^Image, self, "miniwindowImage")
+}
+@(objc_type=Window, objc_name="setMiniwindowImage")
+Window_setMiniwindowImage :: proc "c" (self: ^Window, image: ^Image) {
+	msgSend(nil, self, "setMiniwindowImage:", image)
+}
+@(objc_type=Window, objc_name="miniwindowTitle")
+Window_miniwindowTitle :: proc "c" (self: ^Window) -> ^String {
+	return msgSend(^String, self, "miniwindowTitle")
+}
+@(objc_type=Window, objc_name="setMiniwindowTitle")
+Window_setMiniwindowTitle :: proc "c" (self: ^Window, title: ^String) {
+	msgSend(nil, self, "setMiniwindowTitle:", title)
+}
+
 @(objc_type=Window, objc_name="opaque")
 Window_opaque :: proc "c" (self: ^Window) -> BOOL {
 	return msgSend(BOOL, self, "opaque")
@@ -864,33 +1058,13 @@ Window_backgroundColor :: proc "c" (self: ^Window) -> ^Color {
 Window_setBackgroundColor :: proc "c" (self: ^Window, color: ^Color) {
 	msgSend(nil, self, "setBackgroundColor:", color)
 }
-@(objc_type=Window, objc_name="makeKeyAndOrderFront")
-Window_makeKeyAndOrderFront :: proc "c" (self: ^Window, key: ^Object) {
-	msgSend(nil, self, "makeKeyAndOrderFront:", key)
-}
-@(objc_type=Window, objc_name="setTitle")
-Window_setTitle :: proc "c" (self: ^Window, title: ^String) {
-	msgSend(nil, self, "setTitle:", title)
-}
 @(objc_type=Window, objc_name="setTitlebarAppearsTransparent")
 Window_setTitlebarAppearsTransparent :: proc "c" (self: ^Window, ok: BOOL) {
 	msgSend(nil, self, "setTitlebarAppearsTransparent:", ok)
 }
-@(objc_type=Window, objc_name="setMovable")
-Window_setMovable :: proc "c" (self: ^Window, ok: BOOL) {
-	msgSend(nil, self, "setMovable:", ok)
-}
-@(objc_type=Window, objc_name="setMovableByWindowBackground")
-Window_setMovableByWindowBackground :: proc "c" (self: ^Window, ok: BOOL) {
-	msgSend(nil, self, "setMovableByWindowBackground:", ok)
-}
 @(objc_type=Window, objc_name="setStyleMask")
 Window_setStyleMask :: proc "c" (self: ^Window, style_mask: WindowStyleMask) {
 	msgSend(nil, self, "setStyleMask:", style_mask)
-}
-@(objc_type=Window, objc_name="close")
-Window_close :: proc "c" (self: ^Window) {
-	msgSend(nil, self, "close")
 }
 @(objc_type=Window, objc_name="setDelegate")
 Window_setDelegate :: proc "c" (self: ^Window, delegate: ^WindowDelegate) {
@@ -948,10 +1122,6 @@ Window_hasTitleBar :: proc "c" (self: ^Window) -> BOOL {
 Window_orderedIndex :: proc "c" (self: ^Window) -> Integer {
 	return msgSend(Integer, self, "orderedIndex")
 }
-@(objc_type=Window, objc_name="setTitleVisibility")
-Window_setTitleVisibility :: proc "c" (self: ^Window, visibility: Window_Title_Visibility) {
-	msgSend(nil, self, "setTitleVisibility:", visibility)
-}
 @(objc_type=Window, objc_name="setFrameAutosaveName")
 NSWindow_setFrameAutosaveName :: proc "c" (self: ^Window, name: ^String) {
 	msgSend(nil, self, "setFrameAutosaveName:", name)
@@ -959,8 +1129,4 @@ NSWindow_setFrameAutosaveName :: proc "c" (self: ^Window, name: ^String) {
 @(objc_type=Window, objc_name="performWindowDragWithEvent")
 Window_performWindowDragWithEvent :: proc "c" (self: ^Window, event: ^Event) {
 	msgSend(nil, self, "performWindowDragWithEvent:", event)
-}
-@(objc_type=Window, objc_name="setToolbar")
-Window_setToolbar :: proc "c" (self: ^Window, toolbar: ^Toolbar) {
-	msgSend(nil, self, "setToolbar:", toolbar)
 }


### PR DESCRIPTION
Tested each manually to ensure they work, except a few that are hard to visually or log verify; for those they at least run without exceptions.

There is one removed function in here that didn't work: Window_setFrame. Which gives:
'NSInvalidArgumentException', reason: '-[NSWindow setFrame:]: unrecognized selector...' when used, as frame is a readonly property on the Window.

I've grouped and ordered them according to how they show up in https://developer.apple.com/documentation/appkit/nswindow/frame?language=objc for lack of a better idea.