### PR TITLE
Relax `signature_parameter_similar_enough` on struct params and fix various foreign signatures

### DIFF
--- a/core/c/libc/stdio.odin
+++ b/core/c/libc/stdio.odin
@@ -275,7 +275,7 @@ foreign libc {
 	// 7.21.7 Character input/output functions
 	fgetc     :: proc(stream: ^FILE) -> int ---
 	fgets     :: proc(s: [^]char, n: int, stream: ^FILE) -> [^]char ---
-	fputc     :: proc(s: cstring, stream: ^FILE) -> int ---
+	fputc     :: proc(s: c.int, stream: ^FILE) -> int ---
 	getc      :: proc(stream: ^FILE) -> int ---
 	getchar   :: proc() -> int ---
 	putc      :: proc(c: int, stream: ^FILE) -> int ---

--- a/core/sys/darwin/CoreFoundation/CFString.odin
+++ b/core/sys/darwin/CoreFoundation/CFString.odin
@@ -1,10 +1,12 @@
 package CoreFoundation
 
+import "core:c"
+
 foreign import CoreFoundation "system:CoreFoundation.framework"
 
 String :: distinct TypeRef // same as CFStringRef
 
-StringEncoding :: distinct u32
+StringEncoding :: distinct c.long
 
 StringBuiltInEncodings :: enum StringEncoding {
 	MacRoman      = 0,
@@ -171,7 +173,7 @@ foreign CoreFoundation {
 	// Fetches a range of the characters from a string into a byte buffer after converting the characters to a specified encoding.
 	StringGetBytes :: proc(thestring: String, range: Range, encoding: StringEncoding, lossByte: u8, isExternalRepresentation: b8, buffer: [^]byte, maxBufLen: Index, usedBufLen: ^Index) -> Index ---
 
-	StringIsEncodingAvailable :: proc(encoding: StringEncoding) -> bool ---
+	StringIsEncodingAvailable :: proc(encoding: StringEncoding) -> b8 ---
 
 	@(link_name = "__CFStringMakeConstantString")
 	StringMakeConstantString :: proc "c" (#const c: cstring) -> String ---

--- a/core/sys/posix/arpa_inet.odin
+++ b/core/sys/posix/arpa_inet.odin
@@ -50,7 +50,6 @@ foreign lib {
 		af:   AF,        // INET or INET6
 		src:  cstring,
 		dst:  rawptr,    // either ^in_addr or ^in_addr6
-		size: socklen_t, // size_of(dst^)
 	) -> pton_result ---
 }
 

--- a/core/sys/posix/pthread.odin
+++ b/core/sys/posix/pthread.odin
@@ -124,7 +124,7 @@ foreign lib {
 
 	[[ More; https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_attr_getscope.html ]]
 	*/
-	pthread_attr_setscope :: proc(attr: ^pthread_attr_t, contentionscope: ^Thread_Scope) -> Errno ---
+	pthread_attr_setscope :: proc(attr: ^pthread_attr_t, contentionscope: Thread_Scope) -> Errno ---
 
 	/*
 	Get the area of storage to be used for the created thread's stack.
@@ -400,7 +400,7 @@ when ODIN_OS == .Darwin {
 	PTHREAD_SCOPE_PROCESS   :: 2
 	PTHREAD_SCOPE_SYSTEM    :: 1
 
-	pthread_t :: distinct u64
+	pthread_t :: distinct rawptr
 
 	pthread_attr_t :: struct {
 		__sig:    c.long,

--- a/core/sys/posix/sys_mman.odin
+++ b/core/sys/posix/sys_mman.odin
@@ -92,7 +92,12 @@ foreign lib {
 
 	[[ More; https://pubs.opengroup.org/onlinepubs/9699919799/functions/shm_open.html ]]
 	*/
-	shm_open :: proc(name: cstring, oflag: O_Flags, mode: mode_t) -> FD ---
+	when ODIN_OS == .Darwin {
+		// https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/shm_open.2.html
+		shm_open :: proc(name: cstring, oflag: O_Flags, #c_vararg args: ..any) -> FD ---
+	} else {
+		shm_open :: proc(name: cstring, oflag: O_Flags, mode: mode_t) -> FD ---
+	}
 
 	/*
 	Removes a shared memory object.

--- a/src/check_decl.cpp
+++ b/src/check_decl.cpp
@@ -851,6 +851,12 @@ gb_internal bool signature_parameter_similar_enough(Type *x, Type *y) {
 		}
 	}
 
+	Type *x_base = base_type(x);
+	Type *y_base = base_type(y);
+	if (x_base->kind == y_base->kind && x_base->kind == Type_Struct) {
+		return type_size_of(x_base) == type_size_of(y_base) && type_align_of(x_base) == type_align_of(y_base);
+	}
+
 	return are_types_identical(x, y);
 }
 

--- a/src/llvm_backend_utility.cpp
+++ b/src/llvm_backend_utility.cpp
@@ -2897,7 +2897,7 @@ gb_internal void lb_do_para_poly_diagnostics(lbGenerator *gen) {
 
 		f64 average = cast(f64)code_size / cast(f64)gb_max(count, 1);
 
-		gb_printf("%23td | %19d | %25.2f | %.*s\n", code_size, count, average, LIT(name));
+		gb_printf("%23td | %19td | %25.2f | %.*s\n", code_size, count, average, LIT(name));
 		if (max_count-- <= 0) {
 			break;
 		}
@@ -2930,7 +2930,7 @@ gb_internal void lb_do_para_poly_diagnostics(lbGenerator *gen) {
 
 		f64 average = cast(f64)code_size / cast(f64)gb_max(count, 1);
 
-		gb_printf("%19d | %23td | %25.2f | %.*s\n", count, code_size, average, LIT(name));
+		gb_printf("%19td | %23td | %25.2f | %.*s\n", count, code_size, average, LIT(name));
 		if (max_count-- <= 0) {
 			break;
 		}

--- a/tests/core/sys/posix/posix.odin
+++ b/tests/core/sys/posix/posix.odin
@@ -21,7 +21,7 @@ test_arpa_inet :: proc(t: ^testing.T) {
 			dst: [posix.INET6_ADDRSTRLEN]byte
 		}
 
-		res := posix.inet_pton(af, src, &addr, size_of(addr))
+		res := posix.inet_pton(af, src, &addr)
 		testing.expect_value(t, res, expect, loc)
 
 		if expect == .SUCCESS {


### PR DESCRIPTION
When comparing 2 structs in`signature_parameter_similar_enough()`, it simply checks whether they are the same size and alignment

