### PR TITLE
Fixed Index 0 is out of range 0..<0' when using '-default-to-nil-allocator' for FreeBSD/OpenBSD/NetBSD/Linux

### DIFF
--- a/core/os/os_freebsd.odin
+++ b/core/os/os_freebsd.odin
@@ -967,8 +967,8 @@ _processor_core_count :: proc() -> int {
 @(private, require_results)
 _alloc_command_line_arguments :: proc() -> []string {
 	res := make([]string, len(runtime.args__))
-	for arg, i in runtime.args__ {
-		res[i] = string(arg)
+	for arg, i in res {
+		res[i] = string(runtime.args__[i])
 	}
 	return res
 }

--- a/core/os/os_freebsd.odin
+++ b/core/os/os_freebsd.odin
@@ -967,7 +967,7 @@ _processor_core_count :: proc() -> int {
 @(private, require_results)
 _alloc_command_line_arguments :: proc() -> []string {
 	res := make([]string, len(runtime.args__))
-	for arg, i in res {
+	for _, i in res {
 		res[i] = string(runtime.args__[i])
 	}
 	return res

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -1100,8 +1100,8 @@ _processor_core_count :: proc() -> int {
 @(private, require_results)
 _alloc_command_line_arguments :: proc() -> []string {
 	res := make([]string, len(runtime.args__))
-	for arg, i in runtime.args__ {
-		res[i] = string(arg)
+	for arg, i in  arg {
+		res[i] = string(runtime.args__[i])
 	}
 	return res
 }

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -1100,7 +1100,7 @@ _processor_core_count :: proc() -> int {
 @(private, require_results)
 _alloc_command_line_arguments :: proc() -> []string {
 	res := make([]string, len(runtime.args__))
-	for arg, i in  res {
+	for _, i in  res {
 		res[i] = string(runtime.args__[i])
 	}
 	return res

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -1100,7 +1100,7 @@ _processor_core_count :: proc() -> int {
 @(private, require_results)
 _alloc_command_line_arguments :: proc() -> []string {
 	res := make([]string, len(runtime.args__))
-	for arg, i in  arg {
+	for arg, i in  res {
 		res[i] = string(runtime.args__[i])
 	}
 	return res

--- a/core/os/os_netbsd.odin
+++ b/core/os/os_netbsd.odin
@@ -1017,8 +1017,8 @@ _processor_core_count :: proc() -> int {
 @(private, require_results)
 _alloc_command_line_arguments :: proc() -> []string {
 	res := make([]string, len(runtime.args__))
-	for arg, i in runtime.args__ {
-		res[i] = string(arg)
+	for arg, i in res {
+		res[i] = string(runtime.args__[i])
 	}
 	return res
 }

--- a/core/os/os_netbsd.odin
+++ b/core/os/os_netbsd.odin
@@ -1017,7 +1017,7 @@ _processor_core_count :: proc() -> int {
 @(private, require_results)
 _alloc_command_line_arguments :: proc() -> []string {
 	res := make([]string, len(runtime.args__))
-	for arg, i in res {
+	for _, i in res {
 		res[i] = string(runtime.args__[i])
 	}
 	return res

--- a/core/os/os_openbsd.odin
+++ b/core/os/os_openbsd.odin
@@ -917,7 +917,7 @@ _processor_core_count :: proc() -> int {
 @(private, require_results)
 _alloc_command_line_arguments :: proc() -> []string {
 	res := make([]string, len(runtime.args__))
-	for arg, i in res {
+	for _, i in res {
 		res[i] = string(runtime.args__[i])
 	}
 	return res

--- a/core/os/os_openbsd.odin
+++ b/core/os/os_openbsd.odin
@@ -917,8 +917,8 @@ _processor_core_count :: proc() -> int {
 @(private, require_results)
 _alloc_command_line_arguments :: proc() -> []string {
 	res := make([]string, len(runtime.args__))
-	for arg, i in runtime.args__ {
-		res[i] = string(arg)
+	for arg, i in res {
+		res[i] = string(runtime.args__[i])
 	}
 	return res
 }


### PR DESCRIPTION
I tested on `FreeBSD/Linux`, but the fix code is straightforward, so I applied it to `OpenBSD/NetBSD` as well (since they share the same piece of code).