### PR TITLE
Disable filepath/match.odin and filepath/walk.odin compilation on js targets

### DIFF
--- a/core/path/filepath/match.odin
+++ b/core/path/filepath/match.odin
@@ -1,4 +1,5 @@
 #+build !wasi
+#+build !js
 package filepath
 
 import "core:os"

--- a/core/path/filepath/walk.odin
+++ b/core/path/filepath/walk.odin
@@ -1,4 +1,5 @@
 #+build !wasi
+#+build !js
 package filepath
 
 import "core:os"


### PR DESCRIPTION
Fixes #5481 