### PR TITLE
Fix `WAVEFORMATEX` struct size

### DIFF
--- a/core/sys/windows/winmm.odin
+++ b/core/sys/windows/winmm.odin
@@ -603,7 +603,7 @@ LPCWAVEFORMATEX :: ^WAVEFORMATEX
 //  New wave format development should be based on the WAVEFORMATEXTENSIBLE structure.
 //  WAVEFORMATEXTENSIBLE allows you to avoid having to register a new format tag with Microsoft.
 //  Simply define a new GUID value for the WAVEFORMATEXTENSIBLE.SubFormat field and use WAVE_FORMAT_EXTENSIBLE in the WAVEFORMATEXTENSIBLE.Format.wFormatTag field.
-WAVEFORMATEXTENSIBLE :: struct {
+WAVEFORMATEXTENSIBLE :: struct #packed {
 	using Format: WAVEFORMATEX,
 	Samples: struct #raw_union {
 		wValidBitsPerSample: WORD,      /* bits of precision  */

--- a/core/sys/windows/winmm.odin
+++ b/core/sys/windows/winmm.odin
@@ -589,7 +589,7 @@ WAVE_FORMAT_FLAC                       :: 0xF1AC /* flac.sourceforge.net */
 WAVE_FORMAT_EXTENSIBLE                 :: 0xFFFE /* Microsoft */
 
 
-WAVEFORMATEX :: struct {
+WAVEFORMATEX :: struct #packed {
 	wFormatTag:      WORD,
 	nChannels:       WORD,
 	nSamplesPerSec:  DWORD,

--- a/tests/core/sys/windows/test_windows_generated.odin
+++ b/tests/core/sys/windows/test_windows_generated.odin
@@ -527,8 +527,9 @@ verify_winmm :: proc(t: ^testing.T) {
 	// mmsyscom.h
 	expect_size(t, win32.MMVERSION, 4)
 	expect_size(t, win32.MMTIME, 12)
+	// mmreg.h
+	expect_size(t, win32.WAVEFORMATEX, 18)
 	// mmeapi.h
-	expect_size(t, win32.WAVEFORMATEX, 20)
 	expect_size(t, win32.WAVEHDR, 48)
 	expect_size(t, win32.WAVEINCAPSW, 80)
 	expect_size(t, win32.WAVEOUTCAPSW, 84)

--- a/tests/core/sys/windows/test_windows_generated.odin
+++ b/tests/core/sys/windows/test_windows_generated.odin
@@ -529,6 +529,7 @@ verify_winmm :: proc(t: ^testing.T) {
 	expect_size(t, win32.MMTIME, 12)
 	// mmreg.h
 	expect_size(t, win32.WAVEFORMATEX, 18)
+	expect_size(t, win32.WAVEFORMATEXTENSIBLE, 40)
 	// mmeapi.h
 	expect_size(t, win32.WAVEHDR, 48)
 	expect_size(t, win32.WAVEINCAPSW, 80)

--- a/tests/core/sys/windows/win32gen/win32gen.cpp
+++ b/tests/core/sys/windows/win32gen/win32gen.cpp
@@ -705,6 +705,7 @@ static void verify_winmm(ofstream& out) {
 	expect_size(MMTIME);
 	test_proc_comment("mmreg.h");
 	expect_size(WAVEFORMATEX);
+	expect_size(WAVEFORMATEXTENSIBLE);
 	test_proc_comment("mmeapi.h");
 	expect_size(WAVEHDR);
 	expect_size(WAVEINCAPSW);

--- a/tests/core/sys/windows/win32gen/win32gen.cpp
+++ b/tests/core/sys/windows/win32gen/win32gen.cpp
@@ -1,6 +1,7 @@
 #define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 #include <windows.h>
 #include <timeapi.h>
+#include <mmreg.h>
 #include <mmeapi.h>
 #include <windns.h>
 #include <commdlg.h>
@@ -702,8 +703,9 @@ static void verify_winmm(ofstream& out) {
 	test_proc_comment("mmsyscom.h");
 	expect_size(MMVERSION);
 	expect_size(MMTIME);
-	test_proc_comment("mmeapi.h");
+	test_proc_comment("mmreg.h");
 	expect_size(WAVEFORMATEX);
+	test_proc_comment("mmeapi.h");
 	expect_size(WAVEHDR);
 	expect_size(WAVEINCAPSW);
 	expect_size(WAVEOUTCAPSW);


### PR DESCRIPTION
Was struggling to get WASAPI working, made sanity check in C, found that `WAVEFORMATEX` was `18` bytes in C but `20` bytes in Odin. Added `#packed` and was able to get sound playing. Size is now `18` bytes, and `WAVEFORMATEXTENSIBLE` is now correctly `40` bytes.