### PR TITLE
SDL2 - AudioAllowChangeFlags bit_set

### DIFF
--- a/vendor/sdl2/sdl_audio.odin
+++ b/vendor/sdl2/sdl_audio.odin
@@ -74,12 +74,14 @@ when ODIN_ENDIAN == .Little {
 	AUDIO_F32SYS :: AUDIO_F32MSB
 }
 
-
-AUDIO_ALLOW_FREQUENCY_CHANGE    :: 0x00000001
-AUDIO_ALLOW_FORMAT_CHANGE       :: 0x00000002
-AUDIO_ALLOW_CHANNELS_CHANGE     :: 0x00000004
-AUDIO_ALLOW_SAMPLES_CHANGE      :: 0x00000008
-AUDIO_ALLOW_ANY_CHANGE          :: AUDIO_ALLOW_FREQUENCY_CHANGE|AUDIO_ALLOW_FORMAT_CHANGE|AUDIO_ALLOW_CHANNELS_CHANGE|AUDIO_ALLOW_SAMPLES_CHANGE
+AudioAllowChangeFlags :: distinct bit_set[AudioAllowChangeFlag; c.int]
+AudioAllowChangeFlag :: enum c.int {
+	FREQUENCY    = 0,
+	FORMAT       = 1,
+	CHANNELS     = 2,
+	SAMPLES      = 3,
+}
+AUDIO_ALLOW_ANY_CHANGE :: AudioAllowChangeFlags{.FREQUENCY, .FORMAT, .CHANNELS, .SAMPLES}
 
 AudioCallback :: proc "c" (userdata: rawptr, stream: [^]u8, len: c.int)
 
@@ -151,7 +153,7 @@ foreign lib {
 	                        iscapture: bool,
 	                        desired: ^AudioSpec,
 	                        obtained: ^AudioSpec,
-	                        allowed_changes: bool) -> AudioDeviceID ---
+	                        allowed_changes: AudioAllowChangeFlags) -> AudioDeviceID ---
 }
 
 


### PR DESCRIPTION
sdl.OpenAudioDevice was incorrectly using a bool instead of a c.int for it's last parameter. To make the proc call more idiomatic and inline with other bindings a new bit_set was introduced to be used in place of the constants. 

This would resolve this open issue: https://github.com/odin-lang/Odin/issues/5494