### PR TITLE
Fix Incorrect/Missing Metal Mesh Shading Bindings

### DIFF
--- a/vendor/darwin/Metal/MetalClasses.odin
+++ b/vendor/darwin/Metal/MetalClasses.odin
@@ -2767,6 +2767,10 @@ RenderPipelineDescriptor_fragmentBuffers :: #force_inline proc "c" (self: ^Rende
 RenderPipelineDescriptor_fragmentFunction :: #force_inline proc "c" (self: ^RenderPipelineDescriptor) -> ^Function {
 	return msgSend(^Function, self, "fragmentFunction")
 }
+@(objc_type=RenderPipelineDescriptor, objc_name="fragmentLinkedFunctions")
+RenderPipelineDescriptor_fragmentLinkedFunctions :: #force_inline proc "c" (self: ^RenderPipelineDescriptor) -> ^LinkedFunctions {
+	return msgSend(^LinkedFunctions, self, "fragmentLinkedFunctions")
+}
 @(objc_type=RenderPipelineDescriptor, objc_name="inputPrimitiveTopology")
 RenderPipelineDescriptor_inputPrimitiveTopology :: #force_inline proc "c" (self: ^RenderPipelineDescriptor) -> PrimitiveTopologyClass {
 	return msgSend(PrimitiveTopologyClass, self, "inputPrimitiveTopology")
@@ -2830,6 +2834,10 @@ RenderPipelineDescriptor_setDepthAttachmentPixelFormat :: #force_inline proc "c"
 @(objc_type=RenderPipelineDescriptor, objc_name="setFragmentFunction")
 RenderPipelineDescriptor_setFragmentFunction :: #force_inline proc "c" (self: ^RenderPipelineDescriptor, fragmentFunction: ^Function) {
 	msgSend(nil, self, "setFragmentFunction:", fragmentFunction)
+}
+@(objc_type=RenderPipelineDescriptor, objc_name="setFragmentLinkedFunctions")
+RenderPipelineDescriptor_setFragmentLinkedFunctions :: #force_inline proc "c" (self: ^RenderPipelineDescriptor, fragmentLinkedFunctions: ^LinkedFunctions) {
+	msgSend(nil, self, "setFragmentLinkedFunctions:", fragmentLinkedFunctions)
 }
 @(objc_type=RenderPipelineDescriptor, objc_name="setInputPrimitiveTopology")
 RenderPipelineDescriptor_setInputPrimitiveTopology :: #force_inline proc "c" (self: ^RenderPipelineDescriptor, inputPrimitiveTopology: PrimitiveTopologyClass) {
@@ -2940,86 +2948,6 @@ RenderPipelineDescriptor_vertexFunction :: #force_inline proc "c" (self: ^Render
 	return msgSend(^Function, self, "vertexFunction")
 }
 
