### PR TITLE
Improve OSX threading performance

### DIFF
--- a/src/threading.cpp
+++ b/src/threading.cpp
@@ -195,7 +195,13 @@ gb_internal void mutex_lock(RecursiveMutex *m) {
 			// inside the lock
 			return;
 		}
-		futex_wait(&m->owner, prev_owner);
+
+		// NOTE(lucas): we are doing spin lock since futex signal is expensive on OSX. The recursive locks are
+		// very short lived so we don't hit this mega often and I see no perform regression on windows (with
+		// a performance uplift on OSX).
+
+		//futex_wait(&m->owner, prev_owner);
+		yield_thread();
 	}
 }
 gb_internal bool mutex_try_lock(RecursiveMutex *m) {
@@ -216,7 +222,9 @@ gb_internal void mutex_unlock(RecursiveMutex *m) {
 		return;
 	}
 	m->owner.exchange(0, std::memory_order_release);
-	futex_signal(&m->owner);
+	// NOTE(lucas): see comment about spin lock in mutex_lock above
+
+	// futex_signal(&m->owner);
 	// outside the lock
 }
 

--- a/src/threading.cpp
+++ b/src/threading.cpp
@@ -423,44 +423,28 @@ gb_internal void semaphore_wait(Semaphore *s) {
 	}
 
 	struct RwMutex {
-		BlockingMutex lock;
-		Condition     cond;
-		int32_t       readers;
+		// TODO(bill): make this a proper RW mutex
+		BlockingMutex mutex;
 	};
 
 	gb_internal void rw_mutex_lock(RwMutex *m) {
-		mutex_lock(&m->lock);
-		while (m->readers != 0) {
-			condition_wait(&m->cond, &m->lock);
-		}
+		mutex_lock(&m->mutex);
 	}
 	gb_internal bool rw_mutex_try_lock(RwMutex *m) {
-		// TODO(bill): rw_mutex_try_lock
-		rw_mutex_lock(m);
-		return true;
+		return mutex_try_lock(&m->mutex);
 	}
 	gb_internal void rw_mutex_unlock(RwMutex *m) {
-		condition_signal(&m->cond);
-		mutex_unlock(&m->lock);
+		mutex_unlock(&m->mutex);
 	}
 
 	gb_internal void rw_mutex_shared_lock(RwMutex *m) {
-		mutex_lock(&m->lock);
-		m->readers += 1;
-		mutex_unlock(&m->lock);
+		mutex_lock(&m->mutex);
 	}
 	gb_internal bool rw_mutex_try_shared_lock(RwMutex *m) {
-		// TODO(bill): rw_mutex_try_shared_lock
-		rw_mutex_shared_lock(m);
-		return true;
+		return mutex_try_lock(&m->mutex);
 	}
 	gb_internal void rw_mutex_shared_unlock(RwMutex *m) {
-		mutex_lock(&m->lock);
-		m->readers -= 1;
-		if (m->readers == 0) {
-			condition_signal(&m->cond);
-		}
-		mutex_unlock(&m->lock);
+		mutex_unlock(&m->mutex);
 	}
 #endif
 


### PR DESCRIPTION
* Set flag for if we need to broadcast in thread pool, this reduces number of broadcasts required which helps platforms with slow futexes (such as  OSX).
* Make RecursiveMutex a spin lock. This is to reduce futex signaling, basically all the uses of it are very short lived locks, on OSX get a nice boost and on windows see no difference.
* Revert RWMutex implementation. We guessed that it was a major cause of lockup on OSX but actually its the futex signaling.  This implementation therefore slowed down OSX by a lot. It is much faster just to accept the blocking lock for now.

Only thing I am a little iffy on is `thread_pool_destroy` racing and we get to `thread_join_and_destroy` with the worker thread then going into `futex_wait`.

# Timings

## OSX
```
Odin:    dev-2025-09
OS:      macOS Sequoia 15.5.0 (build 24F74, kernel 24.5.0)
CPU:     Apple M4 Max
RAM:     36864 MiB
Backend: LLVM 20.1.6
```

before:
```
odin build . -show-timings -debug

Total Time                         -  7104.680 ms - 100.00%
initialization                     -     0.851 ms -   0.01%
parse files                        -    33.318 ms -   0.46%
type check                         -   991.919 ms -  13.96%
LLVM API Code Gen (  160 modules ) -  5726.148 ms -  80.59%
lld-link                           -   352.424 ms -   4.96%
```

after:
```
odin build . -show-timings -debug

Total Time                         -  1943.540 ms - 100.00%
initialization                     -     0.815 ms -   0.04%
parse files                        -    32.554 ms -   1.67%
type check                         -   290.742 ms -  14.95%
LLVM API Code Gen (  160 modules ) -  1250.744 ms -  64.35%
lld-link                           -   368.662 ms -  18.96%
```


## Windows
```
Odin:    dev-2025-09:5d9e96a4d
OS:      Windows 10 Home Basic (version: 22H2), build 19045.6332
CPU:     AMD Ryzen 7 5800X 8-Core Processor
RAM:     32711 MiB
Backend: LLVM 20.1.0
```

before:
```
odin build . -debug -show-timings

Total Time                         -  2678.628 ms - 100.00%
initialization                     -     6.555 ms -   0.24%
parse files                        -    35.403 ms -   1.32%
type check                         -   482.179 ms -  18.00%
LLVM API Code Gen (  155 modules ) -  1506.783 ms -  56.25%
msvc-link                          -   647.702 ms -  24.18%
```
after:
```
odin build .  -show-timings

Total Time                         -  2662.298 ms - 100.00%
initialization                     -     6.451 ms -   0.24%
parse files                        -    35.773 ms -   1.34%
type check                         -   458.943 ms -  17.23%
LLVM API Code Gen (  155 modules ) -  1516.844 ms -  56.97%
msvc-link                          -   644.283 ms -  24.20%
```