### PR TITLE
Add `type_enum_is_contiguous` intrinsic (Closes #5395)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -297,3 +297,8 @@ build.sh
 *.rdi
 tests/issues/build/*
 misc/featuregen/featuregen
+
+# Clangd stuff
+.cache/
+.clangd
+compile_commands.json

--- a/base/intrinsics/intrinsics.odin
+++ b/base/intrinsics/intrinsics.odin
@@ -213,6 +213,9 @@ type_is_subtype_of :: proc($T, $U: typeid) -> bool ---
 
 type_field_index_of :: proc($T: typeid, $name: string) -> uintptr ---
 
+// Contiguous as in having a set of constants, when sorted, the difference between consecutive values is only 0 or 1
+type_enum_is_contiguous :: proc($T: typeid) -> bool where type_is_enum(T) ---
+
 type_equal_proc  :: proc($T: typeid) -> (equal:  proc "contextless" (rawptr, rawptr) -> bool)                 where type_is_comparable(T) ---
 type_hasher_proc :: proc($T: typeid) -> (hasher: proc "contextless" (data: rawptr, seed: uintptr) -> uintptr) where type_is_comparable(T) ---
 

--- a/base/intrinsics/intrinsics.odin
+++ b/base/intrinsics/intrinsics.odin
@@ -213,7 +213,7 @@ type_is_subtype_of :: proc($T, $U: typeid) -> bool ---
 
 type_field_index_of :: proc($T: typeid, $name: string) -> uintptr ---
 
-// Contiguous as in having a set of constants, when sorted, the difference between consecutive values is only 0 or 1
+// Contiguous as in having a set of constants, when sorted, the difference between consecutive constants is only 0 or 1
 type_enum_is_contiguous :: proc($T: typeid) -> bool where type_is_enum(T) ---
 
 type_equal_proc  :: proc($T: typeid) -> (equal:  proc "contextless" (rawptr, rawptr) -> bool)                 where type_is_comparable(T) ---

--- a/base/intrinsics/intrinsics.odin
+++ b/base/intrinsics/intrinsics.odin
@@ -213,7 +213,8 @@ type_is_subtype_of :: proc($T, $U: typeid) -> bool ---
 
 type_field_index_of :: proc($T: typeid, $name: string) -> uintptr ---
 
-// Contiguous as in having a set of constants, when sorted, the difference between consecutive constants is only 0 or 1
+// "Contiguous" means that the set of enum constants, when sorted, have a difference of either 0 or 1 between consecutive values.
+// This is the exact opposite of "sparse".
 type_enum_is_contiguous :: proc($T: typeid) -> bool where type_is_enum(T) ---
 
 type_equal_proc  :: proc($T: typeid) -> (equal:  proc "contextless" (rawptr, rawptr) -> bool)                 where type_is_comparable(T) ---

--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -6941,8 +6941,8 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 				return false;
 			}
 			
-			// sort enum fields in place in ascending order
-			Array<Entity *> enum_constants = type->Enum.fields;
+			auto enum_constants = array_make<Entity *>(temporary_allocator(), type->Enum.fields.count);
+			array_copy(&enum_constants, type->Enum.fields, 0);
 			array_sort(enum_constants, enum_constant_entity_cmp);
 			
 			BigInt minus_one = big_int_make_i64(-1);

--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -6946,6 +6946,7 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 			array_sort(enum_constants, enum_constant_entity_cmp);
 			
 			BigInt minus_one = big_int_make_i64(-1);
+			defer (big_int_dealloc(&minus_one));
 			BigInt diff = {};
 			
 			bool contiguous = true;
@@ -6956,6 +6957,7 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 				BigInt curr = enum_constants[i]->Constant.value.value_integer;
 				BigInt next = enum_constants[i + 1]->Constant.value.value_integer;
 				big_int_sub(&diff, &curr, &next);
+				defer (big_int_dealloc(&diff));
 				
 				if (!big_int_is_zero(&diff) && big_int_cmp(&diff, &minus_one) != 0) {
 					contiguous = false;

--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -1,9 +1,12 @@
 typedef bool (BuiltinTypeIsProc)(Type *t);
 
 gb_internal int enum_constant_entity_cmp(void const* a, void const* b) {
-	BigInt bi = (*cast(Entity const **)a)->Constant.value.value_integer;
-	BigInt bj = (*cast(Entity const **)b)->Constant.value.value_integer;
-	return big_int_cmp(&bi, &bj);
+	Entity const *ea = *(cast(Entity const **)a);
+	Entity const *eb = *(cast(Entity const **)b);
+	GB_ASSERT(ea->kind == Entity_Constant && eb->kind == Entity_Constant);
+	GB_ASSERT(ea->Constant.value.kind == ExactValue_Integer && eb->Constant.value.kind == ExactValue_Integer);
+	
+	return big_int_cmp(&ea->Constant.value.value_integer, &eb->Constant.value.value_integer);
 }
 
 gb_global BuiltinTypeIsProc *builtin_type_is_procs[BuiltinProc__type_simple_boolean_end - BuiltinProc__type_simple_boolean_begin] = {

--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -1,5 +1,11 @@
 typedef bool (BuiltinTypeIsProc)(Type *t);
 
+gb_internal int enum_constant_entity_cmp(void const* a, void const* b) {
+	BigInt bi = (*cast(Entity const **)a)->Constant.value.value_integer;
+	BigInt bj = (*cast(Entity const **)b)->Constant.value.value_integer;
+	return big_int_cmp(&bi, &bj);
+}
+
 gb_global BuiltinTypeIsProc *builtin_type_is_procs[BuiltinProc__type_simple_boolean_end - BuiltinProc__type_simple_boolean_begin] = {
 	nullptr, // BuiltinProc__type_simple_boolean_begin
 
@@ -6916,6 +6922,48 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 
 			operand->mode = Addressing_Type;
 			operand->type = bit_set_to_int(bt);
+			break;
+		}
+
+	case BuiltinProc_type_enum_is_contiguous:
+		{
+			Operand op = {};
+			Type *bt = check_type(c, ce->args[0]);
+			Type *type = base_type(bt);
+			if (type == nullptr || type == t_invalid) {
+				error(ce->args[0], "Expected a type for '%.*s'", LIT(builtin_name));
+				return false;
+			}
+			if (!is_type_enum(type)) {
+				gbString t = type_to_string(type);
+				error(ce->args[0], "Expected an enum type for '%.*s', got %s", LIT(builtin_name), t);
+				gb_string_free(t);
+				return false;
+			}
+			
+			// sort enum fields in place in ascending order
+			Array<Entity *> enum_constants = type->Enum.fields;
+			array_sort(enum_constants, enum_constant_entity_cmp);
+			
+			BigInt minus_one = big_int_make_i64(-1);
+			BigInt diff = {};
+			
+			bool contiguous = true;
+			operand->mode = Addressing_Constant;
+			operand->type = t_untyped_bool;
+			
+			for (isize i = 0; i < enum_constants.count - 1; i++) {
+				BigInt curr = enum_constants[i]->Constant.value.value_integer;
+				BigInt next = enum_constants[i + 1]->Constant.value.value_integer;
+				big_int_sub(&diff, &curr, &next);
+				
+				if (!big_int_is_zero(&diff) && big_int_cmp(&diff, &minus_one) != 0) {
+					contiguous = false;
+					break;
+				}
+			}
+
+			operand->value = exact_value_bool(contiguous);
 			break;
 		}
 

--- a/src/checker_builtin_procs.hpp
+++ b/src/checker_builtin_procs.hpp
@@ -325,6 +325,8 @@ BuiltinProc__type_simple_boolean_end,
 
 	BuiltinProc_type_bit_set_backing_type,
 
+	BuiltinProc_type_enum_is_contiguous,
+
 	BuiltinProc_type_equal_proc,
 	BuiltinProc_type_hasher_proc,
 	BuiltinProc_type_map_info,
@@ -677,6 +679,8 @@ gb_global BuiltinProc builtin_procs[BuiltinProc_COUNT] = {
 	{STR_LIT("type_field_index_of"), 2, false, Expr_Expr, BuiltinProcPkg_intrinsics},
 
 	{STR_LIT("type_bit_set_backing_type"), 1, false, Expr_Expr, BuiltinProcPkg_intrinsics},
+
+	{STR_LIT("type_enum_is_contiguous"), 1, false, Expr_Expr, BuiltinProcPkg_intrinsics },
 
 	{STR_LIT("type_equal_proc"),    1, false, Expr_Expr, BuiltinProcPkg_intrinsics},
 	{STR_LIT("type_hasher_proc"),   1, false, Expr_Expr, BuiltinProcPkg_intrinsics},

--- a/tests/internal/test_intrinsics_enum_contiguous.odin
+++ b/tests/internal/test_intrinsics_enum_contiguous.odin
@@ -1,0 +1,24 @@
+package test_internal
+
+import "base:intrinsics"
+import "core:testing"
+
+@(test)
+test_intrinsics_enum_is_contiguous :: proc(t: ^testing.T) {
+	contiguous :: intrinsics.type_enum_is_contiguous
+	testing.expect(t, contiguous(enum { A=0, B=0, C=0 }))
+	testing.expect(t, contiguous(enum { A=0, B=1, C=2 }))
+	testing.expect(t, contiguous(enum { A=1, B=2, C=2 }))
+	testing.expect(t, contiguous(enum { A=-2, B=-1, C=0 }))
+	testing.expect(t, contiguous(enum { A=-8, B=-6, C=-7, D=-8 }))
+	testing.expect(t, contiguous(enum { C=4, A=3 }))
+	testing.expect(t, contiguous(enum { }))
+	testing.expect(t, contiguous(enum { A }))
+	testing.expect(t, contiguous(enum { Delta=-4 }))
+	testing.expect(t, contiguous(enum { X = 2 * len([?]u8{ 0 }) }))
+	testing.expect(t, contiguous(enum { Alpha=-2, Beta=-1, Gamma=0, Delta=-3 }))
+	
+	testing.expect(t, !contiguous(enum { A=1, B=3 }))
+	testing.expect(t, !contiguous(enum { B=-5, Beta=-3 }))
+	testing.expect(t, !contiguous(enum { A=0, B=-2 }))
+}


### PR DESCRIPTION
This adds an intrinsic that indicates whether an enum has a contiguous range.
In this context, "contiguous" means that the enum range, when sorted, have differences of either 0 or 1 between consecutive values, it also allows duplicates.

This could not be done with `max`/`len` fiddling due to duplicate values.

The following holds true:
```go
    c :: intrinsics.type_enum_is_contiguous
    #assert(c(enum { A=-1, B=-1, C=0 }))
    #assert(c(enum { A=3, B=1*1, C=2 }))
    #assert(c(enum { A=-1, B=0, C=1 }))
    #assert(c(enum { A=-4 }))
    #assert(c(enum { }))
    #assert(c(enum { A=-5 }))
    #assert(!c(enum { A=-3, B=-5 }))
    #assert(!c(enum { A=0, B=2 }))
```

Internally this sorts the `Type.Enum.fields` in place. Although I haven't found any issues with this, I am not sure whether the checker expects the exact declaration order of those fields in certain places?