### PR TITLE
Fix the SDL3 GLProfileFlag enum

### DIFF
--- a/vendor/sdl3/sdl3_video.odin
+++ b/vendor/sdl3/sdl3_video.odin
@@ -206,9 +206,9 @@ GL_EGL_PLATFORM               :: GLAttr.EGL_PLATFORM
 
 GLProfile :: distinct bit_set[GLProfileFlag; Uint32]
 GLProfileFlag :: enum Uint32 {
-	CORE          = 0, /**< OpenGL Core Profile context */
-	COMPATIBILITY = 1, /**< OpenGL Compatibility Profile context */
-	ES            = 2, /**< GLX_CONTEXT_ES2_PROFILE_BIT_EXT */
+	CORE          = 1, /**< OpenGL Core Profile context */
+	COMPATIBILITY = 2, /**< OpenGL Compatibility Profile context */
+	ES            = 4, /**< GLX_CONTEXT_ES2_PROFILE_BIT_EXT */
 }
 GL_CONTEXT_PROFILE_CORE          :: GLProfile{.CORE}          /**< OpenGL Core Profile context */
 GL_CONTEXT_PROFILE_COMPATIBILITY :: GLProfile{.COMPATIBILITY} /**< OpenGL Compatibility Profile context */


### PR DESCRIPTION
In `vendor:SDL3` package, there's currently a notable discrepancy between the `SDL_GL_CONTEXT_PROFILE_xyz` defines in [SDL_video](https://wiki.libsdl.org/SDL3/SDL_GLProfile) and as specified in `sdl3_video.odin`:

`SDL_VIDEO`: 
```
#define SDL_GL_CONTEXT_PROFILE_CORE           0x0001  /**< OpenGL Core Profile context */
#define SDL_GL_CONTEXT_PROFILE_COMPATIBILITY  0x0002  /**< OpenGL Compatibility Profile context */
#define SDL_GL_CONTEXT_PROFILE_ES             0x0004  /**< GLX_CONTEXT_ES2_PROFILE_BIT_EXT */
```

`sdl3_video.odin`:
```
GLProfileFlag :: enum Uint32 {
	CORE          = 0, /**< OpenGL Core Profile context */
	COMPATIBILITY = 1, /**< OpenGL Compatibility Profile context */
	ES            = 2, /**< GLX_CONTEXT_ES2_PROFILE_BIT_EXT */
}
```

This error results in unintended behavior, even leading to crashes when used inside a Darwin environment. this PR aims to rectify said discrepancy by enumerating the values as intended.