### PR TITLE
Check for EOF when scanning file tags

### DIFF
--- a/core/odin/tokenizer/tokenizer.odin
+++ b/core/odin/tokenizer/tokenizer.odin
@@ -209,14 +209,14 @@ scan_comment :: proc(t: ^Tokenizer) -> string {
 scan_file_tag :: proc(t: ^Tokenizer) -> string {
 	offset := t.offset - 1
 
-	for t.ch != '\n' {
+	for t.ch != '\n' && t.ch != utf8.RUNE_EOF {
 		if t.ch == '/' {
 			next := peek_byte(t, 0)
 
 			if next == '/' || next == '*' {
 				break
 			}
-		} 
+		}
 		advance_rune(t)
 	}
 


### PR DESCRIPTION
Currently the odin tokenizer will hang when trying to parse a file with just a declaration at the top as it loops forever trying waiting for a newline:

```odin
#+private
```
The cpp tokenizer already handles this.

We had an issue raised in `ols` where it was hanging when trying to add the file tag for a new file https://github.com/DanielGavin/ols/issues/909.

