### PR TITLE
amd64 abi fixes regarding vectors

### DIFF
--- a/src/llvm_abi.cpp
+++ b/src/llvm_abi.cpp
@@ -1028,7 +1028,7 @@ namespace lbAbiAmd64SysV {
 			unify(cls, ix + off/8, RegClass_Int);
 			break;
 		case LLVMHalfTypeKind:
-			unify(cls, ix + off/8, (off%8 == 2) ? RegClass_SSEHv : RegClass_SSEHs);
+			unify(cls, ix + off/8, (off%8 == 6) ? RegClass_SSEHv : RegClass_SSEHs);
 			break;
 		case LLVMFloatTypeKind:
 			unify(cls, ix + off/8, (off%8 == 4) ? RegClass_SSEFv : RegClass_SSEFs);


### PR DESCRIPTION
- Fixes the code so SSEUp is grouped/skipped over properly (Fixes #5429)
- Fixes f16 vectors using garbage widths, because it would call LLVMGetIntTypeWidth and an f16 is not an int so doesn't have that function (opted to support `half` properly instead of using i16 too)