### PR TITLE
On wrong append call, help users pass-by-pointer

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -7283,6 +7283,10 @@ gb_internal CallArgumentData check_call_arguments_proc_group(CheckerContext *c, 
 			error_line("\tNo given arguments\n");
 		} else {
 			print_argument_types();
+			const gbString append_proc_name = gb_string_make(temporary_allocator(), "append");
+			if(gb_string_are_equal(expr_name, append_proc_name)){
+				error_line("Suggestion: Make sure that you passed, as the first argument, a dynamic array by pointer, like so `append(&some_dynamic_array, ...)`.\n");
+			}
 		}
 
 		if (procs.count == 0) {


### PR DESCRIPTION
## WHY?

First Odin users that try to use append often forget to pass a pointer, and pass-by-value.

This is a first attempt at helping with that, but a better version would be a generic way to check when any proc values should be pass-by-pointer instead of pass-by-value, as discussed at https://forum.odin-lang.org/t/least-parsable-most-common-error-message/1241/3

<img width="1819" height="342" alt="image" src="https://github.com/user-attachments/assets/5579e5ff-d0b4-4f94-8951-5896cffe894a" />


## Better takes on it
1. If we keep the gb_string_is_equal, we should have the append_proc_name declaration defined once or at compile time, instead of on all check_call_arguments_proc_group with non-empty arguments.
2. The generic approach for all missed pass-by-pointer arguments:
      a. Check, efficiently, if any argument match a pointer type of the possible procs
      b. If so, have the pass-by-pointer message for that/those argument(s).
      
## Why not have done those things already
I need more practice with C++, not yet familiar enough to make it good and generic yet.
So I might come back to it later.