### PR TITLE
Fix #5321 (on Windows)

### DIFF
--- a/core/thread/thread_windows.odin
+++ b/core/thread/thread_windows.odin
@@ -31,8 +31,6 @@ _create :: proc(procedure: Thread_Proc, priority: Thread_Priority) -> ^Thread {
 			return 0
 		}
 
-		t.id = sync.current_thread_id()
-
 		{
 			init_context := t.init_context
 
@@ -76,6 +74,7 @@ _create :: proc(procedure: Thread_Proc, priority: Thread_Priority) -> ^Thread {
 	thread.procedure       = procedure
 	thread.win32_thread    = win32_thread
 	thread.win32_thread_id = win32_thread_id
+	thread.id              = int(win32_thread_id)
 
 	ok := win32.SetThreadPriority(win32_thread, _thread_priority_map[priority])
 	assert(ok == true)


### PR DESCRIPTION
Can't use this trick on unix because `pthread_t` differs across platforms and can be garbage compared to the later assigned `t.id`.