### PR TITLE
Allow missing trailing comma with proc groups with odin parser

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -2485,7 +2485,7 @@ parse_operand :: proc(p: ^Parser, lhs: bool) -> ^ast.Expr {
 				allow_token(p, .Comma) or_break
 			}
 
-			close := expect_token(p, .Close_Brace)
+			close := expect_closing_brace_of_field_list(p)
 
 			if len(args) == 0 {
 				error(p, tok.pos, "expected at least 1 argument in procedure group")


### PR DESCRIPTION
It was raised in the `ols` repo https://github.com/DanielGavin/ols/issues/988 that proc groups aren't allowed to have missing trailing commas:

```odin
number :: proc(number: int) {  }
text :: proc(text: string) {  }

test :: proc {
	number,
	text // <-- Missing comma here causes the odin parser to error
}
```
however this code compiles fine with the cpp parser.

This just brings parity between the cpp and odin parsers.