### PR TITLE
Jfm sync chan refactor

### DIFF
--- a/core/sync/chan/chan.odin
+++ b/core/sync/chan/chan.odin
@@ -1116,11 +1116,13 @@ Select_Status :: enum {
 
 
 /*
-Attempts to either send or receive messages on the specified channels.
+Attempts to either send or receive messages on the specified channels without blocking.
 
 `select_raw` first identifies which channels have messages ready to be received
 and which are available for sending. It then randomly selects one operation
 (either a send or receive) to perform.
+
+If no channels have messages ready, the procedure is a noop.
 
 Note: Each message in `send_msgs` corresponds to the send channel at the same index in `sends`.
 
@@ -1154,18 +1156,18 @@ Example:
 		// where the value from the read should be stored
 		received_value: int
 
-		idx, ok := chan.select_raw(receive_chans[:], send_chans[:], msgs[:], &received_value)
+		idx, ok := chan.try_select_raw(receive_chans[:], send_chans[:], msgs[:], &received_value)
 		fmt.println("SELECT:        ", idx, ok)
 		fmt.println("RECEIVED VALUE ", received_value)
 
-		idx, ok = chan.select_raw(receive_chans[:], send_chans[:], msgs[:], &received_value)
+		idx, ok = chan.try_select_raw(receive_chans[:], send_chans[:], msgs[:], &received_value)
 		fmt.println("SELECT:        ", idx, ok)
 		fmt.println("RECEIVED VALUE ", received_value)
 
 		// closing of a channel also affects the select operation
 		chan.close(c)
 
-		idx, ok = chan.select_raw(receive_chans[:], send_chans[:], msgs[:], &received_value)
+		idx, ok = chan.try_select_raw(receive_chans[:], send_chans[:], msgs[:], &received_value)
 		fmt.println("SELECT:        ", idx, ok)
 	}
 
@@ -1179,7 +1181,7 @@ Output:
 
 */
 @(require_results)
-select_raw :: proc "odin" (recvs: []^Raw_Chan, sends: []^Raw_Chan, send_msgs: []rawptr, recv_out: rawptr) -> (select_idx: int, status: Select_Status) #no_bounds_check {
+try_select_raw :: proc "odin" (recvs: []^Raw_Chan, sends: []^Raw_Chan, send_msgs: []rawptr, recv_out: rawptr) -> (select_idx: int, status: Select_Status) #no_bounds_check {
 	Select_Op :: struct {
 		idx:     int, // local to the slice that was given
 		is_recv: bool,

--- a/core/sync/chan/chan.odin
+++ b/core/sync/chan/chan.odin
@@ -1126,7 +1126,7 @@ Select_Status :: enum {
 /*
 Attempts to either send or receive messages on the specified channels without blocking.
 
-`select_raw` first identifies which channels have messages ready to be received
+`try_select_raw` first identifies which channels have messages ready to be received
 and which are available for sending. It then randomly selects one operation
 (either a send or receive) to perform.
 

--- a/core/sync/chan/chan.odin
+++ b/core/sync/chan/chan.odin
@@ -1205,7 +1205,10 @@ try_select_raw :: proc "odin" (recvs: []^Raw_Chan, sends: []^Raw_Chan, send_msgs
 		}
 
 		for c, i in sends {
-			if can_send(c) {
+			if i > builtin.len(send_msgs)-1 || send_msgs[i] == nil {
+				continue
+			}
+			if can_send(c)  {
 				candidates[count] = {
 					is_recv = false,
 					idx     = i,

--- a/core/sync/chan/chan.odin
+++ b/core/sync/chan/chan.odin
@@ -7,6 +7,14 @@ import "core:mem"
 import "core:sync"
 import "core:math/rand"
 
+when ODIN_TEST {
+/*
+Hook for testing _try_select_raw allowing the test harness to manipulate the
+channels prior to the select actually operating on them.
+*/
+__try_select_raw_pause : proc() = nil
+}
+
 /*
 Determines what operations `Chan` supports.
 */
@@ -1219,6 +1227,12 @@ try_select_raw :: proc "odin" (recvs: []^Raw_Chan, sends: []^Raw_Chan, send_msgs
 
 		if count == 0 {
 			return -1, .None
+		}
+
+		when ODIN_TEST {
+			if __try_select_raw_pause != nil {
+				__try_select_raw_pause()
+			}
 		}
 
 		candidate_idx := rand.int_max(count) if count > 0 else 0

--- a/core/sync/chan/chan.odin
+++ b/core/sync/chan/chan.odin
@@ -1254,6 +1254,11 @@ try_select_raw :: proc "odin" (recvs: []^Raw_Chan, sends: []^Raw_Chan, send_msgs
 	}
 }
 
+@(require_results, deprecated = "use try_select_raw")
+select_raw :: proc "odin" (recvs: []^Raw_Chan, sends: []^Raw_Chan, send_msgs: []rawptr, recv_out: rawptr) -> (select_idx: int, status: Select_Status) #no_bounds_check {
+	return try_select_raw(recvs, sends, send_msgs, recv_out)
+}
+
 /*
 `Raw_Queue` is a non-thread-safe queue implementation designed to store messages
 of fixed size and alignment.

--- a/tests/core/sync/chan/test_core_sync_chan.odin
+++ b/tests/core/sync/chan/test_core_sync_chan.odin
@@ -35,8 +35,6 @@ MAX_RAND    :: 32
 FAIL_TIME   :: 1 * time.Second
 SLEEP_TIME  :: 1 * time.Millisecond
 
-__global_context_for_test: rawptr
-
 comm_client :: proc(th: ^thread.Thread) {
 	data := cast(^Comm)th.data
 	manual_buffering := data.manual_buffering
@@ -383,6 +381,9 @@ test_try_select_raw_no_toctou :: proc(t: ^testing.T) {
 
 	assert(trigger_err == nil, "allocation failed")
 	defer chan.destroy(trigger)
+
+	@(static)
+	__global_context_for_test: rawptr
 
 	__global_context_for_test = &trigger
 	defer __global_context_for_test = nil


### PR DESCRIPTION
This PR addresses #5287: renaming `select_raw` to `try_select_raw` and fixes the TOCTOU by looping until the `can_{send,recv}` invariant holds. 

I recommend reviewing by commit to see each change in isolation. 

~TODO: I think this deserves a test harness. Currently `select_raw` doesn't seem to have a test.~ 

Tests added. 