### PR TITLE
Fix fontstash crash with .TTC files

### DIFF
--- a/vendor/fontstash/fontstash_os.odin
+++ b/vendor/fontstash/fontstash_os.odin
@@ -4,10 +4,13 @@ package fontstash
 import "core:log"
 import "core:os"
 
+// 'fontIndex' controls which font you want to load within a multi-font format such
+// as TTC. Leave it as zero if you are loading a single-font format such as TTF.
 AddFontPath :: proc(
 	ctx: ^FontContext,
 	name: string,
 	path: string,
+	fontIndex: int = 0,
 ) -> int {
 	data, ok := os.read_entire_file(path)
 
@@ -15,6 +18,6 @@ AddFontPath :: proc(
 		log.panicf("FONT: failed to read font at %s", path)
 	}
 
-	return AddFontMem(ctx, name, data, true)
+	return AddFontMem(ctx, name, data, true, fontIndex)
 }
 

--- a/vendor/fontstash/fontstash_other.odin
+++ b/vendor/fontstash/fontstash_other.odin
@@ -5,6 +5,7 @@ AddFontPath :: proc(
 	ctx: ^FontContext,
 	name: string,
 	path: string,
+	fontIndex: int = 0,
 ) -> int {
 	panic("fontstash.AddFontPath is unsupported on the JS target")
 }


### PR DESCRIPTION
Fix for fontstash crash because it didn't fetch the offset of the first font correctly. The old setup didn't work with TTC files that contain multiple fonts.