### PR TITLE
add missing xlib functions for getting and setting text properties

### DIFF
--- a/vendor/x11/xlib/xlib_procs.odin
+++ b/vendor/x11/xlib/xlib_procs.odin
@@ -389,6 +389,18 @@ foreign xlib {
 		requestor:   Window,
 		time:        Time,
 		) ---
+	GetTextProperty :: proc(
+		display:            ^Display,
+		window:             Window,
+		text_prop_return:   ^XTextProperty,
+		property:           Atom,
+		) -> Status ---
+	SetTextProperty :: proc(
+		display:     ^Display,
+		window:      Window,
+		text_prop:   ^XTextProperty,
+		property:    Atom,
+		) ---
 	// Creating and freeing pixmaps
 	CreatePixmap :: proc(
 		display:   ^Display,


### PR DESCRIPTION
Adding these two XLib functions which I found were missing.

I tested it and it works as expected with this example

```
get_active_window_name :: proc(display: ^xlib.Display, xid: xlib.XID) -> cstring {
  props : xlib.XTextProperty
  active_window_atom := xlib.InternAtom(display, "_NET_WM_NAME", false)
  xlib.GetTextProperty(display, xid, &props, active_window_atom)
  return cast(cstring)props.value
}
```

https://tronche.com/gui/x/xlib/ICC/client-to-window-manager/XGetTextProperty.html
https://tronche.com/gui/x/xlib/ICC/client-to-window-manager/XSetTextProperty.html

Let me know if there's anything else I need to add here, thanks!