-@(objc_type=RenderPipelineDescriptor, objc_name="objectFunction")
-RenderPipelineDescriptor_objectFunction :: #force_inline proc "c" (self: ^RenderPipelineDescriptor) -> ^Function {
-	return msgSend(^Function, self, "objectFunction")
-}
-@(objc_type=RenderPipelineDescriptor, objc_name="setObjectFunction")
-RenderPipelineDescriptor_setObjectFunction :: #force_inline proc "c" (self: ^RenderPipelineDescriptor, objectFunction: ^Function) {
-	msgSend(nil, self, "setObjectFunction:", objectFunction)
-}
-@(objc_type=RenderPipelineDescriptor, objc_name="meshFunction")
-RenderPipelineDescriptor_meshFunction :: #force_inline proc "c" (self: ^RenderPipelineDescriptor) -> ^Function {
-	return msgSend(^Function, self, "meshFunction")
-}
-@(objc_type=RenderPipelineDescriptor, objc_name="setMeshFunction")
-RenderPipelineDescriptor_setMeshFunction :: #force_inline proc "c" (self: ^RenderPipelineDescriptor, meshFunction: ^Function) {
-	msgSend(nil, self, "setMeshFunction:", meshFunction)
-}
-
-@(objc_type=RenderPipelineDescriptor, objc_name="maxTotalThreadsPerObjectThreadgroup")
-RenderPipelineDescriptor_maxTotalThreadsPerObjectThreadgroup :: #force_inline proc "c" (self: ^RenderPipelineDescriptor) -> NS.UInteger {
-	return msgSend(NS.UInteger, self, "maxTotalThreadsPerObjectThreadgroup")
-}
-@(objc_type=RenderPipelineDescriptor, objc_name="setMaxTotalThreadsPerObjectThreadgroup")
-RenderPipelineDescriptor_setMaxTotalThreadsPerObjectThreadgroup :: #force_inline proc "c" (self: ^RenderPipelineDescriptor, maxTotalThreadsPerObjectThreadgroup: NS.UInteger) {
-	msgSend(nil, self, "setMaxTotalThreadsPerObjectThreadgroup:", maxTotalThreadsPerObjectThreadgroup)
-}
-@(objc_type=RenderPipelineDescriptor, objc_name="maxTotalThreadsPerMeshThreadgroup")
-RenderPipelineDescriptor_maxTotalThreadsPerMeshThreadgroup :: #force_inline proc "c" (self: ^RenderPipelineDescriptor) -> NS.UInteger {
-	return msgSend(NS.UInteger, self, "maxTotalThreadsPerMeshThreadgroup")
-}
-@(objc_type=RenderPipelineDescriptor, objc_name="setMaxTotalThreadsPerMeshThreadgroup")
-RenderPipelineDescriptor_setMaxTotalThreadsPerMeshThreadgroup :: #force_inline proc "c" (self: ^RenderPipelineDescriptor, maxTotalThreadsPerMeshThreadgroup: NS.UInteger) {
-	msgSend(nil, self, "setMaxTotalThreadsPerMeshThreadgroup:", maxTotalThreadsPerMeshThreadgroup)
-}
-@(objc_type=RenderPipelineDescriptor, objc_name="objectThreadgroupSizeIsMultipleOfThreadExecutionWidth")
-RenderPipelineDescriptor_objectThreadgroupSizeIsMultipleOfThreadExecutionWidth :: #force_inline proc "c" (self: ^RenderPipelineDescriptor) -> NS.UInteger {
-	return msgSend(NS.UInteger, self, "objectThreadgroupSizeIsMultipleOfThreadExecutionWidth")
-}
-@(objc_type=RenderPipelineDescriptor, objc_name="setObjectThreadgroupSizeIsMultipleOfThreadExecutionWidth")
-RenderPipelineDescriptor_setObjectThreadgroupSizeIsMultipleOfThreadExecutionWidth :: #force_inline proc "c" (self: ^RenderPipelineDescriptor, objectThreadgroupSizeIsMultipleOfThreadExecutionWidth: NS.UInteger) {
-	msgSend(nil, self, "setObjectThreadgroupSizeIsMultipleOfThreadExecutionWidth:", objectThreadgroupSizeIsMultipleOfThreadExecutionWidth)
-}
-
-@(objc_type=RenderPipelineDescriptor, objc_name="meshThreadgroupSizeIsMultipleOfThreadExecutionWidth")
-RenderPipelineDescriptor_meshThreadgroupSizeIsMultipleOfThreadExecutionWidth :: #force_inline proc "c" (self: ^RenderPipelineDescriptor) -> BOOL {
-	return msgSend(BOOL, self, "meshThreadgroupSizeIsMultipleOfThreadExecutionWidth")
-}
-@(objc_type=RenderPipelineDescriptor, objc_name="setMeshThreadgroupSizeIsMultipleOfThreadExecutionWidth")
-RenderPipelineDescriptor_setMeshThreadgroupSizeIsMultipleOfThreadExecutionWidth :: #force_inline proc "c" (self: ^RenderPipelineDescriptor, meshThreadgroupSizeIsMultipleOfThreadExecutionWidth: BOOL) {
-	msgSend(nil, self, "setMeshThreadgroupSizeIsMultipleOfThreadExecutionWidth:", meshThreadgroupSizeIsMultipleOfThreadExecutionWidth)
-}
-
-
-@(objc_type=RenderPipelineDescriptor, objc_name="payloadMemoryLength")
-RenderPipelineDescriptor_payloadMemoryLength :: #force_inline proc "c" (self: ^RenderPipelineDescriptor) -> NS.UInteger {
-	return msgSend(NS.UInteger, self, "payloadMemoryLength")
-}
-@(objc_type=RenderPipelineDescriptor, objc_name="setPayloadMemoryLength")
-RenderPipelineDescriptor_setPayloadMemoryLength :: #force_inline proc "c" (self: ^RenderPipelineDescriptor, payloadMemoryLength: NS.UInteger) {
-	msgSend(nil, self, "setPayloadMemoryLength:", payloadMemoryLength)
-}
-@(objc_type=RenderPipelineDescriptor, objc_name="maxTotalThreadgroupsPerMeshGrid")
-RenderPipelineDescriptor_maxTotalThreadgroupsPerMeshGrid :: #force_inline proc "c" (self: ^RenderPipelineDescriptor) -> NS.UInteger {
-	return msgSend(NS.UInteger, self, "maxTotalThreadgroupsPerMeshGrid")
-}
-@(objc_type=RenderPipelineDescriptor, objc_name="setMaxTotalThreadgroupsPerMeshGrid")
-RenderPipelineDescriptor_setMaxTotalThreadgroupsPerMeshGrid :: #force_inline proc "c" (self: ^RenderPipelineDescriptor, maxTotalThreadgroupsPerMeshGrid: NS.UInteger) {
-	msgSend(nil, self, "setMaxTotalThreadgroupsPerMeshGrid:", maxTotalThreadgroupsPerMeshGrid)
-}
-
-@(objc_type=RenderPipelineDescriptor, objc_name="objectBuffers")
-RenderPipelineDescriptor_objectBuffers :: #force_inline proc "c" (self: ^RenderPipelineDescriptor) -> ^PipelineBufferDescriptorArray {
-	return msgSend(^PipelineBufferDescriptorArray, self, "objectBuffers")
-}
-@(objc_type=RenderPipelineDescriptor, objc_name="meshBuffers")
-RenderPipelineDescriptor_meshBuffers :: #force_inline proc "c" (self: ^RenderPipelineDescriptor) -> ^PipelineBufferDescriptorArray {
-	return msgSend(^PipelineBufferDescriptorArray, self, "meshBuffers")
-}
-
-
-
 @(objc_type=RenderPipelineDescriptor, objc_name="alphaToCoverageEnabled")
 RenderPipelineDescriptor_alphaToCoverageEnabled :: #force_inline proc "c" (self: ^RenderPipelineDescriptor) -> BOOL {
 	return msgSend(BOOL, self, "alphaToCoverageEnabled")
