### PR TITLE
Let tests expect assertion failures and signals raised

### DIFF
--- a/core/testing/signal_handler.odin
+++ b/core/testing/signal_handler.odin
@@ -12,8 +12,26 @@ package testing
 import "base:runtime"
 import "core:log"
 
+@(private, thread_local)
+local_test_expected_failures: struct {
+	signal:         i32,
+
+	message_count:  int,
+	messages:       [MAX_EXPECTED_ASSERTIONS_PER_TEST]string,
+
+	location_count: int,
+	locations:      [MAX_EXPECTED_ASSERTIONS_PER_TEST]runtime.Source_Code_Location,
+}
+
+@(private, thread_local)
+local_test_assertion_raised: struct {
+	message: string,
+	location: runtime.Source_Code_Location,
+}
+
 Stop_Reason :: enum {
 	Unknown,
+	Successful_Stop,
 	Illegal_Instruction,
 	Arithmetic_Error,
 	Segmentation_Fault,
@@ -21,7 +39,12 @@ Stop_Reason :: enum {
 }
 
 test_assertion_failure_proc :: proc(prefix, message: string, loc: runtime.Source_Code_Location) -> ! {
-	log.fatalf("%s: %s", prefix, message, location = loc)
+	if local_test_expected_failures.message_count + local_test_expected_failures.location_count > 0 {
+		local_test_assertion_raised = { message, loc }
+		log.debugf("%s\n\tmessage: %q\n\tlocation: %w", prefix, message, loc)
+	} else {
+		log.fatalf("%s: %s", prefix, message, location = loc)
+	}
 	runtime.trap()
 }
 

--- a/tests/core/testing/test_core_testing.odin
+++ b/tests/core/testing/test_core_testing.odin
@@ -1,0 +1,52 @@
+package test_core_testing
+
+import "core:c/libc"
+import "core:math/rand"
+import "core:testing"
+
+@test
+test_expected_assert :: proc(t: ^testing.T) {
+	target := #location(); target.line += 2; target.column = 2
+	testing.expect_assert_from(t, target)
+	assert(false)
+}
+
+@test
+test_expected_two_assert :: proc(t: ^testing.T) {
+	target1 := #location(); target1.line += 5; target1.column = 3
+	target2 := #location(); target2.line += 6; target2.column = 3
+	testing.expect_assert_from(t, target1)
+	testing.expect_assert_from(t, target2)
+	if rand.uint32() & 1 == 0 {
+		assert(false)
+	} else {
+		assert(false)
+	}
+}
+
+some_proc :: proc() {
+	assert(false)
+}
+
+@test
+test_expected_assert_in_proc :: proc(t: ^testing.T) {
+	target := #location(some_proc)
+	target.line += 1
+	target.column = 2
+	assert(target.procedure == "", "The bug's been fixed; this line and the next can be deleted.")
+	target.procedure = "some_proc" // TODO: Is this supposed to be blank on #location(...)?
+	testing.expect_assert(t, target)
+	some_proc()
+}
+
+@test
+test_expected_assert_message :: proc(t: ^testing.T) {
+	testing.expect_assert(t, "failure")
+	assert(false, "failure")
+}
+
+@test
+test_expected_signal :: proc(t: ^testing.T) {
+	testing.expect_signal(t, libc.SIGILL)
+	libc.raise(libc.SIGILL)
+}


### PR DESCRIPTION
This was simpler to implement than I thought it'd be, and it came out rather clean in the end.

There's three new procedures:
- `expect_assert_from`
- `expect_assert_message`
- `expect_signal`

They do what it says on the tin, and you can expect up to 5 `Source_Code_Location` assertions and 5 messages per test procedure. Only one signal per test, as that's for advanced usage. These limitations are for simplicity and to avoid having to deal with leaked dynamic arrays, as we use a fixed array in TLS to store the expected failure states.

The message version is for simpler, more user-friendly usage, and the location version is for when you need to be precise about where the assertion happens.