### PR TITLE
Improve dereference missing suggestion message

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -2455,7 +2455,8 @@ gb_internal void check_assignment_error_suggestion(CheckerContext *c, Operand *o
 	} else if (is_type_pointer(o->type) &&
 	           are_types_identical(type_deref(o->type), type)) {
 		gbString s = expr_to_string(o->expr);
-		error_line("\tSuggestion: Did you mean `%s^`\n", s);
+		if (s[0] == '&') error_line("\tSuggestion: Did you mean `%s`\n", &s[1]);
+		else error_line("\tSuggestion: Did you mean `%s^`\n", s);
 		gb_string_free(s);
 	}
 }


### PR DESCRIPTION
In certain cases a `^` operator is not needed, we now display different messages depending on the context.
Where before this PR it would provide the redundant suggestion of `Did you mean: '&x^'`

```odin
package main

foo :: proc(x: int) {
}

bar :: proc(x: ^int) {
	foo(x)
}

main :: proc() {
	x: int
	bar(&x)
	foo(&x)
}
```

```
main.odin(7:6) Error: Cannot assign value 'x' of type '^int' to 'int' in a procedure argument
	foo(x)
	    ^
	Suggestion: Did you mean `x^`
main.odin(13:6) Error: Cannot assign value '&x' of type '^int' to 'int' in a procedure argument
	foo(&x)
	    ^^
	Suggestion: Did you mean `x`
```sh
