### PR TITLE
Fix source mismatches in vendor:box2d math functions

### DIFF
--- a/vendor/box2d/math_functions.odin
+++ b/vendor/box2d/math_functions.odin
@@ -247,7 +247,7 @@ Normalize :: proc "c" (v: Vec2) -> Vec2 {
 @(require_results)
 IsNormalized :: proc "c" (v: Vec2) -> bool {
 	aa := Dot(v, v)
-	return abs(1. - aa) < 10. * EPSILON
+	return abs(1. - aa) < 100. * EPSILON
 }
 
 @(require_results)


### PR DESCRIPTION
# Fixes
- Epsilon value used in math functions did not match the value that is used when compiling box2d in a C/C++ compiler (for instance the sample application). The correct value is the same as odin use in it's math library. Changed to use `math.F32_EPSILON`.
- `IsNormalized` had a typo where a multiplier was 10, but in the original box2d source it is actually 100.

# Motivation
Both of these issues triggered IsValidPlane to fail and report `false`, in cases that the original box2d library reported `true`.