### PR TITLE
[llvm-14-fixes] fix `const_pad_to_size` for strings

### DIFF
--- a/src/llvm_backend_const.cpp
+++ b/src/llvm_backend_const.cpp
@@ -114,7 +114,7 @@ gb_internal LLVMValueRef llvm_const_cast(lbModule *m, LLVMValueRef val, LLVMType
 		if (!LLVMIsLiteralStruct(dst)) {
 			return LLVMConstNamedStruct(dst, field_vals, dst_n);
 		} else {
-		return LLVMConstStructInContext(m->ctx, field_vals, dst_n, LLVMIsPackedStruct(dst));
+			return LLVMConstStructInContext(m->ctx, field_vals, dst_n, LLVMIsPackedStruct(dst));
 		}
 	}
 	}
@@ -568,6 +568,7 @@ gb_internal bool lb_is_nested_possibly_constant(Type *ft, Selection const &sel, 
 	return lb_is_elem_const(elem, ft);
 }
 
+#if LLVM_VERSION_MAJOR == 14
 LLVMValueRef llvm_const_pad_to_size(lbModule *m, LLVMValueRef val, LLVMTypeRef dst_ty) {
 	LLVMContextRef ctx = m->ctx;
 	LLVMTargetDataRef td = LLVMGetModuleDataLayout(m->mod);
@@ -597,8 +598,27 @@ LLVMValueRef llvm_const_pad_to_size(lbModule *m, LLVMValueRef val, LLVMTypeRef d
 			LLVMValueRef elem = llvm_const_extract_value(m, val, i);
 			LLVMTypeRef elem_int_ty = LLVMIntTypeInContext(ctx, elem_bits);
 			LLVMValueRef elem_int = llvm_const_pad_to_size(m, elem, elem_int_ty);
-			LLVMValueRef shifted = llvm_const_shl(m, llvm_const_zext(m, elem_int, src_int_ty), LLVMConstInt(src_int_ty, i * elem_bits, false));
-			as_int = llvm_const_or(m, as_int, shifted);
+			LLVMValueRef shifted = LLVMConstShl(LLVMConstZExt(elem_int, src_int_ty), LLVMConstInt(src_int_ty, i * elem_bits, false));
+			as_int = LLVMConstOr(as_int, shifted);
+		}
+	} else if (src_kind == LLVMStructTypeKind) {
+		unsigned field_count = LLVMCountStructElementTypes(src_ty);
+		LLVMTypeRef src_int_ty = LLVMIntTypeInContext(ctx, src_bits);
+		as_int = LLVMConstInt(src_int_ty, 0, false);
+
+		for (unsigned i = 0; i < field_count; i++) {
+			LLVMTypeRef field_ty = LLVMStructGetTypeAtIndex(src_ty, i);
+			unsigned field_bits = (unsigned)LLVMSizeOfTypeInBits(td, field_ty);
+			LLVMValueRef field = llvm_const_extract_value(m, val, i);
+
+			LLVMTypeRef field_int_ty = LLVMIntTypeInContext(ctx, field_bits);
+			LLVMValueRef field_int = llvm_const_pad_to_size(m, field, field_int_ty);
+
+			uint64_t field_offset_bytes = LLVMOffsetOfElement(td, src_ty, i);
+			uint64_t field_offset_bits = field_offset_bytes * 8;
+
+			LLVMValueRef shifted = LLVMConstShl(LLVMConstZExt(field_int, src_int_ty), LLVMConstInt(src_int_ty, field_offset_bits, false));
+			as_int = LLVMConstOr(as_int, shifted);
 		}
 	} else {
 		gb_printf_err("unsupported const_pad source type: %s\n", LLVMPrintTypeToString(src_ty));
@@ -608,7 +628,7 @@ LLVMValueRef llvm_const_pad_to_size(lbModule *m, LLVMValueRef val, LLVMTypeRef d
 	if (src_bits != dst_bits) {
 		LLVMTypeRef dst_int_ty = LLVMIntTypeInContext(ctx, dst_bits);
 		if (src_bits < dst_bits) {
-			as_int = llvm_const_zext(m, as_int, dst_int_ty);
+			as_int = LLVMConstZExt(as_int, dst_int_ty);
 		} else {
 			as_int = LLVMConstTrunc(as_int, dst_int_ty);
 		}
@@ -632,7 +652,7 @@ LLVMValueRef llvm_const_pad_to_size(lbModule *m, LLVMValueRef val, LLVMTypeRef d
 		LLVMTypeRef as_int_ty = LLVMTypeOf(as_int);
 
 		for (unsigned i = 0; i < elem_count; i++) {
-			LLVMValueRef shifted = llvm_const_lshr(m, as_int, LLVMConstInt(as_int_ty, i * elem_bits, false));
+			LLVMValueRef shifted = LLVMConstLShr(as_int, LLVMConstInt(as_int_ty, i * elem_bits, false));
 			LLVMTypeRef elem_int_ty = LLVMIntTypeInContext(ctx, elem_bits);
 			LLVMValueRef trunc = LLVMConstTrunc(shifted, elem_int_ty);
 			elems[i] = llvm_const_pad_to_size(m, trunc, elem_ty);
@@ -644,6 +664,7 @@ LLVMValueRef llvm_const_pad_to_size(lbModule *m, LLVMValueRef val, LLVMTypeRef d
 	gb_printf_err("unsupported const_pad destination type: %s\n", LLVMPrintTypeToString(dst_ty));
 	return nullptr;
 }
+#endif
 
 gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, lbConstContext cc, Type *value_type) {
 	if (cc.allow_local) {
@@ -730,11 +751,19 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, lb
 			lbValue cv = lb_const_value(m, value_type, value, cc, value_type);
 			Type *variant_type = cv.type;
 
-			LLVMValueRef values[3] = {};
+			LLVMValueRef values[4] = {};
 			unsigned value_count = 0;
 
+			#if LLVM_VERSION_MAJOR == 14
 			LLVMTypeRef block_type = lb_type_internal_union_block_type(m, bt);
 			values[value_count++] = llvm_const_pad_to_size(m, cv.value, block_type);
+			#else
+			values[value_count++] = cv.value;
+			if (type_size_of(variant_type) != block_size) {
+				LLVMTypeRef padding_type = lb_type_padding_filler(m, block_size - type_size_of(variant_type), 1);
+				values[value_count++] = LLVMConstNull(padding_type);
+			}
+			#endif
 
 			Type *tag_type = union_tag_type(bt);
 			LLVMTypeRef llvm_tag_type = lb_type(m, tag_type);

--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -449,31 +449,6 @@ gb_internal LLVMValueRef llvm_const_insert_value(lbModule *m, LLVMValueRef agg, 
 }
 
 
-gb_internal LLVMValueRef llvm_const_shl(lbModule *m, LLVMValueRef a, LLVMValueRef b) {
-	LLVMValueRef res = LLVMBuildShl(m->const_dummy_builder, a, b, "");
-	GB_ASSERT(LLVMIsConstant(res));
-	return res;
-}
-
-gb_internal LLVMValueRef llvm_const_lshr(lbModule *m, LLVMValueRef a, LLVMValueRef b) {
-	LLVMValueRef res = LLVMBuildLShr(m->const_dummy_builder, a, b, "");
-	GB_ASSERT(LLVMIsConstant(res));
-	return res;
-}
-
-gb_internal LLVMValueRef llvm_const_or(lbModule *m, LLVMValueRef a, LLVMValueRef b) {
-	LLVMValueRef res = LLVMBuildOr(m->const_dummy_builder, a, b, "");
-	GB_ASSERT(LLVMIsConstant(res));
-	return res;
-}
-
-gb_internal LLVMValueRef llvm_const_zext(lbModule *m, LLVMValueRef a, LLVMTypeRef b) {
-	LLVMValueRef res = LLVMBuildZExt(m->const_dummy_builder, a, b, "");
-	GB_ASSERT(LLVMIsConstant(res));
-	return res;
-}
-
-
 
 
 gb_internal LLVMValueRef llvm_cstring(lbModule *m, String const &str) {


### PR DESCRIPTION
this fixes `ols`. apparently strings in unions have special semantics that cause things to fail. this is a hack that gets things working for the time being but a more robust solution will be needed in the long run

as it stands, it's very difficult without adding llvm 14 specific codepaths but that might be required soon just because of how differently llvm 14 and 20 handle constants and IR value conversions