### PR TITLE
[LLVM backend] SIMD vector transmute only uses bitcast when the elements aren't pointers

### DIFF
--- a/src/llvm_backend_utility.cpp
+++ b/src/llvm_backend_utility.cpp
@@ -286,7 +286,14 @@ gb_internal lbValue lb_emit_transmute(lbProcedure *p, lbValue value, Type *t) {
 		}
 	}
 
+	bool is_simd_vector_bitcastable = false;
 	if (is_type_simd_vector(src) && is_type_simd_vector(dst)) {
+		if (!is_type_internally_pointer_like(src->SimdVector.elem) && !is_type_internally_pointer_like(dst->SimdVector.elem)) {
+			is_simd_vector_bitcastable = true;
+		}
+	}
+
+	if (is_simd_vector_bitcastable) {
 		res.value = LLVMBuildBitCast(p->builder, value.value, lb_type(p->module, t), "");
 		return res;
 	} else if (is_type_array_like(src) && (is_type_simd_vector(dst) || is_type_integer_128bit(dst))) {


### PR DESCRIPTION
This should fix issue #5737.

This crash happened because LLVM Bitcast isn't valid for pointer values. This change handles SIMD vectors of pointers (e.g. `#simd[N]rawptr` for doing a gather) the same way as arrays, where the transmute happens through a pointer.