### PR TITLE
`core:hash/xxhash`: Static SIMD Support for XXH3

### DIFF
--- a/core/hash/xxhash/xxhash_3.odin
+++ b/core/hash/xxhash/xxhash_3.odin
@@ -382,7 +382,6 @@ XXH3_INIT_ACC :: [XXH_ACC_NB]xxh_u64{
 
 XXH_SECRET_MERGEACCS_START :: 11
 
-@(optimization_mode="favor_size")
 XXH3_hashLong_128b_internal :: #force_inline proc(
 			input: []u8,
 			secret: []u8,
@@ -410,7 +409,6 @@ XXH3_hashLong_128b_internal :: #force_inline proc(
 /*
  * It's important for performance that XXH3_hashLong is not inlined.
  */
-@(optimization_mode="favor_size")
 XXH3_hashLong_128b_default :: #force_no_inline proc(input: []u8, seed: xxh_u64, secret: []u8) -> (res: XXH3_128_hash) {
 	return XXH3_hashLong_128b_internal(input, XXH3_kSecret[:], XXH3_accumulate_512, XXH3_scramble_accumulator)
 }
@@ -418,12 +416,10 @@ XXH3_hashLong_128b_default :: #force_no_inline proc(input: []u8, seed: xxh_u64, 
 /*
  * It's important for performance that XXH3_hashLong is not inlined.
  */
-@(optimization_mode="favor_size")
 XXH3_hashLong_128b_withSecret :: #force_no_inline proc(input: []u8, seed: xxh_u64, secret: []u8) -> (res: XXH3_128_hash) {
 	return XXH3_hashLong_128b_internal(input, secret, XXH3_accumulate_512, XXH3_scramble_accumulator)
 }
 
-@(optimization_mode="favor_size")
 XXH3_hashLong_128b_withSeed_internal :: #force_inline proc(
 								input: []u8, seed: xxh_u64, secret: []u8,
 								f_acc512: XXH3_accumulate_512_f,
@@ -444,7 +440,6 @@ XXH3_hashLong_128b_withSeed_internal :: #force_inline proc(
 /*
  * It's important for performance that XXH3_hashLong is not inlined.
  */
- @(optimization_mode="favor_size")
 XXH3_hashLong_128b_withSeed :: #force_no_inline proc(input: []u8, seed: xxh_u64, secret: []u8) -> (res: XXH3_128_hash) {
 	return XXH3_hashLong_128b_withSeed_internal(input, seed, secret, XXH3_accumulate_512, XXH3_scramble_accumulator , XXH3_init_custom_secret)
 }
@@ -784,7 +779,6 @@ XXH3_init_custom_secret_scalar :: #force_inline proc(custom_secret: []u8, seed64
 }
 
 /* generalized SIMD variants */
-@(optimization_mode="favor_size")
 XXH3_accumulate_512_simd_generic :: #force_inline proc(acc: []xxh_u64, input: []u8, secret: []u8, $W: uint) {
 	u32xW :: #simd[W]u32
 	u64xW :: #simd[W]u64
@@ -824,7 +818,6 @@ XXH3_scramble_accumulator_simd_generic :: #force_inline proc(acc: []xxh_u64, sec
 	}
 }
 
-@(optimization_mode="favor_size")
 XXH3_init_custom_secret_simd_generic :: #force_inline proc(custom_secret: []u8, seed64: xxh_u64, $W: uint) {
 	u64xW :: #simd[W]u64
 
@@ -950,7 +943,6 @@ XXH3_hashLong_64b_internal :: #force_inline proc(input: []u8, secret: []u8,
 /*
 	It's important for performance that XXH3_hashLong is not inlined.
 */
-@(optimization_mode="favor_size")
 XXH3_hashLong_64b_withSecret :: #force_no_inline proc(input: []u8, seed64: xxh_u64, secret: []u8) -> (hash: xxh_u64) {
 	return XXH3_hashLong_64b_internal(input, secret, XXH3_accumulate_512, XXH3_scramble_accumulator)
 }
@@ -962,12 +954,10 @@ XXH3_hashLong_64b_withSecret :: #force_no_inline proc(input: []u8, seed64: xxh_u
 	This variant enforces that the compiler can detect that,
 	and uses this opportunity to streamline the generated code for better performance.
 */
-@(optimization_mode="favor_size")
 XXH3_hashLong_64b_default :: #force_no_inline proc(input: []u8, seed64: xxh_u64, secret: []u8) -> (hash: xxh_u64) {
 	return XXH3_hashLong_64b_internal(input, XXH3_kSecret[:], XXH3_accumulate_512, XXH3_scramble_accumulator)
 }
 
-@(optimization_mode="favor_size")
 XXH3_hashLong_64b_withSeed_internal :: #force_inline proc(
 	input:       []u8,
 	seed:        xxh_u64,
@@ -995,7 +985,6 @@ XXH3_hashLong_64b_withSeed_internal :: #force_inline proc(
 	It's important for performance that XXH3_hashLong is not inlined. Not sure
 	why (uop cache maybe?), but the difference is large and easily measurable.
 */
-@(optimization_mode="favor_size")
 XXH3_hashLong_64b_withSeed :: #force_no_inline proc(input: []u8, seed: xxh_u64, secret: []u8) -> (hash: xxh_u64) {
 	return XXH3_hashLong_64b_withSeed_internal(input, seed, XXH3_accumulate_512, XXH3_scramble_accumulator, XXH3_init_custom_secret)
 }

