### PR TITLE
Basic support for constant union literals

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -8686,7 +8686,11 @@ gb_internal bool check_is_operand_compound_lit_constant(CheckerContext *c, Opera
 		}
 	}
 	if (field_type != nullptr && is_type_typeid(field_type) && o->mode == Addressing_Type) {
+		add_type_info_type(c, o->type);
 		return true;
+	}
+	if (is_type_any(field_type)) {
+		return false;
 	}
 	return o->mode == Addressing_Constant;
 }
@@ -10052,7 +10056,9 @@ gb_internal ExprKind check_compound_literal(CheckerContext *c, Operand *o, Ast *
 					check_expr_with_type_hint(c, &operand, fv->value, elem_type);
 					check_assignment(c, &operand, elem_type, context_name);
 
-					is_constant = is_constant && operand.mode == Addressing_Constant;
+					if (is_constant) {
+						is_constant = check_is_operand_compound_lit_constant(c, &operand, elem_type);
+					}
 				} else {
 					Operand op_index = {};
 					check_expr(c, &op_index, fv->field);
@@ -10289,7 +10295,9 @@ gb_internal ExprKind check_compound_literal(CheckerContext *c, Operand *o, Ast *
 					check_expr_with_type_hint(c, &operand, fv->value, elem_type);
 					check_assignment(c, &operand, elem_type, context_name);
 
-					is_constant = is_constant && operand.mode == Addressing_Constant;
+					if (is_constant) {
+						is_constant = check_is_operand_compound_lit_constant(c, &operand, elem_type);
+					}
 
 					TokenKind upper_op = Token_LtEq;
 					if (op.kind == Token_RangeHalf) {
@@ -10330,7 +10338,9 @@ gb_internal ExprKind check_compound_literal(CheckerContext *c, Operand *o, Ast *
 					check_expr_with_type_hint(c, &operand, fv->value, elem_type);
 					check_assignment(c, &operand, elem_type, context_name);
 
-					is_constant = is_constant && operand.mode == Addressing_Constant;
+					if (is_constant) {
+						is_constant = check_is_operand_compound_lit_constant(c, &operand, elem_type);
+					}
 
 					add_to_seen_map(c, &seen, op_index);
 				}
@@ -10360,7 +10370,9 @@ gb_internal ExprKind check_compound_literal(CheckerContext *c, Operand *o, Ast *
 				check_expr_with_type_hint(c, &operand, e, elem_type);
 				check_assignment(c, &operand, elem_type, context_name);
 
-				is_constant = is_constant && operand.mode == Addressing_Constant;
+				if (is_constant) {
+					is_constant = check_is_operand_compound_lit_constant(c, &operand, elem_type);
+				}
 			}
 
 			if (max < index) {

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -9847,7 +9847,7 @@ gb_internal ExprKind check_compound_literal(CheckerContext *c, Operand *o, Ast *
 			if (t->Struct.is_raw_union) {
 				if (cl->elems.count > 0) {
 					// NOTE: unions cannot be constant
-					is_constant = false;
+					is_constant = elem_type_can_be_constant(t);
 
 					if (cl->elems[0]->kind != Ast_FieldValue) {
 						gbString type_str = type_to_string(type);

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -2340,6 +2340,20 @@ gb_internal bool check_representable_as_constant(CheckerContext *c, ExactValue i
 		if (in_value.kind == ExactValue_Integer) {
 			return true;
 		}
+	} else if (is_type_typeid(type)) {
+
+		if (in_value.kind == ExactValue_Compound) {
+			ast_node(cl, CompoundLit, in_value.value_compound);
+			if (cl->elems.count == 0) {
+				in_value = exact_value_typeid(nullptr);
+			} else {
+				return false;
+			}
+		}
+		if (in_value.kind == ExactValue_Typeid) {
+			if (out_value) *out_value = in_value;
+			return true;
+		}
 	}
 
 	return false;
@@ -3509,6 +3523,7 @@ gb_internal bool check_is_castable_to(CheckerContext *c, Operand *operand, Type 
 
 gb_internal bool check_cast_internal(CheckerContext *c, Operand *x, Type *type) {
 	bool is_const_expr = x->mode == Addressing_Constant;
+
 
 	Type *bt = base_type(type);
 	if (is_const_expr && is_type_constant_type(bt)) {

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -5120,7 +5120,11 @@ gb_internal ExactValue get_constant_field_single(CheckerContext *c, ExactValue v
 		}
 
 		if (cl->elems[0]->kind == Ast_FieldValue) {
-			if (is_type_struct(node->tav.type)) {
+			if (is_type_raw_union(node->tav.type)) {
+				if (success_) *success_ = false;
+				if (finish_) *finish_ = true;
+				return empty_exact_value;
+			} else if (is_type_struct(node->tav.type)) {
 				bool found = false;
 				for (Ast *elem : cl->elems) {
 					if (elem->kind != Ast_FieldValue) {
@@ -5834,7 +5838,7 @@ gb_internal Entity *check_selector(CheckerContext *c, Operand *operand, Ast *nod
 
 	switch (entity->kind) {
 	case Entity_Constant:
-	operand->value = entity->Constant.value;
+		operand->value = entity->Constant.value;
 		operand->mode = Addressing_Constant;
 		if (operand->value.kind == ExactValue_Procedure) {
 			Entity *proc = strip_entity_wrapping(operand->value.value_procedure);

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -3520,7 +3520,7 @@ gb_internal bool is_type_union_constantable(Type *type) {
 			return false;
 		}
 	}
-	return false;
+	return true;
 }
 
 gb_internal bool check_cast_internal(CheckerContext *c, Operand *x, Type *type) {

--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -3287,12 +3287,6 @@ gb_internal bool lb_generate_code(lbGenerator *gen) {
 						g.value = nullptr;
 						g.value = LLVMAddGlobal(m->mod, LLVMTypeOf(init.value), alloc_cstring(permanent_allocator(), name));
 
-						if (e->token.string == "node_camera_info") {
-							gb_printf_err("HERE!\n");
-							gb_printf_err("%s\n", LLVMPrintValueToString(init.value));
-						}
-
-
 						LLVMSetInitializer(g.value, init.value);
 						var.is_initialized = true;
 						if (cc.is_rodata) {

--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -3255,6 +3255,7 @@ gb_internal bool lb_generate_code(lbGenerator *gen) {
 		}
 		GB_ASSERT(e->kind == Entity_Variable);
 
+
 		bool is_foreign = e->Variable.is_foreign;
 		bool is_export  = e->Variable.is_export;
 
@@ -3268,7 +3269,6 @@ gb_internal bool lb_generate_code(lbGenerator *gen) {
 		lbValue g = {};
 		g.type = alloc_type_pointer(e->type);
 		g.value = LLVMAddGlobal(m->mod, lb_type(m, e->type), alloc_cstring(permanent_allocator(), name));
-
 
 		if (decl->init_expr != nullptr) {
 			TypeAndValue tav = type_and_value_of_expr(decl->init_expr);
@@ -3313,7 +3313,7 @@ gb_internal bool lb_generate_code(lbGenerator *gen) {
 			LLVMSetDLLStorageClass(g.value, LLVMDLLImportStorageClass);
 			LLVMSetExternallyInitialized(g.value, true);
 			lb_add_foreign_library_path(m, e->Variable.foreign_library);
-		} else if (!var.is_initialized) {
+		} else if (LLVMGetInitializer(g.value) == nullptr) {
 			LLVMSetInitializer(g.value, LLVMConstNull(lb_type(m, e->type)));
 		}
 		if (is_export) {

--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -1947,7 +1947,7 @@ gb_internal bool lb_init_global_var(lbModule *m, lbProcedure *p, Entity *e, Ast 
 			GB_PANIC("Invalid init value, got %s", expr_to_string(init_expr));
 		}
 
-		if (is_type_any(e->type) || is_type_union(e->type)) {
+		if (is_type_any(e->type)) {
 			var.init = init;
 		} else if (lb_is_const_or_global(init)) {
 			if (!var.is_initialized) {
@@ -3272,7 +3272,7 @@ gb_internal bool lb_generate_code(lbGenerator *gen) {
 
 		if (decl->init_expr != nullptr) {
 			TypeAndValue tav = type_and_value_of_expr(decl->init_expr);
-			if (!is_type_any(e->type) && !is_type_union(e->type)) {
+			if (!is_type_any(e->type)) {
 				if (tav.mode != Addressing_Invalid) {
 					if (tav.value.kind != ExactValue_Invalid) {
 						auto cc = LB_CONST_CONTEXT_DEFAULT;
@@ -3286,6 +3286,12 @@ gb_internal bool lb_generate_code(lbGenerator *gen) {
 						LLVMDeleteGlobal(g.value);
 						g.value = nullptr;
 						g.value = LLVMAddGlobal(m->mod, LLVMTypeOf(init.value), alloc_cstring(permanent_allocator(), name));
+
+						if (e->token.string == "node_camera_info") {
+							gb_printf_err("HERE!\n");
+							gb_printf_err("%s\n", LLVMPrintValueToString(init.value));
+						}
+
 
 						LLVMSetInitializer(g.value, init.value);
 						var.is_initialized = true;

--- a/src/llvm_backend.hpp
+++ b/src/llvm_backend.hpp
@@ -455,7 +455,7 @@ static lbConstContext const LB_CONST_CONTEXT_DEFAULT_NO_LOCAL = {false, false, {
 
 gb_internal lbValue lb_const_nil(lbModule *m, Type *type);
 gb_internal lbValue lb_const_undef(lbModule *m, Type *type);
-gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, lbConstContext cc = LB_CONST_CONTEXT_DEFAULT);
+gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, lbConstContext cc = LB_CONST_CONTEXT_DEFAULT, Type *value_type=nullptr);
 gb_internal lbValue lb_const_bool(lbModule *m, Type *type, bool value);
 gb_internal lbValue lb_const_int(lbModule *m, Type *type, u64 value);
 

--- a/src/llvm_backend.hpp
+++ b/src/llvm_backend.hpp
@@ -604,7 +604,7 @@ gb_internal lbValue lb_emit_logical_binary_expr(lbProcedure *p, TokenKind op, As
 gb_internal lbValue lb_build_cond(lbProcedure *p, Ast *cond, lbBlock *true_block, lbBlock *false_block);
 
 gb_internal LLVMValueRef llvm_const_named_struct(lbModule *m, Type *t, LLVMValueRef *values, isize value_count_);
-gb_internal LLVMValueRef llvm_const_named_struct_internal(LLVMTypeRef t, LLVMValueRef *values, isize value_count_);
+gb_internal LLVMValueRef llvm_const_named_struct_internal(lbModule *m, LLVMTypeRef t, LLVMValueRef *values, isize value_count_);
 gb_internal void lb_set_entity_from_other_modules_linkage_correctly(lbModule *other_module, Entity *e, String const &name);
 
 gb_internal lbValue lb_expr_untyped_const_to_typed(lbModule *m, Ast *expr, Type *t);

--- a/src/llvm_backend_const.cpp
+++ b/src/llvm_backend_const.cpp
@@ -1503,14 +1503,6 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, lb
 					if (elem_type_can_be_constant(f->type)) {
 						if (sel.index.count == 1) {
 							lbValue value = lb_const_value(m, f->type, tav.value, cc, tav.type);
-							if (is_type_union(f->type)) {
-								if (f->token.string == "default_value") {
-									if (LLVMIsNull(value.value)) {
-										gb_printf_err("HERE: %s %s\n", type_to_string(f->type), LLVMPrintValueToString(value.value));
-										GB_PANIC("GAH");
-									}
-								}
-							}
 							LLVMTypeRef value_type = LLVMTypeOf(value.value);
 							GB_ASSERT_MSG(lb_sizeof(value_type) == type_size_of(f->type), "%s vs %s", LLVMPrintTypeToString(value_type), type_to_string(f->type));
 							values[index]  = value.value;

--- a/src/llvm_backend_const.cpp
+++ b/src/llvm_backend_const.cpp
@@ -667,6 +667,12 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, lb
 		return lb_const_nil(m, original_type);
 	}
 
+	if (value.kind == ExactValue_Compound) {
+		ast_node(cl, CompoundLit, value.value_compound);
+		if (cl->elems.count == 0) {
+			return lb_const_nil(m, original_type);
+		}
+	}
 
 	bool is_local = cc.allow_local && m->curr_procedure != nullptr;
 
@@ -707,17 +713,11 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, lb
 				return res;
 			}
 		} else {
-			GB_ASSERT(value_type != nullptr);
+			GB_ASSERT_MSG(value_type != nullptr, "%s :: %s", type_to_string(original_type), exact_value_to_string(value));
 
 			i64 block_size = bt->Union.variant_block_size;
 
 			if (are_types_identical(value_type, original_type)) {
-				if (value.kind == ExactValue_Compound) {
-					ast_node(cl, CompoundLit, value.value_compound);
-					GB_ASSERT(cl->elems.count == 0);
-					return lb_const_nil(m, original_type);
-				}
-
 				GB_PANIC("%s vs %s", type_to_string(value_type), type_to_string(original_type));
 			}
 

--- a/src/llvm_backend_const.cpp
+++ b/src/llvm_backend_const.cpp
@@ -1513,7 +1513,7 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, lb
 							values[value_count++] = LLVMConstNull(padding_type);
 						}
 
-						LLVMValueRef res = LLVMConstStructInContext(m->ctx, values, value_count, true);
+						LLVMValueRef res = LLVMConstStructInContext(m->ctx, values, value_count, /*packed*/padding > 0);
 
 						return {res, original_type};
 					}

--- a/src/llvm_backend_const.cpp
+++ b/src/llvm_backend_const.cpp
@@ -603,6 +603,17 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, lb
 				return res;
 			}
 		} else {
+			if (value_type == nullptr) {
+				if (value.kind == ExactValue_Compound) {
+					ast_node(cl, CompoundLit, value.value_compound);
+					if (cl->elems.count == 0) {
+						return lb_const_nil(m, original_type);
+					}
+				} else if (value.kind == ExactValue_Invalid) {
+					return lb_const_nil(m, original_type);
+				}
+			}
+
 			GB_ASSERT_MSG(value_type != nullptr, "%s :: %s", type_to_string(original_type), exact_value_to_string(value));
 
 			i64 block_size = bt->Union.variant_block_size;

--- a/src/llvm_backend_const.cpp
+++ b/src/llvm_backend_const.cpp
@@ -885,6 +885,16 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, lb
 
 			i64 block_size = bt->Union.variant_block_size;
 
+			if (are_types_identical(value_type, original_type)) {
+				if (value.kind == ExactValue_Compound) {
+					ast_node(cl, CompoundLit, value.value_compound);
+					GB_ASSERT(cl->elems.count == 0);
+					return lb_const_nil(m, original_type);
+				}
+
+				GB_PANIC("%s vs %s", type_to_string(value_type), type_to_string(original_type));
+			}
+
 			lbValue cv = lb_const_value(m, value_type, value, cc, value_type);
 			Type *variant_type = cv.type;
 

--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -2495,13 +2495,6 @@ gb_internal lbValue lb_emit_conv(lbProcedure *p, lbValue value, Type *t) {
 			Type *vt = dst->Union.variants[0];
 			if (internal_check_is_assignable_to(src_type, vt)) {
 				value = lb_emit_conv(p, value, vt);
-				if (lb_is_const(value)) {
-					LLVMValueRef res = lb_construct_const_union(m, value.value, vt, t);
-					if (res != nullptr) {
-						return {res, t};
-					}
-				}
-
 				lbAddr parent = lb_add_local_generated(p, t, true);
 				lb_emit_store_union_variant(p, parent.addr, value, vt);
 				return lb_addr_load(p, parent);
@@ -2509,19 +2502,11 @@ gb_internal lbValue lb_emit_conv(lbProcedure *p, lbValue value, Type *t) {
 		}
 		for (Type *vt : dst->Union.variants) {
 			if (src_type == t_llvm_bool && is_type_boolean(vt)) {
-				value = lb_emit_conv(p, value, vt);
-				if (lb_try_construct_const_union(m, &value, vt, t)) {
-					return value;
-				}
-
 				lbAddr parent = lb_add_local_generated(p, t, true);
 				lb_emit_store_union_variant(p, parent.addr, value, vt);
 				return lb_addr_load(p, parent);
 			}
 			if (are_types_identical(src_type, vt)) {
-				if (lb_try_construct_const_union(m, &value, vt, t)) {
-					return value;
-				}
 				lbAddr parent = lb_add_local_generated(p, t, true);
 				lb_emit_store_union_variant(p, parent.addr, value, vt);
 				return lb_addr_load(p, parent);
@@ -2559,9 +2544,6 @@ gb_internal lbValue lb_emit_conv(lbProcedure *p, lbValue value, Type *t) {
 		if (valid_count == 1) {
 			Type *vt = dst->Union.variants[first_success_index];
 			value = lb_emit_conv(p, value, vt);
-			if (lb_try_construct_const_union(m, &value, vt, t)) {
-					return value;
-				}
 			lbAddr parent = lb_add_local_generated(p, t, true);
 			lb_emit_store_union_variant(p, parent.addr, value, vt);
 			return lb_addr_load(p, parent);

--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -3256,7 +3256,7 @@ gb_internal lbAddr lb_add_global_generated_with_name(lbModule *m, Type *type, lb
 	LLVMTypeRef actual_type = lb_type(m, type);
 	if (value.value != nullptr) {
 		LLVMTypeRef value_type = LLVMTypeOf(value.value);
-		GB_ASSERT(lb_sizeof(actual_type) == lb_sizeof(value_type));
+		GB_ASSERT_MSG(lb_sizeof(actual_type) == lb_sizeof(value_type), "%s vs %s", LLVMPrintTypeToString(actual_type), LLVMPrintTypeToString(value_type));
 		actual_type = value_type;
 	}
 

--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -3253,17 +3253,26 @@ gb_internal lbAddr lb_add_global_generated_with_name(lbModule *m, Type *type, lb
 	GB_ASSERT(type != nullptr);
 	type = default_type(type);
 
+	LLVMTypeRef actual_type = lb_type(m, type);
+	if (value.value != nullptr) {
+		LLVMTypeRef value_type = LLVMTypeOf(value.value);
+		GB_ASSERT(lb_sizeof(actual_type) == lb_sizeof(value_type));
+		actual_type = value_type;
+	}
+
 	Scope *scope = nullptr;
 	Entity *e = alloc_entity_variable(scope, make_token_ident(name), type);
 	lbValue g = {};
 	g.type = alloc_type_pointer(type);
-	g.value = LLVMAddGlobal(m->mod, lb_type(m, type), alloc_cstring(temporary_allocator(), name));
+	g.value = LLVMAddGlobal(m->mod, actual_type, alloc_cstring(temporary_allocator(), name));
 	if (value.value != nullptr) {
 		GB_ASSERT_MSG(LLVMIsConstant(value.value), LLVMPrintValueToString(value.value));
 		LLVMSetInitializer(g.value, value.value);
 	} else {
 		LLVMSetInitializer(g.value, LLVMConstNull(lb_type(m, type)));
 	}
+
+	g.value = LLVMConstPointerCast(g.value, lb_type(m, g.type));
 
 	lb_add_entity(m, e, g);
 	lb_add_member(m, name, g);

--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -1493,8 +1493,11 @@ gb_internal lbValue lb_emit_union_tag_ptr(lbProcedure *p, lbValue u) {
 	unsigned element_count = LLVMCountStructElementTypes(uvt);
 	GB_ASSERT_MSG(element_count >= 2, "element_count=%u (%s) != (%s)", element_count, type_to_string(ut), LLVMPrintTypeToString(uvt));
 
+	LLVMValueRef ptr = u.value;
+	ptr = LLVMBuildPointerCast(p->builder, ptr, LLVMPointerType(uvt, 0), "");
+
 	lbValue tag_ptr = {};
-	tag_ptr.value = LLVMBuildStructGEP2(p->builder, uvt, u.value, 1, "");
+	tag_ptr.value = LLVMBuildStructGEP2(p->builder, uvt, ptr, 1, "");
 	tag_ptr.type = alloc_type_pointer(tag_type);
 	return tag_ptr;
 }

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -921,13 +921,20 @@ gb_internal lbValue lb_emit_call_internal(lbProcedure *p, lbValue value, lbValue
 				    arg_type != param_type) {
 					LLVMTypeKind arg_kind = LLVMGetTypeKind(arg_type);
 					LLVMTypeKind param_kind = LLVMGetTypeKind(param_type);
-					if (arg_kind == param_kind &&
-					    arg_kind == LLVMPointerTypeKind) {
-						// NOTE(bill): LLVM's newer `ptr` only type system seems to fail at times
-						// I don't know why...
-						args[i] = LLVMBuildPointerCast(p->builder, args[i], param_type, "");
-						arg_type = param_type;
-						continue;
+					if (arg_kind == param_kind) {
+						if (arg_kind == LLVMPointerTypeKind) {
+							// NOTE(bill): LLVM's newer `ptr` only type system seems to fail at times
+							// I don't know why...
+							args[i] = LLVMBuildPointerCast(p->builder, args[i], param_type, "");
+							arg_type = param_type;
+							continue;
+						} else if (arg_kind == LLVMStructTypeKind) {
+							if (lb_sizeof(arg_type) == lb_sizeof(param_type)) {
+								args[i]	 = LLVMBuildBitCast(p->builder, args[i], param_type, "");
+								arg_type = param_type;
+								continue;
+							}
+						}
 					}
 				}
 

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -928,12 +928,6 @@ gb_internal lbValue lb_emit_call_internal(lbProcedure *p, lbValue value, lbValue
 							args[i] = LLVMBuildPointerCast(p->builder, args[i], param_type, "");
 							arg_type = param_type;
 							continue;
-						} else if (arg_kind == LLVMStructTypeKind) {
-							if (lb_sizeof(arg_type) == lb_sizeof(param_type)) {
-								args[i]	 = LLVMBuildBitCast(p->builder, args[i], param_type, "");
-								arg_type = param_type;
-								continue;
-							}
 						}
 					}
 				}

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -2237,7 +2237,7 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 				elements[i] = element;
 			}
 
-			LLVMValueRef backing_array = llvm_const_array(lb_type(m, t_load_directory_file), elements, count);
+			LLVMValueRef backing_array = llvm_const_array(m, lb_type(m, t_load_directory_file), elements, count);
 
 			Type *array_type = alloc_type_array(t_load_directory_file, count);
 			lbAddr backing_array_addr = lb_add_global_generated_from_procedure(p, array_type, {backing_array, array_type});

--- a/src/llvm_backend_type.cpp
+++ b/src/llvm_backend_type.cpp
@@ -302,7 +302,7 @@ gb_internal void lb_setup_type_info_data_giant_array(lbModule *m, i64 global_typ
 					(name##_values)[i] = LLVMConstNull(elem);                                                      \
 				}                                                                                                      \
 			}                                                                                                              \
-			LLVMSetInitializer(name.addr.value, llvm_const_array(elem, name##_values, at->Array.count));                   \
+			LLVMSetInitializer(name.addr.value, llvm_const_array(m, elem, name##_values, at->Array.count));                   \
 		})
 
 	type_info_allocate_values(lb_global_type_info_member_types);
@@ -752,8 +752,8 @@ gb_internal void lb_setup_type_info_data_giant_array(lbModule *m, i64 global_typ
 						value_values[i] = lb_const_value(m, t_i64, fields[i]->Constant.value).value;
 					}
 
-					LLVMValueRef name_init  = llvm_const_array(lb_type(m, t_string),               name_values,  cast(unsigned)fields.count);
-					LLVMValueRef value_init = llvm_const_array(lb_type(m, t_type_info_enum_value), value_values, cast(unsigned)fields.count);
+					LLVMValueRef name_init  = llvm_const_array(m, lb_type(m, t_string),               name_values,  cast(unsigned)fields.count);
+					LLVMValueRef value_init = llvm_const_array(m, lb_type(m, t_type_info_enum_value), value_values, cast(unsigned)fields.count);
 					LLVMSetInitializer(name_array.value,  name_init);
 					LLVMSetInitializer(value_array.value, value_init);
 					LLVMSetGlobalConstant(name_array.value, true);

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -27,6 +27,24 @@ enum AddressingMode : u8 {
 	Addressing_SwizzleVariable = 14, // Swizzle indexed variable
 };
 
+gb_global String const addressing_mode_strings[] = {
+	str_lit("Invalid"),
+	str_lit("NoValue"),
+	str_lit("Value"),
+	str_lit("Context"),
+	str_lit("Variable"),
+	str_lit("Constant"),
+	str_lit("Type"),
+	str_lit("Builtin"),
+	str_lit("ProcGroup"),
+	str_lit("MapIndex"),
+	str_lit("OptionalOk"),
+	str_lit("OptionalOkPtr"),
+	str_lit("SoaVariable"),
+	str_lit("SwizzleValue"),
+	str_lit("SwizzleVariable"),
+};
+
 struct TypeAndValue {
 	Type *         type;
 	AddressingMode mode;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -2531,6 +2531,20 @@ gb_internal bool is_type_union_constantable(Type *type) {
 	return true;
 }
 
+gb_internal bool is_type_raw_union_constantable(Type *type) {
+	Type *bt = base_type(type);
+	GB_ASSERT(bt->kind == Type_Struct);
+	GB_ASSERT(bt->Struct.is_raw_union);
+
+	for (Entity *f : bt->Struct.fields) {
+		if (!is_type_constant_type(f->type)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+
 gb_internal bool elem_type_can_be_constant(Type *t) {
 	t = base_type(t);
 	if (t == t_invalid) {
@@ -2540,7 +2554,7 @@ gb_internal bool elem_type_can_be_constant(Type *t) {
 		return false;
 	}
 	if (is_type_raw_union(t)) {
-		return false;
+		return is_type_raw_union_constantable(t);
 	}
 	if (is_type_union(t)) {
 		return is_type_union_constantable(t);
@@ -2556,7 +2570,7 @@ gb_internal bool elem_cannot_be_constant(Type *t) {
 		return !is_type_union_constantable(t);
 	}
 	if (is_type_raw_union(t)) {
-		return true;
+		return !is_type_raw_union_constantable(t);
 	}
 	return false;
 }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -2536,7 +2536,10 @@ gb_internal bool elem_type_can_be_constant(Type *t) {
 	if (t == t_invalid) {
 		return false;
 	}
-	if (is_type_any(t) || is_type_raw_union(t)) {
+	if (is_type_any(t)) {
+		return false;
+	}
+	if (is_type_raw_union(t)) {
 		return false;
 	}
 	if (is_type_union(t)) {

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1377,14 +1377,20 @@ gb_internal bool is_type_ordered_numeric(Type *t) {
 gb_internal bool is_type_constant_type(Type *t) {
 	t = core_type(t);
 	if (t == nullptr) { return false; }
-	if (t->kind == Type_Basic) {
+	switch (t->kind) {
+	case Type_Basic:
+		if (t->Basic.kind == Basic_typeid) {
+			return true;
+		}
 		return (t->Basic.flags & BasicFlag_ConstantType) != 0;
-	}
-	if (t->kind == Type_BitSet) {
+	case Type_BitSet:
 		return true;
-	}
-	if (t->kind == Type_Proc) {
+	case Type_Proc:
 		return true;
+	case Type_Array:
+		return is_type_constant_type(t->Array.elem);
+	case Type_EnumeratedArray:
+		return is_type_constant_type(t->EnumeratedArray.elem);
 	}
 	return false;
 }
@@ -2538,6 +2544,20 @@ gb_internal bool elem_type_can_be_constant(Type *t) {
 	}
 	return true;
 }
+
+gb_internal bool elem_cannot_be_constant(Type *t) {
+	if (is_type_any(t)) {
+		return true;
+	}
+	if (is_type_union(t)) {
+		return !is_type_union_constantable(t);
+	}
+	if (is_type_raw_union(t)) {
+		return true;
+	}
+	return false;
+}
+
 
 gb_internal bool is_type_lock_free(Type *t) {
 	t = core_type(t);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -2541,7 +2541,8 @@ gb_internal bool is_type_raw_union_constantable(Type *type) {
 			return false;
 		}
 	}
-	return true;
+	// return true;
+	return false; // Disable raw union constants for the time being
 }
 
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -2507,14 +2507,34 @@ gb_internal bool type_has_nil(Type *t) {
 	return false;
 }
 
+gb_internal bool is_type_union_constantable(Type *type) {
+	Type *bt = base_type(type);
+	GB_ASSERT(bt->kind == Type_Union);
+
+	if (bt->Union.variants.count == 0) {
+		return true;
+	} else if (bt->Union.variants.count == 1) {
+		return is_type_constant_type(bt->Union.variants[0]);
+	}
+
+	for (Type *v : bt->Union.variants) {
+		if (!is_type_constant_type(v)) {
+			return false;
+		}
+	}
+	return true;
+}
 
 gb_internal bool elem_type_can_be_constant(Type *t) {
 	t = base_type(t);
 	if (t == t_invalid) {
 		return false;
 	}
-	if (is_type_any(t) || is_type_union(t) || is_type_raw_union(t)) {
+	if (is_type_any(t) || is_type_raw_union(t)) {
 		return false;
+	}
+	if (is_type_union(t)) {
+		return is_type_union_constantable(t);
 	}
 	return true;
 }


### PR DESCRIPTION
Basic support for constant union literals.

The union must only contain "constant-able" types.


This PR also makes things like `typeid` to be constant too due to how `typeid` is now defined.