### PR TITLE
Move negation in `internal_rat_to_float` to end of procedure

### DIFF
--- a/core/math/big/rat.odin
+++ b/core/math/big/rat.odin
@@ -378,9 +378,6 @@ internal_rat_to_float :: proc($T: typeid, z: ^Rat, allocator := context.allocato
 	}
 	
 	has_sign := a.sign != b.sign
-	defer if has_sign {
-		f = -builtin.abs(f)
-	}
 	
 	exp := alen - blen
 	a2, b2 := &Int{}, &Int{}
@@ -439,6 +436,9 @@ internal_rat_to_float :: proc($T: typeid, z: ^Rat, allocator := context.allocato
 	f = T(math.ldexp(f64(mantissa), exp-MSIZE1))
 	if math.is_inf(f, 0) {
 		exact = false
+	}
+	if has_sign {
+		f = -builtin.abs(f)
 	}
 	return
 }


### PR DESCRIPTION
This should cause a compiler error, due to the assignment to a named return value in a deferred block.

Fixes #4565