### PR TITLE
[LLVM Backend] Prefer the type pointer over LLVMTypeRef when looking up struct_field_remapping (Fix 5826)

### DIFF
--- a/src/llvm_backend_utility.cpp
+++ b/src/llvm_backend_utility.cpp
@@ -981,6 +981,9 @@ gb_internal lbStructFieldRemapping lb_get_struct_remapping(lbModule *m, Type *t)
 
 	mutex_lock(&m->types_mutex);
 
+	// NOTE(jakub): It's very important to check the type pointer first,
+	// because two disctinct but similar structs can end up with the same LLVMTypeRef after interning.
+	// (For example struct{u16,u8} looks identical to LLVM as struct{u16,u8,u8} once padding fields are inserted.)
 	auto *field_remapping = map_get(&m->struct_field_remapping, cast(void *)t);
 	if (field_remapping == nullptr) {
 		field_remapping = map_get(&m->struct_field_remapping, cast(void *)struct_type);


### PR DESCRIPTION
This is a fix for #5826