### PR TITLE
SDL_image save functions should return bool

### DIFF
--- a/vendor/sdl3/image/sdl_image.odin
+++ b/vendor/sdl3/image/sdl_image.odin
@@ -89,12 +89,12 @@ foreign lib {
 	ReadXPMFromArrayToRGB888 :: proc(xpm: [^]cstring) -> ^SDL.Surface ---
 
 	/* Individual saving functions */
-	SaveAVIF    :: proc(surface: ^SDL.Surface, file: cstring, quality: c.int) -> c.int ---
-	SaveAVIF_IO :: proc(surface: ^SDL.Surface, dst: ^SDL.IOStream, closeio: bool, quality: c.int) -> c.int ---
-	SavePNG     :: proc(surface: ^SDL.Surface, file: cstring) -> c.int ---
-	SavePNG_IO  :: proc(surface: ^SDL.Surface, dst: ^SDL.IOStream, closeio: bool) -> c.int ---
-	SaveJPG     :: proc(surface: ^SDL.Surface, file: cstring, quality: c.int) -> c.int ---
-	SaveJPG_IO  :: proc(surface: ^SDL.Surface, dst: ^SDL.IOStream, closeio: bool, quality: c.int) -> c.int ---
+	SaveAVIF    :: proc(surface: ^SDL.Surface, file: cstring, quality: c.int) -> c.bool ---
+	SaveAVIF_IO :: proc(surface: ^SDL.Surface, dst: ^SDL.IOStream, closeio: bool, quality: c.int) -> c.bool ---
+	SavePNG     :: proc(surface: ^SDL.Surface, file: cstring) -> c.bool ---
+	SavePNG_IO  :: proc(surface: ^SDL.Surface, dst: ^SDL.IOStream, closeio: bool) -> c.bool ---
+	SaveJPG     :: proc(surface: ^SDL.Surface, file: cstring, quality: c.int) -> c.bool ---
+	SaveJPG_IO  :: proc(surface: ^SDL.Surface, dst: ^SDL.IOStream, closeio: bool, quality: c.int) -> c.bool ---
 
 	LoadAnimation         :: proc(file: cstring) -> ^Animation ---
 	LoadAnimation_IO      :: proc(src: ^SDL.IOStream, closeio: bool) -> ^Animation ---


### PR DESCRIPTION
Updates SDL image save functions to return bool to match C API

[IMG_SaveAVIF](https://wiki.libsdl.org/SDL3_image/IMG_SaveAVIF)
[IMG_SaveAVIF_IO](https://wiki.libsdl.org/SDL3_image/IMG_SaveAVIF_IO)
[IMG_SaveJPG](https://wiki.libsdl.org/SDL3_image/IMG_SaveJPG)
[IMG_SaveJPG_IO](https://wiki.libsdl.org/SDL3_image/IMG_SaveJPG_IO)
[IMG_SavePNG](https://wiki.libsdl.org/SDL3_image/IMG_SavePNG)
[IMG_SavePNG_IO](https://wiki.libsdl.org/SDL3_image/IMG_SavePNG_IO)