### PR TITLE
Be strict with type switch case column alignment too

### DIFF
--- a/src/check_stmt.cpp
+++ b/src/check_stmt.cpp
@@ -1593,6 +1593,20 @@ gb_internal void check_type_switch_stmt(CheckerContext *ctx, Ast *node, u32 mod_
 			error_line("\tSuggestion: Was '#partial switch' wanted?\n");
 		}
 	}
+
+	if (build_context.strict_style) {
+		Token stok = ss->token;
+		for_array(i, bs->stmts) {
+			Ast *stmt = bs->stmts[i];
+			if (stmt->kind != Ast_CaseClause) {
+				continue;
+			}
+			Token ctok = stmt->CaseClause.token;
+			if (ctok.pos.column > stok.pos.column) {
+				error(ctok, "With '-strict-style', 'case' statements must share the same column as the 'switch' token");
+			}
+		}
+	}
 }
 
 gb_internal void check_block_stmt_for_errors(CheckerContext *ctx, Ast *body)  {


### PR DESCRIPTION
This copies the same block used for regular switch cases.

Fixes #4673