### PR TITLE
Add `@(default_context)` and `intrinsics.__default_context`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
           ./odin test tests/core/normal.odin -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true
           ./odin test tests/core/speed.odin -file -all-packages -vet -strict-style -disallow-do -o:speed -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true
           ./odin test tests/vendor -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true
+          (cd tests/default_context; ./run.sh)
           (cd tests/issues; ./run.sh)
           ./odin check tests/benchmark -vet -strict-style -no-entry-point
 
@@ -68,6 +69,7 @@ jobs:
           ./odin test tests/core/normal.odin -file -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true
           ./odin test tests/core/speed.odin -file -all-packages -vet -strict-style -disallow-do -o:speed -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true
           ./odin test tests/vendor -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true
+          (cd tests/default_context; ./run.sh)
           (cd tests/issues; ./run.sh)
           ./odin check tests/benchmark -vet -strict-style -no-entry-point
   ci:
@@ -134,6 +136,10 @@ jobs:
         run: ./odin test tests/vendor -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -sanitize:address
       - name: Internals tests
         run: ./odin test tests/internal -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -sanitize:address
+      - name: Default Context test
+        run: |
+          cd tests/default_context
+          ./run.sh
       - name: GitHub Issue tests
         run: |
           cd tests/issues
@@ -240,6 +246,12 @@ jobs:
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
           odin test tests/internal -all-packages -vet -strict-style -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true -sanitize:address
+      - name: Default Context test
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+          cd tests/default_context
+          call run.bat
       - name: Check issues
         shell: cmd
         run: |