@@ -3032,6 +2960,272 @@ RenderPipelineDescriptor_alphaToOneEnabled :: #force_inline proc "c" (self: ^Ren
 @(objc_type=RenderPipelineDescriptor, objc_name="rasterizationEnabled")
 RenderPipelineDescriptor_rasterizationEnabled :: #force_inline proc "c" (self: ^RenderPipelineDescriptor) -> BOOL {
 	return msgSend(BOOL, self, "rasterizationEnabled")
+}
+
+@(objc_type=RenderPipelineDescriptor, objc_name="shaderValidation")
+RenderPipelineDescriptor_shaderValidation :: #force_inline proc "c" (self: ^RenderPipelineDescriptor) -> ShaderValidation {
+	return msgSend(ShaderValidation, self, "shaderValidation")
+}
+@(objc_type=RenderPipelineDescriptor, objc_name="setShaderValidation")
+RenderPipelineDescriptor_setShaderValidation :: #force_inline proc "c" (self: ^RenderPipelineDescriptor, shaderValidation: ShaderValidation) {
+	msgSend(nil, self, "setShaderValidation:", shaderValidation)
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+@(objc_class="MTLMeshRenderPipelineDescriptor")
+MeshRenderPipelineDescriptor :: struct{ using _: NS.Copying(MeshRenderPipelineDescriptor) }
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="alloc", objc_is_class_method=true)
+MeshRenderPipelineDescriptor_alloc :: #force_inline proc "c" () -> ^MeshRenderPipelineDescriptor {
+	return msgSend(^MeshRenderPipelineDescriptor, MeshRenderPipelineDescriptor, "alloc")
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="init")
+MeshRenderPipelineDescriptor_init :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> ^MeshRenderPipelineDescriptor {
+	return msgSend(^MeshRenderPipelineDescriptor, self, "init")
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="binaryArchives")
+MeshRenderPipelineDescriptor_binaryArchives :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> ^NS.Array {
+	return msgSend(^NS.Array, self, "binaryArchives")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setBinaryArchives")
+MeshRenderPipelineDescriptor_setBinaryArchives :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, binaryArchives: ^NS.Array) {
+	msgSend(nil, self, "setBinaryArchives:", binaryArchives)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="colorAttachments")
+MeshRenderPipelineDescriptor_colorAttachments :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> ^RenderPipelineColorAttachmentDescriptorArray {
+	return msgSend(^RenderPipelineColorAttachmentDescriptorArray, self, "colorAttachments")
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="depthAttachmentPixelFormat")
+MeshRenderPipelineDescriptor_depthAttachmentPixelFormat :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> PixelFormat {
+	return msgSend(PixelFormat, self, "depthAttachmentPixelFormat")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setDepthAttachmentPixelFormat")
+MeshRenderPipelineDescriptor_setDepthAttachmentPixelFormat :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, depthAttachmentPixelFormat: PixelFormat) {
+	msgSend(nil, self, "setDepthAttachmentPixelFormat:", depthAttachmentPixelFormat)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="fragmentBuffers")
+MeshRenderPipelineDescriptor_fragmentBuffers :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> ^PipelineBufferDescriptorArray {
+	return msgSend(^PipelineBufferDescriptorArray, self, "fragmentBuffers")
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="fragmentFunction")
+MeshRenderPipelineDescriptor_fragmentFunction :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> ^Function {
+	return msgSend(^Function, self, "fragmentFunction")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setFragmentFunction")
+MeshRenderPipelineDescriptor_setFragmentFunction :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, fragmentFunction: ^Function) {
+	msgSend(nil, self, "setFragmentFunction:", fragmentFunction)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="fragmentLinkedFunctions")
+MeshRenderPipelineDescriptor_fragmentLinkedFunctions :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> ^LinkedFunctions {
+	return msgSend(^LinkedFunctions, self, "fragmentLinkedFunctions")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setFragmentLinkedFunctions")
+MeshRenderPipelineDescriptor_setFragmentLinkedFunctions :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, fragmentLinkedFunctions: ^LinkedFunctions) {
+	msgSend(nil, self, "setFragmentLinkedFunctions:", fragmentLinkedFunctions)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="alphaToCoverageEnabled")
+MeshRenderPipelineDescriptor_alphaToCoverageEnabled :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> BOOL {
+	return msgSend(BOOL, self, "alphaToCoverageEnabled")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="isAlphaToCoverageEnabled")
+MeshRenderPipelineDescriptor_isAlphaToCoverageEnabled :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> BOOL {
+	return msgSend(BOOL, self, "isAlphaToCoverageEnabled")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setAlphaToCoverageEnabled")
+MeshRenderPipelineDescriptor_setAlphaToCoverageEnabled :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, alphaToCoverageEnabled: BOOL) {
+	msgSend(nil, self, "setAlphaToCoverageEnabled:", alphaToCoverageEnabled)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="alphaToOneEnabled")
+MeshRenderPipelineDescriptor_alphaToOneEnabled :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> BOOL {
+	return msgSend(BOOL, self, "alphaToOneEnabled")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="isAlphaToOneEnabled")
+MeshRenderPipelineDescriptor_isAlphaToOneEnabled :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> BOOL {
+	return msgSend(BOOL, self, "isAlphaToOneEnabled")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setAlphaToOneEnabled")
+MeshRenderPipelineDescriptor_setAlphaToOneEnabled :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, alphaToOneEnabled: BOOL) {
+	msgSend(nil, self, "setAlphaToOneEnabled:", alphaToOneEnabled)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="rasterizationEnabled")
+MeshRenderPipelineDescriptor_rasterizationEnabled :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> BOOL {
+	return msgSend(BOOL, self, "rasterizationEnabled")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="isRasterizationEnabled")
+MeshRenderPipelineDescriptor_isRasterizationEnabled :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> BOOL {
+	return msgSend(BOOL, self, "isRasterizationEnabled")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setRasterizationEnabled")
+MeshRenderPipelineDescriptor_setRasterizationEnabled :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, rasterizationEnabled: BOOL) {
+	msgSend(nil, self, "setRasterizationEnabled:", rasterizationEnabled)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="label")
+MeshRenderPipelineDescriptor_label :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> ^NS.String {
+	return msgSend(^NS.String, self, "label")
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="maxTotalThreadgroupsPerMeshGrid")
+MeshRenderPipelineDescriptor_maxTotalThreadgroupsPerMeshGrid :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> NS.UInteger {
+	return msgSend(NS.UInteger, self, "maxTotalThreadgroupsPerMeshGrid")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setMaxTotalThreadgroupsPerMeshGrid")
+MeshRenderPipelineDescriptor_setMaxTotalThreadgroupsPerMeshGrid :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, maxTotalThreadgroupsPerMeshGrid: NS.UInteger) {
+	msgSend(nil, self, "setMaxTotalThreadgroupsPerMeshGrid:", maxTotalThreadgroupsPerMeshGrid)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="maxTotalThreadsPerMeshThreadgroup")
+MeshRenderPipelineDescriptor_maxTotalThreadsPerMeshThreadgroup :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> NS.UInteger {
+	return msgSend(NS.UInteger, self, "maxTotalThreadsPerMeshThreadgroup")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setMaxTotalThreadsPerMeshThreadgroup")
+MeshRenderPipelineDescriptor_setMaxTotalThreadsPerMeshThreadgroup :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, maxTotalThreadsPerMeshThreadgroup: NS.UInteger) {
+	msgSend(nil, self, "setMaxTotalThreadsPerMeshThreadgroup:", maxTotalThreadsPerMeshThreadgroup)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="maxTotalThreadsPerObjectThreadgroup")
+MeshRenderPipelineDescriptor_maxTotalThreadsPerObjectThreadgroup :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> NS.UInteger {
+	return msgSend(NS.UInteger, self, "maxTotalThreadsPerObjectThreadgroup")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setMaxTotalThreadsPerObjectThreadgroup")
+MeshRenderPipelineDescriptor_setMaxTotalThreadsPerObjectThreadgroup :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, maxTotalThreadsPerObjectThreadgroup: NS.UInteger) {
+	msgSend(nil, self, "setMaxTotalThreadsPerObjectThreadgroup:", maxTotalThreadsPerObjectThreadgroup)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="maxVertexAmplificationCount")
+MeshRenderPipelineDescriptor_maxVertexAmplificationCount :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> NS.UInteger {
+	return msgSend(NS.UInteger, self, "maxVertexAmplificationCount")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setMaxVertexAmplificationCount")
+MeshRenderPipelineDescriptor_setMaxVertexAmplificationCount :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, maxVertexAmplificationCount: NS.UInteger) {
+	msgSend(nil, self, "setMaxVertexAmplificationCount:", maxVertexAmplificationCount)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="meshBuffers")
+MeshRenderPipelineDescriptor_meshBuffers :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> ^PipelineBufferDescriptorArray {
+	return msgSend(^PipelineBufferDescriptorArray, self, "meshBuffers")
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="meshFunction")
+MeshRenderPipelineDescriptor_meshFunction :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> ^Function {
+	return msgSend(^Function, self, "meshFunction")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setMeshFunction")
+MeshRenderPipelineDescriptor_setMeshFunction :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, meshFunction: ^Function) {
+	msgSend(nil, self, "setMeshFunction:", meshFunction)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="meshLinkedFunctions")
+MeshRenderPipelineDescriptor_meshLinkedFunctions :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> ^LinkedFunctions {
+	return msgSend(^LinkedFunctions, self, "meshLinkedFunctions")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setMeshLinkedFunctions")
+MeshRenderPipelineDescriptor_setMeshLinkedFunctions :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, meshLinkedFunctions: ^LinkedFunctions) {
+	msgSend(nil, self, "setMeshLinkedFunctions:", meshLinkedFunctions)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="meshThreadgroupSizeIsMultipleOfThreadExecutionWidth")
+MeshRenderPipelineDescriptor_meshThreadgroupSizeIsMultipleOfThreadExecutionWidth :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> BOOL {
+	return msgSend(BOOL, self, "meshThreadgroupSizeIsMultipleOfThreadExecutionWidth")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setMeshThreadgroupSizeIsMultipleOfThreadExecutionWidth")
+MeshRenderPipelineDescriptor_setMeshThreadgroupSizeIsMultipleOfThreadExecutionWidth :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, meshThreadgroupSizeIsMultipleOfThreadExecutionWidth: BOOL) {
+	msgSend(nil, self, "setMeshThreadgroupSizeIsMultipleOfThreadExecutionWidth:", meshThreadgroupSizeIsMultipleOfThreadExecutionWidth)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="objectBuffers")
+MeshRenderPipelineDescriptor_objectBuffers :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> ^PipelineBufferDescriptorArray {
+	return msgSend(^PipelineBufferDescriptorArray, self, "objectBuffers")
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="objectFunction")
+MeshRenderPipelineDescriptor_objectFunction :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> ^Function {
+	return msgSend(^Function, self, "objectFunction")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setObjectFunction")
+MeshRenderPipelineDescriptor_setObjectFunction :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, objectFunction: ^Function) {
+	msgSend(nil, self, "setObjectFunction:", objectFunction)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="objectLinkedFunctions")
+MeshRenderPipelineDescriptor_objectLinkedFunctions :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> ^LinkedFunctions {
+	return msgSend(^LinkedFunctions, self, "objectLinkedFunctions")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setObjectLinkedFunctions")
+MeshRenderPipelineDescriptor_setObjectLinkedFunctions :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, objectLinkedFunctions: ^LinkedFunctions) {
+	msgSend(nil, self, "setObjectLinkedFunctions:", objectLinkedFunctions)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="objectThreadgroupSizeIsMultipleOfThreadExecutionWidth")
+MeshRenderPipelineDescriptor_objectThreadgroupSizeIsMultipleOfThreadExecutionWidth :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> BOOL {
+	return msgSend(BOOL, self, "objectThreadgroupSizeIsMultipleOfThreadExecutionWidth")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setObjectThreadgroupSizeIsMultipleOfThreadExecutionWidth")
+MeshRenderPipelineDescriptor_setObjectThreadgroupSizeIsMultipleOfThreadExecutionWidth :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, objectThreadgroupSizeIsMultipleOfThreadExecutionWidth: BOOL) {
+	msgSend(nil, self, "setObjectThreadgroupSizeIsMultipleOfThreadExecutionWidth:", objectThreadgroupSizeIsMultipleOfThreadExecutionWidth)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="payloadMemoryLength")
+MeshRenderPipelineDescriptor_payloadMemoryLength :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> NS.UInteger {
+	return msgSend(NS.UInteger, self, "payloadMemoryLength")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setPayloadMemoryLength")
+MeshRenderPipelineDescriptor_setPayloadMemoryLength :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, payloadMemoryLength: NS.UInteger) {
+	msgSend(nil, self, "setPayloadMemoryLength:", payloadMemoryLength)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="rasterSampleCount")
+MeshRenderPipelineDescriptor_rasterSampleCount :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> NS.UInteger {
+	return msgSend(NS.UInteger, self, "rasterSampleCount")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setRasterSampleCount")
+MeshRenderPipelineDescriptor_setRasterSampleCount :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, rasterSampleCount: NS.UInteger) {
+	msgSend(nil, self, "setRasterSampleCount:", rasterSampleCount)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="shaderValidation")
+MeshRenderPipelineDescriptor_shaderValidation :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> ShaderValidation {
+	return msgSend(ShaderValidation, self, "shaderValidation")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setShaderValidation")
+MeshRenderPipelineDescriptor_setShaderValidation :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, shaderValidation: ShaderValidation) {
+	msgSend(nil, self, "setShaderValidation:", shaderValidation)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="stencilAttachmentPixelFormat")
+MeshRenderPipelineDescriptor_stencilAttachmentPixelFormat :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> PixelFormat {
+	return msgSend(PixelFormat, self, "stencilAttachmentPixelFormat")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setStencilAttachmentPixelFormat")
+MeshRenderPipelineDescriptor_setStencilAttachmentPixelFormat :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, stencilAttachmentPixelFormat: PixelFormat) {
+	msgSend(nil, self, "setStencilAttachmentPixelFormat:", stencilAttachmentPixelFormat)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="supportIndirectCommandBuffers")
+MeshRenderPipelineDescriptor_supportIndirectCommandBuffers :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) -> BOOL {
+	return msgSend(BOOL, self, "supportIndirectCommandBuffers")
+}
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="setSupportIndirectCommandBuffers")
+MeshRenderPipelineDescriptor_setSupportIndirectCommandBuffers :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor, supportIndirectCommandBuffers: BOOL) {
+	msgSend(nil, self, "setSupportIndirectCommandBuffers:", supportIndirectCommandBuffers)
+}
+
+@(objc_type=MeshRenderPipelineDescriptor, objc_name="reset")
+MeshRenderPipelineDescriptor_reset :: #force_inline proc "c" (self: ^MeshRenderPipelineDescriptor) {
+	msgSend(nil, self, "reset")
 }
 
 
