### PR TITLE
Added missing parameter to `gettimeofday`

### DIFF
--- a/core/sys/linux/sys.odin
+++ b/core/sys/linux/sys.odin
@@ -1412,8 +1412,8 @@ umask :: proc "contextless" (mask: Mode) -> Mode {
 	Get current time.
 	Available since Linux 1.0.
 */
-gettimeofday :: proc "contextless" (tv: ^Time_Val, tz: ^Time_Zone) -> (Errno) {
-	ret := syscall(SYS_gettimeofday, tv, tz)
+gettimeofday :: proc "contextless" (tv: ^Time_Val) -> (Errno) {
+	ret := syscall(SYS_gettimeofday, tv, nil)
 	return Errno(-ret)
 }
 

--- a/core/sys/linux/sys.odin
+++ b/core/sys/linux/sys.odin
@@ -1412,8 +1412,8 @@ umask :: proc "contextless" (mask: Mode) -> Mode {
 	Get current time.
 	Available since Linux 1.0.
 */
-gettimeofday :: proc "contextless" (tv: ^Time_Val) -> (Errno) {
-	ret := syscall(SYS_gettimeofday, tv)
+gettimeofday :: proc "contextless" (tv: ^Time_Val, tz: ^Time_Zone) -> (Errno) {
+	ret := syscall(SYS_gettimeofday, tv, tz)
 	return Errno(-ret)
 }
 

--- a/core/sys/linux/types.odin
+++ b/core/sys/linux/types.odin
@@ -73,14 +73,6 @@ Time_Val :: struct {
 }
 
 /*
-	Represents a time zone.
-*/
-Time_Zone :: struct {
-	minutes_west: int,
-	dst_time:     int,
-}
-
-/*
 	Access and modification times for files
 */
 UTim_Buf :: struct {

--- a/core/sys/linux/types.odin
+++ b/core/sys/linux/types.odin
@@ -73,6 +73,14 @@ Time_Val :: struct {
 }
 
 /*
+	Represents a time zone.
+*/
+Time_Zone :: struct {
+	minutes_west: int,
+	dst_time:     int,
+}
+
+/*
 	Access and modification times for files
 */
 UTim_Buf :: struct {


### PR DESCRIPTION
The Linux `gettimeofday` syscall takes 2 parmeters (`tv` and `tz`), but the Odin binding only takes 1 (`tv`). This was causing `gettimeofday` to behave inconsistently on my machine. My fix adds a binding for the missing second parameter (`tz`).

The rest of this PR goes into exactly what inconsistent behavior I observed.

### Extra Details You Likely Don't Need to Read
The following code correctly prints seconds since the Epoch in a release build but prints only "Seconds: 0" in a debug build on my machine.

```
Odin:    dev-2025-06-nightly
OS:      Ubuntu 22.04.5 LTS, Linux 6.6.87.1-microsoft-standard-WSL2
CPU:     11th Gen Intel(R) Core(TM) i7-11700F @ 2.50GHz
RAM:     32028 MiB
Backend: LLVM 20.1.6
```

```
package gettimeofday_bug

import "core:fmt"
import "core:sys/linux"

main :: proc() {
    time: linux.Time_Val
    for {
        linux.gettimeofday(&time)
        fmt.printfln("Seconds: %v", time.seconds)
    }
}
```

In a debugger, right before the `syscall` instruction is executed, `RDI` is correctly set to `&time`, but `RSI` contains a non-zero garbage value (`RDI` and `RSI` are parameters 1 and 2 in the Linux syscall ABI, I think). After executing the syscall, `time.seconds` is equal to 0. But if you change the value of `RSI` to 0 before executing the syscall, `time.seconds` is set to seconds since Epoch.

This reliance on a register whose value the compiler assumes doesn't matter would explain why `gettimeofday` behaves inconsistently depending on release or debug build.
