### PR TITLE
added readgs{byte,word,dword,qword} intrinsics

### DIFF
--- a/base/intrinsics/intrinsics.odin
+++ b/base/intrinsics/intrinsics.odin
@@ -356,6 +356,12 @@ wasm_memory_atomic_notify32 :: proc(ptr: ^u32, waiters: u32) -> (waiters_woken_u
 x86_cpuid  :: proc(ax, cx: u32) -> (eax, ebx, ecx, edx: u32) ---
 x86_xgetbv :: proc(cx: u32) -> (eax, edx: u32) ---
 
+x86_readgsbyte :: proc(offset : u32) -> u8 ---
+x86_readgsword :: proc(offset : u32) -> u16 ---
+x86_readgsdword :: proc(offset : u32) -> u32 ---
+// Used to implement  NtCurrentTeb() since we cant just link against it (only 32bit version of ntdll exposes it).
+x86_readgsqword :: proc(offset : u32) -> u64 ---
+
 
 // Darwin targets only
 objc_object   :: struct{}

--- a/core/sys/windows/winternal.odin
+++ b/core/sys/windows/winternal.odin
@@ -1,0 +1,39 @@
+#+build windows
+package sys_windows
+
+import "base:intrinsics"
+
+when ODIN_ARCH == .amd64 {
+	NtCurrentTeb :: proc() -> ^TEB {
+		return cast(^TEB) cast(uintptr) intrinsics.x86_readgsqword(cast(u32)offset_of(NT_TIB{}.Self))
+	}
+}
+
+NT_TIB :: struct {
+	ExceptionList        : PVOID,
+	StackBase            : PVOID,
+	StackLimit           : PVOID,
+	SubSystemTib         : PVOID,
+	using _ : struct #raw_union {
+			FiberData        : PVOID,
+			Version          : DWORD,
+	},
+	ArbitraryUserPointer : PVOID,
+	Self                 : ^NT_TIB,
+}
+
+TEB :: struct {
+	using _ : struct #raw_union {
+		Tib                   :       NT_TIB,
+		Reserved1             :   [12]PVOID,
+	},
+  ProcessEnvironmentBlock :       ^PEB,
+  Reserved2               :  [399]PVOID,
+  Reserved3               : [1952]BYTE,
+  TlsSlots                :   [64]PVOID,
+  Reserved4               :    [8]BYTE,
+  Reserved5               :   [26]PVOID,
+  ReservedForOle          :       PVOID,
+  Reserved6               :    [4]PVOID,
+  TlsExpansionSlots       :       PVOID,
+}

--- a/src/checker_builtin_procs.hpp
+++ b/src/checker_builtin_procs.hpp
@@ -223,6 +223,11 @@ BuiltinProc__simd_end,
 
 	BuiltinProc_x86_cpuid,
 	BuiltinProc_x86_xgetbv,
+	
+	BuiltinProc_x86_readgsbyte,
+	BuiltinProc_x86_readgsword,
+	BuiltinProc_x86_readgsdword,
+	BuiltinProc_x86_readgsqword,
 
 	// Constant type tests
 
@@ -580,6 +585,11 @@ gb_global BuiltinProc builtin_procs[BuiltinProc_COUNT] = {
 	{STR_LIT("syscall_bsd"), 1, true, Expr_Expr, BuiltinProcPkg_intrinsics, false, true},
 	{STR_LIT("x86_cpuid"),  2, false, Expr_Expr, BuiltinProcPkg_intrinsics},
 	{STR_LIT("x86_xgetbv"), 1, false, Expr_Expr, BuiltinProcPkg_intrinsics},
+
+	{STR_LIT("x86_readgsbyte"), 1, false, Expr_Expr, BuiltinProcPkg_intrinsics},
+	{STR_LIT("x86_readgsword"), 1, false, Expr_Expr, BuiltinProcPkg_intrinsics},
+	{STR_LIT("x86_readgsdword"), 1, false, Expr_Expr, BuiltinProcPkg_intrinsics},
+	{STR_LIT("x86_readgsqword"), 1, false, Expr_Expr, BuiltinProcPkg_intrinsics},
 
 
 	{STR_LIT(""), 0, false, Expr_Stmt, BuiltinProcPkg_intrinsics},

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -3631,6 +3631,33 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 			return res;
 		}
 
+	case BuiltinProc_x86_readgsbyte: case BuiltinProc_x86_readgsword: case BuiltinProc_x86_readgsdword: case BuiltinProc_x86_readgsqword:
+		{
+			Type *type = alloc_type_proc_from_types(&t_u32, 1, tv.type, false, ProcCC_None);
+			LLVMTypeRef func_type = lb_get_procedure_raw_type(p->module, type);
+			String ass;
+			switch (id) {
+				case BuiltinProc_x86_readgsbyte : ass = str_lit("mov rax,  byte ptr gs:[rdx]"); break;
+				case BuiltinProc_x86_readgsword : ass = str_lit("mov rax,  word ptr gs:[rdx]"); break;
+				case BuiltinProc_x86_readgsdword: ass = str_lit("mov rax, dword ptr gs:[rdx]"); break;
+				case BuiltinProc_x86_readgsqword: ass = str_lit("mov rax, qword ptr gs:[rdx]"); break;
+			}
+			LLVMValueRef the_asm = llvm_get_inline_asm(
+				func_type,
+				ass,
+				str_lit("={rax},{rdx}"),
+				true, false, LLVMInlineAsmDialectIntel
+			);
+			GB_ASSERT(the_asm != nullptr);
+
+			LLVMValueRef args[1] = {};
+			args[0] = lb_emit_conv(p, lb_build_expr(p, ce->args[0]), t_u32).value;
+			lbValue res = {};
+			res.type = tv.type;
+			res.value = LLVMBuildCall2(p->builder, func_type, the_asm, args, gb_count_of(args), "");
+			return res;
+		}
+
 	case BuiltinProc_valgrind_client_request:
 		{
 			lbValue args[7] = {};

--- a/tests/internal/test_x86.odin
+++ b/tests/internal/test_x86.odin
@@ -1,0 +1,18 @@
+#+build windows
+
+package test_internal
+
+import "core:testing"
+import win32 "core:sys/windows"
+
+
+@(test)
+test_get_gs :: proc(t: ^testing.T) {
+	context_ := win32.CONTEXT { ContextFlags = win32.WOW64_CONTEXT_CONTROL }
+	win32.GetThreadContext(win32.GetCurrentThread(), &context_)
+
+	tib := win32.NtCurrentTeb().Tib
+	stack_left := cast(uintptr) context_.Rsp - (cast(uintptr) tib.StackLimit)
+
+	testing.expect(t, stack_left != 0, "stack left != 0")
+}


### PR DESCRIPTION
These instrinsics allow reading from the G Sector on x86 machines, which is used for windows internals ThreadInfoBlock s. Specifically I am interested in calculating some stack space metrics, which to my knowledge cannot be obtained in a different way. 

I don't love the implementation i added, but it works. There _might_ be a llvm intrinsic that does this in a more elegant way, but the intel assembler version is the one I am familiar with. 
I mostly just copied the implementation from the `BuiltinProc_x86_xgetbv` one above, I am not sure this necessarily requires a function call. 

I also thought about if it was possible to implement the intrinsic in a way that doesn't require multiple of them, but since odin doesn't have have overload resolution based on the return value i don't really see a way to do this more elegantly. 
An option might be to take a type as the first argument, but i feel like this doesn't really improve anything. 

See core/sys/windows/winternals.odin for an application of the function. 