### PR TITLE
Fix Drawin addObserver methods and add support for new Objc_Block

### DIFF
--- a/core/sys/darwin/Foundation/NSNotification.odin
+++ b/core/sys/darwin/Foundation/NSNotification.odin
@@ -50,10 +50,22 @@ NotificationCenter_defaultCenter :: proc "c" () -> ^NotificationCenter {
 	return msgSend(^NotificationCenter, NotificationCenter, "defaultCenter")
 }
 
-@(objc_type=NotificationCenter, objc_name="addObserver")
-NotificationCenter_addObserverName :: proc "c" (self: ^NotificationCenter, name: NotificationName, pObj: ^Object, pQueue: rawptr, block: ^Block) -> ^Object {
-	return msgSend(^Object, self, "addObserverName:object:queue:block:", name, pObj, pQueue, block)
+@(objc_type=NotificationCenter, objc_name="addObserverForName")
+NotificationCenter_addObserverForName :: proc{NotificationCenter_addObserverForName_old, NotificationCenter_addObserverForName_new}
+
+NotificationCenter_addObserverForName_old :: proc "c" (self: ^NotificationCenter, name: NotificationName, pObj: ^Object, pQueue: rawptr, block: ^Block) -> ^Object {
+	return msgSend(^Object, self, "addObserverForName:object:queue:usingBlock:", name, pObj, pQueue, block)
 }
+
+NotificationCenter_addObserverForName_new :: proc "c" (self: ^NotificationCenter, name: NotificationName, pObj: ^Object, pQueue: rawptr, block: ^Objc_Block) -> ^Object {
+	return msgSend(^Object, self, "addObserverForName:object:queue:usingBlock:", name, pObj, pQueue, block)
+}
+
+@(objc_type=NotificationCenter, objc_name="addObserver")
+NotificationCenter_addObserver :: proc "c" (self: ^NotificationCenter, observer: ^Object, selector: SEL, name: NotificationName, object: ^Object) {
+	msgSend(nil, self, "addObserver:selector:name:object:", observer, selector, name, object)
+}
+
 @(objc_type=NotificationCenter, objc_name="removeObserver")
 NotificationCenter_removeObserver :: proc "c" (self: ^NotificationCenter, pObserver: ^Object) {
 	msgSend(nil, self, "removeObserver:", pObserver)


### PR DESCRIPTION
Hello,

The binding for `NSNotificationCenter`'s `addObserverForName` method (https://developer.apple.com/documentation/foundation/notificationcenter/addobserver(forname:object:queue:using:)?language=objc) was incorrectly named, so I fixed it.

This method uses Obj-C blocks. Since a new syntax for Obj-C blocks was recently introduced, I included a version of the binding that uses the new syntax as well, and the two bindings were placed in a procedure group. Is the plan to remove the old Obj-C block syntax at some point?

Lastly, I noticed there was not a binding for `addObserver` (https://developer.apple.com/documentation/foundation/notificationcenter/addobserver(_:selector:name:object:)?language=objc), so I added that.

I have tested all three of these bindings and verified that they all work.