### PR TITLE
Fix WASM C ABI for raw unions

### DIFF
--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -2206,7 +2206,7 @@ gb_internal LLVMTypeRef lb_type_internal(lbModule *m, Type *type) {
 				field_count = 3;
 			}
 			LLVMTypeRef *fields = gb_alloc_array(permanent_allocator(), LLVMTypeRef, field_count);
-			fields[0] = LLVMPointerType(lb_type(m, type->Pointer.elem), 0);
+			fields[0] = LLVMPointerType(lb_type(m, type->SoaPointer.elem), 0);
 			if (bigger_int) {
 				fields[1] = lb_type_padding_filler(m, build_context.ptr_size, build_context.ptr_size);
 				fields[2] = LLVMIntTypeInContext(ctx, 8*cast(unsigned)build_context.int_size);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -4688,6 +4688,7 @@ gb_internal Type *type_internal_index(Type *t, isize index) {
 	};
 
 	GB_PANIC("Unhandled type %s", type_to_string(bt));
+	return nullptr;
 };
 
 gb_internal gbString write_type_to_string(gbString str, Type *type, bool shorthand=false, bool allow_polymorphic=false) {


### PR DESCRIPTION
LLVM types have already lost the information of being a union or not, and all LLVM unions have 1 field.

This means I had to pipe through our own type definition into the ABI logic to correctly pass raw unions using the C ABI.