### PR TITLE
added IS_SUPPORTED to core:sys/posix

### DIFF
--- a/core/sys/posix/posix.odin
+++ b/core/sys/posix/posix.odin
@@ -53,6 +53,8 @@ import "base:intrinsics"
 
 import "core:c"
 
+IS_SUPPORTED :: _IS_SUPPORTED
+
 result :: enum c.int {
  	// Use `errno` and `strerror` for more information.
 	FAIL = -1,

--- a/core/sys/posix/posix_other.odin
+++ b/core/sys/posix/posix_other.odin
@@ -1,0 +1,10 @@
+#+build !linux
+#+build !darwin
+#+build !netbsd
+#+build !openbsd
+#+build !freebsd
+#+build !haiku
+package posix
+
+_IS_SUPPORTED :: false
+

--- a/core/sys/posix/posix_unix.odin
+++ b/core/sys/posix/posix_unix.odin
@@ -1,0 +1,5 @@
+#+build linux, darwin, netbsd, openbsd, freebsd, haiku
+package posix
+
+_IS_SUPPORTED :: true
+


### PR DESCRIPTION
As suggested by @laytan (https://github.com/odin-lang/Odin/pull/4929#issuecomment-2722563528), I've created an `IS_SUPPORTED` for the posix package