### PR TITLE
[core:image/png] use .Image_Dimensions_Too_Large

### DIFF
--- a/core/image/png/png.odin
+++ b/core/image/png/png.odin
@@ -250,8 +250,12 @@ read_header :: proc(ctx: ^$C) -> (image.PNG_IHDR, Error) {
 	header := (^image.PNG_IHDR)(raw_data(c.data))^
 	// Validate IHDR
 	using header
-	if width == 0 || height == 0 || u128(width) * u128(height) > image.MAX_DIMENSIONS {
+	if width == 0 || height == 0 {
 		return {}, .Invalid_Image_Dimensions
+	}
+
+	if u128(width) * u128(height) > image.MAX_DIMENSIONS {
+		return {}, .Image_Dimensions_Too_Large
 	}
 
 	if compression_method != 0 {


### PR DESCRIPTION
PNG was sending .Invalid_Image_Dimensions for both the zero case and exceeding the MAX_DIMENSIONS.