### PR TITLE
add cgltf filter type and wrap mode enums

### DIFF
--- a/vendor/cgltf/cgltf.odin
+++ b/vendor/cgltf/cgltf.odin
@@ -263,19 +263,19 @@ image :: struct {
 }
 
 filter_type :: enum c.int {
-	undefined = 0,
-	nearest = 9728,
-	linear = 9729,
+	undefined              = 0,
+	nearest                = 9728,
+	linear                 = 9729,
 	nearest_mipmap_nearest = 9984,
-	linear_mipmap_nearest = 9985,
-	nearest_mipmap_linear = 9986,
-	linear_mipmap_linear = 9987,
+	linear_mipmap_nearest  = 9985,
+	nearest_mipmap_linear  = 9986,
+	linear_mipmap_linear   = 9987,
 }
 
 wrap_mode :: enum c.int {
-	clamp_to_edge = 33071,
+	clamp_to_edge   = 33071,
 	mirrored_repeat = 33648,
-	repeat = 10497,
+	repeat          = 10497,
 }
 
 sampler :: struct {


### PR DESCRIPTION
The cgltf library has added enums for the sampler filter types and wrap modes: https://github.com/jkuhlmann/cgltf/pull/258/files. This replaces the bare ints that were being used before.

Even though the vendor library isn't using a version of the header file with these enums, they can still be added to the binding without issue or needing to update.

This PR implements those new enums.