### PR TITLE
Fix renamed function call in bit_not

### DIFF
--- a/core/simd/simd.odin
+++ b/core/simd/simd.odin
@@ -2690,7 +2690,7 @@ Example:
 	   +------+------+------+------+
 */
 bit_not :: #force_inline proc "contextless" (v: $T/#simd[$LANES]$E) -> T where intrinsics.type_is_integer(E) {
-	return xor(v, T(~E(0)))
+	return bit_xor(v, T(~E(0)))
 }
 
 /*


### PR DESCRIPTION
xor was renamed to bit_xor in 63f755554ba5394b4b2843cb4417dcaf105d1656