### PR TITLE
More detailed argument count in the "too many arguments" error

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -6272,11 +6272,16 @@ gb_internal CallArgumentError check_call_arguments_internal(CheckerContext *c, A
 		positional_operand_count = gb_min(positional_operands.count, pt->variadic_index);
 	} else if (positional_operand_count > pt->param_count) {
 		err = CallArgumentError_TooManyArguments;
-		char const *err_fmt = "Too many arguments for '%s', expected %td arguments, got %td";
 		if (show_error) {
 			gbString proc_str = expr_to_string(ce->proc);
 			defer (gb_string_free(proc_str));
-			error(call, err_fmt, proc_str, param_count_excluding_defaults, positional_operands.count);
+			if(param_count_excluding_defaults != pt->param_count) {
+				char const *err_fmt = "Too many arguments for '%s', expected between %td and %td arguments, got %td";
+				error(call, err_fmt, proc_str, param_count_excluding_defaults, pt->param_count, positional_operands.count);
+			} else {
+				char const *err_fmt = "Too many arguments for '%s', expected %td arguments, got %td";
+				error(call, err_fmt, proc_str, pt->param_count, positional_operands.count);
+			}
 		}
 		return err;
 	}


### PR DESCRIPTION
This changes the error message for procedures with default arguments from  
`Too many arguments for '<proc>', expected <arg_count_without_defaults>, got <provided_arg_count>` to  
`Too many arguments for '<proc>', expected between <arg_count_without_defaults> and <arg_count> arguments, got <provided_arg_count>`. 

I found the previous error message to be misleading, as it states the procedure having less arguments than it actually has. The fact that arguments with default values are not included in that count is not clear in the previous message.