### PR TITLE
Add unix build script for kb_text_shape

### DIFF
--- a/vendor/kb_text_shape/kb_text_shape_procs.odin
+++ b/vendor/kb_text_shape/kb_text_shape_procs.odin
@@ -6,7 +6,7 @@ when ODIN_OS == .Windows {
 	}
 } else {
 	foreign import lib {
-		"kb_text_shape.a",
+		"lib/kb_text_shape.a",
 	}
 }
 

--- a/vendor/kb_text_shape/src/build_unix.sh
+++ b/vendor/kb_text_shape/src/build_unix.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+mkdir -p "../lib"
+cc -O2 -c kb_text_shape.c
+ar -rcs ../lib/kb_text_shape.a kb_text_shape.o
+rm *.o

--- a/vendor/kb_text_shape/src/kb_text_shape.c
+++ b/vendor/kb_text_shape/src/kb_text_shape.c
@@ -1,4 +1,7 @@
 #include <stdint.h>
+#ifndef _MSC_VER
+  #include <string.h>
+#endif
 
 #define KB_TEXT_SHAPE_NO_CRT
 #define KB_TEXT_SHAPE_IMPLEMENTATION


### PR DESCRIPTION
Adds a build script to compile the library on Unix systems. I added `#include <string.h>` to the source file so that it builds without errors. This can be removed once the bindings are updated.