### PR TITLE
Change `os2.user_*` on Windows to use `SHGetKnownFolderPath`.

### DIFF
--- a/core/os/os2/user_windows.odin
+++ b/core/os/os2/user_windows.odin
@@ -1,0 +1,20 @@
+package os2
+
+import "base:runtime"
+@(require) import win32 "core:sys/windows"
+
+@(require_results)
+_get_known_folder_path :: proc(rfid: win32.REFKNOWNFOLDERID, allocator: runtime.Allocator) -> (dir: string, err: Error) {
+	// https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath
+	// See also `known_folders.odin` in `core:sys/windows` for the GUIDs.
+	path_w: win32.LPWSTR
+	res  := win32.SHGetKnownFolderPath(rfid, 0, nil, &path_w)
+	defer win32.CoTaskMemFree(path_w)
+
+	if res != 0 {
+		return "", .Invalid_Path
+	}
+
+	dir, _ = win32.wstring_to_utf8(path_w, -1, allocator)
+	return
+}


### PR DESCRIPTION
Known folders can be redirected using `SHSetKnownFolderPath`, and it's a bit iffy to rely on environment variables.

This also more easily allows us to add `user_*_dir` procedures for the remaining 139 GUIDs in `known_folders.odin`, provided they have equivalents on other platforms.