@@ -5702,14 +5896,13 @@ Device_supportsVertexAmplificationCount :: #force_inline proc "c" (self: ^Device
 
 
 @(objc_type=Device, objc_name="newRenderPipelineStateWithMeshDescriptor")
-Device_newRenderPipelineStateWithMeshDescriptor :: #force_inline proc "contextless" (self: ^Device, options: PipelineOption, reflection: ^AutoreleasedRenderPipelineReflection) -> (state: ^RenderPipelineState, error: ^NS.Error) {
-	state = msgSend(^RenderPipelineState, self, "newRenderPipelineStateWithMeshDescriptor:options:reflection:error:", options, reflection, &error)
+Device_newRenderPipelineStateWithMeshDescriptor :: #force_inline proc "c" (self: ^Device, descriptor: ^MeshRenderPipelineDescriptor, options: PipelineOption, reflection: ^AutoreleasedRenderPipelineReflection) -> (state: ^RenderPipelineState, error: ^NS.Error) {
+	state = msgSend(^RenderPipelineState, self, "newRenderPipelineStateWithMeshDescriptor:options:reflection:error:", descriptor, options, reflection, &error)
 	return
 }
 @(objc_type=Device, objc_name="newRenderPipelineStateWithMeshDescriptorAndCompletionHandler")