--- a/base/intrinsics/intrinsics.odin
+++ b/base/intrinsics/intrinsics.odin
@@ -378,4 +378,5 @@ valgrind_client_request :: proc(default: uintptr, request: uintptr, a0, a1, a2, 
 
 // Internal compiler use only
 
+__default_context :: proc(c: ^runtime.Context) -> bool ---
 __entry_point :: proc() ---

--- a/base/runtime/core.odin
+++ b/base/runtime/core.odin
@@ -709,9 +709,19 @@ __init_context_from_ptr :: proc "contextless" (c: ^Context, other: ^Context) {
 	__init_context(c)
 }
 
-@private
+// The linkage here must be weak to permit a main executable to override the
+// default context with a procedure of its choice in optimized builds because
+// of the use of single modules.
+//
+// Mind that this is the precise procedure called internally by the compiler to
+// initialize a context when calling "odin" procedures from builtins and such.
+@(private, linkage="strong" when ODIN_BUILD_MODE == .Executable else "weak")
 __init_context :: proc "contextless" (c: ^Context) {
 	if c == nil {
+		return
+	}
+	// Allow the procedure marked with `@(default_context)` to override us, if one exists.
+	if intrinsics.__default_context(c) {
 		return
 	}
 

--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -2225,6 +2225,26 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 	case BuiltinProc_objc_ivar_get:
 		return check_builtin_objc_procedure(c, operand, call, id, type_hint);
 
+	case BuiltinProc___default_context:
+	{
+		Operand arg = {};
+		check_expr(c, &arg, ce->args[0]);
+		if (arg.mode == Addressing_Invalid) {
+			operand->mode = Addressing_Invalid;
+			operand->type = t_invalid;
+			return false;
+		}
+		if (!are_types_identical(arg.type, t_context_ptr)) {
+			gbString s = expr_to_string(ce->args[0]);
+			error(ce->args[0], "Expected a type of '^runtime.Context' for argument to '__default_context', got '%s'", s);
+			gb_string_free(s);
+			return false;
+		}
+
+		operand->mode = Addressing_Value;
+		operand->type = t_bool;
+		break;
+	}
 	case BuiltinProc___entry_point:
 		operand->mode = Addressing_NoValue;
 		operand->type = nullptr;

--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -3737,6 +3737,15 @@ gb_internal DECL_ATTRIBUTE_PROC(proc_decl_attribute) {
 			error(elem, "Expected a string value for '%.*s'", LIT(name));
 		}
 		return true;
+	} else if (name == "default_context") {
+		if (value != nullptr) {
+			error(value, "'%.*s' expects no parameter", LIT(name));
+		}
+		if (build_context.build_mode != BuildMode_Executable) {
+			error(elem, "'%.*s' is only allowed in executable builds", LIT(name));
+		}
+		ac->default_context = true;
+		return true;
 	} else if (name == "entry_point_only") {
 		if (value != nullptr) {
 			error(value, "'%.*s' expects no parameter", LIT(name));

--- a/src/checker.hpp
+++ b/src/checker.hpp
@@ -136,6 +136,7 @@ struct AttributeContext {
 	bool    init                  : 1;
 	bool    fini                  : 1;
 	bool    set_cold              : 1;
+	bool    default_context       : 1;
 	bool    entry_point_only      : 1;
 	bool    instrumentation_enter : 1;
 	bool    instrumentation_exit  : 1;
@@ -438,6 +439,7 @@ struct CheckerInfo {
 	AstPackage *          runtime_package;
 	AstPackage *          init_package;
 	Scope *               init_scope;
+	Entity *              default_context;
 	Entity *              entry_point;
 	PtrSet<Entity *>      minimum_dependency_set;
 	BlockingMutex minimum_dependency_type_info_mutex;

--- a/src/checker_builtin_procs.hpp
+++ b/src/checker_builtin_procs.hpp
@@ -336,6 +336,7 @@ BuiltinProc__type_end,
 
 	BuiltinProc_procedure_of,
 
+	BuiltinProc___default_context,
 	BuiltinProc___entry_point,
 
 	BuiltinProc_objc_send,
@@ -689,6 +690,7 @@ gb_global BuiltinProc builtin_procs[BuiltinProc_COUNT] = {
 
 	{STR_LIT("procedure_of"), 1, false, Expr_Expr, BuiltinProcPkg_intrinsics},
 
+	{STR_LIT("__default_context"), 1, false, Expr_Stmt, BuiltinProcPkg_intrinsics},
 	{STR_LIT("__entry_point"), 0, false, Expr_Stmt, BuiltinProcPkg_intrinsics},
 
 	{STR_LIT("objc_send"),   3, true,  Expr_Expr, BuiltinProcPkg_intrinsics, false, true},

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -3079,6 +3079,19 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 			return res;
 		}
 
+	case BuiltinProc___default_context:
+		if (p->module->info->default_context) {
+			auto args = array_make<lbValue>(temporary_allocator(), 1);
+			args[0] = lb_emit_conv(p, lb_build_expr(p, ce->args[0]), t_rawptr);
+
+			lbValue default_context = lb_find_procedure_value_from_entity(p->module, p->module->info->default_context);
+			GB_ASSERT(default_context.value != nullptr);
+			lb_emit_call(p, default_context, args);
+
+			return lb_const_bool(p->module, t_llvm_bool, true);
+		} else {
+			return lb_const_bool(p->module, t_llvm_bool, false);
+		}
 	case BuiltinProc___entry_point:
 		if (p->module->info->entry_point) {
 			lbValue entry_point = lb_find_procedure_value_from_entity(p->module, p->module->info->entry_point);

--- a/tests/default_context/main.odin
+++ b/tests/default_context/main.odin
@@ -1,0 +1,83 @@
+package test_default_context
+
+import "base:intrinsics"
+import "base:runtime"
+
+import "userctx"
+
+TEST_TAG :: #config(TEST_TAG, "")
+USE_SHARED_CONTEXT :: #config(USE_SHARED_CONTEXT, false)
+
+when ODIN_OS == .Windows {
+	foreign import shared "shared.lib"
+} else when ODIN_OS == .Darwin {
+	foreign import shared "shared.dylib"
+} else {
+	foreign import shared "shared.so"
+}
+
+foreign shared {
+	shared_call :: proc "odin" () ---
+
+	// Foreign procedures may be used as the default context, so long as they
+	// follow the signature. This test will work the same whether we use the
+	// shared default context or the one in main.
+
+	@(default_context, disabled=!USE_SHARED_CONTEXT)
+	shared_context :: proc "contextless" (^runtime.Context) ---
+}
+
+
+global_user_context: userctx.User_Context
+
+@(default_context, disabled=USE_SHARED_CONTEXT)
+default_context :: proc "contextless" (c: ^runtime.Context) {
+	@static alert: bool
+
+	// NOTE: Only this pointer is set in the default context, nothing else.
+	// All allocations, logs, asserts, and such will fail.
+	c.user_ptr = &global_user_context
+	if !alert {
+		runtime.print_string("Default Context: main program   | ")
+		alert = true
+	}
+}
+
+@(init)
+p_init :: proc() {
+	userctx.set_flag(.Init)
+}
+
+// Global variables which are not referenced outside their initializer must be
+// `@require` or they and their called procedure will not be built in, even in
+// `-o:none`.
+@(require)
+set_by_global_initializer := init_by_return()
+init_by_return :: proc() -> int {
+	userctx.set_flag(.Global)
+	return 1
+}
+
+main :: proc() {
+	runtime.print_string("["+TEST_TAG+"]:")
+	for i in 0..<32-len(TEST_TAG) {
+		runtime.print_rune(' ')
+	}
+
+	userctx.set_flag(.Main)
+
+	shared_call()
+
+	success_mask: u64
+	for i in 0..<u64(max(userctx.Flag))+1 {
+		success_mask |= 1 << i
+	}
+
+	raw_bits := transmute(^u64)context.user_ptr
+	if raw_bits != nil && raw_bits^ == success_mask {
+		runtime.print_string("passed.\n")
+	} else {
+		runtime.print_string("FAILED.\n")
+		panic("The @(default_context) test [" + TEST_TAG + "] has failed.")
+	}
+}

--- a/tests/default_context/run.bat
+++ b/tests/default_context/run.bat
@@ -1,0 +1,45 @@
+@echo off
+
+set ODIN==..\..\odin
+
+%ODIN% build shared -build-mode:dll                                                                      || exit /b
+
+%ODIN% run .               -define:TEST_TAG="main:default/default"                                       || exit /b
+%ODIN% run . -o:none       -define:TEST_TAG="main:none/default"                                          || exit /b
+%ODIN% run . -o:size       -define:TEST_TAG="main:size/default"                                          || exit /b
+%ODIN% run . -o:speed      -define:TEST_TAG="main:speed/default"                                         || exit /b
+%ODIN% run . -o:aggressive -define:TEST_TAG="main:aggressive/default"                                    || exit /b
+
+%ODIN% run .               -define:TEST_TAG="shared:default/default"    -define:USE_SHARED_CONTEXT=true  || exit /b
+%ODIN% run . -o:none       -define:TEST_TAG="shared:none/default"       -define:USE_SHARED_CONTEXT=true  || exit /b
+%ODIN% run . -o:size       -define:TEST_TAG="shared:size/default"       -define:USE_SHARED_CONTEXT=true  || exit /b
+%ODIN% run . -o:speed      -define:TEST_TAG="shared:speed/default"      -define:USE_SHARED_CONTEXT=true  || exit /b
+%ODIN% run . -o:aggressive -define:TEST_TAG="shared:aggressive/default" -define:USE_SHARED_CONTEXT=true  || exit /b
+
+%ODIN% build shared -build-mode:dll -o:speed                                                             || exit /b
+
+%ODIN% run .               -define:TEST_TAG="main:default/speed"                                         || exit /b
+%ODIN% run . -o:none       -define:TEST_TAG="main:none/speed"                                            || exit /b
+%ODIN% run . -o:size       -define:TEST_TAG="main:size/speed"                                            || exit /b
+%ODIN% run . -o:speed      -define:TEST_TAG="main:speed/speed"                                           || exit /b
+%ODIN% run . -o:aggressive -define:TEST_TAG="main:aggressive/speed"                                      || exit /b
+
+%ODIN% run .               -define:TEST_TAG="shared:default/speed"    -define:USE_SHARED_CONTEXT=true    || exit /b
+%ODIN% run . -o:none       -define:TEST_TAG="shared:none/speed"       -define:USE_SHARED_CONTEXT=true    || exit /b
+%ODIN% run . -o:size       -define:TEST_TAG="shared:size/speed"       -define:USE_SHARED_CONTEXT=true    || exit /b
+%ODIN% run . -o:speed      -define:TEST_TAG="shared:speed/speed"      -define:USE_SHARED_CONTEXT=true    || exit /b
+%ODIN% run . -o:aggressive -define:TEST_TAG="shared:aggressive/speed" -define:USE_SHARED_CONTEXT=true    || exit /b
+
+
+
+%ODIN% build shared -build-mode:dll -use-separate-modules                                                || exit /b
+
+%ODIN% run .               -define:TEST_TAG="main:default/separate"                                      || exit /b
+%ODIN% run .               -define:TEST_TAG="main:separate/separate" -use-separate-modules               || exit /b
+
+%ODIN% build shared -build-mode:dll -use-single-module                                                   || exit /b
+
+%ODIN% run .               -define:TEST_TAG="main:default/single"                                        || exit /b
+%ODIN% run .               -define:TEST_TAG="main:single/single" -use-single-module                      || exit /b
+
+del shared.lib

--- a/tests/default_context/run.sh
+++ b/tests/default_context/run.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+# The program will panic if anything fails, which should be enough to trigger the CI.
+set -e
+
+readonly ODIN=../../odin
+
+# The default context must be able to be found no matter what our linkage
+# situation is. By testing the various optimization modes, we can detect if
+# there are any issues with everyday usage.
+#
+# Normally, the compiler builds with separate modules for compilation speed,
+# but when a higher optimization level is used to make a release build, we
+# switch to a single module build. This can have consequences for the linkage
+# state of symbols.
+$ODIN build shared -build-mode:dll
+
+$ODIN run .               -define:TEST_TAG="main:default/default"
+$ODIN run . -o:none       -define:TEST_TAG="main:none/default"
+$ODIN run . -o:size       -define:TEST_TAG="main:size/default"
+$ODIN run . -o:speed      -define:TEST_TAG="main:speed/default"
+$ODIN run . -o:aggressive -define:TEST_TAG="main:aggressive/default"
+
+$ODIN run .               -define:TEST_TAG="shared:default/default"    -define:USE_SHARED_CONTEXT=true
+$ODIN run . -o:none       -define:TEST_TAG="shared:none/default"       -define:USE_SHARED_CONTEXT=true
+$ODIN run . -o:size       -define:TEST_TAG="shared:size/default"       -define:USE_SHARED_CONTEXT=true
+$ODIN run . -o:speed      -define:TEST_TAG="shared:speed/default"      -define:USE_SHARED_CONTEXT=true
+$ODIN run . -o:aggressive -define:TEST_TAG="shared:aggressive/default" -define:USE_SHARED_CONTEXT=true
+
+$ODIN build shared -build-mode:dll -o:speed
+
+$ODIN run .               -define:TEST_TAG="main:default/speed"
+$ODIN run . -o:none       -define:TEST_TAG="main:none/speed"
+$ODIN run . -o:size       -define:TEST_TAG="main:size/speed"
+$ODIN run . -o:speed      -define:TEST_TAG="main:speed/speed"
+$ODIN run . -o:aggressive -define:TEST_TAG="main:aggressive/speed"
+
+$ODIN run .               -define:TEST_TAG="shared:default/speed"    -define:USE_SHARED_CONTEXT=true
+$ODIN run . -o:none       -define:TEST_TAG="shared:none/speed"       -define:USE_SHARED_CONTEXT=true
+$ODIN run . -o:size       -define:TEST_TAG="shared:size/speed"       -define:USE_SHARED_CONTEXT=true
+$ODIN run . -o:speed      -define:TEST_TAG="shared:speed/speed"      -define:USE_SHARED_CONTEXT=true
+$ODIN run . -o:aggressive -define:TEST_TAG="shared:aggressive/speed" -define:USE_SHARED_CONTEXT=true
+
+# Here we'll explicitly test mixing module modes.
+
+$ODIN build shared -build-mode:dll -use-separate-modules
+
+$ODIN run .               -define:TEST_TAG="main:default/separate"
+$ODIN run .               -define:TEST_TAG="main:separate/separate" -use-separate-modules
+
+$ODIN build shared -build-mode:dll -use-single-module
+
+$ODIN run .               -define:TEST_TAG="main:default/single"
+$ODIN run .               -define:TEST_TAG="main:single/single" -use-single-module
+
+set +e
+
+# Darwin
+rm -f shared.dylib
+# Every other *nix-like
+rm -f shared.so

--- a/tests/default_context/shared/shared.odin
+++ b/tests/default_context/shared/shared.odin
@@ -27,7 +27,7 @@ shared_init_by_return :: proc() -> int {
 shared_global_user_context: userctx.User_Context
 
 @export
-shared_context :: proc(c: ^runtime.Context) {
+shared_context :: proc "contextless" (c: ^runtime.Context) {
 	@static alert: bool
 
 	c.user_ptr = &shared_global_user_context

--- a/tests/default_context/shared/shared.odin
+++ b/tests/default_context/shared/shared.odin
@@ -1,0 +1,38 @@
+package shared
+
+import "base:runtime"
+
+import "../userctx"
+
+@export
+shared_call :: proc() {
+	userctx.set_flag(.Shared)
+}
+
+@(private, init)
+shared_init :: proc() {
+	userctx.set_flag(.Shared_Init)
+}
+
+@(private, require)
+set_by_global_initializer := shared_init_by_return()
+
+@private
+shared_init_by_return :: proc() -> int {
+	userctx.set_flag(.Shared_Global)
+	return 1
+}
+
+@private
+shared_global_user_context: userctx.User_Context
+
+@export
+shared_context :: proc(c: ^runtime.Context) {
+	@static alert: bool
+
+	c.user_ptr = &shared_global_user_context
+	if !alert {
+		runtime.print_string("Default Context: shared library | ")
+		alert = true
+	}
+}

--- a/tests/default_context/userctx/userctx.odin
+++ b/tests/default_context/userctx/userctx.odin
@@ -1,0 +1,47 @@
+package userctx	
+
+import "base:runtime"
+
+Flag :: enum u64 {
+	Main,
+	Init,
+	Global,
+
+	Shared,
+	Shared_Init,
+	Shared_Global,
+}
+
+Flag_Set :: bit_set[Flag; u64]
+
+Flag_Names :: [Flag]string {
+	.Main          = "Main",
+	.Init          = "Init",
+	.Global        = "Global",
+	.Shared        = "Shared",
+	.Shared_Init   = "Shared_Init",
+	.Shared_Global = "Shared_Global"
+}
+
+User_Context :: struct {
+	flags: Flag_Set,
+}
+
+set_flag :: proc(flag: Flag) {
+	@(static, rodata) names := Flag_Names
+
+	if context.user_ptr == nil {
+		runtime.print_string("User_Context missing for: ")
+		runtime.print_string(names[flag])
+		runtime.print_string("\n")
+		return
+	}
+
+	when ODIN_DEBUG {
+		runtime.print_string("((@ ")
+		runtime.print_string(names[flag])
+		runtime.print_string("))")
+	}
+	uc := cast(^User_Context)context.user_ptr
+	uc.flags += {flag}
+}


### PR DESCRIPTION
The `__default_context` intrinsic calls the procedure marked with`@(default_context)` if it exists and returns true. If it does not exist, it returns false.

The `@(default_context)` is a file-scope procedure attribute that designates a procedure fitting the signature of `proc "contextless" (^runtime.Context)` as the procedure which will initialize all default contexts used throughout the entire program, including `@(init)` initializers, global variables, shared library initializers and shared global variables.

This change gives the programmer full control over the Odin context, and hence allocation, throughout all initialization that happens before `main` is reached.

Currently, `@(default_context)` is only supported in full executable builds, including `-build-mode:test`.

---

Fixes #5136 

Presently, the test suite I added for this is failing only on Windows. ~~I am unable to debug it for lack of the platform, so~~ any help is appreciated.

Given that only the shared global and shared `@(init)` are failing, I suspect there are linkage particulars involved here, possibly order-related. I had to set `__init_context` to be linkage `"weak"` by default and `"strong"` for the executable build in order to link correctly on Linux with a single module build in `-o:speed` mode. I tried setting it to `"internal"` and `"link_once"` for Windows only instead of `"weak"` to exhaust the other linkage options, but neither proved to work on my testing commits against the CI; ~~someone on Windows will have to investigate this, unfortunately.~~

Pinging @karl-zylinski to see if this works for the original problem and @laytan as I've iterated on his original idea.