### PR TITLE
Fix proc group named operands issue #4971

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -7488,8 +7488,6 @@ gb_internal CallArgumentData check_call_arguments_proc_group(CheckerContext *c, 
 		Entity *e = proc_entities[valids[0].index];
 		GB_ASSERT(e != nullptr);
 
-		Array<Operand> named_operands = {};
-
 		check_call_arguments_single(c, call, operand,
 			e, e->type,
 			positional_operands, named_operands,


### PR DESCRIPTION
For some reason, which I think might have just been an oversight. During `check_call_arguments_proc_group`, `named_operands` gets shadowed to an empty value then passed to `check_call_arguments_single` which then leads to the issue  #4971 
Now calls to `make([]T, len = N)` no longer throw a false error of `len` being missing.