### PR TITLE
Add iOS & iPhoneSimulator subtargets for Darwin target

### DIFF
--- a/base/builtin/builtin.odin
+++ b/base/builtin/builtin.odin
@@ -145,7 +145,7 @@ ODIN_OS_STRING                  :: ODIN_OS_STRING
 
 /*
 	An `enum` value indicating the platform subtarget, chosen using the `-subtarget` switch.
-	Possible values are: `.Default` `.iOS`, and `.Android`.
+	Possible values are: `.Default` `.iOS`, .iPhoneSimulator, and `.Android`.
 */
 ODIN_PLATFORM_SUBTARGET         :: ODIN_PLATFORM_SUBTARGET
 

--- a/base/runtime/core.odin
+++ b/base/runtime/core.odin
@@ -558,6 +558,7 @@ ALL_ODIN_OS_TYPES :: Odin_OS_Types{
 	Odin_Platform_Subtarget_Type :: enum int {
 		Default,
 		iOS,
+		iPhoneSimulator
 		Android,
 	}
 */

--- a/base/runtime/heap_allocator_unix.odin
+++ b/base/runtime/heap_allocator_unix.odin
@@ -3,7 +3,7 @@
 package runtime
 
 when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/complex.odin
+++ b/core/c/libc/complex.odin
@@ -5,7 +5,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/ctype.odin
+++ b/core/c/libc/ctype.odin
@@ -3,7 +3,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/errno.odin
+++ b/core/c/libc/errno.odin
@@ -5,7 +5,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/locale.odin
+++ b/core/c/libc/locale.odin
@@ -5,7 +5,7 @@ import "core:c"
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/math.odin
+++ b/core/c/libc/math.odin
@@ -7,7 +7,7 @@ import "base:intrinsics"
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/setjmp.odin
+++ b/core/c/libc/setjmp.odin
@@ -5,7 +5,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/signal.odin
+++ b/core/c/libc/signal.odin
@@ -5,7 +5,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/stdio.odin
+++ b/core/c/libc/stdio.odin
@@ -9,7 +9,7 @@ when ODIN_OS == .Windows {
 		"system:legacy_stdio_definitions.lib",
 	}
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/stdlib.odin
+++ b/core/c/libc/stdlib.odin
@@ -5,7 +5,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/string.odin
+++ b/core/c/libc/string.odin
@@ -7,7 +7,7 @@ import "base:runtime"
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/time.odin
+++ b/core/c/libc/time.odin
@@ -5,7 +5,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/uchar.odin
+++ b/core/c/libc/uchar.odin
@@ -5,7 +5,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/wchar.odin
+++ b/core/c/libc/wchar.odin
@@ -5,7 +5,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/c/libc/wctype.odin
+++ b/core/c/libc/wctype.odin
@@ -5,7 +5,7 @@ package libc
 when ODIN_OS == .Windows {
 	foreign import libc "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/net/interface_darwin.odin
+++ b/core/net/interface_darwin.odin
@@ -23,7 +23,7 @@ package net
 import "core:strings"
 import "core:sys/posix"
 
-foreign import lib "system:System.framework"
+foreign import lib "system:System"
 
 @(private)
 _enumerate_interfaces :: proc(allocator := context.allocator) -> (interfaces: []Network_Interface, err: Interfaces_Error) {

--- a/core/os/os2/process_posix_darwin.odin
+++ b/core/os/os2/process_posix_darwin.odin
@@ -10,7 +10,7 @@ import "core:sys/posix"
 import "core:sys/unix"
 import "core:time"
 
-foreign import lib "system:System.framework"
+foreign import lib "system:System"
 
 foreign lib {
 	sysctl :: proc(

--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -1,8 +1,8 @@
 package os
 
 foreign import dl   "system:dl"
-foreign import libc "system:System.framework"
-foreign import pthread "system:System.framework"
+foreign import libc "system:System"
+foreign import pthread "system:System"
 
 import "base:runtime"
 import "core:strings"

--- a/core/sync/futex_darwin.odin
+++ b/core/sync/futex_darwin.odin
@@ -6,7 +6,7 @@ import "core:c"
 import "core:sys/darwin"
 import "core:time"
 
-foreign import System "system:System.framework"
+foreign import System "system:System"
 
 foreign System {
 	// __ulock_wait is not available on 10.15

--- a/core/sync/primitives_darwin.odin
+++ b/core/sync/primitives_darwin.odin
@@ -5,7 +5,7 @@ package sync
 import "core:c"
 import "base:intrinsics"
 
-foreign import pthread "system:System.framework"
+foreign import pthread "system:System"
 
 _current_thread_id :: proc "contextless" () -> int {
 	tid: u64

--- a/core/sys/darwin/Foundation/NSBlock.odin
+++ b/core/sys/darwin/Foundation/NSBlock.odin
@@ -62,7 +62,7 @@ global_block_descriptor := Block_Descriptor{
 	size     = size_of(Internal_Block_Literal),
 }
 
-foreign import libSystem "system:System.framework"
+foreign import libSystem "system:System"
 foreign libSystem {
 	_NSConcreteGlobalBlock: intrinsics.objc_class
 	_NSConcreteStackBlock: intrinsics.objc_class

--- a/core/sys/darwin/darwin.odin
+++ b/core/sys/darwin/darwin.odin
@@ -4,7 +4,7 @@ package darwin
 import "core:c"
 
 @(export)
-foreign import system "system:System.framework"
+foreign import system "system:System"
 
 Bool :: b8
 

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -1,6 +1,6 @@
 package darwin
 
-foreign import mach "system:System.framework"
+foreign import mach "system:System"
 
 import "core:c"
 import "base:intrinsics"

--- a/core/sys/darwin/proc.odin
+++ b/core/sys/darwin/proc.odin
@@ -4,7 +4,7 @@ import "base:intrinsics"
 
 import "core:sys/posix"
 
-foreign import lib "system:System.framework"
+foreign import lib "system:System"
 
 // Incomplete bindings to the proc API on MacOS, add to when needed.
 

--- a/core/sys/kqueue/kqueue.odin
+++ b/core/sys/kqueue/kqueue.odin
@@ -2,7 +2,7 @@
 package kqueue
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/arpa_inet.odin
+++ b/core/sys/posix/arpa_inet.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else when ODIN_OS == .Haiku {
 	foreign import lib "system:network"
 } else {

--- a/core/sys/posix/dirent.odin
+++ b/core/sys/posix/dirent.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/dlfcn.odin
+++ b/core/sys/posix/dlfcn.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else when ODIN_OS == .FreeBSD || ODIN_OS == .NetBSD {
 	foreign import lib "system:dl"
 } else {

--- a/core/sys/posix/fcntl.odin
+++ b/core/sys/posix/fcntl.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/fnmatch.odin
+++ b/core/sys/posix/fnmatch.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/glob.odin
+++ b/core/sys/posix/glob.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/grp.odin
+++ b/core/sys/posix/grp.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/langinfo.odin
+++ b/core/sys/posix/langinfo.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/libgen.odin
+++ b/core/sys/posix/libgen.odin
@@ -2,7 +2,7 @@
 package posix
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/monetary.odin
+++ b/core/sys/posix/monetary.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/net_if.odin
+++ b/core/sys/posix/net_if.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/netdb.odin
+++ b/core/sys/posix/netdb.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/netinet_in.odin
+++ b/core/sys/posix/netinet_in.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/poll.odin
+++ b/core/sys/posix/poll.odin
@@ -6,7 +6,7 @@ import "base:intrinsics"
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/pthread.odin
+++ b/core/sys/posix/pthread.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else when ODIN_OS == .FreeBSD || ODIN_OS == .NetBSD || ODIN_OS == .Linux {
 	foreign import lib "system:pthread"
 } else {

--- a/core/sys/posix/pwd.odin
+++ b/core/sys/posix/pwd.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/sched.odin
+++ b/core/sys/posix/sched.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/setjmp.odin
+++ b/core/sys/posix/setjmp.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/signal.odin
+++ b/core/sys/posix/signal.odin
@@ -6,7 +6,7 @@ import "base:intrinsics"
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/signal_libc.odin
+++ b/core/sys/posix/signal_libc.odin
@@ -9,7 +9,7 @@ import "core:c/libc"
 when ODIN_OS == .Windows {
 	foreign import lib "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/stdio.odin
+++ b/core/sys/posix/stdio.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/stdio_libc.odin
+++ b/core/sys/posix/stdio_libc.odin
@@ -10,7 +10,7 @@ when ODIN_OS == .Windows {
 		"system:legacy_stdio_definitions.lib",
 	}
 } else when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/stdlib.odin
+++ b/core/sys/posix/stdlib.odin
@@ -6,7 +6,7 @@ import "base:intrinsics"
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/stdlib_libc.odin
+++ b/core/sys/posix/stdlib_libc.odin
@@ -9,7 +9,7 @@ import "core:c/libc"
 when ODIN_OS == .Windows {
 	foreign import lib "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/string.odin
+++ b/core/sys/posix/string.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/string_libc.odin
+++ b/core/sys/posix/string_libc.odin
@@ -4,7 +4,7 @@ package posix
 when ODIN_OS == .Windows {
 	foreign import lib "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/sys_ipc.odin
+++ b/core/sys/posix/sys_ipc.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/sys_mman.odin
+++ b/core/sys/posix/sys_mman.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/sys_msg.odin
+++ b/core/sys/posix/sys_msg.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/sys_resource.odin
+++ b/core/sys/posix/sys_resource.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/sys_select.odin
+++ b/core/sys/posix/sys_select.odin
@@ -6,7 +6,7 @@ import "base:intrinsics"
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/sys_sem.odin
+++ b/core/sys/posix/sys_sem.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/sys_shm.odin
+++ b/core/sys/posix/sys_shm.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/sys_socket.odin
+++ b/core/sys/posix/sys_socket.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/sys/posix/sys_stat.odin
+++ b/core/sys/posix/sys_stat.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/sys_statvfs.odin
+++ b/core/sys/posix/sys_statvfs.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/sys_time.odin
+++ b/core/sys/posix/sys_time.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/sys_times.odin
+++ b/core/sys/posix/sys_times.odin
@@ -2,7 +2,7 @@
 package posix
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/sys_uio.odin
+++ b/core/sys/posix/sys_uio.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import libc "system:System.framework"
+	foreign import libc "system:System"
 } else {
 	foreign import libc "system:c"
 }

--- a/core/sys/posix/sys_utsname.odin
+++ b/core/sys/posix/sys_utsname.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/sys_wait.odin
+++ b/core/sys/posix/sys_wait.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/termios.odin
+++ b/core/sys/posix/termios.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/time.odin
+++ b/core/sys/posix/time.odin
@@ -5,7 +5,7 @@ import "core:c"
 import "core:c/libc"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/ulimit.odin
+++ b/core/sys/posix/ulimit.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/unistd.odin
+++ b/core/sys/posix/unistd.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/unistd_libc.odin
+++ b/core/sys/posix/unistd_libc.odin
@@ -6,7 +6,7 @@ import "core:c"
 when ODIN_OS == .Windows {
 	foreign import lib "system:libucrt.lib"
 } else when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/utime.odin
+++ b/core/sys/posix/utime.odin
@@ -2,7 +2,7 @@
 package posix
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/core/sys/posix/wordexp.odin
+++ b/core/sys/posix/wordexp.odin
@@ -4,7 +4,7 @@ package posix
 import "core:c"
 
 when ODIN_OS == .Darwin {
-	foreign import lib "system:System.framework"
+	foreign import lib "system:System"
 } else {
 	foreign import lib "system:c"
 }

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -172,6 +172,7 @@ struct TargetMetrics {
 enum Subtarget : u32 {
 	Subtarget_Default,
 	Subtarget_iOS,
+	Subtarget_iPhoneSimulator,
 	Subtarget_Android,
 
 	Subtarget_COUNT,
@@ -180,6 +181,7 @@ enum Subtarget : u32 {
 gb_global String subtarget_strings[Subtarget_COUNT] = {
 	str_lit(""),
 	str_lit("ios"),
+	str_lit("iphonesimulator"),
 	str_lit("android"),
 };
 
@@ -1824,16 +1826,29 @@ gb_internal void init_build_context(TargetMetrics *cross_target, Subtarget subta
 		}
 	}
 
-	if (metrics->os == TargetOs_darwin && subtarget == Subtarget_iOS) {
-		switch (metrics->arch) {
-		case TargetArch_arm64:
-			bc->metrics.target_triplet = str_lit("arm64-apple-ios");
-			break;
-		case TargetArch_amd64:
-			bc->metrics.target_triplet = str_lit("x86_64-apple-ios");
-			break;
-		default:
-			GB_PANIC("Unknown architecture for darwin");
+	if (metrics->os == TargetOs_darwin) {
+		switch (subtarget) {
+			case Subtarget_iOS:
+				switch (metrics->arch) {
+				case TargetArch_arm64:
+					bc->metrics.target_triplet = str_lit("arm64-apple-ios");
+					break;
+				default:
+					GB_PANIC("Unknown architecture for -subtarget:ios");
+				}
+				break;
+			case Subtarget_iPhoneSimulator:
+				switch (metrics->arch) {
+				case TargetArch_arm64:
+					bc->metrics.target_triplet = str_lit("arm64-apple-ios-simulator");
+					break;
+				case TargetArch_amd64:
+					bc->metrics.target_triplet = str_lit("x86_64-apple-ios-simulator");
+					break;
+				default:
+					GB_PANIC("Unknown architecture for -subtarget:iphonesimulator");
+				}
+				break;
 		}
 	} else if (metrics->os == TargetOs_linux && subtarget == Subtarget_Android) {
 		switch (metrics->arch) {

--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -1171,9 +1171,10 @@ gb_internal void init_universal(void) {
 
 	{
 		GlobalEnumValue values[Subtarget_COUNT] = {
-			{"Default", Subtarget_Default},
-			{"iOS",     Subtarget_iOS},
-			{"Android", Subtarget_Android},
+			{"Default",         Subtarget_Default},
+			{"iOS",             Subtarget_iOS},
+			{"iPhoneSimulator", Subtarget_iPhoneSimulator},
+			{"Android",         Subtarget_Android},
 		};
 
 		auto fields = add_global_enum_type(str_lit("Odin_Platform_Subtarget_Type"), values, gb_count_of(values));

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -797,7 +797,7 @@ try_cross_linking:;
 					break;
 				}
 
-				const char* original_clang_path = original_clang_path;
+				const char* original_clang_path = clang_path;
 
 				gbString darwin_find_sdk_cmd = gb_string_make(temporary_allocator(), "");
 				darwin_find_sdk_cmd = gb_string_append_fmt(darwin_find_sdk_cmd, "xcrun --sdk %s --show-sdk-path", darwin_xcrun_sdk_name);

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -591,7 +591,7 @@ try_cross_linking:;
 						// Do not add libc again, this is added later already, and omitted with
 						// the `-no-crt` flag, not skipping here would cause duplicate library
 						// warnings when linking on darwin and might link libc silently even with `-no-crt`.
-						if (lib == str_lit("System.framework") || lib == str_lit("c")) {
+						if (lib == str_lit("System.framework") || lib == str_lit("System") || lib == str_lit("c")) {
 							continue;
 						}
 
@@ -772,10 +772,54 @@ try_cross_linking:;
 			gbString platform_lib_str = gb_string_make(heap_allocator(), "");
 			defer (gb_string_free(platform_lib_str));
 			if (build_context.metrics.os == TargetOs_darwin) {
-				// Get the MacOSX SDK path.
+				// Get the SDK path.
 				gbString darwin_sdk_path = gb_string_make(temporary_allocator(), "");
-				if (!system_exec_command_line_app_output("xcrun --sdk macosx --show-sdk-path", &darwin_sdk_path)) {
-					darwin_sdk_path = gb_string_set(darwin_sdk_path, "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk");
+
+				char const* darwin_platform_name  = "MacOSX";
+				char const* darwin_xcrun_sdk_name = "macosx";
+				char const* darwin_min_version_id = "macosx";
+
+				// NOTE(harold): We set the clang_path to run through xcrun because otherwise it complaints about the the sysroot
+				//               being set to 'MacOSX' even though we've set the sysroot to the correct SDK (-Wincompatible-sysroot).
+				//               This is because it is likely not using the SDK's toolchain Apple Clang but another one installed in the system.
+				switch (selected_subtarget) {
+				case Subtarget_iOS:
+					darwin_platform_name  = "iPhoneOS";
+					darwin_xcrun_sdk_name = "iphoneos";
+					darwin_min_version_id = "ios";
+					clang_path            = "xcrun --sdk iphoneos clang";
+					break;
+				case Subtarget_iPhoneSimulator:
+					darwin_platform_name  = "iPhoneSimulator";
+					darwin_xcrun_sdk_name = "iphonesimulator";
+					darwin_min_version_id = "ios-simulator";
+					clang_path            = "xcrun --sdk iphonesimulator clang";
+					break;
+				}
+
+				const char* original_clang_path = original_clang_path;
+
+				gbString darwin_find_sdk_cmd = gb_string_make(temporary_allocator(), "");
+				darwin_find_sdk_cmd = gb_string_append_fmt(darwin_find_sdk_cmd, "xcrun --sdk %s --show-sdk-path", darwin_xcrun_sdk_name);
+
+				if (!system_exec_command_line_app_output(darwin_find_sdk_cmd, &darwin_sdk_path)) {
+
+					// Fallback to default clang, since `xcrun --sdk` did not work.
+					clang_path = original_clang_path;
+
+					// Best-effort fallback to known locations
+					gbString darwin_sdk_path = gb_string_make(temporary_allocator(), "");
+					darwin_sdk_path = gb_string_append_fmt(darwin_sdk_path, "/Library/Developer/CommandLineTools/SDKs/%s.sdk", darwin_platform_name);
+
+					if (!path_is_directory(make_string_c(darwin_sdk_path))) {
+						gb_string_clear(darwin_sdk_path);
+						darwin_sdk_path = gb_string_append_fmt(darwin_sdk_path, "/Applications/Xcode.app/Contents/Developer/Platforms/%s.platform/Developer/SDKs/%s.sdk", darwin_platform_name);
+
+						if (!path_is_directory(make_string_c(darwin_sdk_path))) {
+							gb_printf_err("Failed to find %s SDK\n", darwin_platform_name);
+							return -1;
+						}
+					}
 				} else {
 					// Trim the trailing newline.
 					darwin_sdk_path = gb_string_trim_space(darwin_sdk_path);
@@ -797,7 +841,7 @@ try_cross_linking:;
 				// Only specify this flag if the user has given a minimum version to target.
 				// This will cause warnings to show up for mismatched libraries.
 				if (build_context.minimum_os_version_string_given) {
-					link_settings = gb_string_append_fmt(link_settings, "-mmacosx-version-min=%.*s ", LIT(build_context.minimum_os_version_string));
+					link_settings = gb_string_append_fmt(link_settings, "-m%s-version-min=%.*s ", darwin_min_version_id, LIT(build_context.minimum_os_version_string));
 				}
 
 				if (build_context.build_mode != BuildMode_DynamicLibrary) {


### PR DESCRIPTION
Updated PR to provides build support for iOS & iPhoneSimulator

This does not provide bundling support, but I plan to add it as a separate PR later. The bare minimum packaging is simple and there's an example in my frameworks repo.