### PR TITLE
Fix return types for vendor:box2d callbacks

### DIFF
--- a/vendor/box2d/types.odin
+++ b/vendor/box2d/types.odin
@@ -41,13 +41,13 @@ FinishTaskCallback :: #type proc "c" (userTask: rawptr, userContext: rawptr)
 // from a worker thread.
 // @warning This function should not attempt to modify Box2D state or user application state.
 // @ingroup world
-FrictionCallback :: #type proc "c" (frictionA: f32, userMaterialIdA: i32, frictionB: f32, userMaterialIdB: i32)
+FrictionCallback :: #type proc "c" (frictionA: f32, userMaterialIdA: i32, frictionB: f32, userMaterialIdB: i32) -> f32
 
 // Optional restitution mixing callback. This intentionally provides no context objects because this is called
 // from a worker thread.
 // @warning This function should not attempt to modify Box2D state or user application state.
 // @ingroup world
-RestitutionCallback :: #type proc "c" (restitutionA: f32, userMaterialIdA: i32, restitutuionB: f32, userMaterialIdB: i32)
+RestitutionCallback :: #type proc "c" (restitutionA: f32, userMaterialIdA: i32, restitutionB: f32, userMaterialIdB: i32) -> f32
 
 // Result from b2World_RayCastClosest
 // @ingroup world


### PR DESCRIPTION
Just noticed that the Odin definitions of a couple of Box2D callbacks weren't matching the ones in the original C code.

I have tested the change to `RestitutionCallback` in my project, but not the `FrictionCallback` change. (They are both trivial, FWIW.)
