### PR TITLE
Fix @objc_implement methods not respecting @objc_is_class_method

### DIFF
--- a/base/runtime/procs_darwin.odin
+++ b/base/runtime/procs_darwin.odin
@@ -31,5 +31,6 @@ foreign ObjC {
 	class_getInstanceVariable :: proc "c" (cls : objc_Class, name: cstring) -> objc_Ivar ---
 	class_getInstanceSize     :: proc "c" (cls : objc_Class) -> uint ---
 	ivar_getOffset            :: proc "c" (v: objc_Ivar) -> uintptr ---
+	object_getClass           :: proc "c" (obj: objc_id) -> objc_Class ---
 }
 


### PR DESCRIPTION
I accidentally missed class methods not being registered to the metaclass of the class in the original objc_implement PR.

This fixes that and also fixes type encoding for objc_class and objc_selector.