### PR TITLE
Fix a couple `quaternion` bugs

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -2990,7 +2990,7 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 			gbString ty = type_to_string(xyzw[1].type);
 			gbString tz = type_to_string(xyzw[2].type);
 			gbString tw = type_to_string(xyzw[3].type);
-			error(call, "Mismatched types to 'quaternion', 'x=%s' vs 'y=%s' vs 'z=%s' vs 'w=%s'", tx, ty, tz, tw);
+			error(call, "Mismatched types to 'quaternion', 'w=%s' vs 'x=%s' vs 'y=%s' vs 'z=%s'", tw, tx, ty, tz);
 			gb_string_free(tw);
 			gb_string_free(tz);
 			gb_string_free(ty);


### PR DESCRIPTION
Fixes #2079

Also fixes an unreported bug I found while fixing that bug, which is that if you try to make a `real=0, real=1, real=2, real=3` quaternion, the compiler fails the upcoming assert.

Hopefully order of the named arguments shouldn't matter in how this finds which type to use first (it just picks the first typed numeric one it finds), as they should all be the same type; we don't support quaternions with `f16` for one field and `f32` for another, for example.