### PR TITLE
Add `add/remove_document_event_listener()` to `core:sys/wasm/js`

### DIFF
--- a/core/sys/wasm/js/events.odin
+++ b/core/sys/wasm/js/events.odin
@@ -373,12 +373,32 @@ remove_window_event_listener :: proc(kind: Event_Kind, user_data: rawptr, callba
 	return _remove_window_event_listener(event_kind_string[kind], user_data, callback, use_capture)
 }
 
+add_document_event_listener :: proc(kind: Event_Kind, user_data: rawptr, callback: proc(e: Event), use_capture := false) -> bool {
+	@(default_calling_convention="contextless")
+	foreign dom_lib {
+		@(link_name="add_document_event_listener")
+		_add_document_event_listener :: proc(name: string, name_code: Event_Kind, user_data: rawptr, callback: proc "odin" (Event), use_capture: bool) -> bool ---
+	}
+	return _add_document_event_listener(event_kind_string[kind], kind, user_data, callback, use_capture)
+}
+
+remove_document_event_listener :: proc(kind: Event_Kind, user_data: rawptr, callback: proc(e: Event), use_capture := false) -> bool {
+	@(default_calling_convention="contextless")
+	foreign dom_lib {
+		@(link_name="remove_document_event_listener")
+		_remove_document_event_listener :: proc(name: string, user_data: rawptr, callback: proc "odin" (Event), use_capture: bool) -> bool ---
+	}
+	return _remove_document_event_listener(event_kind_string[kind], user_data, callback, use_capture)
+}
+
 remove_event_listener_from_event :: proc(e: Event) -> bool {
 	from_use_capture_false: bool
 	from_use_capture_true: bool
 	if e.id == "" {
 		from_use_capture_false = remove_window_event_listener(e.kind, e.user_data, e.callback, false)
 		from_use_capture_true = remove_window_event_listener(e.kind, e.user_data, e.callback, true)
+		from_use_capture_false |= remove_document_event_listener(e.kind, e.user_data, e.callback, false)
+		from_use_capture_true |= remove_document_event_listener(e.kind, e.user_data, e.callback, true)
 	} else {
 		from_use_capture_false = remove_event_listener(e.id, e.kind, e.user_data, e.callback, false)
 		from_use_capture_true = remove_event_listener(e.id, e.kind, e.user_data, e.callback, true)

--- a/core/sys/wasm/js/events_all_targets.odin
+++ b/core/sys/wasm/js/events_all_targets.odin
@@ -275,6 +275,14 @@ remove_window_event_listener :: proc(kind: Event_Kind, user_data: rawptr, callba
 	panic("vendor:wasm/js not supported on non JS targets")
 }
 
+add_document_event_listener :: proc(kind: Event_Kind, user_data: rawptr, callback: proc(e: Event), use_capture := false) -> bool {
+	panic("vendor:wasm/js not supported on non JS targets")
+}
+
+remove_document_event_listener :: proc(kind: Event_Kind, user_data: rawptr, callback: proc(e: Event), use_capture := false) -> bool {
+	panic("vendor:wasm/js not supported on non JS targets")
+}
+
 remove_event_listener_from_event :: proc(e: Event) -> bool {
 	panic("vendor:wasm/js not supported on non JS targets")
 }


### PR DESCRIPTION
Some events belong to the js `document` element and can't be accessed through the existing procs.
This PR adds the equivalent of `js.add_window_event()`, but applied to the js `document` instead.

I'm using these new procs to listen for the `.Pointer_Lock_Error` and `.Pointer_Lock_Change` events.

```odin
// existing procs
js.add_event_listener(CANVAS_NAME, .Pointer_Down, nil, _event_js) or_return
js.add_event_listener(CANVAS_NAME, .Pointer_Up, nil, _event_js) or_return
js.add_event_listener(CANVAS_NAME, .Pointer_Move, nil, _event_js) or_return
js.add_event_listener(CANVAS_NAME, .Pointer_Enter, nil, _event_js) or_return
js.add_event_listener(CANVAS_NAME, .Pointer_Leave, nil, _event_js) or_return
js.add_event_listener(CANVAS_NAME, .Pointer_Cancel, nil, _event_js) or_return
// new procs
js.add_document_event_listener(.Pointer_Lock_Change, nil, _event_js) or_return
js.add_document_event_listener(.Pointer_Lock_Error, nil, _event_js) or_return
```
