### PR TITLE
Fix buddy allocator assert

### DIFF
--- a/core/mem/allocators.odin
+++ b/core/mem/allocators.odin
@@ -2331,7 +2331,7 @@ buddy_allocator_alloc_bytes_non_zeroed :: proc(b: ^Buddy_Allocator, size: uint) 
 		}
 		found.is_free = false
 		data := ([^]byte)(found)[b.alignment:][:size]
-		assert(cast(uintptr)raw_data(data)+cast(uintptr)size < cast(uintptr)buddy_block_next(found), "Buddy_Allocator has made an allocation which overlaps a block header.")
+		assert(cast(uintptr)raw_data(data)+cast(uintptr)(size-1) < cast(uintptr)buddy_block_next(found), "Buddy_Allocator has made an allocation which overlaps a block header.")
 		// ensure_poisoned(data)
 		// sanitizer.address_unpoison(data)
 		return data, nil


### PR DESCRIPTION
The last address of "data" is not "cast(uintptr)raw_data(data)+cast(uintptr)size" but "cast(uintptr)raw_data(data)+cast(uintptr)(size-1)".

The original assert would fail, for example, when both the requested allocation size and the buddy allocator’s alignment were 64. In that case, the found block would have a size of 128 (alignment + size), and, supposing that the found block’s start address were 0 (to simplify the math), "data" would cover the address range [64, 127]. However, the original assert treats the address 128 ("data" + size) as part of "data", and therefore incorrectly considers it to overlap with the next block header, which starts at 128.

Here is a test that reproduces the bug (it fails at "test := make([]byte, 64)"):
`
```
import "core:testing"
import "base:runtime"
import "core:mem"

@(test)
test_buddy :: proc(t: ^testing.T) {
    alignment := 64
    backing_buffer_size :: runtime.Megabyte
    backing_buffer : []byte = runtime.make_aligned([]byte, backing_buffer_size, alignment)
    defer delete(backing_buffer)

    buddy_allocator : mem.Buddy_Allocator
    mem.buddy_allocator_init(
        &buddy_allocator,
        data=backing_buffer,
        alignment=cast(uint)alignment
    )

    context.allocator = mem.buddy_allocator(&buddy_allocator)

    test := make([]byte, 64)
    testing.expect(t, len(test) == 64)
}`