### PR TITLE
Add hint when only missing '&' in polymorphic parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -308,3 +308,6 @@ build/
 cmake-build*/
 CMakeLists.txt
 sandbox/
+
+# Ctags
+tags

--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -1611,6 +1611,10 @@ gb_internal Type *determine_type_from_polymorphic(CheckerContext *ctx, Type *pol
 				error_line("\tSuggestion: Try slicing the value with '%s[:]'\n", os);
 				gb_string_free(os);
 			}
+		} else if (is_type_pointer(poly_type) && is_polymorphic_type_assignable(ctx, type_deref(poly_type), operand.type, false, modify_type)) {
+			gbString os = expr_to_string(operand.expr);
+			error_line("\tSuggestion: Did you mean '&%s'\n", os);
+			gb_string_free(os);
 		}
 	}
 	return t_invalid;


### PR DESCRIPTION
Provides useful suggestion in cases where applicable such as:
main.odin
```odin
package main

main :: proc() {
    arr := make([dynamic]int)
    append_elem(arr, 3)
}
```
```sh
$ odin check .
.../main.odin(5:14) Error: Cannot determine polymorphic type from parameter: '[dynamic]int' to '^$T/[dynamic]$E'
	append_elem(arr, 3)
	            ^~^
	Suggestion: Did you mean '&arr'
```
This commits also add the ctags file `tags` to `.gitignore`