### PR TITLE
[parser.cpp] - packages with `.odin` in the name no longer attempt to parse as odin files

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -5794,7 +5794,7 @@ gb_internal AstPackage *try_add_import_path(Parser *p, String path, String const
 	for (FileInfo fi : list) {
 		String name = fi.name;
 		String ext = path_extension(name);
-		if (ext == FILE_EXT) {
+		if (ext == FILE_EXT && !path_is_directory(name)) {
 			files_with_ext += 1;
 		}
 		if (ext == FILE_EXT && !is_excluded_target_filename(name)) {
@@ -5819,7 +5819,7 @@ gb_internal AstPackage *try_add_import_path(Parser *p, String path, String const
 	for (FileInfo fi : list) {
 		String name = fi.name;
 		String ext = path_extension(name);
-		if (ext == FILE_EXT) {
+		if (ext == FILE_EXT && !path_is_directory(name)) {
 			if (is_excluded_target_filename(name)) {
 				continue;
 			}


### PR DESCRIPTION
previously, if the following directory structure existed:
```
├──  my_fancy_package.odin/
└──  main.odin
```
the compiler would attempt to parse the directory as if it were a file, this adds checks to ensure that the files are in fact files before adding them to the parser's task list