-Device_newRenderPipelineStateWithMeshDescriptorAndCompletionHandler :: #force_inline proc "c" (self: ^Device, options: PipelineOption, completionHandler: ^NewRenderPipelineStateWithReflectionCompletionHandler) -> (state: ^RenderPipelineState) {
-	state = msgSend(^RenderPipelineState, self, "newRenderPipelineStateWithMeshDescriptor:options:completionHandler:", options, completionHandler)
-	return
+Device_newRenderPipelineStateWithMeshDescriptorAndCompletionHandler :: #force_inline proc "c" (self: ^Device, descriptor: ^MeshRenderPipelineDescriptor, options: PipelineOption, completionHandler: NewRenderPipelineStateWithReflectionCompletionHandler) {
+	msgSend(nil, self, "newRenderPipelineStateWithMeshDescriptor:options:completionHandler:", descriptor, options, completionHandler)
 }
 
 @(objc_type=Device, objc_name="newIOHandle")

--- a/vendor/darwin/Metal/MetalClasses.odin
+++ b/vendor/darwin/Metal/MetalClasses.odin
@@ -2767,6 +2767,10 @@ RenderPipelineDescriptor_fragmentBuffers :: #force_inline proc "c" (self: ^Rende
 RenderPipelineDescriptor_fragmentFunction :: #force_inline proc "c" (self: ^RenderPipelineDescriptor) -> ^Function {
 	return msgSend(^Function, self, "fragmentFunction")
 }
