### PR TITLE
fix: pool_join hangs if no threads are started

### DIFF
--- a/core/thread/thread_pool.odin
+++ b/core/thread/thread_pool.odin
@@ -120,6 +120,20 @@ pool_join :: proc(pool: ^Pool) {
 
 	yield()
 
+	unstarted_count: int
+	for t in pool.threads {
+		flags := intrinsics.atomic_load(&t.flags)
+		if .Started not_in flags {
+			unstarted_count += 1
+		}
+	}
+
+	// most likely the user forgot to call `pool_start`
+	// exit here, so we don't hang forever
+	if len(pool.threads) == unstarted_count {
+		return
+	}
+
 	started_count: int
 	for started_count < len(pool.threads) {
 		started_count = 0


### PR DESCRIPTION
I was trying out thread pools just now and found this issue. I forgot to call `pool_start`, which made `pool_join` hang completely.

## Reproducible example

```odin
package main

import "core:fmt"
import "core:mem"
import "core:strings"
import "core:thread"

Job :: struct {
	data: string,
	pool: ^thread.Pool,
}

main :: proc() {
	pool: thread.Pool
	m_alloc: mem.Mutex_Allocator
	mem.mutex_allocator_init(&m_alloc, context.allocator)
	pool_allocator := mem.mutex_allocator(&m_alloc)

	thread.pool_init(&pool, pool_allocator, 10)
	// this makes pool_finish hang
	// thread.pool_start(&pool)
	defer thread.pool_destroy(&pool)

	j := Job {
		data = "oh my!",
		pool = &pool,
	}

	thread.pool_add_task(&pool, pool_allocator, do_work, &j)
	thread.pool_add_task(&pool, pool_allocator, do_work, &j)
	thread.pool_finish(&pool)
}

do_work :: proc(task: thread.Task) {
	data := (^Job)(task.data)
	fmt.printfln("doing work! data: %v", (^Job)(task.data))
}
```