### PR TITLE
wasm: Set stack first and increase stack size to 1mb

### DIFF
--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -72,7 +72,7 @@ gb_internal i32 linker_stage(LinkerData *gen) {
 		inputs = gb_string_append_fmt(inputs, "\"%.*s.o\"", LIT(output_filename));
 
 
-		gb_string_appendc(inputs, "--stack-first -z stack-size=1048576")
+		inputs = gb_string_appendc(inputs, " --stack-first -z stack-size=1048576");
 
 		for (Entity *e : gen->foreign_libraries) {
 			GB_ASSERT(e->kind == Entity_LibraryName);

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -72,6 +72,8 @@ gb_internal i32 linker_stage(LinkerData *gen) {
 		inputs = gb_string_append_fmt(inputs, "\"%.*s.o\"", LIT(output_filename));
 
 
+		gb_string_appendc(inputs, "--stack-first -z stack-size=1048576")
+
 		for (Entity *e : gen->foreign_libraries) {
 			GB_ASSERT(e->kind == Entity_LibraryName);
 			// NOTE(bill): Add these before the linking values


### PR DESCRIPTION
The stack size is 64 KB by default, which is too small to be useful and leads to difficult-to-guess problems.

I recommend setting the stack size to 1 MB, which is precisely what emscripten, [zig](https://github.com/ziglang/zig/issues/3735), and rust are doing.



And the rationale for `--stack-first`: https://github.com/ziglang/zig/issues/4496

