### PR TITLE
Fix stride in `memory_equal/compare_zero` giving false positves

### DIFF
--- a/base/runtime/internal.odin
+++ b/base/runtime/internal.odin
@@ -268,8 +268,8 @@ memory_equal :: proc "contextless" (x, y: rawptr, n: int) -> bool {
 			}
 		}
 
-		m = (n-i) / 8 * 8
-		for /**/; i < m; i += 8 {
+		m = (n-i) / size_of(uintptr) * size_of(uintptr)
+		for /**/; i < m; i += size_of(uintptr) {
 			if intrinsics.unaligned_load(cast(^uintptr)&a[i]) != intrinsics.unaligned_load(cast(^uintptr)&b[i]) {
 				return false
 			}
@@ -389,8 +389,8 @@ memory_compare_zero :: proc "contextless" (a: rawptr, n: int) -> int #no_bounds_
 			}
 		}
 
-		m = (n-i) / 8 * 8
-		for /**/; i < m; i += 8 {
+		m = (n-i) / size_of(uintptr) * size_of(uintptr)
+		for /**/; i < m; i += size_of(uintptr) {
 			if intrinsics.unaligned_load(cast(^uintptr)&bytes[i]) != 0 {
 				return 1
 			}


### PR DESCRIPTION
The previous stride of 8 assumed `uintptr` size is 8 which isn't the case on 32bit & wasm64p32. Skipping every other set of 4 bytes.

Fixes https://github.com/odin-lang/Odin/issues/5605