### PR TITLE
Fix ICE on missing procedure in base:runtime

### DIFF
--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -2792,6 +2792,7 @@ gb_internal lbValue lb_find_ident(lbProcedure *p, lbModule *m, Entity *e, Ast *e
 gb_internal lbValue lb_find_procedure_value_from_entity(lbModule *m, Entity *e) {
 	lbGenerator *gen = m->gen;
 
+	GB_ASSERT(e != nullptr);
 	GB_ASSERT(is_type_proc(e->type));
 	e = strip_entity_wrapping(e);
 	GB_ASSERT(e != nullptr);


### PR DESCRIPTION
## Context

Returned to working on my odin-os project, found out it doesn't compile because `base:runtime` just got updated and the compiler is crashing with my runtime implementation.

## Detail

When a required built-in procedure is missing from the base:runtime package, an assert should be triggered. However this does not happen and instead the compiler crashes silently. The cause is the null-dereference after scope_lookup_current returns nullptr.

This adds an assertion that the runtime procedure is found, before proceeding to check it's type and performing further lookups.