### PR TITLE
Use Maybe in sdl.RenderGeometry

### DIFF
--- a/vendor/sdl3/sdl3_render.odin
+++ b/vendor/sdl3/sdl3_render.odin
@@ -212,8 +212,8 @@ foreign lib {
 	RenderTextureAffine              :: proc(renderer: ^Renderer, texture: ^Texture, srcrect: Maybe(^FRect), origin, right, down: Maybe(^FPoint)) -> bool ---
 	RenderTextureTiled               :: proc(renderer: ^Renderer, texture: ^Texture, srcrect: Maybe(^FRect), scale: f32, dstrect: Maybe(^FRect)) -> bool ---
 	RenderTexture9Grid               :: proc(renderer: ^Renderer, texture: ^Texture, srcrect: Maybe(^FRect), left_width, right_width, top_height, bottom_height: f32, scale: f32, dstrect: Maybe(^FRect)) -> bool ---
-	RenderGeometry                   :: proc(renderer: ^Renderer, texture: Maybe(^Texture), vertices: [^]Vertex, num_vertices: c.int, indices: Maybe([^]c.int), num_indices: c.int) -> bool ---
-	RenderGeometryRaw                :: proc(renderer: ^Renderer, texture: Maybe(^Texture), xy: [^]f32, xy_stride: c.int, color: [^]FColor, color_stride: c.int, uv: [^]f32, uv_stride: c.int, num_vertices: c.int, indices: Maybe(rawptr), num_indices: c.int, size_indices: c.int) -> bool ---
+	RenderGeometry                   :: proc(renderer: ^Renderer, texture: Maybe(^Texture), vertices: [^]Vertex, num_vertices: c.int, indices: [^]c.int, num_indices: c.int) -> bool ---
+	RenderGeometryRaw                :: proc(renderer: ^Renderer, texture: Maybe(^Texture), xy: [^]f32, xy_stride: c.int, color: [^]FColor, color_stride: c.int, uv: [^]f32, uv_stride: c.int, num_vertices: c.int, indices: rawptr, num_indices: c.int, size_indices: c.int) -> bool ---
 	RenderPresent                    :: proc(renderer: ^Renderer) -> bool ---
 	DestroyTexture                   :: proc(texture: ^Texture) ---
 	DestroyRenderer                  :: proc(renderer: ^Renderer) ---

--- a/vendor/sdl3/sdl3_render.odin
+++ b/vendor/sdl3/sdl3_render.odin
@@ -212,8 +212,8 @@ foreign lib {
 	RenderTextureAffine              :: proc(renderer: ^Renderer, texture: ^Texture, srcrect: Maybe(^FRect), origin, right, down: Maybe(^FPoint)) -> bool ---
 	RenderTextureTiled               :: proc(renderer: ^Renderer, texture: ^Texture, srcrect: Maybe(^FRect), scale: f32, dstrect: Maybe(^FRect)) -> bool ---
 	RenderTexture9Grid               :: proc(renderer: ^Renderer, texture: ^Texture, srcrect: Maybe(^FRect), left_width, right_width, top_height, bottom_height: f32, scale: f32, dstrect: Maybe(^FRect)) -> bool ---
-	RenderGeometry                   :: proc(renderer: ^Renderer, texture: ^Texture, vertices: [^]Vertex, num_vertices: c.int, indices: [^]c.int, num_indices: c.int) -> bool ---
-	RenderGeometryRaw                :: proc(renderer: ^Renderer, texture: ^Texture, xy: [^]f32, xy_stride: c.int, color: [^]FColor, color_stride: c.int, uv: [^]f32, uv_stride: c.int, num_vertices: c.int, indices: rawptr, num_indices: c.int, size_indices: c.int) -> bool ---
+	RenderGeometry                   :: proc(renderer: ^Renderer, texture: Maybe(^Texture), vertices: [^]Vertex, num_vertices: c.int, indices: Maybe([^]c.int), num_indices: c.int) -> bool ---
+	RenderGeometryRaw                :: proc(renderer: ^Renderer, texture: Maybe(^Texture), xy: [^]f32, xy_stride: c.int, color: [^]FColor, color_stride: c.int, uv: [^]f32, uv_stride: c.int, num_vertices: c.int, indices: Maybe(rawptr), num_indices: c.int, size_indices: c.int) -> bool ---
 	RenderPresent                    :: proc(renderer: ^Renderer) -> bool ---
 	DestroyTexture                   :: proc(texture: ^Texture) ---
 	DestroyRenderer                  :: proc(renderer: ^Renderer) ---


### PR DESCRIPTION
In [sdl docs](https://wiki.libsdl.org/SDL3/SDL_RenderGeometry) the texture parameter for `sdl.RenderGeometry` is optional,
which was not obvious from the bindings alone.
`Maybe` should help expressing that.