### PR TITLE
Update GetPlatformDisplay and CreatePlatformWindowSurface to take in intptr_t/int instead of i32

### DIFF
--- a/vendor/egl/egl.odin
+++ b/vendor/egl/egl.odin
@@ -81,12 +81,12 @@ foreign import egl "system:EGL"
 @(default_calling_convention="c", link_prefix="egl")
 foreign egl {
 	GetDisplay          :: proc(display: NativeDisplayType) -> Display ---
-	GetPlatformDisplay  :: proc(platform: Platform, native_display: rawptr, attrib_list: ^i32) -> Display ---
+	GetPlatformDisplay  :: proc(platform: Platform, native_display: rawptr, attrib_list: ^int) -> Display ---
 	Initialize          :: proc(display: Display, major: ^i32, minor: ^i32) -> Boolean ---
 	BindAPI             :: proc(api: u32) -> Boolean ---
 	ChooseConfig        :: proc(display: Display, attrib_list: ^i32, configs: [^]Config, config_size: i32, num_config: ^i32) -> Boolean ---
 	CreateWindowSurface :: proc(display: Display, config: Config, native_window: NativeWindowType, attrib_list: ^i32) -> Surface ---
-	CreatePlatformWindowSurface :: proc(display: Display, config: Config, native_window: rawptr, attrib_list: ^i32) -> Surface ---
+	CreatePlatformWindowSurface :: proc(display: Display, config: Config, native_window: rawptr, attrib_list: ^int) -> Surface ---
 	CreateContext       :: proc(display: Display, config: Config, share_context: Context, attrib_list: ^i32) -> Context ---
 	MakeCurrent         :: proc(display: Display, draw: Surface, read: Surface, ctx: Context) -> Boolean ---
 	QuerySurface        :: proc(display: Display, surface: Surface, attribute: i32, value: ^i32) -> Boolean ---


### PR DESCRIPTION
I had an issue where on x11 where ported mmozeikos Opengl context on X11 with EGL gist. Where it segfaulted. [odin thread](https://discord.com/channels/568138951836172421/1429235927640707124) where we found out `eglCreatePlatformWIndowSurface` takes in EGLAttrib which is intptr_t. And I think they assumed every `egl_attrib` was `EGLint` / i32. But apparently they are not.
<img width="453" height="73" alt="image" src="https://github.com/user-attachments/assets/17b53d94-3d2f-4961-b839-526f472309c0" />
