### PR TITLE
Fix broken wglUseFontBitmaps binding

### DIFF
--- a/core/sys/windows/wgl.odin
+++ b/core/sys/windows/wgl.odin
@@ -82,7 +82,8 @@ foreign Opengl32 {
 	wglSetLayerPaletteEntries :: proc(hdc: HDC, layer_plane, start, entries: c.int, cr: ^COLORREF) -> c.int ---
 	wglShareLists             :: proc(HGLRC1, HGLRC2: HGLRC) -> BOOL ---
 	wglSwapLayerBuffers       :: proc(hdc: HDC, planes: DWORD) -> BOOL ---
-	wglUseFontBitmaps         :: proc(hdc: HDC, first, count, list_base: DWORD) -> BOOL ---
+	wglUseFontBitmapsA        :: proc(hdc: HDC, first, count, list_base: DWORD) -> BOOL ---
+	wglUseFontBitmapsW        :: proc(hdc: HDC, first, count, list_base: DWORD) -> BOOL ---
 	wglUseFontOutlines        :: proc(hdc: HDC, first, count, list_base: DWORD, deviation, extrusion: f32, format: c.int, gmf: LPGLYPHMETRICSFLOAT) -> BOOL ---
 }
 


### PR DESCRIPTION
`wglUseFontBitmaps` is actually a macro and not a symbol that is exported.

<img width="625" height="142" alt="image" src="https://github.com/user-attachments/assets/f1c53699-c54b-4c5c-906c-5d7313f3e5be" />

Only wglUseFontBitmapsA and wglUseFontBitmapsW are exported.

<img width="668" height="72" alt="image" src="https://github.com/user-attachments/assets/fd322f56-6180-4e88-a706-c6a6fd0f89e8" />

This change adds bindings for those.