### PR TITLE
[core:os/os2] zeroed `n` value on failed file operations

### DIFF
--- a/core/os/os2/file_linux.odin
+++ b/core/os/os2/file_linux.odin
@@ -198,7 +198,7 @@ _seek :: proc(f: ^File_Impl, offset: i64, whence: io.Seek_From) -> (ret: i64, er
 	case .NONE:
 		return n, nil
 	case:
-		return -1, _get_platform_error(errno)
+		return 0, _get_platform_error(errno)
 	}
 }
 
@@ -209,7 +209,7 @@ _read :: proc(f: ^File_Impl, p: []byte) -> (i64, Error) {
 
 	n, errno := linux.read(f.fd, p[:min(len(p), MAX_RW)])
 	if errno != .NONE {
-		return -1, _get_platform_error(errno)
+		return 0, _get_platform_error(errno)
 	}
 	return i64(n), io.Error.EOF if n == 0 else nil
 }
@@ -223,7 +223,7 @@ _read_at :: proc(f: ^File_Impl, p: []byte, offset: i64) -> (i64, Error) {
 	}
 	n, errno := linux.pread(f.fd, p[:min(len(p), MAX_RW)], offset)
 	if errno != .NONE {
-		return -1, _get_platform_error(errno)
+		return 0, _get_platform_error(errno)
 	}
 	if n == 0 {
 		return 0, .EOF
@@ -276,7 +276,7 @@ _file_size :: proc(f: ^File_Impl) -> (n: i64, err: Error) {
 	s: linux.Stat = ---
 	errno := linux.fstat(f.fd, &s)
 	if errno != .NONE {
-		return -1, _get_platform_error(errno)
+		return 0, _get_platform_error(errno)
 	}
 
 	if s.mode & linux.S_IFMT == linux.S_IFREG {

--- a/core/os/os2/file_posix.odin
+++ b/core/os/os2/file_posix.odin
@@ -382,12 +382,14 @@ _file_stream_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, 
 		}
 
 		to_read := uint(min(len(p), MAX_RW))
-		n = i64(posix.read(fd, raw_data(p), to_read))
+		_n := i64(posix.read(fd, raw_data(p), to_read))
 		switch {
-		case n == 0:
+		case _n == 0:
 			err = .EOF
-		case n < 0:
+		case _n < 0:
 			err = .Unknown
+		case:
+			n = _n
 		}
 		return
 
@@ -402,12 +404,14 @@ _file_stream_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, 
 		}
 
 		to_read := uint(min(len(p), MAX_RW))
-		n = i64(posix.pread(fd, raw_data(p), to_read, posix.off_t(offset)))
+		_n := i64(posix.pread(fd, raw_data(p), to_read, posix.off_t(offset)))
 		switch {
-		case n == 0:
+		case _n == 0:
 			err = .EOF
-		case n < 0:
+		case _n < 0:
 			err = .Unknown
+		case:
+			n = _n
 		}
 		return
 
@@ -460,15 +464,18 @@ _file_stream_proc :: proc(stream_data: rawptr, mode: io.Stream_Mode, p: []byte, 
 			return
 		}
 
-		n = i64(posix.lseek(fd, posix.off_t(offset), posix.Whence(whence)))
-		if n < 0 {
+		_n := i64(posix.lseek(fd, posix.off_t(offset), posix.Whence(whence)))
+		if _n < 0 {
 			#partial switch posix.get_errno() {
 			case .EINVAL:
 				err = .Invalid_Offset
 			case:
 				err = .Unknown
 			}
+			return
 		}
+
+		n = _n
 		return
 
 	case .Size:


### PR DESCRIPTION
fixes an issue with `read_entire_file` where pseudo-files were resulting in a bounds trap since `read` on linux and posix would return `-1` instead of `0` (which windows does). should also provide more consistent behavior across platforms

sample program:
```odin
package demo

import "core:fmt"
import "core:os/os2"

main :: proc() {
	curr_pid := os2.get_pid()
	filename := fmt.aprintf("/proc/%d/mem", curr_pid)
	contents, err := os2.read_entire_file(filename, context.allocator)
	fmt.println(contents, err)
}
```
crashes with:
```
Odin/core/os/os2/file_util.odin(154:38) Invalid slice indices 0:-1 is out of range 0..<1024
```