### PR TITLE
fix(sys/linux): incorrect epoll_wait & EPoll_Event on  arm64 & riscv64 

### DIFF
--- a/core/sys/linux/sys.odin
+++ b/core/sys/linux/sys.odin
@@ -2477,18 +2477,8 @@ exit_group :: proc "contextless" (code: i32) -> ! {
 	Available since Linux 2.6.
 */
 epoll_wait :: proc(epfd: Fd, events: [^]EPoll_Event, count: i32, timeout: i32) -> (i32, Errno) {
-	when ODIN_ARCH != .arm64 && ODIN_ARCH != .riscv64 {
-		ret := syscall(SYS_epoll_wait, epfd, events, count, timeout)
-		return errno_unwrap(ret, i32)
-	} else {
-		// Convert milliseconds to nanosecond timespec
-		timeout_ns := Time_Spec {
-			time_sec = uint(timeout * 1000),
-			time_nsec = 0,
-		}
-		ret := syscall(SYS_epoll_pwait, epfd, events, count, &timeout_ns, rawptr(nil))
-		return errno_unwrap(ret, i32)
-	}
+	ret := syscall(SYS_epoll_pwait, epfd, events, count, timeout, rawptr(nil))
+	return errno_unwrap(ret, i32)
 }
 
 /*

--- a/core/sys/linux/types.odin
+++ b/core/sys/linux/types.odin
@@ -1446,9 +1446,16 @@ EPoll_Data :: struct #raw_union {
 	u64: u64,
 }
 
-EPoll_Event :: struct #packed {
-	events: EPoll_Event_Set,
-	data:   EPoll_Data,
+when ODIN_ARCH == .amd64 || ODIN_ARCH == .i386 {
+	EPoll_Event :: struct #packed {
+		events: EPoll_Event_Set,
+		data:   EPoll_Data,
+	}
+} else {
+	EPoll_Event :: struct {
+		events: EPoll_Event_Set,
+		data:   EPoll_Data,
+	}
 }
 
 /*


### PR DESCRIPTION
previous code uses epoll_pwait for arm64 & riscv64 and epoll_wait for other archs, but it uses it incorrectly.
The syscall expects timeout in milliseconds but the code passes Time_Spec
new code calls epoll_pwait for all archs with NULL sigmask so it will act as epoll_wait

updated:
also fixes EPoll_Event struct always being packed, it should be packed only for x86/x86_64