### PR TITLE
Remove inaccurate tprint concern

### DIFF
--- a/core/log/log.odin
+++ b/core/log/log.odin
@@ -193,7 +193,7 @@ log :: proc(level: Level, args: ..any, sep := " ", location := #caller_location)
 		return
 	}
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
-	str := fmt.tprint(..args, sep=sep) //NOTE(Hoej): While tprint isn't thread-safe, no logging is.
+	str := fmt.tprint(..args, sep=sep)
 	logger.procedure(logger.data, level, str, logger.options, location)
 }
 


### PR DESCRIPTION
This comment is over 7 years old!
The temporary allocator should be thread-safe, making `tprint` thread-safe. The logger proc isn't necessarily.