### PR TITLE
Vulkan generator - Support bitwise NOT for constants

### DIFF
--- a/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
+++ b/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
@@ -312,7 +312,11 @@ def parse_constants(f):
         value = remove_prefix(value, 'VK_')
         v = number_suffix_re.findall(value)
         if v:
-            value = v[0]
+            if '~' in value:
+                value = "~u32(" + v[0] + ")"
+            else:
+                value = v[0]
+
         f.write("{}{} :: {}\n".format(name, "".rjust(max_len-len(name)), value))
     f.write("\n")
 

--- a/vendor/vulkan/core.odin
+++ b/vendor/vulkan/core.odin
@@ -690,7 +690,7 @@ NV_SHADING_RATE_IMAGE_EXTENSION_NAME                      :: "VK_NV_shading_rate
 NV_ray_tracing                                            :: 1
 NV_RAY_TRACING_SPEC_VERSION                               :: 3
 NV_RAY_TRACING_EXTENSION_NAME                             :: "VK_NV_ray_tracing"
-SHADER_UNUSED_KHR                                         :: 0
+SHADER_UNUSED_KHR                                         :: ~u32(0)
 NV_representative_fragment_test                           :: 1
 NV_REPRESENTATIVE_FRAGMENT_TEST_SPEC_VERSION              :: 2
 NV_REPRESENTATIVE_FRAGMENT_TEST_EXTENSION_NAME            :: "VK_NV_representative_fragment_test"


### PR DESCRIPTION
Generator was previously discarding the ~ operator in constants so values like ~(0U) were being interpreted as just 0. 

This change ensures such expressions are handled correctly.

Here's the value I focused on as reference:
https://registry.khronos.org/vulkan/specs/latest/man/html/VK_SHADER_UNUSED_KHR.html