--- a/core/hash/xxhash/xxhash_3.odin
+++ b/core/hash/xxhash/xxhash_3.odin
@@ -64,7 +64,7 @@ XXH3_INTERNAL_BUFFER_SIZE :: 256
 
 	IMPORTANT: This structure has a strict alignment requirement of 64 bytes!! **
 	Default allocators will align it correctly if created via `new`, as will
-	placing this struct on the cache, but if using a custom allocator make sure
+	placing this struct on the stack, but if using a custom allocator make sure
 	that it handles the alignment correctly!
 */
 XXH3_state :: struct #align(64) {
@@ -870,7 +870,7 @@ XXH_PREFETCH_DIST :: 320
 XXH3_accumulate :: #force_inline proc(
 	acc: []xxh_u64, input: []u8, secret: []u8, nbStripes: uint, f_acc512: XXH3_accumulate_512_f) {
 
-	for n := uint(0); n < nbStripes; n += 1 {
+	#no_bounds_check for n := uint(0); n < nbStripes; n += 1 {
 		when !XXH_DISABLE_PREFETCH {
 			in_ptr := &input[n * XXH_STRIPE_LEN]
 			prefetch(in_ptr, XXH_PREFETCH_DIST)

--- a/core/hash/xxhash/xxhash_3_intel.odin
+++ b/core/hash/xxhash/xxhash_3_intel.odin
@@ -1,0 +1,13 @@
+#+build amd64, i386
+package xxhash
+
+import "base:intrinsics"
+
+@(private="file") SSE2_FEATURES :: "sse2"
+@(private="file") AVX2_FEATURES :: "avx2"
+@(private="file") AVX512_FEATURES :: "avx512dq,evex512"
+
+XXH_NATIVE_WIDTH :: min(XXH_MAX_WIDTH,
+	8 when intrinsics.has_target_feature(AVX512_FEATURES) else
+	4 when intrinsics.has_target_feature(AVX2_FEATURES) else
+	2 when intrinsics.has_target_feature(SSE2_FEATURES) else 1)

--- a/core/hash/xxhash/xxhash_3_other.odin
+++ b/core/hash/xxhash/xxhash_3_other.odin
@@ -1,0 +1,8 @@
+#+build !amd64
+#+build !i386
+package xxhash
+
+import "base:runtime"
+
+XXH_NATIVE_WIDTH :: min(XXH_MAX_WIDTH,
+	2 when runtime.HAS_HARDWARE_SIMD else 1)


### PR DESCRIPTION
This adds a SIMD implementation of the kernel functions for XXH3, and uses compile-time build features to decide how large of a SIMD vector to use for the default implementation.

There are currently checks for `amd64`/`i386` to size the vectors accordingly for SSE2/AVX2/AVX512, and for other platforms will just use `runtime.HAS_HARDWARE_SIMD` to select between 128-bit vectors or scalar code.

There are also some other minor changes/improvements that were made to the code along the way, but which generally shouldn't have much tangible impact (see [the "minor changes" commit](https://github.com/odin-lang/Odin/pull/5525/commits/2f8b390c1922f096daf56c2400b212457fd37dca) for some details).

For performance comparison, here are the results of the existing XXH3_128 benchmark on 1 MiB of data in `tests/benchmark/hash` on two different `amd64` systems (my desktop PC and a Steam Deck):

| System | `master` | `xxh3-simd` (this PR) | Reference (Clang) | Reference (GCC) |
|---|---|---|---|---|
| Desktop (`x86-64-v2`/SSE, default) | 16,925 MiB/s | 46,764 MiB/s | 49,170 MiB/s | 44,093 MiB/s |
| Desktop (`x86-64-v3`/AVX2) | --- | 59,850 MiB/s | 65,987 MiB/s | 94,399 MiB/s |
| Desktop (`x86-64-v4`/AVX512) | --- | 88,772 MiB/s | 71,141 MiB/s | 148,134 MiB/s \* |
| Steam Deck (`x86-64-v2`/SSE, default) | 6,314 MiB/s | 16,006 MiB/s | 22,977 MiB/s | 21,424 MiB/s |
| Steam Deck (`x86-64-v3`/AVX2) | --- | 30,300 MiB/s | 48,212 MiB/s | 48,015 MiB/s |

\* This one actually hits almost 190 GiB/s for sizes below 1 MiB (!), but falls off at 1 MiB, probably due to running into the limits of the cache size.

I've also included runs of [the reference implementation's benchmark](https://github.com/Cyan4973/xxHash/tree/dev/tests/bench) for comparison. The changes in this PR have narrowed the gap, but there's definitely room for improvement.

Unfortunately, I don't really have any systems of other arches to test on, but I would welcome comparisons on other systems too, `amd64` or otherwise, to ensure there aren't regressions on some hardware. There were notes in some of the comments here hinting at the possibility of instruction cache sizes being a possible factor in performance here, and getting good SIMD performance has seemingly required removing some `optimization_mode="favor_size"`.

The SIMD kernel procs are also generalized to allow them to be used with the SIMD size as a parameter, which is intended to lay some groundwork for a multi-versioned implementation as well (i.e. to include SSE/AVX2/AVX512 implementations and choose the implementation at run-time using `core:sys/info`). I was hoping to include that here, but that has proven difficult to get the up-featured code to run well, so I'm going to revisit that in a possible future PR.
