### PR TITLE
Linux executable path bug fix

### DIFF
--- a/core/os/os2/process_linux.odin
+++ b/core/os/os2/process_linux.odin
@@ -427,7 +427,8 @@ _process_start :: proc(desc: Process_Desc) -> (process: Process, err: Error) {
 			strings.write_string(&exe_builder, executable_name)
 
 			exe_path = strings.to_cstring(&exe_builder) or_return
-			if linux.access(exe_path, linux.X_OK) == .NONE {
+			stat := linux.Stat{}
+			if linux.stat(exe_path, &stat) == .NONE && .IFREG in stat.mode && .IXUSR in stat.mode {
 				found = true
 				break
 			}


### PR DESCRIPTION
Fixes a bug caused by an executable named identically to the directory it is in, where then the parent of that directory is both on the path and marked as executable
Avoid this via stat, as we can check we are working with a file which is executable