+@(objc_type=RenderPipelineDescriptor, objc_name="vertexLinkedFunctions")
+RenderPipelineDescriptor_vertexLinkedFunctions :: #force_inline proc "c" (self: ^RenderPipelineDescriptor) -> ^LinkedFunctions {
+	return msgSend(^LinkedFunctions, self, "vertexLinkedFunctions")
+}
 @(objc_type=RenderPipelineDescriptor, objc_name="fragmentLinkedFunctions")
 RenderPipelineDescriptor_fragmentLinkedFunctions :: #force_inline proc "c" (self: ^RenderPipelineDescriptor) -> ^LinkedFunctions {
 	return msgSend(^LinkedFunctions, self, "fragmentLinkedFunctions")
@@ -2834,6 +2838,10 @@ RenderPipelineDescriptor_setDepthAttachmentPixelFormat :: #force_inline proc "c"
 @(objc_type=RenderPipelineDescriptor, objc_name="setFragmentFunction")
 RenderPipelineDescriptor_setFragmentFunction :: #force_inline proc "c" (self: ^RenderPipelineDescriptor, fragmentFunction: ^Function) {
 	msgSend(nil, self, "setFragmentFunction:", fragmentFunction)
+}
+@(objc_type=RenderPipelineDescriptor, objc_name="setVertexLinkedFunctions")
+RenderPipelineDescriptor_setVertexLinkedFunctions :: #force_inline proc "c" (self: ^RenderPipelineDescriptor, vertexLinkedFunctions: ^LinkedFunctions) {
+	msgSend(nil, self, "setVertexLinkedFunctions:", vertexLinkedFunctions)
 }
 @(objc_type=RenderPipelineDescriptor, objc_name="setFragmentLinkedFunctions")
 RenderPipelineDescriptor_setFragmentLinkedFunctions :: #force_inline proc "c" (self: ^RenderPipelineDescriptor, fragmentLinkedFunctions: ^LinkedFunctions) {

