### PR TITLE
[core:time] time_js: tick_now(): Use f64 (was f32) as a return type of odin_env.tick_now()

### DIFF
--- a/core/time/time_js.odin
+++ b/core/time/time_js.odin
@@ -24,7 +24,7 @@ _sleep :: proc "contextless" (d: Duration) {
 
 _tick_now :: proc "contextless" () -> Tick {
 	foreign odin_env {
-		tick_now :: proc "contextless" () -> f32 ---
+		tick_now :: proc "contextless" () -> f64 ---
 	}
 	return Tick{i64(tick_now()*1e6)}
 }


### PR DESCRIPTION
Fix for issue #5604.

The change is tiny, but please review it.

I changed return type of used `odin_env.tick_now()`. Tested, and produced web build works (time ticks). If the fix is incorrect, please reject and fix the issue in correct way. Please do not leave the issue open, as I think it is quite severe one, because currently in a web build the core:time.tick_now() doesn't work (doesn't tick after 2 sec).