### PR TITLE
Fix issue parsing `vendor/stb/image` with the `core:odin/parser` parser

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -2307,6 +2307,7 @@ parse_operand :: proc(p: ^Parser, lhs: bool) -> ^ast.Expr {
 		open := expect_token(p, .Open_Paren)
 		p.expr_level += 1
 		expr := parse_expr(p, false)
+		skip_possible_newline(p)
 		p.expr_level -= 1
 		close := expect_token(p, .Close_Paren)
 
@@ -3526,6 +3527,7 @@ parse_binary_expr :: proc(p: ^Parser, lhs: bool, prec_in: int) -> ^ast.Expr {
 			case .When:
 				x := expr
 				cond := parse_expr(p, lhs)
+				skip_possible_newline(p)
 				else_tok := expect_token(p, .Else)
 				y := parse_expr(p, lhs)
 				te := ast.new(ast.Ternary_When_Expr, expr.pos, end_pos(p.prev_tok))
@@ -3778,10 +3780,6 @@ parse_import_decl :: proc(p: ^Parser, kind := Import_Decl_Kind.Standard) -> ^ast
 		import_name = advance_token(p)
 	case:
 		import_name.pos = p.curr_tok.pos
-	}
-
-	if !is_using && is_blank_ident(import_name) {
-		error(p, import_name.pos, "illegal import name: '_'")
 	}
 
 	path := expect_token_after(p, .String, "import")

--- a/tests/core/odin/test_parser.odin
+++ b/tests/core/odin/test_parser.odin
@@ -66,3 +66,31 @@ Foo :: bit_field uint {
 	ok := parser.parse_file(&p, &file)
 	testing.expect(t, ok, "bad parse")
 }
+
+@test
+test_parse_parser :: proc(t: ^testing.T) {
+	context.allocator = context.temp_allocator
+	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
+
+	pkg, ok := parser.parse_package_from_path(ODIN_ROOT + "core/odin/parser")
+	
+	testing.expect(t, ok, "parser.parse_package_from_path failed")
+
+	for key, value in pkg.files {
+		testing.expectf(t, value.syntax_error_count == 0, "%v should contain zero errors", key)
+	}
+}
+
+@test
+test_parse_stb_image :: proc(t: ^testing.T) {
+	context.allocator = context.temp_allocator
+	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
+
+	pkg, ok := parser.parse_package_from_path(ODIN_ROOT + "vendor/stb/image")
+	
+	testing.expect(t, ok, "parser.parse_package_from_path failed")
+
+	for key, value in pkg.files {
+		testing.expectf(t, value.syntax_error_count == 0, "%v should contain zero errors", key)
+	}
+}


### PR DESCRIPTION
Currently the `core:odin/parser` parser fails to parse the `vendor:stb/image` package due to 2 issues:

1. It doesn't like the import in `stb_image_wasm.odin`:
```odin
@(require) import _ "vendor:libc" // illegal import name '_'
```

2. It doesn't like the when statements in the rest of the files. For example in `stb_image.odin`:
```odin
@(private)
LIB :: (
	     "../lib/stb_image.lib"      when ODIN_OS == .Windows // expected 'else', got 'newline'
	else "../lib/stb_image.a"        when ODIN_OS == .Linux // expected ')', got 'newline'
	else "../lib/darwin/stb_image.a" when ODIN_OS == .Darwin // 'else' unattached to an 'if' statement
	else "../lib/stb_image_wasm.o"   when ODIN_ARCH == .wasm32 || ODIN_ARCH == .wasm64p32 // 'else' unattached to an 'if' statement
	else ""  // 'else' unattached to an 'if' statement
) // expected a statement, got )
```

These files are parsed correctly with the cpp parser. The cpp parser has logic concerning when to skip lines (`f->allow_newline` on the `AstFile`, and `ignore_newlines` based on `f->expr_level`), which does not exist on the `core:odin/parser` parser. Since this infrastructure doesn't exist for the odin parser, I opted to simply skip possible newlines on the problematic parts. If the cpp style `allow_newline` and ignoring newlines based on expr level is desired, I could also pursue that route instead. Though there does seem to be some divergences between the 2 parsers that might make it difficult.

Similarly, the check for the "illegal import name '_'" does not exist on the cpp parser. I wasn't sure which of these is considered "correct", but I assumed the cpp parser is the desired behaviour.