### PR TITLE
add quaternion marshal and unmarshal to `core:encoding/json`

### DIFF
--- a/core/encoding/json/marshal.odin
+++ b/core/encoding/json/marshal.odin
@@ -150,7 +150,23 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 		io.write_byte(w, ']')    or_return
 
 	case runtime.Type_Info_Quaternion:
-		return .Unsupported_Type
+		i, j, k, r: f64
+		switch q in a {
+		case quaternion64: i, j, k, r =  imag(q), jmag(q), kmag(q), real(q)
+		case quaternion128: i, j, k, r =  imag(q), jmag(q), kmag(q), real(q)
+		case quaternion256: i, j, k, r =  imag(q), jmag(q), kmag(q), real(q)
+		}
+
+		io.write_byte(w, '[') or_return
+		io.write_f64(w, i) or_return
+		io.write_byte(w, ',') or_return
+		io.write_f64(w, j) or_return
+		io.write_byte(w, ',') or_return
+		io.write_f64(w, k) or_return
+		io.write_byte(w, ',') or_return
+		io.write_f64(w, r) or_return
+		io.write_byte(w, ']') or_return
+		// return .Unsupported_Type
 
 	case runtime.Type_Info_String:
 		switch s in a {

--- a/core/encoding/json/unmarshal.odin
+++ b/core/encoding/json/unmarshal.odin
@@ -713,7 +713,18 @@ unmarshal_array :: proc(p: ^Parser, v: any) -> (err: Unmarshal_Error) {
 		}
 		
 		return assign_array(p, v.data, t.elem, length)
-		
+
+	case reflect.Type_Info_Quaternion:
+		if int(length) > 4 {
+			return UNSUPPORTED_TYPE
+		}
+
+		switch ti.id {
+		case quaternion64: return assign_array(p, v.data, type_info_of(f16), 4)
+		case quaternion128: return assign_array(p, v.data, type_info_of(f32), 4)
+		case quaternion256: return assign_array(p, v.data, type_info_of(f64), 4)
+		}
+
 	case reflect.Type_Info_Enumerated_Array:
 		// NOTE(bill): Allow lengths which are less than the dst array
 		if int(length) > t.count {

--- a/tests/core/encoding/json/test_core_json.odin
+++ b/tests/core/encoding/json/test_core_json.odin
@@ -529,3 +529,35 @@ enumerated_array :: proc(t: ^testing.T) {
 		testing.expect_value(t, unmarshaled, Sparse_Fruit_Stock)
 	}
 }
+
+import "core:fmt"
+@test
+quaternion :: proc(t: ^testing.T) {
+	rotation: quaternion128
+	rotation.x = 0
+	rotation.y = 0.95
+	rotation.z = 0
+	rotation.w = 0.3
+
+	{ // test unmarshaling
+		marshaled := "[0, 0.95, 0, 0.300]"
+
+		unmarshaled: quaternion128
+		err := json.unmarshal_string(marshaled, &unmarshaled)
+		testing.expect_value(t, err, nil)
+		testing.expect_value(t, unmarshaled, rotation)
+	}
+
+	{ // test marshal -> unmarshal
+		marshaled, err_marshal := json.marshal(rotation)
+		defer delete(marshaled)
+		testing.expect_value(t, err_marshal, nil)
+
+		fmt.println(marshaled)
+
+		unmarshaled: quaternion128
+		err_unmarshal := json.unmarshal(marshaled, &unmarshaled)
+		testing.expect_value(t, err_unmarshal, nil)
+		testing.expect_value(t, unmarshaled, rotation)
+	}
+}


### PR DESCRIPTION
Add JSON marshal/unmarshal support for quaternion types in `core:encoding/json`.

- **Marshal**: Quaternions are serialized as JSON arrays with four float components in [x, y, z, w] order
- **Unmarshal**: JSON arrays of exactly 4 numeric values are parsed back into quaternion types in [x, y, z, w] order
- **Tests**: Add a corresponding test `quaternion` to the test suits `tests/core/encoding/json`