### PR TITLE
#5270 Escape Object files properly during linker_stage

### DIFF
--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -704,12 +704,12 @@ try_cross_linking:;
 					return result;
 				}
 
-				object_files = gb_string_append_fmt(object_files, "\"%.*s\" ", LIT(android_glue_static_lib));
+				object_files = gb_string_append_fmt(object_files, "\'%.*s\' ", LIT(android_glue_static_lib));
 			}
 
 
 			for (String object_path : gen->output_object_paths) {
-				object_files = gb_string_append_fmt(object_files, "\"%.*s\" ", LIT(object_path));
+				object_files = gb_string_append_fmt(object_files, "\'%.*s\' ", LIT(object_path));
 			}
 
 			gbString link_settings = gb_string_make_reserve(heap_allocator(), 32);


### PR DESCRIPTION
`system` function calls `sh` in the background which in turn introduces string interpolation and `$` expansion...
In order to avoid that and to fix #5270 we use single quotes which are used to express static string literals in `sh`. 