### PR TITLE
Fix correct versioned target triplet for iphonesimulator subtarget

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1916,7 +1916,16 @@ gb_internal void init_build_context(TargetMetrics *cross_target, Subtarget subta
 			}
 		}
 
-		bc->metrics.target_triplet = concatenate_strings(permanent_allocator(), bc->metrics.target_triplet, bc->minimum_os_version_string);
+		if (subtarget == Subtarget_iPhoneSimulator) {
+			// For the iOS simulator subtarget, the version must be between 'ios' and '-simulator'.
+			String suffix = str_lit("-simulator");
+			GB_ASSERT(string_ends_with(bc->metrics.target_triplet, suffix));
+
+			String prefix = substring(bc->metrics.target_triplet, 0, bc->metrics.target_triplet.len - suffix.len);
+			bc->metrics.target_triplet = concatenate3_strings(permanent_allocator(), prefix, bc->minimum_os_version_string, suffix);
+		} else {
+			bc->metrics.target_triplet = concatenate_strings(permanent_allocator(), bc->metrics.target_triplet, bc->minimum_os_version_string);
+		}
 	} else if (selected_subtarget == Subtarget_Android) {
 		init_android_values(bc->build_mode == BuildMode_Executable && (bc->command_kind & Command__does_build) != 0);
 	}

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -846,7 +846,9 @@ try_cross_linking:;
 
 				// Only specify this flag if the user has given a minimum version to target.
 				// This will cause warnings to show up for mismatched libraries.
-				if (build_context.minimum_os_version_string_given) {
+				// NOTE(harold): For device subtargets we have to explicitly set the default version to 
+				//               avoid the same warning since we configure our own minimum version when compiling for devices.
+				if (build_context.minimum_os_version_string_given || selected_subtarget != Subtarget_Default) {
 					link_settings = gb_string_append_fmt(link_settings, "-m%s-version-min=%.*s ", darwin_min_version_id, LIT(build_context.minimum_os_version_string));
 				}
 


### PR DESCRIPTION
- Always set the `-m*-version-min` linker flag for non-macOS Darwin subtargets