### PR TITLE
skip errors on polymorphic procs when in a proc group with other options

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -7126,6 +7126,7 @@ gb_internal CallArgumentData check_call_arguments_proc_group(CheckerContext *c, 
 	gbString expr_name = expr_to_string(operand->expr);
 	defer (gb_string_free(expr_name));
 
+	c->in_proc_group = true;
 	for_array(i, procs) {
 		Entity *p = procs[i];
 		if (p->flags & EntityFlag_Disabled) {
@@ -7168,6 +7169,7 @@ gb_internal CallArgumentData check_call_arguments_proc_group(CheckerContext *c, 
 			array_add(&valids, item);
 		}
 	}
+	c->in_proc_group = false;
 
 	if (max_matched_features > 0) {
 		for_array(i, valids) {

--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -2085,7 +2085,9 @@ gb_internal Type *check_get_params(CheckerContext *ctx, Scope *scope, Ast *_para
 							if (op.mode == Addressing_Constant) {
 								poly_const = op.value;
 							} else {
-								error(op.expr, "Expected a constant value for this polymorphic name parameter, got %s", expr_to_string(op.expr));
+								if (!ctx->in_proc_group) {
+									error(op.expr, "Expected a constant value for this polymorphic name parameter, got %s", expr_to_string(op.expr));
+								}
 								success = false;
 							}
 						}

--- a/src/checker.hpp
+++ b/src/checker.hpp
@@ -563,6 +563,7 @@ struct CheckerContext {
 
 	u32        stmt_flags;
 	bool       in_enum_type;
+	bool       in_proc_group;
 	bool       collect_delayed_decls;
 	bool       allow_polymorphic_types;
 	bool       disallow_polymorphic_return_types; // NOTE(zen3ger): no poly type decl in return types


### PR DESCRIPTION
This resolves an issue where polymorphic procedures would immediately fail a procedure group, even when there were more procedures to check. For example:
```odin
foo :: proc { bar, baz }
bar :: proc(text: string) {}
baz :: proc($text: string) {}

foo("foo")
bar := "bar"
foo(bar)
```

Would ostensibly use `baz` in the case of the constant string while it would use `bar` in the case of the variable string. This *previously* has worked but was removed in this commit: [Add error message for non-constant polymorphic name parameters](https://github.com/odin-lang/Odin/commit/5877017d30999388c832f6467116336733b607e2). That was seemingly done to prevent the following code:
```odin
foo :: proc($text: string) {}

bar := "bar"
foo(bar)
```
but had impacts on the proc group system. As of now, this fix just special cases the situation where the user is in a proc group that has multiple resolution candidates. In testing, this still produces sane error messages in the case where no variant can be satisfied and doesn't mess up cases where there is only a single proc in the group.

Fixes: #5446

Addendum:
It should be noted that the first example *does* compile and doesn't complain about the proc group until the `foo(bar)` line. If the behavior added by this PR isn't intended, there should be an error message for "duplicate" procs in the group in that case.