### PR TITLE
fix amd64 no-crt entry assembly

### DIFF
--- a/base/runtime/entry_unix_no_crt_amd64.asm
+++ b/base/runtime/entry_unix_no_crt_amd64.asm
@@ -35,7 +35,7 @@ _start:
     xor rbp, rbp
     ;; Load argc into 1st param reg, argv into 2nd param reg
     pop rdi
-    mov rdx, rsi
+    mov rsi, rsp
     ;; Align stack pointer down to 16-bytes (sysv calling convention)
     and rsp, -16
     ;; Call into odin entry point


### PR DESCRIPTION
Previously argv was always nil at startup since the second argument register that should contain argv started out as nil and was never modified, rdx is the 3rd argument register, but `_start_odin` only takes the arguments. This should fix it, after popping argc the last thing on the stack is argv[0] so the stack pointer at this point is argv.