### PR TITLE
windows i386 support

### DIFF
--- a/base/runtime/core_builtin.odin
+++ b/base/runtime/core_builtin.odin
@@ -54,8 +54,8 @@ container_of :: #force_inline proc "contextless" (ptr: $P/^$Field_Type, $T: type
 
 
 when !NO_DEFAULT_TEMP_ALLOCATOR {
-	when ODIN_ARCH == .i386 && ODIN_OS == .Windows {
-		// Thread-local storage is problematic on Windows i386
+	when ODIN_ARCH == .i386 && ODIN_OS == .Windows && ODIN_NO_CRT {
+		// Thread-local storage doesn't work on Windows i386 without CRT
 		global_default_temp_allocator_data: Default_Temp_Allocator
 	} else {
 		@thread_local global_default_temp_allocator_data: Default_Temp_Allocator

--- a/base/runtime/core_builtin.odin
+++ b/base/runtime/core_builtin.odin
@@ -54,7 +54,12 @@ container_of :: #force_inline proc "contextless" (ptr: $P/^$Field_Type, $T: type
 
 
 when !NO_DEFAULT_TEMP_ALLOCATOR {
-	@thread_local global_default_temp_allocator_data: Default_Temp_Allocator
+	when ODIN_ARCH == .i386 && ODIN_OS == .Windows {
+		// Thread-local storage is problematic on Windows i386
+		global_default_temp_allocator_data: Default_Temp_Allocator
+	} else {
+		@thread_local global_default_temp_allocator_data: Default_Temp_Allocator
+	}
 }
 
 @(builtin, disabled=NO_DEFAULT_TEMP_ALLOCATOR)

--- a/base/runtime/core_builtin.odin
+++ b/base/runtime/core_builtin.odin
@@ -54,8 +54,8 @@ container_of :: #force_inline proc "contextless" (ptr: $P/^$Field_Type, $T: type
 
 
 when !NO_DEFAULT_TEMP_ALLOCATOR {
-	when ODIN_ARCH == .i386 && ODIN_OS == .Windows && ODIN_NO_CRT {
-		// Thread-local storage doesn't work on Windows i386 without CRT
+	when ODIN_ARCH == .i386 && ODIN_OS == .Windows {
+		// Thread-local storage is problematic on Windows i386
 		global_default_temp_allocator_data: Default_Temp_Allocator
 	} else {
 		@thread_local global_default_temp_allocator_data: Default_Temp_Allocator

--- a/base/runtime/entry_windows.odin
+++ b/base/runtime/entry_windows.odin
@@ -28,7 +28,19 @@ when ODIN_BUILD_MODE == .Dynamic {
 		return true
 	}
 } else when !ODIN_TEST && !ODIN_NO_ENTRY_POINT {
-	when ODIN_ARCH == .i386 || ODIN_NO_CRT {
+	when ODIN_ARCH == .i386 && !ODIN_NO_CRT {
+		// Windows i386 with CRT: libcmt provides mainCRTStartup which calls _main
+		// Note: "c" calling convention adds underscore prefix automatically on i386
+		@(link_name="main", linkage="strong", require)
+		main :: proc "c" (argc: i32, argv: [^]cstring) -> i32 {
+			args__ = argv[:argc]
+			context = default_context()
+			#force_no_inline _startup_runtime()
+			intrinsics.__entry_point()
+			#force_no_inline _cleanup_runtime()
+			return 0
+		}
+	} else when ODIN_NO_CRT {
 		@(link_name="mainCRTStartup", linkage="strong", require)
 		mainCRTStartup :: proc "system" () -> i32 {
 			context = default_context()

--- a/core/testing/signal_handler_libc.odin
+++ b/core/testing/signal_handler_libc.odin
@@ -24,10 +24,18 @@ import "core:terminal/ansi"
 @(private="file") stop_test_passed: libc.sig_atomic_t
 @(private="file") stop_test_alert:  libc.sig_atomic_t
 
-@(private="file", thread_local)
-local_test_index: libc.sig_atomic_t
-@(private="file", thread_local)
-local_test_index_set: bool
+when ODIN_ARCH == .i386 && ODIN_OS == .Windows {
+	// Thread-local storage is problematic on Windows i386
+	@(private="file")
+	local_test_index: libc.sig_atomic_t
+	@(private="file")
+	local_test_index_set: bool
+} else {
+	@(private="file", thread_local)
+	local_test_index: libc.sig_atomic_t
+	@(private="file", thread_local)
+	local_test_index_set: bool
+}
 
 // Windows does not appear to have a SIGTRAP, so this is defined here, instead
 // of in the libc package, just so there's no confusion about it being

--- a/core/testing/signal_handler_libc.odin
+++ b/core/testing/signal_handler_libc.odin
@@ -24,8 +24,8 @@ import "core:terminal/ansi"
 @(private="file") stop_test_passed: libc.sig_atomic_t
 @(private="file") stop_test_alert:  libc.sig_atomic_t
 
-when ODIN_ARCH == .i386 && ODIN_OS == .Windows && ODIN_NO_CRT {
-	// Thread-local storage doesn't work on Windows i386 without CRT
+when ODIN_ARCH == .i386 && ODIN_OS == .Windows {
+	// Thread-local storage is problematic on Windows i386
 	@(private="file")
 	local_test_index: libc.sig_atomic_t
 	@(private="file")

--- a/core/testing/signal_handler_libc.odin
+++ b/core/testing/signal_handler_libc.odin
@@ -24,8 +24,8 @@ import "core:terminal/ansi"
 @(private="file") stop_test_passed: libc.sig_atomic_t
 @(private="file") stop_test_alert:  libc.sig_atomic_t
 
-when ODIN_ARCH == .i386 && ODIN_OS == .Windows {
-	// Thread-local storage is problematic on Windows i386
+when ODIN_ARCH == .i386 && ODIN_OS == .Windows && ODIN_NO_CRT {
+	// Thread-local storage doesn't work on Windows i386 without CRT
 	@(private="file")
 	local_test_index: libc.sig_atomic_t
 	@(private="file")

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -281,7 +281,11 @@ try_cross_linking:;
 					link_settings = gb_string_append_fmt(link_settings, " /NOENTRY");
 				}
 			} else {
-				link_settings = gb_string_append_fmt(link_settings, " /ENTRY:mainCRTStartup");
+				// For i386 with CRT, libcmt provides the entry point
+				// For other cases or no_crt, we need to specify the entry point
+				if (!(build_context.metrics.arch == TargetArch_i386 && !build_context.no_crt)) {
+					link_settings = gb_string_append_fmt(link_settings, " /ENTRY:mainCRTStartup");
+				}
 			}
 
 			if (build_context.build_paths[BuildPath_Symbols].name != "") {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3619,9 +3619,8 @@ int main(int arg_count, char const **arg_ptr) {
 	// }
 	
 	// Warn about Windows i386 thread-local storage limitations
-	if (build_context.metrics.arch == TargetArch_i386 && build_context.metrics.os == TargetOs_windows && build_context.no_crt) {
-		gb_printf_err("Warning: Thread-local storage is not supported on Windows i386 with -no-crt.\n");
-		gb_printf_err("         Multi-threaded code will not work correctly.\n");
+	if (build_context.metrics.arch == TargetArch_i386 && build_context.metrics.os == TargetOs_windows) {
+		gb_printf_err("Warning: Thread-local storage is disabled on Windows i386.\n");
 	}
 
 	// Check chosen microarchitecture. If not found or ?, print list.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3617,6 +3617,11 @@ int main(int arg_count, char const **arg_ptr) {
 	// 	print_usage_line(0, "%.*s 32-bit is not yet supported for this platform", LIT(args[0]));
 	// 	return 1;
 	// }
+	
+	// Warn about Windows i386 thread-local storage limitations
+	if (build_context.metrics.arch == TargetArch_i386 && build_context.metrics.os == TargetOs_windows) {
+		gb_printf_err("Warning: Thread-local storage is disabled on Windows i386.\n");
+	}
 
 	// Check chosen microarchitecture. If not found or ?, print list.
 	bool print_microarch_list = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3619,8 +3619,9 @@ int main(int arg_count, char const **arg_ptr) {
 	// }
 	
 	// Warn about Windows i386 thread-local storage limitations
-	if (build_context.metrics.arch == TargetArch_i386 && build_context.metrics.os == TargetOs_windows) {
-		gb_printf_err("Warning: Thread-local storage is disabled on Windows i386.\n");
+	if (build_context.metrics.arch == TargetArch_i386 && build_context.metrics.os == TargetOs_windows && build_context.no_crt) {
+		gb_printf_err("Warning: Thread-local storage is not supported on Windows i386 with -no-crt.\n");
+		gb_printf_err("         Multi-threaded code will not work correctly.\n");
 	}
 
 	// Check chosen microarchitecture. If not found or ?, print list.


### PR DESCRIPTION
base/runtime/entry_windows.odin - Correct entry point generation
base/runtime/core_builtin.odin - TLS disabled for temp allocator
core/testing/signal_handler_libc.odin - TLS disabled for test indices
src/llvm_backend.cpp - Entry point handling for test builds
src/linker.cpp - Skip /ENTRY: directive for i386 with CRT
src/main.cpp - Warning message about TLS limitations

I wasn't sure if there is a better location to put the TLS limit warning.