### PR TITLE
Disable bounds check for the first utf8 byte

### DIFF
--- a/core/unicode/utf8/utf8.odin
+++ b/core/unicode/utf8/utf8.odin
@@ -108,7 +108,7 @@ decode_rune_in_bytes :: proc "contextless" (s: []u8) -> (rune, int) {
 	if n < 1 {
 		return RUNE_ERROR, 0
 	}
-	s0 := s[0]
+	#no_bounds_check s0 := s[0]
 	x := accept_sizes[s0]
 	if x >= 0xF0 {
 		mask := rune(x) << 31 >> 31 // NOTE(bill): Create 0x0000 or 0xffff.


### PR DESCRIPTION
Known safe from prior `n < 1` check.

I don't think the other array access are guaranteed to be in bounds, even after the `x & 7` into `n < int(sz)` check.