### PR TITLE
Fix ITimer_Flags_Bits enum value

### DIFF
--- a/core/sys/linux/bits.odin
+++ b/core/sys/linux/bits.odin
@@ -1838,7 +1838,7 @@ Clock_Id :: enum {
 	Bits for POSIX interval timer flags.
 */
 ITimer_Flags_Bits :: enum {
-	ABSTIME = 1,
+	ABSTIME = 0,
 }
 
 /*


### PR DESCRIPTION
`TIMER_ABSTIME` is the first and only value of this bitmask, defined as 0b01. Since the enum values are used for the bit position in a bit set, this used to actually result in 0b10 when passing `ITimer_Flags_bits.ABSTIME` to syscalls, breaking functionality.