### PR TITLE
[llvm-14-entry-fix] bitcast context pointer to match types for llvm 14

### DIFF
--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -2041,7 +2041,8 @@ gb_internal void lb_create_startup_runtime_generate_body(lbModule *m, lbProcedur
 			lb_end_procedure_body(dummy);
 
 			LLVMValueRef context_ptr = lb_find_or_generate_context_ptr(p).addr.value;
-			LLVMBuildCall2(p->builder, raw_dummy_type, dummy->value, &context_ptr, 1, "");
+			LLVMValueRef cast_ctx = LLVMBuildBitCast(p->builder, context_ptr, LLVMPointerType(LLVMInt8TypeInContext(m->ctx), 0), "");
+			LLVMBuildCall2(p->builder, raw_dummy_type, dummy->value, &cast_ctx, 1, "");
 		} else {
 			lb_init_global_var(m, p, e, init_expr, var);
 		}


### PR DESCRIPTION
this fixes one of the current issues that causes llvm 14 to not work with the latest odin release. this change *does* properly work if backported to `0233dc5d31e1db7b4da9e6c5a4a614e2cbb550a9` but there are currently other issues introduced by the const union changes that cause llvm 14 to still be broken