### PR TITLE
On polymorphic args, suggest pointer when sensible

### DIFF
--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -1594,6 +1594,11 @@ gb_internal Type *determine_type_from_polymorphic(CheckerContext *ctx, Type *pol
 		defer (gb_string_free(pts));
 		defer (gb_string_free(ots));
 		error(operand.expr, "Cannot determine polymorphic type from parameter: '%s' to '%s'", ots, pts);
+		if (pts[0] == '^' && pts[0] != ots[0]){
+			gbString os = expr_to_string(operand.expr);
+			defer (gb_string_free(os));
+			error_line("\tSuggestion: Try passing the pointer instead of the value with '&%s'\n", os);
+		}
 
 		Type *pt = poly_type;
 		while (pt && pt->kind == Type_Generic && pt->Generic.specialized) {


### PR DESCRIPTION
Related to #5817, but independent, as this targets error messages for polymorphic procs, not proc_groups. But the "why" is the same, help new odin users more quickly figure out when they forgot/missed a pass-by-pointer.

When the polymorphic type is explicitly a pointer and our input is not, then we suggest using a pointer.
<img width="1827" height="148" alt="image" src="https://github.com/user-attachments/assets/5d72e263-0644-4f2a-bc87-20b164f64526" />

This might not work if you use indirect types to a pointer, but should cover most cases of new odin user not figuring out why the append_elem, etc calls won't work.

TODO MAYBE:
 - resolve the poly_type to the concrete/direct type, if able/efficient

NOTE:
 - We don't add that error_line for the `if(!is_operand_value(operand))` case, because pointers to invalid types won't make it more valid, so the if-then-suggestion would never happen there:
  - Invalid argument types being: ``` enum AddressingMode : u8 {
        Addressing_Invalid   = 0,        // invalid addressing mode
        Addressing_NoValue   = 1,        // no value (void in C)
        [...]
        Addressing_Type      = 6,        // type
        Addressing_Builtin   = 7,        // built-in procedure
        Addressing_ProcGroup = 8,        // procedure group (overloaded procedure)
        [...]
    }
    ```