### PR TITLE
Additional obj-c methods for darwin Foundation

### DIFF
--- a/core/sys/darwin/Foundation/NSBitmapImageRep.odin
+++ b/core/sys/darwin/Foundation/NSBitmapImageRep.odin
@@ -1,0 +1,50 @@
+package objc_Foundation
+
+import "base:intrinsics"
+
+@(objc_class="NSBitmapImageRep")
+BitmapImageRep :: struct { using _: Object }
+
+@(objc_type=BitmapImageRep, objc_name="alloc", objc_is_class_method=true)
+BitmapImageRep_alloc :: proc "c" () -> ^BitmapImageRep {
+        return msgSend(^BitmapImageRep, BitmapImageRep, "alloc")
+}
+
+@(objc_type=BitmapImageRep, objc_name="initWithBitmapDataPlanes")
+BitmapImageRep_initWithBitmapDataPlanes :: proc "c" (
+        self: ^BitmapImageRep, 
+        bitmapDataPlanes: ^^u8,
+        pixelsWide: Integer, 
+        pixelsHigh: Integer,
+        bitsPerSample: Integer,
+        samplesPerPixel: Integer,
+        hasAlpha: bool, 
+        isPlanar: bool,
+        colorSpaceName: ^String,
+        bytesPerRow: Integer,
+        bitsPerPixel: Integer) -> ^BitmapImageRep {
+
+	return msgSend(^BitmapImageRep, 
+                self, 
+                "initWithBitmapDataPlanes:pixelsWide:pixelsHigh:bitsPerSample:samplesPerPixel:hasAlpha:isPlanar:colorSpaceName:bytesPerRow:bitsPerPixel:",
+                bitmapDataPlanes,
+                pixelsWide, 
+                pixelsHigh,
+                bitsPerSample,
+                samplesPerPixel,
+                hasAlpha,
+                isPlanar, 
+                colorSpaceName,
+                bytesPerRow,
+                bitsPerPixel)
+}
+
+@(objc_type=BitmapImageRep, objc_name="bitmapData")
+BitmapImageRep_bitmapData :: proc "c" (self: ^BitmapImageRep) -> rawptr {
+        return msgSend(rawptr, self, "bitmapData") 
+}
+
+@(objc_type=BitmapImageRep, objc_name="CGImage")
+BitmapImageRep_CGImage :: proc "c" (self: ^BitmapImageRep) -> rawptr {
+        return msgSend(rawptr, self, "CGImage") 
+}

--- a/core/sys/darwin/Foundation/NSBitmapImageRep.odin
+++ b/core/sys/darwin/Foundation/NSBitmapImageRep.odin
@@ -7,44 +7,44 @@ BitmapImageRep :: struct { using _: Object }
 
 @(objc_type=BitmapImageRep, objc_name="alloc", objc_is_class_method=true)
 BitmapImageRep_alloc :: proc "c" () -> ^BitmapImageRep {
-        return msgSend(^BitmapImageRep, BitmapImageRep, "alloc")
+	return msgSend(^BitmapImageRep, BitmapImageRep, "alloc")
 }
 
 @(objc_type=BitmapImageRep, objc_name="initWithBitmapDataPlanes")
 BitmapImageRep_initWithBitmapDataPlanes :: proc "c" (
-        self: ^BitmapImageRep, 
-        bitmapDataPlanes: ^^u8,
-        pixelsWide: Integer, 
-        pixelsHigh: Integer,
-        bitsPerSample: Integer,
-        samplesPerPixel: Integer,
-        hasAlpha: bool, 
-        isPlanar: bool,
-        colorSpaceName: ^String,
-        bytesPerRow: Integer,
-        bitsPerPixel: Integer) -> ^BitmapImageRep {
+	self: ^BitmapImageRep, 
+	bitmapDataPlanes: ^^u8,
+	pixelsWide: Integer, 
+	pixelsHigh: Integer,
+	bitsPerSample: Integer,
+	samplesPerPixel: Integer,
+	hasAlpha: bool, 
+	isPlanar: bool,
+	colorSpaceName: ^String,
+	bytesPerRow: Integer,
+	bitsPerPixel: Integer) -> ^BitmapImageRep {
 
 	return msgSend(^BitmapImageRep, 
-                self, 
-                "initWithBitmapDataPlanes:pixelsWide:pixelsHigh:bitsPerSample:samplesPerPixel:hasAlpha:isPlanar:colorSpaceName:bytesPerRow:bitsPerPixel:",
-                bitmapDataPlanes,
-                pixelsWide, 
-                pixelsHigh,
-                bitsPerSample,
-                samplesPerPixel,
-                hasAlpha,
-                isPlanar, 
-                colorSpaceName,
-                bytesPerRow,
-                bitsPerPixel)
+		self, 
+		"initWithBitmapDataPlanes:pixelsWide:pixelsHigh:bitsPerSample:samplesPerPixel:hasAlpha:isPlanar:colorSpaceName:bytesPerRow:bitsPerPixel:",
+		bitmapDataPlanes,
+		pixelsWide, 
+		pixelsHigh,
+		bitsPerSample,
+		samplesPerPixel,
+		hasAlpha,
+		isPlanar, 
+		colorSpaceName,
+		bytesPerRow,
+		bitsPerPixel)
 }
 
 @(objc_type=BitmapImageRep, objc_name="bitmapData")
 BitmapImageRep_bitmapData :: proc "c" (self: ^BitmapImageRep) -> rawptr {
-        return msgSend(rawptr, self, "bitmapData") 
+	return msgSend(rawptr, self, "bitmapData") 
 }
 
 @(objc_type=BitmapImageRep, objc_name="CGImage")
 BitmapImageRep_CGImage :: proc "c" (self: ^BitmapImageRep) -> rawptr {
-        return msgSend(rawptr, self, "CGImage") 
+	return msgSend(rawptr, self, "CGImage") 
 }

--- a/core/sys/darwin/Foundation/NSWindow.odin
+++ b/core/sys/darwin/Foundation/NSWindow.odin
@@ -568,6 +568,14 @@ window_delegate_register_and_alloc :: proc(template: WindowDelegateTemplate, cla
 @(objc_class="CALayer")
 Layer :: struct { using _: Object }
 
+@(objc_type=Layer, objc_name="contents")
+Layer_contents :: proc "c" (self: ^Layer) -> rawptr {
+	return msgSend(rawptr, self, "contents")
+}
+@(objc_type=Layer, objc_name="setContents")
+Layer_setContents :: proc "c" (self: ^Layer, contents: rawptr) {
+	msgSend(nil, self, "setContents:", contents)
+}
 @(objc_type=Layer, objc_name="contentsScale")
 Layer_contentsScale :: proc "c" (self: ^Layer) -> Float {
 	return msgSend(Float, self, "contentsScale")


### PR DESCRIPTION
Added support for NSBitmapImageRep class.
Added ability to set contents to a CALayer.
I needed these to support a port of Handmade Hero, but they are of general use.