### PR TITLE
Make D3D12_FEATURE_DATA_D3D12_OPTIONS.MinPrecisionSupport a bitset

### DIFF
--- a/vendor/directx/d3d12/d3d12.odin
+++ b/vendor/directx/d3d12/d3d12.odin
@@ -851,10 +851,10 @@ FEATURE :: enum i32 {
 	OPTIONS19                             = 48,
 }
 
-SHADER_MIN_PRECISION_SUPPORT :: enum i32 {
-	NONE    = 0,
-	_10_BIT = 1,
-	_16_BIT = 2,
+SHADER_MIN_PRECISION_SUPPORT :: distinct bit_set[SHADER_MIN_PRECISION_SUPPORT_FLAG; u32]
+SHADER_MIN_PRECISION_SUPPORT_FLAG :: enum i32 {
+	_10_BIT,
+	_16_BIT,
 }
 
 TILED_RESOURCES_TIER :: enum i32 {


### PR DESCRIPTION
https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ns-d3d12-d3d12_feature_data_d3d12_options

Nobody seems to support 10-bit precision except WARP. So code that did `== ._16_bit` with the incorrect bindings would've worked for most cases.