### PR TITLE
Preserve insert_semicolon info and correctly parse incomplete switch cases for implicit selector expressions

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -673,7 +673,9 @@ parse_ident :: proc(p: ^Parser) -> ^ast.Ident {
 		name = tok.text
 		advance_token(p)
 	} else {
-		expect_token(p, .Ident)
+		e := tokenizer.to_string(.Ident)
+		g := tokenizer.token_to_string(tok)
+		error(p, pos, "expected '%s', got '%s'", e, g)
 	}
 	i := ast.new(ast.Ident, pos, end_pos(tok))
 	i.name = name

--- a/core/odin/tokenizer/tokenizer.odin
+++ b/core/odin/tokenizer/tokenizer.odin
@@ -745,7 +745,7 @@ scan :: proc(t: ^Tokenizer) -> Token {
 		case .Ident, .Context, .Typeid, .Break, .Continue, .Fallthrough, .Return,
 		     .Integer, .Float, .Imag, .Rune, .String, .Undef,
 		     .Question, .Pointer, .Close_Paren, .Close_Bracket, .Close_Brace,
-		     .Increment, .Decrement, .Or_Return, .Or_Break, .Or_Continue:
+		     .Increment, .Decrement, .Or_Return, .Or_Break, .Or_Continue, .Period:
 			/*fallthrough*/
 			t.insert_semicolon = true
 		case:


### PR DESCRIPTION
Currently with the `core:odin/parser` parser, when parsing incomplete switch cases the behaviour is inconsistent. 

For example
```odin
Foo :: enum {
    AA,
    AB,
}

main :: proc() {
    foo: Foo

    // This switch provides 2 cases in the ast, one for the incomplete `A` , and another for `AB`
    switch foo {
    case .A
    case .AB:
    }

    // This switch only provides 1 case in the ast, for a field `_`, and we don't get the information for `AB`.
    switch foo {
    case .
    case .AB:
    }
}
```

In particular this is to resolve an issue with completions with `ols`, https://github.com/DanielGavin/ols/issues/474

Edit: I've realised this would actually have some more consequences outside of what I want as things like 
```
Foo :: struct {
    foo_int: int,
}

main :: proc() {
    foo := Foo{}
    x := foo.
        foo_int
}
```
are currently valid, but would no longer be with these changes. I'll close this for now and have a think on how else I could approach this.