### PR TITLE
`vendor:box2d` add `targetAngle` to `RevoluteJoint` struct/procs

### DIFF
--- a/vendor/box2d/box2d.odin
+++ b/vendor/box2d/box2d.odin
@@ -1562,6 +1562,12 @@ foreign lib {
 	// Get the revolute joint spring damping ratio, non-dimensional
 	RevoluteJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> f32 ---
 
+	// Set the revolute joint spring target angle, radians
+	RevoluteJoint_SetTargetAngle        :: proc(jointId: JointId, angle: f32) ---
+
+	// Get the revolute joint spring target angle, radians
+	RevoluteJoint_GetTargetAngle        :: proc(jointId: JointId) -> f32 ---
+
 	// Get the revolute joint current angle in radians relative to the reference angle
 	//	@see b2RevoluteJointDef::referenceAngle
 	RevoluteJoint_GetAngle              :: proc(jointId: JointId) -> f32 ---

--- a/vendor/box2d/types.odin
+++ b/vendor/box2d/types.odin
@@ -727,6 +727,10 @@ RevoluteJointDef :: struct {
 	// This defines the zero angle for the joint limit.
 	referenceAngle: f32,
 
+	// The target angle for the joint in radians. The spring-damper will drive
+	// to this angle.
+	targetAngle: f32,
+
 	// Enable a rotational spring on the revolute hinge axis
 	enableSpring: bool,
 


### PR DESCRIPTION
`targetAngle` member is missing from the `RevoluteJoint` struct, breaking the interface.

also added get/setters from upstream

v3.1.1 upstream:
- `RevoluteJointDef` [src](https://github.com/erincatto/box2d/blob/v3.1.1/include/box2d/types.h#L796-L798)
- `Get/SetTargetAngle` [src](https://github.com/erincatto/box2d/blob/v3.1.1/include/box2d/box2d.h#L1101-L1105)