### PR TITLE
fix typo in CLSIDFromProgIDEx signature

### DIFF
--- a/core/sys/windows/ole32.odin
+++ b/core/sys/windows/ole32.odin
@@ -58,7 +58,7 @@ foreign Ole32 {
 	CoTaskMemFree :: proc(pv: rawptr) ---
 
 	CLSIDFromProgID :: proc(lpszProgID: LPCOLESTR, lpclsid: LPCLSID) -> HRESULT ---
-	CLSIDFromProgIDEx :: proc(lpszProgID, LPCOLESTR, lpclsid: LPCLSID) -> HRESULT ---
+	CLSIDFromProgIDEx :: proc(lpszProgID: LPCOLESTR, lpclsid: LPCLSID) -> HRESULT ---
 	CLSIDFromString :: proc(lpsz: LPOLESTR, pclsid: LPCLSID) -> HRESULT ---
 	IIDFromString :: proc(lpsz: LPOLESTR, lpiid: LPIID) -> HRESULT ---
 	ProgIDFromCLSID :: proc(clsid: REFCLSID, lplpszProgID: ^LPOLESTR) -> HRESULT ---


### PR DESCRIPTION
CLSIDFromProgIDEx had a comma rather than colon, making type signature incorrect