### PR TITLE
vendor:Vulkan correct SHADER_UNUSED_KHR value

### DIFF
--- a/vendor/vulkan/core.odin
+++ b/vendor/vulkan/core.odin
@@ -690,7 +690,7 @@ NV_SHADING_RATE_IMAGE_EXTENSION_NAME                      :: "VK_NV_shading_rate
 NV_ray_tracing                                            :: 1
 NV_RAY_TRACING_SPEC_VERSION                               :: 3
 NV_RAY_TRACING_EXTENSION_NAME                             :: "VK_NV_ray_tracing"
-SHADER_UNUSED_KHR                                         :: 0
+SHADER_UNUSED_KHR                                         :: ~u32(0)
 NV_representative_fragment_test                           :: 1
 NV_REPRESENTATIVE_FRAGMENT_TEST_SPEC_VERSION              :: 2
 NV_REPRESENTATIVE_FRAGMENT_TEST_EXTENSION_NAME            :: "VK_NV_representative_fragment_test"


### PR DESCRIPTION
VK_SHADER_UNUSED_KHR was 0, it should be ~u32(0)

https://registry.khronos.org/vulkan/specs/latest/man/html/VK_SHADER_UNUSED_KHR.html

Validation layer result when it was 0:
```
Validation Layer: Validation Error: [ VUID-VkRayTracingShaderGroupCreateInfoKHR-type-03475 ] | MessageID = 0x38a68524 | vkCreateRayTracingPipelinesKHR(): pCreateInfos[0].pGroups[0] anyHitShader is 0, closestHitShader is 0, intersectionShader is 0.
The Vulkan spec states: If type is VK_RAY_TRACING_SHADER_GROUP_TYPE_GENERAL_KHR then closestHitShader, anyHitShader, and intersectionShader must be VK_SHADER_UNUSED_KHR (https://vulkan.lunarg.com/doc/view/1.3.296.0/windows/1.3-extensions/vkspec.html#VUID-VkRayTracingShaderGroupCreateInfoKHR-type-03475)
```

