### PR TITLE
`vendor:box2d` fix CreateMotorJoint proc signature

### DIFF
--- a/vendor/box2d/box2d.odin
+++ b/vendor/box2d/box2d.odin
@@ -1370,7 +1370,7 @@ foreign lib {
 
 	// Create a motor joint
 	//	@see b2MotorJointDef for details
-	CreateMotorJoint               :: proc(worldId: WorldId, def: MotorJointDef) -> JointId ---
+	CreateMotorJoint               :: proc(worldId: WorldId, #by_ptr def: MotorJointDef) -> JointId ---
 
 	// Set the motor joint linear offset target
 	MotorJoint_SetLinearOffset     :: proc(jointId: JointId, linearOffset: Vec2) ---


### PR DESCRIPTION
upstream in box2D v3.1.0, `CreateMotorJoint` is [defined](https://github.com/erincatto/box2d/blob/v3.1.0/include/box2d/box2d.h#L866) as:
```
B2_API b2JointId b2CreateMotorJoint( b2WorldId worldId, const b2MotorJointDef* def );
```

currently, this proc segfaults as-is