### PR TITLE
Correct parser end_pos for multiline strings

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -99,10 +99,8 @@ end_pos :: proc(tok: tokenizer.Token) -> tokenizer.Pos {
 	pos := tok.pos
 	pos.offset += len(tok.text)
 
-	if tok.kind == .Comment {
-		if tok.text[:2] != "/*" {
-			pos.column += len(tok.text)
-		} else {
+	if tok.kind == .Comment || tok.kind == .String {
+		if tok.text[:2] == "/*" || tok.text[:1] == "`" {
 			for i := 0; i < len(tok.text); i += 1 {
 				c := tok.text[i]
 				if c == '\n' {
@@ -112,6 +110,8 @@ end_pos :: proc(tok: tokenizer.Token) -> tokenizer.Pos {
 					pos.column += 1
 				}
 			}
+		} else {
+			pos.column += len(tok.text)
 		}
 	} else {
 		pos.column += len(tok.text)


### PR DESCRIPTION
In `ols` we had an issue reported with the formatter here https://github.com/DanielGavin/ols/issues/1100. After a brief investigation, I found that the odin parser doesn't handle multi-line strings correctly and would report the end position on the same line as the start. This just updates to parsing to behave the same as multi-line comments.