### PR TITLE
add a missing nullptr check

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -263,11 +263,13 @@ gb_internal void check_did_you_mean_scope(String const &name, Scope *scope, char
 
 gb_internal Entity *entity_from_expr(Ast *expr) {
 	expr = unparen_expr(expr);
-	switch (expr->kind) {
-	case Ast_Ident:
-		return expr->Ident.entity;
-	case Ast_SelectorExpr:
-		return entity_from_expr(expr->SelectorExpr.selector);
+	if (expr != nullptr) {
+		switch (expr->kind) {
+			case Ast_Ident:
+				return expr->Ident.entity;
+			case Ast_SelectorExpr:
+				return entity_from_expr(expr->SelectorExpr.selector);
+		}
 	}
 	return nullptr;
 }

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -263,13 +263,14 @@ gb_internal void check_did_you_mean_scope(String const &name, Scope *scope, char
 
 gb_internal Entity *entity_from_expr(Ast *expr) {
 	expr = unparen_expr(expr);
-	if (expr != nullptr) {
-		switch (expr->kind) {
-			case Ast_Ident:
-				return expr->Ident.entity;
-			case Ast_SelectorExpr:
-				return entity_from_expr(expr->SelectorExpr.selector);
-		}
+	if (expr == nullptr) {
+		return nullptr;
+	}
+	switch (expr->kind) {
+	case Ast_Ident:
+		return expr->Ident.entity;
+	case Ast_SelectorExpr:
+		return entity_from_expr(expr->SelectorExpr.selector);
 	}
 	return nullptr;
 }


### PR DESCRIPTION
When I build my package with `odin build .`, the compiler segfaults. The reason was a missing `nullptr` check. After that fix, the package now builds, and the compiler does not segfault anymore (at least in my scenario).