--- a/vendor/darwin/Metal/MetalEnums.odin
+++ b/vendor/darwin/Metal/MetalEnums.odin
@@ -1050,3 +1050,9 @@ VertexStepFunction :: enum NS.UInteger {
 	PerPatch             = 3,
 	PerPatchControlPoint = 4,
 }
+
+ShaderValidation :: enum NS.UInteger {
+	Default  = 0,
+	Enabled  = 1,
+	Disabled = 2,
+}


### PR DESCRIPTION
While working on a mesh shaded graphics pipeline using Metal for MacOS, I noticed that the related Odin bindings were incorrect or missing. This pull request fixes all the errors I found.

To determine whether a binding was incorrect or missing, I checked against Apple's online documentation (mostly https://developer.apple.com/documentation/metal/mtlrenderpipelinedescriptor?language=objc and https://developer.apple.com/documentation/metal/mtlmeshrenderpipelinedescriptor?language=objc) and the MacOS 15.5 Metal Obj-C header files on my MacBook (mostly `MTLRenderPipeline.h`).

<hr/>

### Some `MeshRenderPipelineDescriptor` Bindings Were Incorrectly Under `RenderPipelineDescriptor`
For example, there existed `RenderPipelineDescriptor_meshFunction`, but according to documentation, `RenderPipelineDescriptor` does not have the property `meshFunction`, which makes sense because the mesh shader stage only exists in mesh shaded graphics pipelines. I converted this into `MeshRenderPipelineDescriptor_meshFunction`.

List of converted bindings:
- `RenderPipelineDescriptor_objectFunction` and its setter
- `RenderPipelineDescriptor_meshFunction` and its setter
- `RenderPipelineDescriptor_maxTotalThreadsPerObjectThreadgroup` and its setter
- `RenderPipelineDescriptor_maxTotalThreadsPerMeshThreadgroup` and its setter
- `RenderPipelineDescriptor_objectThreadgroupSizeIsMultipleOfThreadExecutionWidth` and its setter
- `RenderPipelineDescriptor_meshThreadgroupSizeIsMultipleOfThreadExecutionWidth` and its setter
- `RenderPipelineDescriptor_payloadMemoryLength` and its setter
- `RenderPipelineDescriptor_maxTotalThreadgroupsPerMeshGrid` and its setter
- `RenderPipelineDescriptor_objectBuffers`
- `RenderPipelineDescriptor_meshBuffers`

