### PR TITLE
Fix #5734, Default params exclusion counting in proc groups issue

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -6211,7 +6211,6 @@ gb_internal isize get_procedure_param_count_excluding_defaults(Type *pt, isize *
 					continue;
 				}
 			}
-			break;
 		}
 	}
 


### PR DESCRIPTION
I tried to git blame the `break` statement, it seems to be 8 years old, back when the compiler disallowed default values outside of trailing parameters.
Unless I misunderstood this issue, the solution is as proposed in this PR.