### PR TITLE
Made packed conditional on EPoll_Event to match kernel

### DIFF
--- a/core/sys/linux/types.odin
+++ b/core/sys/linux/types.odin
@@ -1446,9 +1446,25 @@ EPoll_Data :: struct #raw_union {
 	u64: u64,
 }
 
-EPoll_Event :: struct #packed {
-	events: EPoll_Event_Set,
-	data:   EPoll_Data,
+/*
+	Linux kernel only packs this struct on x86_64.
+	include/uapi/linux/eventpoll.h:	
+		#ifdef __x86_64__
+		#define EPOLL_PACKED __attribute__((packed))
+		#else
+		#define EPOLL_PACKED
+		#endif
+*/
+when ODIN_ARCH == .amd64 {
+	EPoll_Event :: struct #packed {
+		events: EPoll_Event_Set,
+		data:   EPoll_Data,
+	}
+} else {
+	EPoll_Event :: struct {
+		events: EPoll_Event_Set,
+		data:   EPoll_Data,
+	}
 }
 
 /*


### PR DESCRIPTION
Fix: ARM64 EPoll_Event struct layout causes epoll corruption

Problem

On ARM64, `epoll_wait()` returns corrupted file descriptor values, causing:
- Infinite busy loops from garbage fd values (e.g., fd=0)
- Complete application failures when using epoll

Root Cause

The Linux kernel only packs struct epoll_event on x86_64:

[From include/uapi/linux/eventpoll.h](https://github.com/torvalds/linux/blob/6548d364a3e850326831799d7e3ea2d7bb97ba08/include/uapi/linux/eventpoll.h#L77)
```
// include/uapi/linux/eventpoll.h
#ifdef __x86_64__
#define EPOLL_PACKED __attribute__((packed))
#else
#define EPOLL_PACKED
#endif

struct epoll_event {
    __poll_t events;  // uint32_t, 4 bytes
    __u64 data;       // uint64_t, 8 bytes
} EPOLL_PACKED;
```

Actual kernel layout:
- x86_64: 12 bytes (4 + 8, packed)
- ARM64/others: 16 bytes (4 + 4 padding + 8, unpacked for alignment)

Odin's current implementation:
```
EPoll_Event :: struct #packed {  // Packed on ALL architectures
    events: EPoll_Event_Set,
    data:   EPoll_Data,
}
```

This creates a size mismatch on ARM64: Odin expects 12 bytes, kernel writes 16
bytes. The misalignment causes epoll_wait() to write event data at wrong memory
offsets, corrupting the data.fd field.

Solution

Match the kernel's architecture-specific layout:

```
when ODIN_ARCH == .amd64 {
    EPoll_Event :: struct #packed {
        events: EPoll_Event_Set,
        data:   EPoll_Data,
    }
} else {
    EPoll_Event :: struct {
        events: EPoll_Event_Set,
        data:   EPoll_Data,
    }
}
```

Testing

- Verified on ARM64 (AWS Graviton 2, Ubuntu 24.04)
- x86_64: No changes, maintains existing behavior (12 bytes, packed)

Impact

- Fixes critical epoll failures on ARM64, RISC-V, and other non-x86_64
architectures
- No changes to x86_64 behavior
- No breaking changes to API
