### PR TITLE
Review `core/mem/allocators.odin`

### DIFF
--- a/base/runtime/core_builtin.odin
+++ b/base/runtime/core_builtin.odin
@@ -67,7 +67,7 @@ init_global_temporary_allocator :: proc(size: int, backup_allocator := context.a
 // Prefer the procedure group `copy`.
 @builtin
 copy_slice :: proc "contextless" (dst, src: $T/[]$E) -> int {
-	n := max(0, min(len(dst), len(src)))
+	n := min(len(dst), len(src))
 	if n > 0 {
 		intrinsics.mem_copy(raw_data(dst), raw_data(src), n*size_of(E))
 	}
@@ -80,7 +80,7 @@ copy_slice :: proc "contextless" (dst, src: $T/[]$E) -> int {
 // Prefer the procedure group `copy`.
 @builtin
 copy_from_string :: proc "contextless" (dst: $T/[]$E/u8, src: $S/string) -> int {
-	n := max(0, min(len(dst), len(src)))
+	n := min(len(dst), len(src))
 	if n > 0 {
 		intrinsics.mem_copy(raw_data(dst), raw_data(src), n)
 	}

--- a/base/runtime/default_temp_allocator_arena.odin
+++ b/base/runtime/default_temp_allocator_arena.odin
@@ -1,7 +1,7 @@
 package runtime
 
 import "base:intrinsics"
-import "base:sanitizer"
+// import "base:sanitizer"
 
 DEFAULT_ARENA_GROWING_MINIMUM_BLOCK_SIZE :: uint(DEFAULT_TEMP_ALLOCATOR_BACKING_SIZE)
 
@@ -44,7 +44,7 @@ memory_block_alloc :: proc(allocator: Allocator, capacity: uint, alignment: uint
 	block.base = ([^]byte)(uintptr(block) + base_offset)
 	block.capacity = uint(end - uintptr(block.base))
 
-	sanitizer.address_poison(block.base, block.capacity)
+	// sanitizer.address_poison(block.base, block.capacity)
 
 	// Should be zeroed
 	assert(block.used == 0)
@@ -55,7 +55,7 @@ memory_block_alloc :: proc(allocator: Allocator, capacity: uint, alignment: uint
 memory_block_dealloc :: proc(block_to_free: ^Memory_Block, loc := #caller_location) {
 	if block_to_free != nil {
 		allocator := block_to_free.allocator
-		sanitizer.address_unpoison(block_to_free.base, block_to_free.capacity)
+		// sanitizer.address_unpoison(block_to_free.base, block_to_free.capacity)
 		mem_free(block_to_free, allocator, loc)
 	}
 }
@@ -87,7 +87,7 @@ alloc_from_memory_block :: proc(block: ^Memory_Block, min_size, alignment: uint)
 		return
 	}
 	data = block.base[block.used+alignment_offset:][:min_size]
-	sanitizer.address_unpoison(block.base[block.used:block.used+size])
+	// sanitizer.address_unpoison(block.base[block.used:block.used+size])
 	block.used += size
 	return
 }
@@ -167,7 +167,7 @@ arena_free_all :: proc(arena: ^Arena, loc := #caller_location) {
 	if arena.curr_block != nil {
 		intrinsics.mem_zero(arena.curr_block.base, arena.curr_block.used)
 		arena.curr_block.used = 0
-		sanitizer.address_poison(arena.curr_block.base, arena.curr_block.capacity)
+		// sanitizer.address_poison(arena.curr_block.base, arena.curr_block.capacity)
 	}
 	arena.total_used = 0
 }
@@ -232,7 +232,7 @@ arena_allocator_proc :: proc(allocator_data: rawptr, mode: Allocator_Mode,
 					// grow data in-place, adjusting next allocation
 					block.used = uint(new_end)
 					data = block.base[start:new_end]
-					sanitizer.address_unpoison(data)
+					// sanitizer.address_unpoison(data)
 					return
 				}
 			}
@@ -306,7 +306,7 @@ arena_temp_end :: proc(temp: Arena_Temp, loc := #caller_location) {
 			assert(block.used >= temp.used, "out of order use of arena_temp_end", loc)
 			amount_to_zero := block.used-temp.used
 			intrinsics.mem_zero(block.base[temp.used:], amount_to_zero)
-			sanitizer.address_poison(block.base[temp.used:block.capacity])
+			// sanitizer.address_poison(block.base[temp.used:block.capacity])
 			block.used = temp.used
 			arena.total_used -= amount_to_zero
 		}

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -979,7 +979,6 @@ stack_free :: proc(
 	header := (^Stack_Allocation_Header)(curr_addr - size_of(Stack_Allocation_Header))
 	old_offset := int(curr_addr - uintptr(header.padding) - uintptr(raw_data(s.data)))
 	if old_offset != s.prev_offset {
-		// panic("Out of order stack allocator free");
 		return .Invalid_Pointer
 	}
 

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -959,7 +959,7 @@ stack_alloc_bytes_non_zeroed :: proc(
 Free memory to the stack.
 
 This procedure frees the memory region starting at `old_memory` to the stack.
-If the freeing does is an out of order freeing, the `.Invalid_Pointer` error
+If the freeing is an out of order freeing, the `.Invalid_Pointer` error
 is returned.
 */
 stack_free :: proc(

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -921,7 +921,7 @@ This procedure allocates `size` bytes of memory, aligned to the boundary
 specified by `alignment`. The allocated memory is not explicitly
 zero-initialized. This procedure returns the slice of the allocated memory.
 */
-@(require_results)
+@(require_results, no_sanitize_address)
 stack_alloc_bytes_non_zeroed :: proc(
 	s:    ^Stack,
 	size: int,
@@ -945,7 +945,6 @@ stack_alloc_bytes_non_zeroed :: proc(
 	s.curr_offset += padding
 	next_addr := curr_addr + uintptr(padding)
 	header := (^Stack_Allocation_Header)(next_addr - size_of(Stack_Allocation_Header))
-	sanitizer.address_unpoison(header)
 	header.padding = padding
 	header.prev_offset = old_offset
 	s.curr_offset += size

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -1133,7 +1133,7 @@ stack_resize_bytes_non_zeroed :: proc(
 		return stack_alloc_bytes_non_zeroed(s, size, alignment, loc)
 	}
 	if size == 0 {
-		return nil, nil
+		return nil, stack_free(s, old_memory, loc)
 	}
 	start     := uintptr(raw_data(s.data))
 	end       := start + uintptr(len(s.data))

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -249,7 +249,7 @@ arena_alloc_bytes_non_zeroed :: proc(
 	loc       := #caller_location
 ) -> ([]byte, Allocator_Error) {
 	if a.data == nil {
-		panic("Arena is not initialized", loc)
+		panic("Allocation on uninitialized Arena allocator.", loc)
 	}
 	#no_bounds_check end := &a.data[a.offset]
 	ptr := align_forward(end, uintptr(alignment))
@@ -509,7 +509,7 @@ scratch_alloc_bytes_non_zeroed :: proc(
 	if s.data == nil {
 		DEFAULT_BACKING_SIZE :: 4 * Megabyte
 		if !(context.allocator.procedure != scratch_allocator_proc && context.allocator.data != s) {
-			panic("cyclic initialization of the scratch allocator with itself", loc)
+			panic("Cyclic initialization of the scratch allocator with itself.", loc)
 		}
 		scratch_init(s, DEFAULT_BACKING_SIZE)
 	}
@@ -570,7 +570,7 @@ operation is a no-op.
 */
 scratch_free :: proc(s: ^Scratch, ptr: rawptr, loc := #caller_location) -> Allocator_Error {
 	if s.data == nil {
-		panic("Free on an uninitialized scratch allocator", loc)
+		panic("Free on an uninitialized Scratch allocator.", loc)
 	}
 	if ptr == nil {
 		return nil
@@ -733,7 +733,7 @@ scratch_resize_bytes_non_zeroed :: proc(
 	if s.data == nil {
 		DEFAULT_BACKING_SIZE :: 4 * Megabyte
 		if !(context.allocator.procedure != scratch_allocator_proc && context.allocator.data != s) {
-			panic("cyclic initialization of the scratch allocator with itself", loc)
+			panic("Cyclic initialization of the scratch allocator with itself.", loc)
 		}
 		scratch_init(s, DEFAULT_BACKING_SIZE)
 	}
@@ -927,7 +927,7 @@ stack_alloc_bytes_non_zeroed :: proc(
 	loc       := #caller_location
 ) -> ([]byte, Allocator_Error) {
 	if s.data == nil {
-		panic("Stack allocation on an uninitialized stack allocator", loc)
+		panic("Allocation on an uninitialized Stack allocator.", loc)
 	}
 	curr_addr := uintptr(raw_data(s.data)) + uintptr(s.curr_offset)
 	padding := calc_padding_with_header(
@@ -966,7 +966,7 @@ stack_free :: proc(
 	loc := #caller_location,
 ) -> (Allocator_Error) {
 	if s.data == nil {
-		panic("Stack free on an uninitialized stack allocator", loc)
+		panic("Free on an uninitialized Stack allocator.", loc)
 	}
 	if old_memory == nil {
 		return nil
@@ -975,7 +975,7 @@ stack_free :: proc(
 	end := start + uintptr(len(s.data))
 	curr_addr := uintptr(old_memory)
 	if !(start <= curr_addr && curr_addr < end) {
-		panic("Out of bounds memory address passed to stack allocator (free)", loc)
+		panic("Out of bounds memory address passed to Stack allocator. (free)", loc)
 	}
 	if curr_addr >= start+uintptr(s.curr_offset) {
 		// NOTE(bill): Allow double frees
@@ -1123,7 +1123,7 @@ stack_resize_bytes_non_zeroed :: proc(
 	old_memory := raw_data(old_data)
 	old_size := len(old_data)
 	if s.data == nil {
-		panic("Stack resize on an uninitialized stack allocator", loc)
+		panic("Resize on an uninitialized Stack allocator.", loc)
 	}
 	if old_memory == nil {
 		return stack_alloc_bytes_non_zeroed(s, size, alignment, loc)
@@ -1135,7 +1135,7 @@ stack_resize_bytes_non_zeroed :: proc(
 	end       := start + uintptr(len(s.data))
 	curr_addr := uintptr(old_memory)
 	if !(start <= curr_addr && curr_addr < end) {
-		panic("Out of bounds memory address passed to stack allocator (resize)")
+		panic("Out of bounds memory address passed to Stack allocator. (resize)")
 	}
 	if curr_addr >= start+uintptr(s.curr_offset) {
 		// NOTE(bill): Allow double frees
@@ -1344,7 +1344,7 @@ small_stack_alloc_bytes_non_zeroed :: proc(
 	loc       := #caller_location,
 ) -> ([]byte, Allocator_Error) {
 	if s.data == nil {
-		panic("Small stack is not initialized", loc)
+		panic("Allocation on an uninitialized Small Stack allocator.", loc)
 	}
 	alignment := alignment
 	alignment = clamp(alignment, 1, 8*size_of(Stack_Allocation_Header{}.padding)/2)
@@ -1382,7 +1382,7 @@ small_stack_free :: proc(
 	loc := #caller_location,
 ) -> Allocator_Error {
 	if s.data == nil {
-		panic("Small stack is not initialized", loc)
+		panic("Free on an uninitialized Small Stack allocator.", loc)
 	}
 	if old_memory == nil {
 		return nil
@@ -1391,7 +1391,7 @@ small_stack_free :: proc(
 	end := start + uintptr(len(s.data))
 	curr_addr := uintptr(old_memory)
 	if !(start <= curr_addr && curr_addr < end) {
-		panic("Out of bounds memory address passed to small stack allocator (free)", loc)
+		panic("Out of bounds memory address passed to Small Stack allocator. (free)", loc)
 	}
 	if curr_addr >= start+uintptr(s.offset) {
 		// NOTE(bill): Allow double frees
@@ -1530,7 +1530,7 @@ small_stack_resize_bytes_non_zeroed :: proc(
 	loc       := #caller_location,
 ) -> ([]byte, Allocator_Error) {
 	if s.data == nil {
-		panic("Small stack is not initialized", loc)
+		panic("Resize on an uninitialized Small Stack allocator.", loc)
 	}
 	old_memory := raw_data(old_data)
 	old_size   := len(old_data)
@@ -1546,7 +1546,7 @@ small_stack_resize_bytes_non_zeroed :: proc(
 	end       := start + uintptr(len(s.data))
 	curr_addr := uintptr(old_memory)
 	if !(start <= curr_addr && curr_addr < end) {
-		panic("Out of bounds memory address passed to small stack allocator (resize)", loc)
+		panic("Out of bounds memory address passed to Small Stack allocator. (resize)", loc)
 	}
 	if curr_addr >= start+uintptr(s.offset) {
 		// NOTE(bill): Treat as a double free

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -1119,7 +1119,7 @@ stack_resize_bytes_non_zeroed :: proc(
 	old_memory := raw_data(old_data)
 	old_size := len(old_data)
 	if s.data == nil {
-		panic("Stack free all on an uninitialized stack allocator", loc)
+		panic("Stack resize on an uninitialized stack allocator", loc)
 	}
 	if old_memory == nil {
 		return stack_alloc_bytes_non_zeroed(s, size, alignment, loc)

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -541,10 +541,6 @@ scratch_alloc_bytes_non_zeroed :: proc(
 	} else {
 		// NOTE: No need to use `aligned_size` here, as the backup allocator will handle alignment for us.
 		a := s.backup_allocator
-		if a.procedure == nil {
-			a = context.allocator
-			s.backup_allocator = a
-		}
 		ptr, err := alloc_bytes_non_zeroed(size, alignment, a, loc)
 		if err != nil {
 			return ptr, err

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -2327,7 +2327,7 @@ buddy_allocator_free_all :: proc(b: ^Buddy_Allocator) {
 	head := ([^]byte)(b.head)
 	tail := ([^]byte)(b.tail)
 	data := head[:ptr_sub(tail, head)]
-	buddy_allocator_init(b, data, alignment)	
+	buddy_allocator_init(b, data, alignment)
 }
 
 buddy_allocator_proc :: proc(

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -1719,7 +1719,7 @@ dynamic_arena_destroy :: proc(a: ^Dynamic_Arena) {
 @(private="file")
 _dynamic_arena_cycle_new_block :: proc(a: ^Dynamic_Arena, loc := #caller_location) -> (err: Allocator_Error) {
 	if a.block_allocator.procedure == nil {
-		panic("You must call arena_init on a Pool before using it", loc)
+		panic("You must call `dynamic_arena_init` on a Dynamic Arena before using it.", loc)
 	}
 	if a.current_block != nil {
 		append(&a.used_blocks, a.current_block, loc=loc)

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -1537,7 +1537,7 @@ small_stack_resize_bytes_non_zeroed :: proc(
 		return small_stack_alloc_bytes_non_zeroed(s, size, alignment, loc)
 	}
 	if size == 0 {
-		return nil, nil
+		return nil, small_stack_free(s, old_memory, loc)
 	}
 	start     := uintptr(raw_data(s.data))
 	end       := start + uintptr(len(s.data))

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -1872,9 +1872,6 @@ If `old_memory` is `nil`, this procedure acts just like `dynamic_arena_alloc()`,
 allocating a memory region `size` bytes in size, aligned on a boundary specified
 by `alignment`.
 
-If `size` is 0, this procedure acts just like `dynamic_arena_free()`, freeing
-the memory region located at an address specified by `old_memory`.
-
 This procedure returns the pointer to the resized memory region.
 */
 @(require_results)
@@ -1899,9 +1896,6 @@ zero-initialized.
 If `old_memory` is `nil`, this procedure acts just like `dynamic_arena_alloc()`,
 allocating a memory region `size` bytes in size, aligned on a boundary specified
 by `alignment`.
-
-If `size` is 0, this procedure acts just like `dynamic_arena_free()`, freeing the
-memory region located at an address specified by `old_memory`.
 
 This procedure returns the slice of the resized memory region.
 */
@@ -1934,9 +1928,6 @@ If `old_memory` is `nil`, this procedure acts just like `dynamic_arena_alloc()`,
 allocating a memory region `size` bytes in size, aligned on a boundary specified
 by `alignment`.
 
-If `size` is 0, this procedure acts just like `dynamic_arena_free()`, freeing the
-memory region located at an address specified by `old_memory`.
-
 This procedure returns the pointer to the resized memory region.
 */
 @(require_results)
@@ -1961,9 +1952,6 @@ explicitly zero-initialized.
 If `old_memory` is `nil`, this procedure acts just like `dynamic_arena_alloc()`,
 allocating a memory region `size` bytes in size, aligned on a boundary specified
 by `alignment`.
-
-If `size` is 0, this procedure acts just like `dynamic_arena_free()`, freeing
-the memory region located at an address specified by `old_memory`.
 
 This procedure returns the slice of the resized memory region.
 */

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -1156,6 +1156,7 @@ stack_resize_bytes_non_zeroed :: proc(
 		data, err := stack_alloc_bytes_non_zeroed(s, size, alignment, loc)
 		if err == nil {
 			runtime.copy(data, byte_slice(old_memory, old_size))
+			sanitizer.address_poison(old_memory)
 		}
 		return data, err
 	}
@@ -1165,6 +1166,8 @@ stack_resize_bytes_non_zeroed :: proc(
 	s.curr_offset += diff // works for smaller sizes too
 	if diff > 0 {
 		zero(rawptr(curr_addr + uintptr(diff)), diff)
+	} else {
+		sanitizer.address_poison(old_data[size:])
 	}
 	result := byte_slice(old_memory, size)
 	ensure_poisoned(result)

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -1248,7 +1248,10 @@ Small stack allocator.
 
 The small stack allocator is just like a stack allocator, with the only
 difference being an extremely small header size. Unlike the stack allocator,
-small stack allows out-of order freeing of memory.
+small stack allows out-of order freeing of memory, with the stipulation that
+all allocations made after the freed allocation will become invalidated upon
+following allocations as they will begin to overwrite the memory formerly used
+by the freed allocation.
 
 The memory is allocated in the backing buffer linearly, from start to end.
 Each subsequent allocation will get the next adjacent memory region.

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -1750,7 +1750,7 @@ by `alignment` from a dynamic arena `a`. The allocated memory is
 zero-initialized. This procedure returns a pointer to the newly allocated memory
 region.
 */
-@(private, require_results)
+@(require_results)
 dynamic_arena_alloc :: proc(a: ^Dynamic_Arena, size: int, loc := #caller_location) -> (rawptr, Allocator_Error) {
 	data, err := dynamic_arena_alloc_bytes(a, size, loc)
 	return raw_data(data), err

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -1912,6 +1912,10 @@ dynamic_arena_resize_bytes :: proc(
 	size:     int,
 	loc := #caller_location,
 ) -> ([]byte, Allocator_Error) {
+	if size == 0 {
+		// NOTE: This allocator has no Free mode.
+		return nil, nil
+	}
 	bytes, err := dynamic_arena_resize_bytes_non_zeroed(a, old_data, size, loc)
 	if bytes != nil {
 		if old_data == nil {
@@ -1968,6 +1972,10 @@ dynamic_arena_resize_bytes_non_zeroed :: proc(
 	size:     int,
 	loc := #caller_location,
 ) -> ([]byte, Allocator_Error) {
+	if size == 0 {
+		// NOTE: This allocator has no Free mode.
+		return nil, nil
+	}
 	old_memory := raw_data(old_data)
 	old_size := len(old_data)
 	if old_size >= size {

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -545,9 +545,6 @@ scratch_alloc_bytes_non_zeroed :: proc(
 		if err != nil {
 			return ptr, err
 		}
-		if s.leaked_allocations == nil {
-			s.leaked_allocations, err = make([dynamic][]byte, a)
-		}
 		append(&s.leaked_allocations, ptr)
 		if logger := context.logger; logger.lowest_level <= .Warning {
 			if logger.procedure != nil {

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -1052,8 +1052,8 @@ stack_resize_bytes :: proc(
 	alignment := DEFAULT_ALIGNMENT,
 	loc       := #caller_location,
 ) -> ([]byte, Allocator_Error) {
-	bytes, err := stack_alloc_bytes_non_zeroed(s, size, alignment, loc)
-	if bytes != nil {
+	bytes, err := stack_resize_bytes_non_zeroed(s, old_data, size, alignment, loc)
+	if err == nil {
 		if old_data == nil {
 			zero_slice(bytes)
 		} else if size > len(old_data) {

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -1550,6 +1550,16 @@ small_stack_resize_bytes_non_zeroed :: proc(
 		// NOTE(bill): Treat as a double free
 		return nil, nil
 	}
+	if uintptr(old_memory) & uintptr(alignment-1) != 0 {
+		// A different alignment has been requested and the current address
+		// does not satisfy it.
+		data, err := small_stack_alloc_bytes_non_zeroed(s, size, alignment, loc)
+		if err == nil {
+			runtime.copy(data, byte_slice(old_memory, old_size))
+			sanitizer.address_poison(old_memory)
+		}
+		return data, err
+	}
 	if old_size == size {
 		result := byte_slice(old_memory, size)
 		sanitizer.address_unpoison(result)

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -2448,8 +2448,8 @@ compat_allocator_proc :: proc(allocator_data: rawptr, mode: Allocator_Mode,
 	@(no_sanitize_address)
 	get_unpoisoned_header :: #force_inline proc(ptr: rawptr) -> Header {
 		header := ([^]Header)(ptr)[-1]
-		a      := max(header.alignment, size_of(Header))
-		sanitizer.address_unpoison(rawptr(uintptr(ptr)-uintptr(a)), a)
+		// a      := max(header.alignment, size_of(Header))
+		// sanitizer.address_unpoison(rawptr(uintptr(ptr)-uintptr(a)), a)
 		return header
 	}
 
@@ -2468,7 +2468,7 @@ compat_allocator_proc :: proc(allocator_data: rawptr, mode: Allocator_Mode,
 			alignment = alignment,
 		}
 
-		sanitizer.address_poison(raw_data(allocation), a)
+		// sanitizer.address_poison(raw_data(allocation), a)
 		return
 
 	case .Free:
@@ -2499,7 +2499,7 @@ compat_allocator_proc :: proc(allocator_data: rawptr, mode: Allocator_Mode,
 			alignment = new_alignment,
 		}
 
-		sanitizer.address_poison(raw_data(allocation), a)
+		// sanitizer.address_poison(raw_data(allocation), a)
 		return
 
 	case .Free_All:

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -1387,8 +1387,7 @@ small_stack_free :: proc(
 	end := start + uintptr(len(s.data))
 	curr_addr := uintptr(old_memory)
 	if !(start <= curr_addr && curr_addr < end) {
-		// panic("Out of bounds memory address passed to stack allocator (free)");
-		return .Invalid_Pointer
+		panic("Out of bounds memory address passed to small stack allocator (free)", loc)
 	}
 	if curr_addr >= start+uintptr(s.offset) {
 		// NOTE(bill): Allow double frees
@@ -1543,8 +1542,7 @@ small_stack_resize_bytes_non_zeroed :: proc(
 	end       := start + uintptr(len(s.data))
 	curr_addr := uintptr(old_memory)
 	if !(start <= curr_addr && curr_addr < end) {
-		// panic("Out of bounds memory address passed to stack allocator (resize)");
-		return nil, .Invalid_Pointer
+		panic("Out of bounds memory address passed to small stack allocator (resize)", loc)
 	}
 	if curr_addr >= start+uintptr(s.offset) {
 		// NOTE(bill): Treat as a double free

--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -1349,7 +1349,7 @@ small_stack_alloc_bytes_non_zeroed :: proc(
 	s.offset += padding
 	next_addr := curr_addr + uintptr(padding)
 	header := (^Small_Stack_Allocation_Header)(next_addr - size_of(Small_Stack_Allocation_Header))
-	header.padding = auto_cast padding
+	header.padding = cast(u8)padding
 	// We must poison the header, no matter what its state is, because there
 	// may have been an out-of-order free before this point.
 	sanitizer.address_poison(header)

--- a/core/mem/rollback_stack_allocator.odin
+++ b/core/mem/rollback_stack_allocator.odin
@@ -1,7 +1,7 @@
 package mem
 
 import "base:runtime"
-import "base:sanitizer"
+// import "base:sanitizer"
 
 /*
 Rollback stack default block size.
@@ -134,7 +134,7 @@ rb_free_all :: proc(stack: ^Rollback_Stack) {
 	stack.head.next_block = nil
 	stack.head.last_alloc = nil
 	stack.head.offset = 0
-	sanitizer.address_poison(stack.head.buffer)
+	// sanitizer.address_poison(stack.head.buffer)
 }
 
 /*
@@ -241,7 +241,7 @@ rb_alloc_bytes_non_zeroed :: proc(
 			block.offset = cast(uintptr)len(block.buffer)
 		}
 		res := ptr[:size]
-		sanitizer.address_unpoison(res)
+		// sanitizer.address_unpoison(res)
 		return res, nil
 	}
 	return nil, .Out_Of_Memory
@@ -338,7 +338,7 @@ rb_resize_bytes_non_zeroed :: proc(
 					block.offset += cast(uintptr)size - cast(uintptr)old_size
 				}
 				res := (ptr)[:size]
-				sanitizer.address_unpoison(res)
+				// sanitizer.address_unpoison(res)
 				#no_bounds_check return res, nil
 			}
 		}

--- a/core/mem/tlsf/tlsf_internal.odin
+++ b/core/mem/tlsf/tlsf_internal.odin
@@ -10,7 +10,7 @@
 package mem_tlsf
 
 import "base:intrinsics"
-import "base:sanitizer"
+// import "base:sanitizer"
 import "base:runtime"
 
 // log2 of number of linear subdivisions of block sizes.
@@ -210,7 +210,7 @@ alloc_bytes_non_zeroed :: proc(control: ^Allocator, size: uint, align: uint) -> 
 				return nil, .Out_Of_Memory
 			}
 
-			sanitizer.address_poison(new_pool_buf)
+			// sanitizer.address_poison(new_pool_buf)
 
 			// Allocate a new link in the `control.pool` tracking structure.
 			new_pool := new_clone(Pool{
@@ -277,7 +277,7 @@ free_with_size :: proc(control: ^Allocator, ptr: rawptr, size: uint) {
 
 	block := block_from_ptr(ptr)
 	assert(!block_is_free(block), "block already marked as free") // double free
-	sanitizer.address_poison(ptr, block.size)
+	// sanitizer.address_poison(ptr, block.size)
 	block_mark_as_free(block)
 	block = block_merge_prev(control, block)
 	block = block_merge_next(control, block)
@@ -321,7 +321,7 @@ resize :: proc(control: ^Allocator, ptr: rawptr, old_size, new_size: uint, align
 
 	block_trim_used(control, block, adjust)
 	res = ([^]byte)(ptr)[:new_size]
-	sanitizer.address_unpoison(res)
+	// sanitizer.address_unpoison(res)
 
 	if min_size < new_size {
 		to_zero := ([^]byte)(ptr)[min_size:new_size]
@@ -789,7 +789,7 @@ block_prepare_used :: proc(control: ^Allocator, block: ^Block_Header, size: uint
 		block_trim_free(control, block, size)
 		block_mark_as_used(block)
 		res = ([^]byte)(block_to_ptr(block))[:size]
-		sanitizer.address_unpoison(res)
+		// sanitizer.address_unpoison(res)
 	}
 	return
 }

--- a/core/mem/virtual/virtual.odin
+++ b/core/mem/virtual/virtual.odin
@@ -2,7 +2,7 @@ package mem_virtual
 
 import "core:mem"
 import "base:intrinsics"
-import "base:sanitizer"
+// import "base:sanitizer"
 import "base:runtime"
 _ :: runtime
 
@@ -22,7 +22,7 @@ reserve :: proc "contextless" (size: uint) -> (data: []byte, err: Allocator_Erro
 
 @(no_sanitize_address)
 commit :: proc "contextless" (data: rawptr, size: uint) -> Allocator_Error {
-	sanitizer.address_unpoison(data, size)
+	// sanitizer.address_unpoison(data, size)
 	return _commit(data, size)
 }
 
@@ -35,13 +35,13 @@ reserve_and_commit :: proc "contextless" (size: uint) -> (data: []byte, err: All
 
 @(no_sanitize_address)
 decommit :: proc "contextless" (data: rawptr, size: uint) {
-	sanitizer.address_poison(data, size)
+	// sanitizer.address_poison(data, size)
 	_decommit(data, size)
 }
 
 @(no_sanitize_address)
 release :: proc "contextless" (data: rawptr, size: uint) {
-	sanitizer.address_unpoison(data, size)
+	// sanitizer.address_unpoison(data, size)
 	_release(data, size)
 }
 
@@ -179,7 +179,7 @@ alloc_from_memory_block :: proc(block: ^Memory_Block, min_size, alignment: uint,
 
 	data = block.base[block.used+alignment_offset:][:min_size]
 	block.used += size
-	sanitizer.address_unpoison(data)
+	// sanitizer.address_unpoison(data)
 	return
 }
 

--- a/tests/issues/run.bat
+++ b/tests/issues/run.bat
@@ -16,6 +16,7 @@ set COMMON=-define:ODIN_TEST_FANCY=false -file -vet -strict-style
 ..\..\..\odin test ..\test_issue_2615.odin %COMMON%  || exit /b
 ..\..\..\odin test ..\test_issue_2637.odin %COMMON%  || exit /b
 ..\..\..\odin test ..\test_issue_2666.odin %COMMON%  || exit /b
+..\..\..\odin test ..\test_issue_2694.odin %COMMON%  || exit /b
 ..\..\..\odin test ..\test_issue_4210.odin %COMMON%  || exit /b
 ..\..\..\odin test ..\test_issue_4364.odin %COMMON%  || exit /b
 ..\..\..\odin test ..\test_issue_4584.odin %COMMON%  || exit /b

--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -17,6 +17,7 @@ $ODIN test ../test_issue_2466.odin $COMMON
 $ODIN test ../test_issue_2615.odin $COMMON
 $ODIN test ../test_issue_2637.odin $COMMON
 $ODIN test ../test_issue_2666.odin $COMMON
+$ODIN test ../test_issue_2694.odin $COMMON
 $ODIN test ../test_issue_4210.odin $COMMON
 $ODIN test ../test_issue_4364.odin $COMMON
 $ODIN test ../test_issue_4584.odin $COMMON

--- a/tests/issues/test_issue_2694.odin
+++ b/tests/issues/test_issue_2694.odin
@@ -1,0 +1,42 @@
+package test_issues
+
+import "core:fmt"
+import "core:encoding/json"
+import "core:log"
+import "core:mem"
+import "core:testing"
+
+// This is a minimal reproduction of the code in #2694.
+// It exemplifies the original problem as briefly as possible.
+
+SAMPLE_JSON :: `
+{
+	"foo": 0,
+	"things": [
+		{ "a": "ZZZZ"},
+	]
+}
+`
+
+@test
+test_issue_2694 :: proc(t: ^testing.T) {
+	into: struct {
+		foo: int,
+		things: []json.Object,
+	}
+
+	scratch := new(mem.Scratch_Allocator)
+	defer free(scratch)
+	if mem.scratch_allocator_init(scratch, 4 * mem.Megabyte) != .None {
+		log.error("unable to initialize scratch allocator")
+		return
+	}
+	defer mem.scratch_allocator_destroy(scratch)
+
+	err := json.unmarshal_string(SAMPLE_JSON, &into, allocator = mem.scratch_allocator(scratch))
+	testing.expect(t, err == nil)
+
+	output := fmt.tprintf("%v", into)
+	expected := `{foo = 0, things = [map[a="ZZZZ"]]}`
+	testing.expectf(t, output == expected, "\n\texpected: %q\n\tgot:      %q", expected, output)
+}


### PR DESCRIPTION
I originally wanted to just fix #2694, but that snowballed into a total review after noticing more problems.

The problem was due to the Scratch allocator not accounting for alignment when calculating the final size. It tried to align the size forward, which makes no sense without the context of a base pointer to align on. It would then end up overwriting memory of adjacent allocations when they came around. The allocator was also letting any allocation resize in-place, independent of location, which as you can imagine would lead to more problems.

So I tried to fix everything I could find.

Fixes #2694 

---

As an important addendum, I noticed that our `Scratch_Allocator` has a certain log message `"mem.Scratch_Allocator resorted to backup_allocator"`. Back when I used to use `ols` for an LSP, I recalled seeing that a lot in the error logs. So while I was investigating this bug, I went to check on `ols`'s source code, and they are using an old copy (not an import) of our current Scratch allocator with a similar bug.

I will be contacting them about this later with a link here.

---

As a second addendum, after doing some testing of the newly-poisonable allocators, I found that ASan doesn't actually support sub-8-byte ranges: https://github.com/google/sanitizers/wiki/AddressSanitizerAlgorithm#mapping

So, I have disabled ASan everywhere until each allocator can be reviewed whether or not it should actually use ASan. I thought TLSF would be okay, given the recent review by @laytan, but I got use-after-poison failures when I disabled ASan in everything _but_ TLSF. The error was coming from one of the rollback stack allocator (the test runner's allocator) procedures, which I am assuming was hiding this bug because of the layered poison state management.

Allocators should probably not be only tested in the test suite because of this kind of layering that can hide issues, but ideally we would build all applicable general-purpose allocators in their own DLLs and run them up against a worthy test suite or benchmark, running in various debug and production modes, with and without sanitizers, in addition to running specific tests in Odin code.