### Added Missing Mesh Shading Bindings
- `MeshRenderPipelineDescriptor`
  - `MeshRenderPipelineDescriptor_alloc`
  - `MeshRenderPipelineDescriptor_init`
  - `MeshRenderPipelineDescriptor_binaryArchives` and its setter
  - `MeshRenderPipelineDescriptor_colorAttachments`
  - `MeshRenderPipelineDescriptor_depthAttachmentPixelFormat` and its setter
  - `MeshRenderPipelineDescriptor_fragmentBuffers`
  - `MeshRenderPipelineDescriptor_fragmentFunction` and its setter
  - `MeshRenderPipelineDescriptor_fragmentLinkedFunctions` and its setter
  - `MeshRenderPipelineDescriptor_alphaToCoverageEnabled` and its getter and setter
  - `MeshRenderPipelineDescriptor_alphaToOneEnabled` and its getter and setter
  - `MeshRenderPipelineDescriptor_rasterizationEnabled` and its getter and setter
  - `MeshRenderPipelineDescriptor_label`
  - `MeshRenderPipelineDescriptor_maxVertexAmplificationCount` and its setter
  - `MeshRenderPipelineDescriptor_meshLinkedFunctions` and its setter
  - `MeshRenderPipelineDescriptor_objectLinkedFunctions` and its setter
  - `MeshRenderPipelineDescriptor_rasterSampleCount` and its setter
  - `MeshRenderPipelineDescriptor_shaderValidation` and its setter
  - `MeshRenderPipelineDescriptor_stencilAttachmentPixelFormat` and its setter
  - `MeshRenderPipelineDescriptor_supportIndirectCommandBuffers` and its setter
  - `MeshRenderPipelineDescriptor_reset`
  
### Added Missing `MeshRenderPipelineDescriptor` Parameter to `Device` Functions
`Device_newRenderPipelineStateWithMeshDescriptor` and `Device_newRenderPipelineStateWithMeshDescriptorAndCompletionHandler` were missing the `MeshRenderPipelineDescriptor` parameter, so I added it.

Additionally, the calling convention of `Device_newRenderPipelineStateWithMeshDescriptor` was converted from `contextless` to `c`. Calling this function crashes otherwise.

And `Device_newRenderPipelineStateWithMeshDescriptorAndCompletionHandler` was modified to not return anything, in accordance with documentation for this function.

### Added Other Misc. Missing Bindings
Just some other Metal bindings I noticed were missing that have nothing to do with mesh shading.

- `RenderPipelineDescriptor_vertexLinkedFunctions` and its setter
- `RenderPipelineDescriptor_fragmentLinkedFunctions` and its setter
- `RenderPipelineDescriptor_shaderValidation` and its setter
- `ShaderValidation`

### A Note About Metal Beta Functions
The documentation includes some functions that are marked "Beta":
- `requiredThreadsPerMeshThreadgroup`
- `requiredThreadsPerObjectThreadgroup`

I did not create bindings for these as they are subject to change by Apple. Are we interested in adding them?

<hr/>

I typed these bindings manually (with some help from Vim macros). Though the code compiles, I very well could have made typos. I'm going to triple-check my bindings for mistakes over the next couple of days. So far, I have written a test program that draws a red triangle to a window using a small subset of these mesh shader bindings. I've attached the files to this pull request if you are interested (as .txt files because GitHub does not support .odin or .metal files).

[main.metal.txt](https://github.com/user-attachments/files/21654518/main.metal.txt)
[main.odin.txt](https://github.com/user-attachments/files/21654519/main.odin.txt)

Lastly, I will list some other missing/incorrect Metal bindings that I found but did not fix in this pull request:
- These should return nothing:
  - `Device_newRenderPipelineStateWithDescriptorWithCompletionHandler`
  - `Device_newRenderPipelineStateWithDescriptorWithOptionsAndCompletionHandler`
  - `Device_newRenderPipelineStateWithTileDescriptorWithCompletionHandler`
  - `Device_newComputePipelineStateWithDescriptorWithCompletionHandler`
  - `Device_newComputePipelineStateWithFunctionWithCompletionHandler`
  - `Device_newComputePipelineStateWithFunctionWithOptionsAndCompletionHandler`
- These need a setter:
  - `RenderPipelineDescriptor_label`
  - `TileRenderPipelineDescriptor_label`
  - `MeshRenderPipelineDescriptor_label`
  - `ComputePipelineDescriptor_label`

Please let me know what you think.