### PR TITLE
Parse line comments correctly

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -321,9 +321,6 @@ consume_comment :: proc(p: ^Parser) -> (tok: tokenizer.Token, end_line: int) {
 	}
 
 	_ = next_token0(p)
-	if p.curr_tok.pos.line > tok.pos.line {
-		end_line += 1
-	}
 
 	return
 }
@@ -354,7 +351,7 @@ consume_comment_groups :: proc(p: ^Parser, prev: tokenizer.Token) {
 
 		if p.curr_tok.pos.line == prev.pos.line {
 			comment, end_line = consume_comment_group(p, 0)
-			if p.curr_tok.pos.line != end_line || p.curr_tok.kind == .EOF {
+			if p.curr_tok.pos.line != end_line || p.curr_tok.kind == .EOF  || p.curr_tok.pos.line == prev.pos.line + 1 {
 				p.line_comment = comment
 			}
 		}


### PR DESCRIPTION
Addresses https://github.com/odin-lang/Odin/issues/5353

I noticed that the odin parser is very similar to the go parser (which handles this case correctly). Essentially, rather than parsing just one line for the comment after a field definition, the odin parser would continue scanning until it finished parsing all of the comments, meaning that the line comment would end up being interpreted as a leading comment for the next field.

This PR just makes the parser first parse the comment on the same line for the line comment, and then continue to parsing the lead comment, which is the behaviour of the go parser.

This just updates the odin parser, but if it looks good it should be easy to make the same change on the cpp parser.