### PR TITLE
Let `-no-entry-point` work for Windows DLLs

### DIFF
--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -277,6 +277,9 @@ try_cross_linking:;
 
 			if (build_context.build_mode == BuildMode_DynamicLibrary) {
 				link_settings = gb_string_append_fmt(link_settings, " /DLL");
+				if (build_context.no_entry_point) {
+					link_settings = gb_string_append_fmt(link_settings, " /NOENTRY");
+				}
 			} else {
 				link_settings = gb_string_append_fmt(link_settings, " /ENTRY:mainCRTStartup");
 			}


### PR DESCRIPTION
Fixes #4660

According to [the documentation](https://learn.microsoft.com/en-us/cpp/build/reference/noentry-no-entry-point?view=msvc-170), `/NOENTRY` is for creating resource-only DLLs. I'm assuming something like this can be done with `#load` in order for this to be valid and make sense.