### PR TITLE
Fix #5843

### DIFF
--- a/core/sys/wasm/js/odin.js
+++ b/core/sys/wasm/js/odin.js
@@ -2112,7 +2112,9 @@ async function runWasm(wasmPath, consoleElement, extraForeignImports, wasmMemory
 		wasmMemoryInterface.setMemory(exports.memory);
 	}
 
-	exports._start();
+	if (exports._start) {
+		exports._start();
+	}
 
 	// Define a `@export step :: proc(delta_time: f64) -> (keep_going: bool) {`
 	// in your app and it will get called every frame.
@@ -2130,7 +2132,9 @@ async function runWasm(wasmPath, consoleElement, extraForeignImports, wasmMemory
 			prevTimeStamp = currTimeStamp;
 
 			if (!exports.step(dt, odin_ctx)) {
-				exports._end();
+				if (exports._end) {
+					exports._end();
+				}
 				return;
 			}
 
@@ -2139,7 +2143,9 @@ async function runWasm(wasmPath, consoleElement, extraForeignImports, wasmMemory
 
 		window.requestAnimationFrame(step);
 	} else {
-		exports._end();
+		if (exports._end) {
+			exports._end();
+		}
 	}
 
 	return;


### PR DESCRIPTION
**Avoids runtime errors in `odin.js` by conditionally invoking `_start` and `_end` only if they exist in the WASM export table.**

This change resolves an issue where libraries compiled with the `-no-entry-point` flag omit `_start` and `_end`, causing `odin.js` to throw `TypeError: exports._start is not a function` at runtime.