### PR TITLE
posix: add RTLD_DEEPBIND

### DIFF
--- a/core/sys/posix/dlfcn.odin
+++ b/core/sys/posix/dlfcn.odin
@@ -119,6 +119,7 @@ when ODIN_OS == .Darwin {
 
 	RTLD_LAZY    :: 0x001
 	RTLD_NOW     :: 0x002
+	RTLD_DEEPBIND :: 0x008
 	RTLD_GLOBAL  :: 0x100
 
 	_RTLD_LOCAL  :: 0

--- a/core/sys/posix/dlfcn.odin
+++ b/core/sys/posix/dlfcn.odin
@@ -119,11 +119,12 @@ when ODIN_OS == .Darwin {
 
 	RTLD_LAZY    :: 0x001
 	RTLD_NOW     :: 0x002
-	RTLD_DEEPBIND :: 0x008
+	_RTLD_DEEPBIND     :: 0x008
 	RTLD_GLOBAL  :: 0x100
 
 	_RTLD_LOCAL  :: 0
 	RTLD_LOCAL   :: RTLD_Flags{}
+	RTLD_DEEPBIND   :: RRTLD_Flags{RTLD_Flag_Bits(log2(_RTLD_DEEPBIND))}
 
 }
 

--- a/core/sys/posix/dlfcn.odin
+++ b/core/sys/posix/dlfcn.odin
@@ -124,7 +124,7 @@ when ODIN_OS == .Darwin {
 
 	_RTLD_LOCAL  :: 0
 	RTLD_LOCAL   :: RTLD_Flags{}
-	RTLD_DEEPBIND   :: RRTLD_Flags{RTLD_Flag_Bits(log2(_RTLD_DEEPBIND))}
+	RTLD_DEEPBIND   :: RTLD_Flags{RTLD_Flag_Bits(log2(_RTLD_DEEPBIND))}
 
 }
 


### PR DESCRIPTION
https://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h

Btw, what architectures does Odin officially support? this posix package seems to only care about X86/ARM? on MIPS the values for dlfcn are different

This value is also only supported on Linux, what should be done to update the `RTLD_Flag_Bits`? since odin's `dlopen` requires it