### PR TITLE
Add support for `half` types to `core:math/linalg/hlsl`

### DIFF
--- a/core/math/linalg/hlsl/linalg_hlsl.odin
+++ b/core/math/linalg/hlsl/linalg_hlsl.odin
@@ -131,8 +131,12 @@ int4x2 :: matrix[4, 2]int
 int4x3 :: matrix[4, 3]int
 
 cos :: proc{
+	cos_half,
 	cos_float,
 	cos_double,
+	cos_half2,
+	cos_half3,
+	cos_half4,
 	cos_float2,
 	cos_float3,
 	cos_float4,
@@ -140,6 +144,9 @@ cos :: proc{
 	cos_double3,
 	cos_double4,
 }
+@(require_results) cos_half2 :: proc "c" (x: half2) -> half2 { return {cos(x.x), cos(x.y)} }
+@(require_results) cos_half3 :: proc "c" (x: half3) -> half3 { return {cos(x.x), cos(x.y), cos(x.z)} }
+@(require_results) cos_half4 :: proc "c" (x: half4) -> half4 { return {cos(x.x), cos(x.y), cos(x.z), cos(x.w)} }
 @(require_results) cos_float2 :: proc "c" (x: float2) -> float2 { return {cos(x.x), cos(x.y)} }
 @(require_results) cos_float3 :: proc "c" (x: float3) -> float3 { return {cos(x.x), cos(x.y), cos(x.z)} }
 @(require_results) cos_float4 :: proc "c" (x: float4) -> float4 { return {cos(x.x), cos(x.y), cos(x.z), cos(x.w)} }
@@ -148,8 +155,12 @@ cos :: proc{
 @(require_results) cos_double4 :: proc "c" (x: double4) -> double4 { return {cos(x.x), cos(x.y), cos(x.z), cos(x.w)} }
 
 sin :: proc{
+	sin_half,
 	sin_float,
 	sin_double,
+	sin_half2,
+	sin_half3,
+	sin_half4,
 	sin_float2,
 	sin_float3,
 	sin_float4,
@@ -157,6 +168,9 @@ sin :: proc{
 	sin_double3,
 	sin_double4,
 }
+@(require_results) sin_half2 :: proc "c" (x: half2) -> half2 { return {sin(x.x), sin(x.y)} }
+@(require_results) sin_half3 :: proc "c" (x: half3) -> half3 { return {sin(x.x), sin(x.y), sin(x.z)} }
+@(require_results) sin_half4 :: proc "c" (x: half4) -> half4 { return {sin(x.x), sin(x.y), sin(x.z), sin(x.w)} }
 @(require_results) sin_float2 :: proc "c" (x: float2) -> float2 { return {sin(x.x), sin(x.y)} }
 @(require_results) sin_float3 :: proc "c" (x: float3) -> float3 { return {sin(x.x), sin(x.y), sin(x.z)} }
 @(require_results) sin_float4 :: proc "c" (x: float4) -> float4 { return {sin(x.x), sin(x.y), sin(x.z), sin(x.w)} }
@@ -165,8 +179,12 @@ sin :: proc{
 @(require_results) sin_double4 :: proc "c" (x: double4) -> double4 { return {sin(x.x), sin(x.y), sin(x.z), sin(x.w)} }
 
 tan :: proc{
+	tan_half,
 	tan_float,
 	tan_double,
+	tan_half2,
+	tan_half3,
+	tan_half4,
 	tan_float2,
 	tan_float3,
 	tan_float4,
@@ -174,6 +192,9 @@ tan :: proc{
 	tan_double3,
 	tan_double4,
 }
+@(require_results) tan_half2 :: proc "c" (x: half2) -> half2 { return {tan(x.x), tan(x.y)} }
+@(require_results) tan_half3 :: proc "c" (x: half3) -> half3 { return {tan(x.x), tan(x.y), tan(x.z)} }
+@(require_results) tan_half4 :: proc "c" (x: half4) -> half4 { return {tan(x.x), tan(x.y), tan(x.z), tan(x.w)} }
 @(require_results) tan_float2 :: proc "c" (x: float2) -> float2 { return {tan(x.x), tan(x.y)} }
 @(require_results) tan_float3 :: proc "c" (x: float3) -> float3 { return {tan(x.x), tan(x.y), tan(x.z)} }
 @(require_results) tan_float4 :: proc "c" (x: float4) -> float4 { return {tan(x.x), tan(x.y), tan(x.z), tan(x.w)} }
@@ -182,8 +203,12 @@ tan :: proc{
 @(require_results) tan_double4 :: proc "c" (x: double4) -> double4 { return {tan(x.x), tan(x.y), tan(x.z), tan(x.w)} }
 
 acos :: proc{
+	acos_half,
 	acos_float,
 	acos_double,
+	acos_half2,
+	acos_half3,
+	acos_half4,
 	acos_float2,
 	acos_float3,
 	acos_float4,
@@ -191,6 +216,9 @@ acos :: proc{
 	acos_double3,
 	acos_double4,
 }
+@(require_results) acos_half2 :: proc "c" (x: half2) -> half2 { return {acos(x.x), acos(x.y)} }
+@(require_results) acos_half3 :: proc "c" (x: half3) -> half3 { return {acos(x.x), acos(x.y), acos(x.z)} }
+@(require_results) acos_half4 :: proc "c" (x: half4) -> half4 { return {acos(x.x), acos(x.y), acos(x.z), acos(x.w)} }
 @(require_results) acos_float2 :: proc "c" (x: float2) -> float2 { return {acos(x.x), acos(x.y)} }
 @(require_results) acos_float3 :: proc "c" (x: float3) -> float3 { return {acos(x.x), acos(x.y), acos(x.z)} }
 @(require_results) acos_float4 :: proc "c" (x: float4) -> float4 { return {acos(x.x), acos(x.y), acos(x.z), acos(x.w)} }
@@ -199,8 +227,12 @@ acos :: proc{
 @(require_results) acos_double4 :: proc "c" (x: double4) -> double4 { return {acos(x.x), acos(x.y), acos(x.z), acos(x.w)} }
 
 asin :: proc{
+	asin_half,
 	asin_float,
 	asin_double,
+	asin_half2,
+	asin_half3,
+	asin_half4,
 	asin_float2,
 	asin_float3,
 	asin_float4,
@@ -208,6 +240,9 @@ asin :: proc{
 	asin_double3,
 	asin_double4,
 }
+@(require_results) asin_half2 :: proc "c" (x: half2) -> half2 { return {asin(x.x), asin(x.y)} }
+@(require_results) asin_half3 :: proc "c" (x: half3) -> half3 { return {asin(x.x), asin(x.y), asin(x.z)} }
+@(require_results) asin_half4 :: proc "c" (x: half4) -> half4 { return {asin(x.x), asin(x.y), asin(x.z), asin(x.w)} }
 @(require_results) asin_float2 :: proc "c" (x: float2) -> float2 { return {asin(x.x), asin(x.y)} }
 @(require_results) asin_float3 :: proc "c" (x: float3) -> float3 { return {asin(x.x), asin(x.y), asin(x.z)} }
 @(require_results) asin_float4 :: proc "c" (x: float4) -> float4 { return {asin(x.x), asin(x.y), asin(x.z), asin(x.w)} }
@@ -216,8 +251,12 @@ asin :: proc{
 @(require_results) asin_double4 :: proc "c" (x: double4) -> double4 { return {asin(x.x), asin(x.y), asin(x.z), asin(x.w)} }
 
 atan :: proc{
+	atan_half,
 	atan_float,
 	atan_double,
+	atan_half2,
+	atan_half3,
+	atan_half4,
 	atan_float2,
 	atan_float3,
 	atan_float4,
@@ -233,6 +272,9 @@ atan :: proc{
 	atan2_double3,
 	atan2_double4,
 }
+@(require_results) atan_half2 :: proc "c" (x: half2) -> half2 { return {atan(x.x), atan(x.y)} }
+@(require_results) atan_half3 :: proc "c" (x: half3) -> half3 { return {atan(x.x), atan(x.y), atan(x.z)} }
+@(require_results) atan_half4 :: proc "c" (x: half4) -> half4 { return {atan(x.x), atan(x.y), atan(x.z), atan(x.w)} }
 @(require_results) atan_float2 :: proc "c" (x: float2) -> float2 { return {atan(x.x), atan(x.y)} }
 @(require_results) atan_float3 :: proc "c" (x: float3) -> float3 { return {atan(x.x), atan(x.y), atan(x.z)} }
 @(require_results) atan_float4 :: proc "c" (x: float4) -> float4 { return {atan(x.x), atan(x.y), atan(x.z), atan(x.w)} }
@@ -241,8 +283,12 @@ atan :: proc{
 @(require_results) atan_double4 :: proc "c" (x: double4) -> double4 { return {atan(x.x), atan(x.y), atan(x.z), atan(x.w)} }
 
 atan2 :: proc{
+	atan2_half,
 	atan2_float,
 	atan2_double,
+	atan2_half2,
+	atan2_half3,
+	atan2_half4,
 	atan2_float2,
 	atan2_float3,
 	atan2_float4,
@@ -250,6 +296,9 @@ atan2 :: proc{
 	atan2_double3,
 	atan2_double4,
 }
+@(require_results) atan2_half2 :: proc "c" (y, x: half2) -> half2 { return {atan2(y.x, x.x), atan2(y.y, x.y)} }
+@(require_results) atan2_half3 :: proc "c" (y, x: half3) -> half3 { return {atan2(y.x, x.x), atan2(y.y, x.y), atan2(y.z, x.z)} }
+@(require_results) atan2_half4 :: proc "c" (y, x: half4) -> half4 { return {atan2(y.x, x.x), atan2(y.y, x.y), atan2(y.z, x.z), atan2(y.w, x.w)} }
 @(require_results) atan2_float2 :: proc "c" (y, x: float2) -> float2 { return {atan2(y.x, x.x), atan2(y.y, x.y)} }
 @(require_results) atan2_float3 :: proc "c" (y, x: float3) -> float3 { return {atan2(y.x, x.x), atan2(y.y, x.y), atan2(y.z, x.z)} }
 @(require_results) atan2_float4 :: proc "c" (y, x: float4) -> float4 { return {atan2(y.x, x.x), atan2(y.y, x.y), atan2(y.z, x.z), atan2(y.w, x.w)} }
@@ -260,8 +309,12 @@ atan2 :: proc{
 
 
 cosh :: proc{
+	cosh_half,
 	cosh_float,
 	cosh_double,
+	cosh_half2,
+	cosh_half3,
+	cosh_half4,
 	cosh_float2,
 	cosh_float3,
 	cosh_float4,
@@ -269,6 +322,9 @@ cosh :: proc{
 	cosh_double3,
 	cosh_double4,
 }
+@(require_results) cosh_half2 :: proc "c" (x: half2) -> half2 { return {cosh(x.x), cosh(x.y)} }
+@(require_results) cosh_half3 :: proc "c" (x: half3) -> half3 { return {cosh(x.x), cosh(x.y), cosh(x.z)} }
+@(require_results) cosh_half4 :: proc "c" (x: half4) -> half4 { return {cosh(x.x), cosh(x.y), cosh(x.z), cosh(x.w)} }
 @(require_results) cosh_float2 :: proc "c" (x: float2) -> float2 { return {cosh(x.x), cosh(x.y)} }
 @(require_results) cosh_float3 :: proc "c" (x: float3) -> float3 { return {cosh(x.x), cosh(x.y), cosh(x.z)} }
 @(require_results) cosh_float4 :: proc "c" (x: float4) -> float4 { return {cosh(x.x), cosh(x.y), cosh(x.z), cosh(x.w)} }
@@ -278,8 +334,12 @@ cosh :: proc{
 
 
 sinh :: proc{
+	sinh_half,
 	sinh_float,
 	sinh_double,
+	sinh_half2,
+	sinh_half3,
+	sinh_half4,
 	sinh_float2,
 	sinh_float3,
 	sinh_float4,
@@ -287,6 +347,9 @@ sinh :: proc{
 	sinh_double3,
 	sinh_double4,
 }
+@(require_results) sinh_half2 :: proc "c" (x: half2) -> half2 { return {sinh(x.x), sinh(x.y)} }
+@(require_results) sinh_half3 :: proc "c" (x: half3) -> half3 { return {sinh(x.x), sinh(x.y), sinh(x.z)} }
+@(require_results) sinh_half4 :: proc "c" (x: half4) -> half4 { return {sinh(x.x), sinh(x.y), sinh(x.z), sinh(x.w)} }
 @(require_results) sinh_float2 :: proc "c" (x: float2) -> float2 { return {sinh(x.x), sinh(x.y)} }
 @(require_results) sinh_float3 :: proc "c" (x: float3) -> float3 { return {sinh(x.x), sinh(x.y), sinh(x.z)} }
 @(require_results) sinh_float4 :: proc "c" (x: float4) -> float4 { return {sinh(x.x), sinh(x.y), sinh(x.z), sinh(x.w)} }
@@ -295,8 +358,12 @@ sinh :: proc{
 @(require_results) sinh_double4 :: proc "c" (x: double4) -> double4 { return {sinh(x.x), sinh(x.y), sinh(x.z), sinh(x.w)} }
 
 tanh :: proc{
+	tanh_half,
 	tanh_float,
 	tanh_double,
+	tanh_half2,
+	tanh_half3,
+	tanh_half4,
 	tanh_float2,
 	tanh_float3,
 	tanh_float4,
@@ -304,6 +371,9 @@ tanh :: proc{
 	tanh_double3,
 	tanh_double4,
 }
+@(require_results) tanh_half2 :: proc "c" (x: half2) -> half2 { return {tanh(x.x), tanh(x.y)} }
+@(require_results) tanh_half3 :: proc "c" (x: half3) -> half3 { return {tanh(x.x), tanh(x.y), tanh(x.z)} }
+@(require_results) tanh_half4 :: proc "c" (x: half4) -> half4 { return {tanh(x.x), tanh(x.y), tanh(x.z), tanh(x.w)} }
 @(require_results) tanh_float2 :: proc "c" (x: float2) -> float2 { return {tanh(x.x), tanh(x.y)} }
 @(require_results) tanh_float3 :: proc "c" (x: float3) -> float3 { return {tanh(x.x), tanh(x.y), tanh(x.z)} }
 @(require_results) tanh_float4 :: proc "c" (x: float4) -> float4 { return {tanh(x.x), tanh(x.y), tanh(x.z), tanh(x.w)} }
@@ -312,8 +382,12 @@ tanh :: proc{
 @(require_results) tanh_double4 :: proc "c" (x: double4) -> double4 { return {tanh(x.x), tanh(x.y), tanh(x.z), tanh(x.w)} }
 
 acosh :: proc{
+	acosh_half,
 	acosh_float,
 	acosh_double,
+	acosh_half2,
+	acosh_half3,
+	acosh_half4,
 	acosh_float2,
 	acosh_float3,
 	acosh_float4,
@@ -321,6 +395,9 @@ acosh :: proc{
 	acosh_double3,
 	acosh_double4,
 }
+@(require_results) acosh_half2 :: proc "c" (x: half2) -> half2 { return {acosh(x.x), acosh(x.y)} }
+@(require_results) acosh_half3 :: proc "c" (x: half3) -> half3 { return {acosh(x.x), acosh(x.y), acosh(x.z)} }
+@(require_results) acosh_half4 :: proc "c" (x: half4) -> half4 { return {acosh(x.x), acosh(x.y), acosh(x.z), acosh(x.w)} }
 @(require_results) acosh_float2 :: proc "c" (x: float2) -> float2 { return {acosh(x.x), acosh(x.y)} }
 @(require_results) acosh_float3 :: proc "c" (x: float3) -> float3 { return {acosh(x.x), acosh(x.y), acosh(x.z)} }
 @(require_results) acosh_float4 :: proc "c" (x: float4) -> float4 { return {acosh(x.x), acosh(x.y), acosh(x.z), acosh(x.w)} }
@@ -329,8 +406,12 @@ acosh :: proc{
 @(require_results) acosh_double4 :: proc "c" (x: double4) -> double4 { return {acosh(x.x), acosh(x.y), acosh(x.z), acosh(x.w)} }
 
 asinh :: proc{
+	asinh_half,
 	asinh_float,
 	asinh_double,
+	asinh_half2,
+	asinh_half3,
+	asinh_half4,
 	asinh_float2,
 	asinh_float3,
 	asinh_float4,
@@ -338,6 +419,9 @@ asinh :: proc{
 	asinh_double3,
 	asinh_double4,
 }
+@(require_results) asinh_half2 :: proc "c" (x: half2) -> half2 { return {asinh(x.x), asinh(x.y)} }
+@(require_results) asinh_half3 :: proc "c" (x: half3) -> half3 { return {asinh(x.x), asinh(x.y), asinh(x.z)} }
+@(require_results) asinh_half4 :: proc "c" (x: half4) -> half4 { return {asinh(x.x), asinh(x.y), asinh(x.z), asinh(x.w)} }
 @(require_results) asinh_float2 :: proc "c" (x: float2) -> float2 { return {asinh(x.x), asinh(x.y)} }
 @(require_results) asinh_float3 :: proc "c" (x: float3) -> float3 { return {asinh(x.x), asinh(x.y), asinh(x.z)} }
 @(require_results) asinh_float4 :: proc "c" (x: float4) -> float4 { return {asinh(x.x), asinh(x.y), asinh(x.z), asinh(x.w)} }
@@ -346,8 +430,12 @@ asinh :: proc{
 @(require_results) asinh_double4 :: proc "c" (x: double4) -> double4 { return {asinh(x.x), asinh(x.y), asinh(x.z), asinh(x.w)} }
 
 atanh :: proc{
+	atanh_half,
 	atanh_float,
 	atanh_double,
+	atanh_half2,
+	atanh_half3,
+	atanh_half4,
 	atanh_float2,
 	atanh_float3,
 	atanh_float4,
@@ -355,6 +443,9 @@ atanh :: proc{
 	atanh_double3,
 	atanh_double4,
 }
+@(require_results) atanh_half2 :: proc "c" (x: half2) -> half2 { return {atanh(x.x), atanh(x.y)} }
+@(require_results) atanh_half3 :: proc "c" (x: half3) -> half3 { return {atanh(x.x), atanh(x.y), atanh(x.z)} }
+@(require_results) atanh_half4 :: proc "c" (x: half4) -> half4 { return {atanh(x.x), atanh(x.y), atanh(x.z), atanh(x.w)} }
 @(require_results) atanh_float2 :: proc "c" (x: float2) -> float2 { return {atanh(x.x), atanh(x.y)} }
 @(require_results) atanh_float3 :: proc "c" (x: float3) -> float3 { return {atanh(x.x), atanh(x.y), atanh(x.z)} }
 @(require_results) atanh_float4 :: proc "c" (x: float4) -> float4 { return {atanh(x.x), atanh(x.y), atanh(x.z), atanh(x.w)} }
@@ -363,8 +454,12 @@ atanh :: proc{
 @(require_results) atanh_double4 :: proc "c" (x: double4) -> double4 { return {atanh(x.x), atanh(x.y), atanh(x.z), atanh(x.w)} }
 
 sqrt :: proc{
+	sqrt_half,
 	sqrt_float,
 	sqrt_double,
+	sqrt_half2,
+	sqrt_half3,
+	sqrt_half4,
 	sqrt_float2,
 	sqrt_float3,
 	sqrt_float4,
@@ -372,6 +467,9 @@ sqrt :: proc{
 	sqrt_double3,
 	sqrt_double4,
 }
+@(require_results) sqrt_half2 :: proc "c" (x: half2) -> half2 { return {sqrt(x.x), sqrt(x.y)} }
+@(require_results) sqrt_half3 :: proc "c" (x: half3) -> half3 { return {sqrt(x.x), sqrt(x.y), sqrt(x.z)} }
+@(require_results) sqrt_half4 :: proc "c" (x: half4) -> half4 { return {sqrt(x.x), sqrt(x.y), sqrt(x.z), sqrt(x.w)} }
 @(require_results) sqrt_float2 :: proc "c" (x: float2) -> float2 { return {sqrt(x.x), sqrt(x.y)} }
 @(require_results) sqrt_float3 :: proc "c" (x: float3) -> float3 { return {sqrt(x.x), sqrt(x.y), sqrt(x.z)} }
 @(require_results) sqrt_float4 :: proc "c" (x: float4) -> float4 { return {sqrt(x.x), sqrt(x.y), sqrt(x.z), sqrt(x.w)} }
@@ -380,8 +478,12 @@ sqrt :: proc{
 @(require_results) sqrt_double4 :: proc "c" (x: double4) -> double4 { return {sqrt(x.x), sqrt(x.y), sqrt(x.z), sqrt(x.w)} }
 
 rsqrt :: proc{
+	rsqrt_half,
 	rsqrt_float,
 	rsqrt_double,
+	rsqrt_half2,
+	rsqrt_half3,
+	rsqrt_half4,
 	rsqrt_float2,
 	rsqrt_float3,
 	rsqrt_float4,
@@ -389,6 +491,9 @@ rsqrt :: proc{
 	rsqrt_double3,
 	rsqrt_double4,
 }
+@(require_results) rsqrt_half2 :: proc "c" (x: half2) -> half2 { return {rsqrt(x.x), rsqrt(x.y)} }
+@(require_results) rsqrt_half3 :: proc "c" (x: half3) -> half3 { return {rsqrt(x.x), rsqrt(x.y), rsqrt(x.z)} }
+@(require_results) rsqrt_half4 :: proc "c" (x: half4) -> half4 { return {rsqrt(x.x), rsqrt(x.y), rsqrt(x.z), rsqrt(x.w)} }
 @(require_results) rsqrt_float2 :: proc "c" (x: float2) -> float2 { return {rsqrt(x.x), rsqrt(x.y)} }
 @(require_results) rsqrt_float3 :: proc "c" (x: float3) -> float3 { return {rsqrt(x.x), rsqrt(x.y), rsqrt(x.z)} }
 @(require_results) rsqrt_float4 :: proc "c" (x: float4) -> float4 { return {rsqrt(x.x), rsqrt(x.y), rsqrt(x.z), rsqrt(x.w)} }
@@ -397,8 +502,12 @@ rsqrt :: proc{
 @(require_results) rsqrt_double4 :: proc "c" (x: double4) -> double4 { return {rsqrt(x.x), rsqrt(x.y), rsqrt(x.z), rsqrt(x.w)} }
 
 rcp :: proc{
+	rcp_half,
 	rcp_float,
 	rcp_double,
+	rcp_half2,
+	rcp_half3,
+	rcp_half4,
 	rcp_float2,
 	rcp_float3,
 	rcp_float4,
@@ -406,6 +515,9 @@ rcp :: proc{
 	rcp_double3,
 	rcp_double4,
 }
+@(require_results) rcp_half2 :: proc "c" (x: half2) -> half2 { return {rcp(x.x), rcp(x.y)} }
+@(require_results) rcp_half3 :: proc "c" (x: half3) -> half3 { return {rcp(x.x), rcp(x.y), rcp(x.z)} }
+@(require_results) rcp_half4 :: proc "c" (x: half4) -> half4 { return {rcp(x.x), rcp(x.y), rcp(x.z), rcp(x.w)} }
 @(require_results) rcp_float2 :: proc "c" (x: float2) -> float2 { return {rcp(x.x), rcp(x.y)} }
 @(require_results) rcp_float3 :: proc "c" (x: float3) -> float3 { return {rcp(x.x), rcp(x.y), rcp(x.z)} }
 @(require_results) rcp_float4 :: proc "c" (x: float4) -> float4 { return {rcp(x.x), rcp(x.y), rcp(x.z), rcp(x.w)} }
@@ -415,8 +527,12 @@ rcp :: proc{
 
 
 pow :: proc{
+	pow_half,
 	pow_float,
 	pow_double,
+	pow_half2,
+	pow_half3,
+	pow_half4,
 	pow_float2,
 	pow_float3,
 	pow_float4,
@@ -424,6 +540,9 @@ pow :: proc{
 	pow_double3,
 	pow_double4,
 }
+@(require_results) pow_half2 :: proc "c" (x, y: half2) -> half2 { return {pow(x.x, y.x), pow(x.y, y.y)} }
+@(require_results) pow_half3 :: proc "c" (x, y: half3) -> half3 { return {pow(x.x, y.x), pow(x.y, y.y), pow(x.z, y.z)} }
+@(require_results) pow_half4 :: proc "c" (x, y: half4) -> half4 { return {pow(x.x, y.x), pow(x.y, y.y), pow(x.z, y.z), pow(x.w, y.w)} }
 @(require_results) pow_float2 :: proc "c" (x, y: float2) -> float2 { return {pow(x.x, y.x), pow(x.y, y.y)} }
 @(require_results) pow_float3 :: proc "c" (x, y: float3) -> float3 { return {pow(x.x, y.x), pow(x.y, y.y), pow(x.z, y.z)} }
 @(require_results) pow_float4 :: proc "c" (x, y: float4) -> float4 { return {pow(x.x, y.x), pow(x.y, y.y), pow(x.z, y.z), pow(x.w, y.w)} }
@@ -434,8 +553,12 @@ pow :: proc{
 
 
 exp :: proc{
+	exp_half,
 	exp_float,
 	exp_double,
+	exp_half2,
+	exp_half3,
+	exp_half4,
 	exp_float2,
 	exp_float3,
 	exp_float4,
@@ -443,6 +566,9 @@ exp :: proc{
 	exp_double3,
 	exp_double4,
 }
+@(require_results) exp_half2 :: proc "c" (x: half2) -> half2 { return {exp(x.x), exp(x.y)} }
+@(require_results) exp_half3 :: proc "c" (x: half3) -> half3 { return {exp(x.x), exp(x.y), exp(x.z)} }
+@(require_results) exp_half4 :: proc "c" (x: half4) -> half4 { return {exp(x.x), exp(x.y), exp(x.z), exp(x.w)} }
 @(require_results) exp_float2 :: proc "c" (x: float2) -> float2 { return {exp(x.x), exp(x.y)} }
 @(require_results) exp_float3 :: proc "c" (x: float3) -> float3 { return {exp(x.x), exp(x.y), exp(x.z)} }
 @(require_results) exp_float4 :: proc "c" (x: float4) -> float4 { return {exp(x.x), exp(x.y), exp(x.z), exp(x.w)} }
@@ -453,8 +579,12 @@ exp :: proc{
 
 
 log :: proc{
+	log_half,
 	log_float,
 	log_double,
+	log_half2,
+	log_half3,
+	log_half4,
 	log_float2,
 	log_float3,
 	log_float4,
@@ -462,6 +592,9 @@ log :: proc{
 	log_double3,
 	log_double4,
 }
+@(require_results) log_half2 :: proc "c" (x: half2) -> half2 { return {log(x.x), log(x.y)} }
+@(require_results) log_half3 :: proc "c" (x: half3) -> half3 { return {log(x.x), log(x.y), log(x.z)} }
+@(require_results) log_half4 :: proc "c" (x: half4) -> half4 { return {log(x.x), log(x.y), log(x.z), log(x.w)} }
 @(require_results) log_float2 :: proc "c" (x: float2) -> float2 { return {log(x.x), log(x.y)} }
 @(require_results) log_float3 :: proc "c" (x: float3) -> float3 { return {log(x.x), log(x.y), log(x.z)} }
 @(require_results) log_float4 :: proc "c" (x: float4) -> float4 { return {log(x.x), log(x.y), log(x.z), log(x.w)} }
@@ -471,8 +604,12 @@ log :: proc{
 
 
 log2 :: proc{
+	log2_half,
 	log2_float,
 	log2_double,
+	log2_half2,
+	log2_half3,
+	log2_half4,
 	log2_float2,
 	log2_float3,
 	log2_float4,
@@ -480,6 +617,9 @@ log2 :: proc{
 	log2_double3,
 	log2_double4,
 }
+@(require_results) log2_half2 :: proc "c" (x: half2) -> half2 { return {log2(x.x), log2(x.y)} }
+@(require_results) log2_half3 :: proc "c" (x: half3) -> half3 { return {log2(x.x), log2(x.y), log2(x.z)} }
+@(require_results) log2_half4 :: proc "c" (x: half4) -> half4 { return {log2(x.x), log2(x.y), log2(x.z), log2(x.w)} }
 @(require_results) log2_float2 :: proc "c" (x: float2) -> float2 { return {log2(x.x), log2(x.y)} }
 @(require_results) log2_float3 :: proc "c" (x: float3) -> float3 { return {log2(x.x), log2(x.y), log2(x.z)} }
 @(require_results) log2_float4 :: proc "c" (x: float4) -> float4 { return {log2(x.x), log2(x.y), log2(x.z), log2(x.w)} }
@@ -490,8 +630,12 @@ log2 :: proc{
 
 
 log10 :: proc{
+	log10_half,
 	log10_float,
 	log10_double,
+	log10_half2,
+	log10_half3,
+	log10_half4,
 	log10_float2,
 	log10_float3,
 	log10_float4,
@@ -499,6 +643,9 @@ log10 :: proc{
 	log10_double3,
 	log10_double4,
 }
+@(require_results) log10_half2 :: proc "c" (x: half2) -> half2 { return {log10(x.x), log10(x.y)} }
+@(require_results) log10_half3 :: proc "c" (x: half3) -> half3 { return {log10(x.x), log10(x.y), log10(x.z)} }
+@(require_results) log10_half4 :: proc "c" (x: half4) -> half4 { return {log10(x.x), log10(x.y), log10(x.z), log10(x.w)} }
 @(require_results) log10_float2 :: proc "c" (x: float2) -> float2 { return {log10(x.x), log10(x.y)} }
 @(require_results) log10_float3 :: proc "c" (x: float3) -> float3 { return {log10(x.x), log10(x.y), log10(x.z)} }
 @(require_results) log10_float4 :: proc "c" (x: float4) -> float4 { return {log10(x.x), log10(x.y), log10(x.z), log10(x.w)} }
@@ -510,8 +657,12 @@ log10 :: proc{
 
 
 exp2 :: proc{
+	exp2_half,
 	exp2_float,
 	exp2_double,
+	exp2_half2,
+	exp2_half3,
+	exp2_half4,
 	exp2_float2,
 	exp2_float3,
 	exp2_float4,
@@ -519,6 +670,9 @@ exp2 :: proc{
 	exp2_double3,
 	exp2_double4,
 }
+@(require_results) exp2_half2 :: proc "c" (x: half2) -> half2 { return {exp2(x.x), exp2(x.y)} }
+@(require_results) exp2_half3 :: proc "c" (x: half3) -> half3 { return {exp2(x.x), exp2(x.y), exp2(x.z)} }
+@(require_results) exp2_half4 :: proc "c" (x: half4) -> half4 { return {exp2(x.x), exp2(x.y), exp2(x.z), exp2(x.w)} }
 @(require_results) exp2_float2 :: proc "c" (x: float2) -> float2 { return {exp2(x.x), exp2(x.y)} }
 @(require_results) exp2_float3 :: proc "c" (x: float3) -> float3 { return {exp2(x.x), exp2(x.y), exp2(x.z)} }
 @(require_results) exp2_float4 :: proc "c" (x: float4) -> float4 { return {exp2(x.x), exp2(x.y), exp2(x.z), exp2(x.w)} }
@@ -528,10 +682,14 @@ exp2 :: proc{
 
 
 sign :: proc{
+	sign_half,
 	sign_int,
 	sign_uint,
 	sign_float,
 	sign_double,
+	sign_half2,
+	sign_half3,
+	sign_half4,
 	sign_float2,
 	sign_float3,
 	sign_float4,
@@ -547,6 +705,9 @@ sign :: proc{
 }
 @(require_results) sign_int :: proc "c" (x: int) -> int { return -1 if x < 0 else +1 if x > 0 else 0 }
 @(require_results) sign_uint :: proc "c" (x: uint) -> uint { return +1 if x > 0 else 0 }
+@(require_results) sign_half2 :: proc "c" (x: half2) -> half2 { return {sign(x.x), sign(x.y)} }
+@(require_results) sign_half3 :: proc "c" (x: half3) -> half3 { return {sign(x.x), sign(x.y), sign(x.z)} }
+@(require_results) sign_half4 :: proc "c" (x: half4) -> half4 { return {sign(x.x), sign(x.y), sign(x.z), sign(x.w)} }
 @(require_results) sign_float2 :: proc "c" (x: float2) -> float2 { return {sign(x.x), sign(x.y)} }
 @(require_results) sign_float3 :: proc "c" (x: float3) -> float3 { return {sign(x.x), sign(x.y), sign(x.z)} }
 @(require_results) sign_float4 :: proc "c" (x: float4) -> float4 { return {sign(x.x), sign(x.y), sign(x.z), sign(x.w)} }
@@ -561,8 +722,12 @@ sign :: proc{
 @(require_results) sign_uint4 :: proc "c" (x: uint4) -> uint4 { return {sign(x.x), sign(x.y), sign(x.z), sign(x.w)} }
 
 floor :: proc{
+	floor_half,
 	floor_float,
 	floor_double,
+	floor_half2,
+	floor_half3,
+	floor_half4,
 	floor_float2,
 	floor_float3,
 	floor_float4,
@@ -570,6 +735,9 @@ floor :: proc{
 	floor_double3,
 	floor_double4,
 }
+@(require_results) floor_half2 :: proc "c" (x: half2) -> half2 { return {floor(x.x), floor(x.y)} }
+@(require_results) floor_half3 :: proc "c" (x: half3) -> half3 { return {floor(x.x), floor(x.y), floor(x.z)} }
+@(require_results) floor_half4 :: proc "c" (x: half4) -> half4 { return {floor(x.x), floor(x.y), floor(x.z), floor(x.w)} }
 @(require_results) floor_float2 :: proc "c" (x: float2) -> float2 { return {floor(x.x), floor(x.y)} }
 @(require_results) floor_float3 :: proc "c" (x: float3) -> float3 { return {floor(x.x), floor(x.y), floor(x.z)} }
 @(require_results) floor_float4 :: proc "c" (x: float4) -> float4 { return {floor(x.x), floor(x.y), floor(x.z), floor(x.w)} }
@@ -578,8 +746,12 @@ floor :: proc{
 @(require_results) floor_double4 :: proc "c" (x: double4) -> double4 { return {floor(x.x), floor(x.y), floor(x.z), floor(x.w)} }
 
 round :: proc{
+	round_half,
 	round_float,
 	round_double,
+	round_half2,
+	round_half3,
+	round_half4,
 	round_float2,
 	round_float3,
 	round_float4,
@@ -587,6 +759,9 @@ round :: proc{
 	round_double3,
 	round_double4,
 }
+@(require_results) round_half2 :: proc "c" (x: half2) -> half2 { return {round(x.x), round(x.y)} }
+@(require_results) round_half3 :: proc "c" (x: half3) -> half3 { return {round(x.x), round(x.y), round(x.z)} }
+@(require_results) round_half4 :: proc "c" (x: half4) -> half4 { return {round(x.x), round(x.y), round(x.z), round(x.w)} }
 @(require_results) round_float2 :: proc "c" (x: float2) -> float2 { return {round(x.x), round(x.y)} }
 @(require_results) round_float3 :: proc "c" (x: float3) -> float3 { return {round(x.x), round(x.y), round(x.z)} }
 @(require_results) round_float4 :: proc "c" (x: float4) -> float4 { return {round(x.x), round(x.y), round(x.z), round(x.w)} }
@@ -596,8 +771,12 @@ round :: proc{
 
 
 ceil :: proc{
+	ceil_half,
 	ceil_float,
 	ceil_double,
+	ceil_half2,
+	ceil_half3,
+	ceil_half4,
 	ceil_float2,
 	ceil_float3,
 	ceil_float4,
@@ -605,6 +784,9 @@ ceil :: proc{
 	ceil_double3,
 	ceil_double4,
 }
+@(require_results) ceil_half2 :: proc "c" (x: half2) -> half2 { return {ceil(x.x), ceil(x.y)} }
+@(require_results) ceil_half3 :: proc "c" (x: half3) -> half3 { return {ceil(x.x), ceil(x.y), ceil(x.z)} }
+@(require_results) ceil_half4 :: proc "c" (x: half4) -> half4 { return {ceil(x.x), ceil(x.y), ceil(x.z), ceil(x.w)} }
 @(require_results) ceil_float2 :: proc "c" (x: float2) -> float2 { return {ceil(x.x), ceil(x.y)} }
 @(require_results) ceil_float3 :: proc "c" (x: float3) -> float3 { return {ceil(x.x), ceil(x.y), ceil(x.z)} }
 @(require_results) ceil_float4 :: proc "c" (x: float4) -> float4 { return {ceil(x.x), ceil(x.y), ceil(x.z), ceil(x.w)} }
@@ -613,6 +795,10 @@ ceil :: proc{
 @(require_results) ceil_double4 :: proc "c" (x: double4) -> double4 { return {ceil(x.x), ceil(x.y), ceil(x.z), ceil(x.w)} }
 
 
+@(require_results) isfinite_half  :: proc "c" (x: half)  -> bool  { return !isinf_half(x) }
+@(require_results) isfinite_half2 :: proc "c" (x: half2) -> bool2 { return {isfinite_half(x.x), isfinite_half(x.y)} }
+@(require_results) isfinite_half3 :: proc "c" (x: half3) -> bool3 { return {isfinite_half(x.x), isfinite_half(x.y), isfinite_half(x.z)} }
+@(require_results) isfinite_half4 :: proc "c" (x: half4) -> bool4 { return {isfinite_half(x.x), isfinite_half(x.y), isfinite_half(x.z), isfinite_half(x.w)} }
 @(require_results) isfinite_float  :: proc "c" (x: float)  -> bool  { return !isinf_float(x) }
 @(require_results) isfinite_float2 :: proc "c" (x: float2) -> bool2 { return {isfinite_float(x.x), isfinite_float(x.y)} }
 @(require_results) isfinite_float3 :: proc "c" (x: float3) -> bool3 { return {isfinite_float(x.x), isfinite_float(x.y), isfinite_float(x.z)} }
@@ -624,6 +810,10 @@ ceil :: proc{
 
 // isfinite is the opposite of isinf and returns true if the number is neither positive-infinite or negative-infinite
 isfinite :: proc{
+	isfinite_half,
+	isfinite_half2,
+	isfinite_half3,
+	isfinite_half4,
 	isfinite_float,
 	isfinite_float2,
 	isfinite_float3,
@@ -635,6 +825,10 @@ isfinite :: proc{
 }
 
 
+@(require_results) isinf_half  :: proc "c" (x: half)  -> bool  { return x * 0.5 == x }
+@(require_results) isinf_half2 :: proc "c" (x: half2) -> bool2 { return {isinf_half(x.x), isinf_half(x.y)} }
+@(require_results) isinf_half3 :: proc "c" (x: half3) -> bool3 { return {isinf_half(x.x), isinf_half(x.y), isinf_half(x.z)} }
+@(require_results) isinf_half4 :: proc "c" (x: half4) -> bool4 { return {isinf_half(x.x), isinf_half(x.y), isinf_half(x.z), isinf_half(x.w)} }
 @(require_results) isinf_float  :: proc "c" (x: float)  -> bool  { return x * 0.5 == x }
 @(require_results) isinf_float2 :: proc "c" (x: float2) -> bool2 { return {isinf_float(x.x), isinf_float(x.y)} }
 @(require_results) isinf_float3 :: proc "c" (x: float3) -> bool3 { return {isinf_float(x.x), isinf_float(x.y), isinf_float(x.z)} }
@@ -646,6 +840,10 @@ isfinite :: proc{
 
 // isinf is the opposite of isfinite and returns true if the number is either positive-infinite or negative-infinite
 isinf :: proc{
+	isinf_half,
+	isinf_half2,
+	isinf_half3,
+	isinf_half4,
 	isinf_float,
 	isinf_float2,
 	isinf_float3,
@@ -657,6 +855,9 @@ isinf :: proc{
 }
 
 
+@(require_results) isnan_half2 :: proc "c" (x: half2) -> bool2 { return {isnan_half(x.x), isnan_half(x.y)} }
+@(require_results) isnan_half3 :: proc "c" (x: half3) -> bool3 { return {isnan_half(x.x), isnan_half(x.y), isnan_half(x.z)} }
+@(require_results) isnan_half4 :: proc "c" (x: half4) -> bool4 { return {isnan_half(x.x), isnan_half(x.y), isnan_half(x.z), isnan_half(x.w)} }
 @(require_results) isnan_float2 :: proc "c" (x: float2) -> bool2 { return {isnan_float(x.x), isnan_float(x.y)} }
 @(require_results) isnan_float3 :: proc "c" (x: float3) -> bool3 { return {isnan_float(x.x), isnan_float(x.y), isnan_float(x.z)} }
 @(require_results) isnan_float4 :: proc "c" (x: float4) -> bool4 { return {isnan_float(x.x), isnan_float(x.y), isnan_float(x.z), isnan_float(x.w)} }
@@ -666,6 +867,10 @@ isinf :: proc{
 
 // isnan returns true if the input value is the special case of Not-A-Number
 isnan :: proc{
+	isnan_half,
+	isnan_half2,
+	isnan_half3,
+	isnan_half4,
 	isnan_float,
 	isnan_float2,
 	isnan_float3,
@@ -677,8 +882,12 @@ isnan :: proc{
 }
 
 fmod :: proc{
+	fmod_half,
 	fmod_float,
 	fmod_double,
+	fmod_half2,
+	fmod_half3,
+	fmod_half4,
 	fmod_float2,
 	fmod_float3,
 	fmod_float4,
@@ -686,6 +895,9 @@ fmod :: proc{
 	fmod_double3,
 	fmod_double4,
 }
+@(require_results) fmod_half2 :: proc "c" (x, y: half2) -> half2 { return {fmod(x.x, y.x), fmod(x.y, y.y)} }
+@(require_results) fmod_half3 :: proc "c" (x, y: half3) -> half3 { return {fmod(x.x, y.x), fmod(x.y, y.y), fmod(x.z, y.z)} }
+@(require_results) fmod_half4 :: proc "c" (x, y: half4) -> half4 { return {fmod(x.x, y.x), fmod(x.y, y.y), fmod(x.z, y.z), fmod(x.w, y.w)} }
 @(require_results) fmod_float2 :: proc "c" (x, y: float2) -> float2 { return {fmod(x.x, y.x), fmod(x.y, y.y)} }
 @(require_results) fmod_float3 :: proc "c" (x, y: float3) -> float3 { return {fmod(x.x, y.x), fmod(x.y, y.y), fmod(x.z, y.z)} }
 @(require_results) fmod_float4 :: proc "c" (x, y: float4) -> float4 { return {fmod(x.x, y.x), fmod(x.y, y.y), fmod(x.z, y.z), fmod(x.w, y.w)} }
@@ -695,8 +907,12 @@ fmod :: proc{
 
 
 frac :: proc{
+	frac_half,
 	frac_float,
 	frac_double,
+	frac_half2,
+	frac_half3,
+	frac_half4,
 	frac_float2,
 	frac_float3,
 	frac_float4,
@@ -704,6 +920,9 @@ frac :: proc{
 	frac_double3,
 	frac_double4,
 }
+@(require_results) frac_half2 :: proc "c" (x: half2) -> half2 { return {frac(x.x), frac(x.y)} }
+@(require_results) frac_half3 :: proc "c" (x: half3) -> half3 { return {frac(x.x), frac(x.y), frac(x.z)} }
+@(require_results) frac_half4 :: proc "c" (x: half4) -> half4 { return {frac(x.x), frac(x.y), frac(x.z), frac(x.w)} }
 @(require_results) frac_float2 :: proc "c" (x: float2) -> float2 { return {frac(x.x), frac(x.y)} }
 @(require_results) frac_float3 :: proc "c" (x: float3) -> float3 { return {frac(x.x), frac(x.y), frac(x.z)} }
 @(require_results) frac_float4 :: proc "c" (x: float4) -> float4 { return {frac(x.x), frac(x.y), frac(x.z), frac(x.w)} }
@@ -714,8 +933,12 @@ frac :: proc{
 
 
 radians :: proc{
+	radians_half,
 	radians_float,
 	radians_double,
+	radians_half2,
+	radians_half3,
+	radians_half4,
 	radians_float2,
 	radians_float3,
 	radians_float4,
@@ -723,8 +946,12 @@ radians :: proc{
 	radians_double3,
 	radians_double4,
 }
+@(require_results) radians_half  :: proc "c" (degrees: half)  -> half  { return degrees * TAU / 360.0 }
 @(require_results) radians_float  :: proc "c" (degrees: float)  -> float  { return degrees * TAU / 360.0 }
 @(require_results) radians_double  :: proc "c" (degrees: double)  -> double  { return degrees * TAU / 360.0 }
+@(require_results) radians_half2 :: proc "c" (degrees: half2) -> half2 { return degrees * TAU / 360.0 }
+@(require_results) radians_half3 :: proc "c" (degrees: half3) -> half3 { return degrees * TAU / 360.0 }
+@(require_results) radians_half4 :: proc "c" (degrees: half4) -> half4 { return degrees * TAU / 360.0 }
 @(require_results) radians_float2 :: proc "c" (degrees: float2) -> float2 { return degrees * TAU / 360.0 }
 @(require_results) radians_float3 :: proc "c" (degrees: float3) -> float3 { return degrees * TAU / 360.0 }
 @(require_results) radians_float4 :: proc "c" (degrees: float4) -> float4 { return degrees * TAU / 360.0 }
@@ -734,8 +961,12 @@ radians :: proc{
 
 
 degrees :: proc{
+	degrees_half,
 	degrees_float,
 	degrees_double,
+	degrees_half2,
+	degrees_half3,
+	degrees_half4,
 	degrees_float2,
 	degrees_float3,
 	degrees_float4,
@@ -743,8 +974,12 @@ degrees :: proc{
 	degrees_double3,
 	degrees_double4,
 }
+@(require_results) degrees_half  :: proc "c" (radians: half)  -> half  { return radians * 360.0 / TAU }
 @(require_results) degrees_float  :: proc "c" (radians: float)  -> float  { return radians * 360.0 / TAU }
 @(require_results) degrees_double  :: proc "c" (radians: double)  -> double  { return radians * 360.0 / TAU }
+@(require_results) degrees_half2 :: proc "c" (radians: half2) -> half2 { return radians * 360.0 / TAU }
+@(require_results) degrees_half3 :: proc "c" (radians: half3) -> half3 { return radians * 360.0 / TAU }
+@(require_results) degrees_half4 :: proc "c" (radians: half4) -> half4 { return radians * 360.0 / TAU }
 @(require_results) degrees_float2 :: proc "c" (radians: float2) -> float2 { return radians * 360.0 / TAU }
 @(require_results) degrees_float3 :: proc "c" (radians: float3) -> float3 { return radians * 360.0 / TAU }
 @(require_results) degrees_float4 :: proc "c" (radians: float4) -> float4 { return radians * 360.0 / TAU }
@@ -753,10 +988,14 @@ degrees :: proc{
 @(require_results) degrees_double4 :: proc "c" (radians: double4) -> double4 { return radians * 360.0 / TAU }
 
 min :: proc{
+	min_half,
 	min_int,  
 	min_uint,  
 	min_float,  
 	min_double,
+	min_half2,
+	min_half3,
+	min_half4,
 	min_float2, 
 	min_float3, 
 	min_float4, 
@@ -772,8 +1011,12 @@ min :: proc{
 }
 @(require_results) min_int  :: proc "c" (x, y: int) -> int   { return builtin.min(x, y) }
 @(require_results) min_uint  :: proc "c" (x, y: uint) -> uint   { return builtin.min(x, y) }
+@(require_results) min_half  :: proc "c" (x, y: half) -> half   { return builtin.min(x, y) }
 @(require_results) min_float  :: proc "c" (x, y: float) -> float   { return builtin.min(x, y) }
 @(require_results) min_double  :: proc "c" (x, y: double) -> double   { return builtin.min(x, y) }
+@(require_results) min_half2 :: proc "c" (x, y: half2) -> half2 { return {min(x.x, y.x), min(x.y, y.y)} }
+@(require_results) min_half3 :: proc "c" (x, y: half3) -> half3 { return {min(x.x, y.x), min(x.y, y.y), min(x.z, y.z)} }
+@(require_results) min_half4 :: proc "c" (x, y: half4) -> half4 { return {min(x.x, y.x), min(x.y, y.y), min(x.z, y.z), min(x.w, y.w)} }
 @(require_results) min_float2 :: proc "c" (x, y: float2) -> float2 { return {min(x.x, y.x), min(x.y, y.y)} }
 @(require_results) min_float3 :: proc "c" (x, y: float3) -> float3 { return {min(x.x, y.x), min(x.y, y.y), min(x.z, y.z)} }
 @(require_results) min_float4 :: proc "c" (x, y: float4) -> float4 { return {min(x.x, y.x), min(x.y, y.y), min(x.z, y.z), min(x.w, y.w)} }
@@ -790,9 +1033,13 @@ min :: proc{
 
 max :: proc{
 	max_int,  
-	max_uint,  
+	max_uint,
+	max_half,
 	max_float,  
 	max_double,
+	max_half2,
+	max_half3,
+	max_half4,
 	max_float2, 
 	max_float3, 
 	max_float4, 
@@ -809,7 +1056,11 @@ max :: proc{
 @(require_results) max_int  :: proc "c" (x, y: int) -> int   { return builtin.max(x, y) }
 @(require_results) max_uint  :: proc "c" (x, y: uint) -> uint   { return builtin.max(x, y) }
 @(require_results) max_float  :: proc "c" (x, y: float) -> float   { return builtin.max(x, y) }
+@(require_results) max_half  :: proc "c" (x, y: half) -> half   { return builtin.max(x, y) }
 @(require_results) max_double  :: proc "c" (x, y: double) -> double   { return builtin.max(x, y) }
+@(require_results) max_half2 :: proc "c" (x, y: half2) -> half2 { return {max(x.x, y.x), max(x.y, y.y)} }
+@(require_results) max_half3 :: proc "c" (x, y: half3) -> half3 { return {max(x.x, y.x), max(x.y, y.y), max(x.z, y.z)} }
+@(require_results) max_half4 :: proc "c" (x, y: half4) -> half4 { return {max(x.x, y.x), max(x.y, y.y), max(x.z, y.z), max(x.w, y.w)} }
 @(require_results) max_float2 :: proc "c" (x, y: float2) -> float2 { return {max(x.x, y.x), max(x.y, y.y)} }
 @(require_results) max_float3 :: proc "c" (x, y: float3) -> float3 { return {max(x.x, y.x), max(x.y, y.y), max(x.z, y.z)} }
 @(require_results) max_float4 :: proc "c" (x, y: float4) -> float4 { return {max(x.x, y.x), max(x.y, y.y), max(x.z, y.z), max(x.w, y.w)} }
@@ -828,8 +1079,12 @@ max :: proc{
 clamp :: proc{
 	clamp_int, 
 	clamp_uint, 
-	clamp_float,  
+	clamp_half,
+	clamp_float,
 	clamp_double,
+	clamp_half2,
+	clamp_half3,
+	clamp_half4,
 	clamp_float2, 
 	clamp_float3, 
 	clamp_float4, 
@@ -845,8 +1100,12 @@ clamp :: proc{
 }
 @(require_results) clamp_int  :: proc "c" (x, y, z: int) -> int   { return builtin.clamp(x, y, z) }
 @(require_results) clamp_uint  :: proc "c" (x, y, z: uint) -> uint   { return builtin.clamp(x, y, z) }
+@(require_results) clamp_half  :: proc "c" (x, y, z: half) -> half   { return builtin.clamp(x, y, z) }
 @(require_results) clamp_float  :: proc "c" (x, y, z: float) -> float   { return builtin.clamp(x, y, z) }
 @(require_results) clamp_double  :: proc "c" (x, y, z: double) -> double   { return builtin.clamp(x, y, z) }
+@(require_results) clamp_half2 :: proc "c" (x, y, z: half2) -> half2 { return {clamp(x.x, y.x, z.x), clamp(x.y, y.y, z.y)} }
+@(require_results) clamp_half3 :: proc "c" (x, y, z: half3) -> half3 { return {clamp(x.x, y.x, z.x), clamp(x.y, y.y, z.y), clamp(x.z, y.z, z.z)} }
+@(require_results) clamp_half4 :: proc "c" (x, y, z: half4) -> half4 { return {clamp(x.x, y.x, z.x), clamp(x.y, y.y, z.y), clamp(x.z, y.z, z.z), clamp(x.w, y.w, z.w)} }
 @(require_results) clamp_float2 :: proc "c" (x, y, z: float2) -> float2 { return {clamp(x.x, y.x, z.x), clamp(x.y, y.y, z.y)} }
 @(require_results) clamp_float3 :: proc "c" (x, y, z: float3) -> float3 { return {clamp(x.x, y.x, z.x), clamp(x.y, y.y, z.y), clamp(x.z, y.z, z.z)} }
 @(require_results) clamp_float4 :: proc "c" (x, y, z: float4) -> float4 { return {clamp(x.x, y.x, z.x), clamp(x.y, y.y, z.y), clamp(x.z, y.z, z.z), clamp(x.w, y.w, z.w)} }
@@ -863,8 +1122,12 @@ clamp :: proc{
 saturate :: proc{
 	saturate_int,
 	saturate_uint,
+	saturate_half,
 	saturate_float,
 	saturate_double,
+	saturate_half2,
+	saturate_half3,
+	saturate_half4,
 	saturate_float2,
 	saturate_float3,
 	saturate_float4,
@@ -880,8 +1143,12 @@ saturate :: proc{
 }
 @(require_results) saturate_int  :: proc "c" (v: int) -> int   { return builtin.clamp(v, 0, 1) }
 @(require_results) saturate_uint  :: proc "c" (v: uint) -> uint   { return builtin.clamp(v, 0, 1) }
+@(require_results) saturate_half  :: proc "c" (v: half) -> half   { return builtin.clamp(v, 0, 1) }
 @(require_results) saturate_float  :: proc "c" (v: float) -> float   { return builtin.clamp(v, 0, 1) }
 @(require_results) saturate_double  :: proc "c" (v: double) -> double   { return builtin.clamp(v, 0, 1) }
+@(require_results) saturate_half2 :: proc "c" (v: half2) -> half2 { return {builtin.clamp(v.x, 0, 1), builtin.clamp(v.y, 0, 1)} }
+@(require_results) saturate_half3 :: proc "c" (v: half3) -> half3 { return {builtin.clamp(v.x, 0, 1), builtin.clamp(v.y, 0, 1), builtin.clamp(v.z, 0, 1)} }
+@(require_results) saturate_half4 :: proc "c" (v: half4) -> half4 { return {builtin.clamp(v.x, 0, 1), builtin.clamp(v.y, 0, 1), builtin.clamp(v.z, 0, 1), builtin.clamp(v.w, 0, 1)} }
 @(require_results) saturate_float2 :: proc "c" (v: float2) -> float2 { return {builtin.clamp(v.x, 0, 1), builtin.clamp(v.y, 0, 1)} }
 @(require_results) saturate_float3 :: proc "c" (v: float3) -> float3 { return {builtin.clamp(v.x, 0, 1), builtin.clamp(v.y, 0, 1), builtin.clamp(v.z, 0, 1)} }
 @(require_results) saturate_float4 :: proc "c" (v: float4) -> float4 { return {builtin.clamp(v.x, 0, 1), builtin.clamp(v.y, 0, 1), builtin.clamp(v.z, 0, 1), builtin.clamp(v.w, 0, 1)} }
@@ -897,8 +1164,12 @@ saturate :: proc{
 
 
 lerp :: proc{
+	lerp_half,
 	lerp_float,
 	lerp_double,
+	lerp_half2,
+	lerp_half3,
+	lerp_half4,
 	lerp_float2,
 	lerp_float3,
 	lerp_float4,
@@ -906,8 +1177,12 @@ lerp :: proc{
 	lerp_double3,
 	lerp_double4,
 }
+@(require_results) lerp_half  :: proc "c" (x, y, t: half) -> half   { return x*(1-t) + y*t }
 @(require_results) lerp_float  :: proc "c" (x, y, t: float) -> float   { return x*(1-t) + y*t }
 @(require_results) lerp_double  :: proc "c" (x, y, t: double) -> double   { return x*(1-t) + y*t }
+@(require_results) lerp_half2 :: proc "c" (x, y, t: half2) -> half2 { return {lerp(x.x, y.x, t.x), lerp(x.y, y.y, t.y)} }
+@(require_results) lerp_half3 :: proc "c" (x, y, t: half3) -> half3 { return {lerp(x.x, y.x, t.x), lerp(x.y, y.y, t.y), lerp(x.z, y.z, t.z)} }
+@(require_results) lerp_half4 :: proc "c" (x, y, t: half4) -> half4 { return {lerp(x.x, y.x, t.x), lerp(x.y, y.y, y.y), lerp(x.z, y.z, t.z), lerp(x.w, y.w, t.w)} }
 @(require_results) lerp_float2 :: proc "c" (x, y, t: float2) -> float2 { return {lerp(x.x, y.x, t.x), lerp(x.y, y.y, t.y)} }
 @(require_results) lerp_float3 :: proc "c" (x, y, t: float3) -> float3 { return {lerp(x.x, y.x, t.x), lerp(x.y, y.y, t.y), lerp(x.z, y.z, t.z)} }
 @(require_results) lerp_float4 :: proc "c" (x, y, t: float4) -> float4 { return {lerp(x.x, y.x, t.x), lerp(x.y, y.y, y.y), lerp(x.z, y.z, t.z), lerp(x.w, y.w, t.w)} }
@@ -917,8 +1192,12 @@ lerp :: proc{
 
 
 step :: proc{
+	step_half,
 	step_float,
 	step_double,
+	step_half2,
+	step_half3,
+	step_half4,
 	step_float2,
 	step_float3,
 	step_float4,
@@ -926,8 +1205,12 @@ step :: proc{
 	step_double3,
 	step_double4,
 }
+@(require_results) step_half  :: proc "c" (edge, x: half) -> half   { return 0 if x < edge else 1 }
 @(require_results) step_float  :: proc "c" (edge, x: float) -> float   { return 0 if x < edge else 1 }
 @(require_results) step_double  :: proc "c" (edge, x: double) -> double   { return 0 if x < edge else 1 }
+@(require_results) step_half2 :: proc "c" (edge, x: half2) -> half2 { return {step(edge.x, x.x), step(edge.y, x.y)} }
+@(require_results) step_half3 :: proc "c" (edge, x: half3) -> half3 { return {step(edge.x, x.x), step(edge.y, x.y), step(edge.z, x.z)} }
+@(require_results) step_half4 :: proc "c" (edge, x: half4) -> half4 { return {step(edge.x, x.x), step(edge.y, x.y), step(edge.z, x.z), step(edge.w, x.w)} }
 @(require_results) step_float2 :: proc "c" (edge, x: float2) -> float2 { return {step(edge.x, x.x), step(edge.y, x.y)} }
 @(require_results) step_float3 :: proc "c" (edge, x: float3) -> float3 { return {step(edge.x, x.x), step(edge.y, x.y), step(edge.z, x.z)} }
 @(require_results) step_float4 :: proc "c" (edge, x: float4) -> float4 { return {step(edge.x, x.x), step(edge.y, x.y), step(edge.z, x.z), step(edge.w, x.w)} }
@@ -936,14 +1219,22 @@ step :: proc{
 @(require_results) step_double4 :: proc "c" (edge, x: double4) -> double4 { return {step(edge.x, x.x), step(edge.y, x.y), step(edge.z, x.z), step(edge.w, x.w)} }
 
 smoothstep :: proc{
+	smoothstep_half,
 	smoothstep_float,
 	smoothstep_double,
+	smoothstep_half2,
+	smoothstep_half3,
+	smoothstep_half4,
 	smoothstep_float2,
 	smoothstep_float3,
 	smoothstep_float4,
 	smoothstep_double2,
 	smoothstep_double3,
 	smoothstep_double4,
+}
+@(require_results) smoothstep_half :: proc "c" (edge0, edge1, x: half) -> half {
+	y := clamp(((x-edge0) / (edge1 - edge0)), 0, 1)
+	return y * y * (3 - 2*y)
 }
 @(require_results) smoothstep_float :: proc "c" (edge0, edge1, x: float) -> float {
 	y := clamp(((x-edge0) / (edge1 - edge0)), 0, 1)
@@ -953,6 +1244,9 @@ smoothstep :: proc{
 	y := clamp(((x-edge0) / (edge1 - edge0)), 0, 1)
 	return y * y * (3 - 2*y)
 }
+@(require_results) smoothstep_half2  :: proc "c" (edge0, edge1, x: half2) -> half2   { return {smoothstep(edge0.x, edge1.x, x.x), smoothstep(edge0.y, edge1.y, x.y)} }
+@(require_results) smoothstep_half3  :: proc "c" (edge0, edge1, x: half3) -> half3   { return {smoothstep(edge0.x, edge1.x, x.x), smoothstep(edge0.y, edge1.y, x.y), smoothstep(edge0.z, edge1.z, x.z)} }
+@(require_results) smoothstep_half4  :: proc "c" (edge0, edge1, x: half4) -> half4   { return {smoothstep(edge0.x, edge1.x, x.x), smoothstep(edge0.y, edge1.y, x.y), smoothstep(edge0.z, edge1.z, x.z), smoothstep(edge0.w, edge1.w, x.w)} }
 @(require_results) smoothstep_float2  :: proc "c" (edge0, edge1, x: float2) -> float2   { return {smoothstep(edge0.x, edge1.x, x.x), smoothstep(edge0.y, edge1.y, x.y)} }
 @(require_results) smoothstep_float3  :: proc "c" (edge0, edge1, x: float3) -> float3   { return {smoothstep(edge0.x, edge1.x, x.x), smoothstep(edge0.y, edge1.y, x.y), smoothstep(edge0.z, edge1.z, x.z)} }
 @(require_results) smoothstep_float4  :: proc "c" (edge0, edge1, x: float4) -> float4   { return {smoothstep(edge0.x, edge1.x, x.x), smoothstep(edge0.y, edge1.y, x.y), smoothstep(edge0.z, edge1.z, x.z), smoothstep(edge0.w, edge1.w, x.w)} }
@@ -964,8 +1258,12 @@ smoothstep :: proc{
 abs :: proc{
 	abs_int,
 	abs_uint,
+	abs_half,
 	abs_float,
 	abs_double,
+	abs_half2,
+	abs_half3,
+	abs_half4,
 	abs_float2,
 	abs_float3,
 	abs_float4,
@@ -981,8 +1279,12 @@ abs :: proc{
 }
 @(require_results) abs_int  :: proc "c" (x: int)  -> int  { return builtin.abs(x) }
 @(require_results) abs_uint  :: proc "c" (x: uint)  -> uint  { return x }
+@(require_results) abs_half  :: proc "c" (x: half)  -> half  { return builtin.abs(x) }
 @(require_results) abs_float  :: proc "c" (x: float)  -> float  { return builtin.abs(x) }
 @(require_results) abs_double  :: proc "c" (x: double)  -> double  { return builtin.abs(x) }
+@(require_results) abs_half2 :: proc "c" (x: half2) -> half2 { return {abs(x.x), abs(x.y)} }
+@(require_results) abs_half3 :: proc "c" (x: half3) -> half3 { return {abs(x.x), abs(x.y), abs(x.z)} }
+@(require_results) abs_half4 :: proc "c" (x: half4) -> half4 { return {abs(x.x), abs(x.y), abs(x.z), abs(x.w)} }
 @(require_results) abs_float2 :: proc "c" (x: float2) -> float2 { return {abs(x.x), abs(x.y)} }
 @(require_results) abs_float3 :: proc "c" (x: float3) -> float3 { return {abs(x.x), abs(x.y), abs(x.z)} }
 @(require_results) abs_float4 :: proc "c" (x: float4) -> float4 { return {abs(x.x), abs(x.y), abs(x.z), abs(x.w)} }
@@ -999,8 +1301,12 @@ abs :: proc{
 dot :: proc{
 	dot_int,
 	dot_uint,
+	dot_half,
 	dot_float,
 	dot_double,
+	dot_half2,
+	dot_half3,
+	dot_half4,
 	dot_float2,
 	dot_float3,
 	dot_float4,
@@ -1016,8 +1322,12 @@ dot :: proc{
 }
 @(require_results) dot_int  :: proc "c" (a, b: int)  -> int { return a*b }
 @(require_results) dot_uint  :: proc "c" (a, b: uint)  -> uint { return a*b }
+@(require_results) dot_half  :: proc "c" (a, b: half)  -> half { return a*b }
 @(require_results) dot_float  :: proc "c" (a, b: float)  -> float { return a*b }
 @(require_results) dot_double  :: proc "c" (a, b: double)  -> double { return a*b }
+@(require_results) dot_half2 :: proc "c" (a, b: half2) -> half { return a.x*b.x + a.y*b.y }
+@(require_results) dot_half3 :: proc "c" (a, b: half3) -> half { return a.x*b.x + a.y*b.y + a.z*b.z }
+@(require_results) dot_half4 :: proc "c" (a, b: half4) -> half { return a.x*b.x + a.y*b.y + a.z*b.z + a.w*b.w }
 @(require_results) dot_float2 :: proc "c" (a, b: float2) -> float { return a.x*b.x + a.y*b.y }
 @(require_results) dot_float3 :: proc "c" (a, b: float3) -> float { return a.x*b.x + a.y*b.y + a.z*b.z }
 @(require_results) dot_float4 :: proc "c" (a, b: float4) -> float { return a.x*b.x + a.y*b.y + a.z*b.z + a.w*b.w }
@@ -1032,8 +1342,12 @@ dot :: proc{
 @(require_results) dot_uint4 :: proc "c" (a, b: uint4) -> uint { return a.x*b.x + a.y*b.y + a.z*b.z + a.w*b.w }
 
 length :: proc{
+	length_half,
 	length_float,
 	length_double,
+	length_half2,
+	length_half3,
+	length_half4,
 	length_float2,
 	length_float3,
 	length_float4,
@@ -1041,8 +1355,12 @@ length :: proc{
 	length_double3,
 	length_double4,
 }
+@(require_results) length_half  :: proc "c" (x: half)  -> half { return builtin.abs(x) }
 @(require_results) length_float  :: proc "c" (x: float)  -> float { return builtin.abs(x) }
 @(require_results) length_double  :: proc "c" (x: double)  -> double { return builtin.abs(x) }
+@(require_results) length_half2 :: proc "c" (x: half2) -> half { return sqrt(x.x*x.x + x.y*x.y) }
+@(require_results) length_half3 :: proc "c" (x: half3) -> half { return sqrt(x.x*x.x + x.y*x.y + x.z*x.z) }
+@(require_results) length_half4 :: proc "c" (x: half4) -> half { return sqrt(x.x*x.x + x.y*x.y + x.z*x.z + x.w*x.w) }
 @(require_results) length_float2 :: proc "c" (x: float2) -> float { return sqrt(x.x*x.x + x.y*x.y) }
 @(require_results) length_float3 :: proc "c" (x: float3) -> float { return sqrt(x.x*x.x + x.y*x.y + x.z*x.z) }
 @(require_results) length_float4 :: proc "c" (x: float4) -> float { return sqrt(x.x*x.x + x.y*x.y + x.z*x.z + x.w*x.w) }
@@ -1052,8 +1370,12 @@ length :: proc{
 
 
 distance :: proc{
+	distance_half,
 	distance_float,
 	distance_double,
+	distance_half2,
+	distance_half3,
+	distance_half4,
 	distance_float2,
 	distance_float3,
 	distance_float4,
@@ -1061,8 +1383,12 @@ distance :: proc{
 	distance_double3,
 	distance_double4,
 }
+@(require_results) distance_half  :: proc "c" (x, y: half)  -> half { return length(y-x) }
 @(require_results) distance_float  :: proc "c" (x, y: float)  -> float { return length(y-x) }
 @(require_results) distance_double  :: proc "c" (x, y: double)  -> double { return length(y-x) }
+@(require_results) distance_half2 :: proc "c" (x, y: half2) -> half { return length(y-x) }
+@(require_results) distance_half3 :: proc "c" (x, y: half3) -> half { return length(y-x) }
+@(require_results) distance_half4 :: proc "c" (x, y: half4) -> half { return length(y-x) }
 @(require_results) distance_float2 :: proc "c" (x, y: float2) -> float { return length(y-x) }
 @(require_results) distance_float3 :: proc "c" (x, y: float3) -> float { return length(y-x) }
 @(require_results) distance_float4 :: proc "c" (x, y: float4) -> float { return length(y-x) }
@@ -1072,11 +1398,18 @@ distance :: proc{
 
 
 cross :: proc{
+	cross_half3,
 	cross_float3,
 	cross_double3,
 	cross_int3,
 }
 
+@(require_results) cross_half3 :: proc "c" (a, b: half3) -> (c: half3) {
+	c.x = a.y*b.z - b.y*a.z
+	c.y = a.z*b.x - b.z*a.x
+	c.z = a.x*b.y - b.x*a.y
+	return
+}
 @(require_results) cross_float3 :: proc "c" (a, b: float3) -> (c: float3) {
 	c.x = a.y*b.z - b.y*a.z
 	c.y = a.z*b.x - b.z*a.x
@@ -1097,8 +1430,12 @@ cross :: proc{
 }
 
 normalize :: proc{
+	normalize_half,
 	normalize_float,
 	normalize_double,
+	normalize_half2,
+	normalize_half3,
+	normalize_half4,
 	normalize_float2,
 	normalize_float3,
 	normalize_float4,
@@ -1106,8 +1443,12 @@ normalize :: proc{
 	normalize_double3,
 	normalize_double4,
 }
+@(require_results) normalize_half  :: proc "c" (x: half)  -> half  { return 1.0 }
 @(require_results) normalize_float  :: proc "c" (x: float)  -> float  { return 1.0 }
 @(require_results) normalize_double  :: proc "c" (x: double)  -> double  { return 1.0 }
+@(require_results) normalize_half2 :: proc "c" (x: half2) -> half2 { return x / length(x) }
+@(require_results) normalize_half3 :: proc "c" (x: half3) -> half3 { return x / length(x) }
+@(require_results) normalize_half4 :: proc "c" (x: half4) -> half4 { return x / length(x) }
 @(require_results) normalize_float2 :: proc "c" (x: float2) -> float2 { return x / length(x) }
 @(require_results) normalize_float3 :: proc "c" (x: float3) -> float3 { return x / length(x) }
 @(require_results) normalize_float4 :: proc "c" (x: float4) -> float4 { return x / length(x) }
@@ -1117,8 +1458,12 @@ normalize :: proc{
 
 
 faceforward :: proc{
+	faceforward_half,
 	faceforward_float,
 	faceforward_double,
+	faceforward_half2,
+	faceforward_half3,
+	faceforward_half4,
 	faceforward_float2,
 	faceforward_float3,
 	faceforward_float4,
@@ -1126,8 +1471,12 @@ faceforward :: proc{
 	faceforward_double3,
 	faceforward_double4,
 }
+@(require_results) faceforward_half  :: proc "c" (N, I, Nref: half)  -> half  { return N if dot(I, Nref) < 0 else -N }
 @(require_results) faceforward_float  :: proc "c" (N, I, Nref: float)  -> float  { return N if dot(I, Nref) < 0 else -N }
 @(require_results) faceforward_double  :: proc "c" (N, I, Nref: double)  -> double  { return N if dot(I, Nref) < 0 else -N }
+@(require_results) faceforward_half2 :: proc "c" (N, I, Nref: half2) -> half2 { return N if dot(I, Nref) < 0 else -N }
+@(require_results) faceforward_half3 :: proc "c" (N, I, Nref: half3) -> half3 { return N if dot(I, Nref) < 0 else -N }
+@(require_results) faceforward_half4 :: proc "c" (N, I, Nref: half4) -> half4 { return N if dot(I, Nref) < 0 else -N }
 @(require_results) faceforward_float2 :: proc "c" (N, I, Nref: float2) -> float2 { return N if dot(I, Nref) < 0 else -N }
 @(require_results) faceforward_float3 :: proc "c" (N, I, Nref: float3) -> float3 { return N if dot(I, Nref) < 0 else -N }
 @(require_results) faceforward_float4 :: proc "c" (N, I, Nref: float4) -> float4 { return N if dot(I, Nref) < 0 else -N }
@@ -1137,8 +1486,12 @@ faceforward :: proc{
 
 
 reflect :: proc{
+	reflect_half,
 	reflect_float,
 	reflect_double,
+	reflect_half2,
+	reflect_half3,
+	reflect_half4,
 	reflect_float2,
 	reflect_float3,
 	reflect_float4,
@@ -1146,8 +1499,12 @@ reflect :: proc{
 	reflect_double3,
 	reflect_double4,
 }
+@(require_results) reflect_half  :: proc "c" (I, N: half)  -> half  { return I - 2*N*dot(N, I) }
 @(require_results) reflect_float  :: proc "c" (I, N: float)  -> float  { return I - 2*N*dot(N, I) }
 @(require_results) reflect_double  :: proc "c" (I, N: double)  -> double  { return I - 2*N*dot(N, I) }
+@(require_results) reflect_half2 :: proc "c" (I, N: half2) -> half2 { return I - 2*N*dot(N, I) }
+@(require_results) reflect_half3 :: proc "c" (I, N: half3) -> half3 { return I - 2*N*dot(N, I) }
+@(require_results) reflect_half4 :: proc "c" (I, N: half4) -> half4 { return I - 2*N*dot(N, I) }
 @(require_results) reflect_float2 :: proc "c" (I, N: float2) -> float2 { return I - 2*N*dot(N, I) }
 @(require_results) reflect_float3 :: proc "c" (I, N: float3) -> float3 { return I - 2*N*dot(N, I) }
 @(require_results) reflect_float4 :: proc "c" (I, N: float4) -> float4 { return I - 2*N*dot(N, I) }
@@ -1159,14 +1516,25 @@ reflect :: proc{
 
 
 refract :: proc{
+	refract_half,
 	refract_float,
 	refract_double,
+	refract_half2,
+	refract_half3,
+	refract_half4,
 	refract_float2,
 	refract_float3,
 	refract_float4,
 	refract_double2,
 	refract_double3,
 	refract_double4,
+}
+@(require_results)
+refract_half  :: proc "c" (i, n, eta: half) -> half {
+	cosi := dot(-i, n)
+	cost2 := 1 - eta*eta*(1 - cosi*cosi)
+	t := eta*i + ((eta*cosi - sqrt(abs(cost2))) * n)
+	return t * half(int(cost2 > 0))
 }
 @(require_results)
 refract_float  :: proc "c" (i, n, eta: float) -> float {
@@ -1181,6 +1549,27 @@ refract_double  :: proc "c" (i, n, eta: double) -> double {
 	cost2 := 1 - eta*eta*(1 - cosi*cosi)
 	t := eta*i + ((eta*cosi - sqrt(abs(cost2))) * n)
 	return t * double(int(cost2 > 0))
+}
+@(require_results)
+refract_half2  :: proc "c" (i, n, eta: half2) -> half2 {
+	cosi := dot(-i, n)
+	cost2 := 1 - eta*eta*(1 - cosi*cosi)
+	t := eta*i + ((eta*cosi - sqrt(abs(cost2))) * n)
+	return t * half2{half(int(cost2.x > 0)), half(int(cost2.y > 0))}
+}
+@(require_results)
+refract_half3  :: proc "c" (i, n, eta: half3) -> half3 {
+	cosi := dot(-i, n)
+	cost2 := 1 - eta*eta*(1 - cosi*cosi)
+	t := eta*i + ((eta*cosi - sqrt(abs(cost2))) * n)
+	return t * half3{half(int(cost2.x > 0)), half(int(cost2.y > 0)), half(int(cost2.z > 0))}
+}
+@(require_results)
+refract_half4  :: proc "c" (i, n, eta: half4) -> half4 {
+	cosi := dot(-i, n)
+	cost2 := 1 - eta*eta*(1 - cosi*cosi)
+	t := eta*i + ((eta*cosi - sqrt(abs(cost2))) * n)
+	return t * half4{half(int(cost2.x > 0)), half(int(cost2.y > 0)), half(int(cost2.z > 0)), half(int(cost2.w > 0))}
 }
 @(require_results)
 refract_float2  :: proc "c" (i, n, eta: float2) -> float2 {
@@ -1226,19 +1615,23 @@ refract_double4  :: proc "c" (i, n, eta: double4) -> double4 {
 }
 
 scalarTripleProduct :: proc{
+	scalarTripleProduct_half3,
 	scalarTripleProduct_float3,
 	scalarTripleProduct_double3,
 	scalarTripleProduct_int3,
 }
+@(require_results) scalarTripleProduct_half3 :: proc "c" (a, b, c: half3) -> half  { return dot(a, cross(b, c)) }
 @(require_results) scalarTripleProduct_float3 :: proc "c" (a, b, c: float3) -> float  { return dot(a, cross(b, c)) }
 @(require_results) scalarTripleProduct_double3 :: proc "c" (a, b, c: double3) -> double  { return dot(a, cross(b, c)) }
 @(require_results) scalarTripleProduct_int3 :: proc "c" (a, b, c: int3) -> int  { return dot(a, cross(b, c)) }
 
 vectorTripleProduct :: proc {
+	vectorTripleProduct_half3,
 	vectorTripleProduct_float3,
 	vectorTripleProduct_double3,
 	vectorTripleProduct_int3,	
 }
+@(require_results) vectorTripleProduct_half3 :: proc "c" (a, b, c: half3) -> half3 { return cross(a, cross(b, c)) }
 @(require_results) vectorTripleProduct_float3 :: proc "c" (a, b, c: float3) -> float3 { return cross(a, cross(b, c)) }
 @(require_results) vectorTripleProduct_double3 :: proc "c" (a, b, c: double3) -> double3 { return cross(a, cross(b, c)) }
 @(require_results) vectorTripleProduct_int3 :: proc "c" (a, b, c: int3) -> int3 { return cross(a, cross(b, c)) }
@@ -1247,35 +1640,43 @@ vectorTripleProduct :: proc {
 // Vector Relational Procedures
 
 lessThan :: proc{
+	lessThan_half,
 	lessThan_float,
 	lessThan_double,
 	lessThan_int,
 	lessThan_uint,
+	lessThan_half2,
 	lessThan_float2,
 	lessThan_double2,
 	lessThan_int2,
 	lessThan_uint2,
+	lessThan_half3,
 	lessThan_float3,
 	lessThan_double3,
 	lessThan_int3,
 	lessThan_uint3,
+	lessThan_half4,
 	lessThan_float4,
 	lessThan_double4,
 	lessThan_int4,
 	lessThan_uint4,
 }
+@(require_results) lessThan_half   :: proc "c" (a, b: half) -> bool { return a < b }
 @(require_results) lessThan_float   :: proc "c" (a, b: float) -> bool { return a < b }
 @(require_results) lessThan_double   :: proc "c" (a, b: double) -> bool { return a < b }
 @(require_results) lessThan_int   :: proc "c" (a, b: int) -> bool { return a < b }
 @(require_results) lessThan_uint   :: proc "c" (a, b: uint) -> bool { return a < b }
+@(require_results) lessThan_half2  :: proc "c" (a, b: half2) -> bool2 { return {a.x < b.x, a.y < b.y} }
 @(require_results) lessThan_float2  :: proc "c" (a, b: float2) -> bool2 { return {a.x < b.x, a.y < b.y} }
 @(require_results) lessThan_double2 :: proc "c" (a, b: double2) -> bool2 { return {a.x < b.x, a.y < b.y} }
 @(require_results) lessThan_int2 :: proc "c" (a, b: int2) -> bool2 { return {a.x < b.x, a.y < b.y} }
 @(require_results) lessThan_uint2 :: proc "c" (a, b: uint2) -> bool2 { return {a.x < b.x, a.y < b.y} }
+@(require_results) lessThan_half3  :: proc "c" (a, b: half3) -> bool3 { return {a.x < b.x, a.y < b.y, a.z < b.z} }
 @(require_results) lessThan_float3  :: proc "c" (a, b: float3) -> bool3 { return {a.x < b.x, a.y < b.y, a.z < b.z} }
 @(require_results) lessThan_double3  :: proc "c" (a, b: double3) -> bool3 { return {a.x < b.x, a.y < b.y, a.z < b.z} }
 @(require_results) lessThan_int3 :: proc "c" (a, b: int3) -> bool3 { return {a.x < b.x, a.y < b.y, a.z < b.z} }
 @(require_results) lessThan_uint3 :: proc "c" (a, b: uint3) -> bool3 { return {a.x < b.x, a.y < b.y, a.z < b.z} }
+@(require_results) lessThan_half4  :: proc "c" (a, b: half4) -> bool4 { return {a.x < b.x, a.y < b.y, a.z < b.z, a.w < b.w} }
 @(require_results) lessThan_float4  :: proc "c" (a, b: float4) -> bool4 { return {a.x < b.x, a.y < b.y, a.z < b.z, a.w < b.w} }
 @(require_results) lessThan_double4  :: proc "c" (a, b: double4) -> bool4 { return {a.x < b.x, a.y < b.y, a.z < b.z, a.w < b.w} }
 @(require_results) lessThan_int4 :: proc "c" (a, b: int4) -> bool4 { return {a.x < b.x, a.y < b.y, a.z < b.z, a.w < b.w} }
@@ -1283,35 +1684,43 @@ lessThan :: proc{
 
 
 lessThanEqual :: proc{
+	lessThanEqual_half,
 	lessThanEqual_float,
 	lessThanEqual_double,
 	lessThanEqual_int,
 	lessThanEqual_uint,
+	lessThanEqual_half2,
 	lessThanEqual_float2,
 	lessThanEqual_double2,
 	lessThanEqual_int2,
 	lessThanEqual_uint2,
+	lessThanEqual_half3,
 	lessThanEqual_float3,
 	lessThanEqual_double3,
 	lessThanEqual_int3,
 	lessThanEqual_uint3,
+	lessThanEqual_half4,
 	lessThanEqual_float4,
 	lessThanEqual_double4,
 	lessThanEqual_int4,
 	lessThanEqual_uint4,
 }
+@(require_results) lessThanEqual_half   :: proc "c" (a, b: half) -> bool { return a <= b }
 @(require_results) lessThanEqual_float   :: proc "c" (a, b: float) -> bool { return a <= b }
 @(require_results) lessThanEqual_double   :: proc "c" (a, b: double) -> bool { return a <= b }
 @(require_results) lessThanEqual_int   :: proc "c" (a, b: int) -> bool { return a <= b }
 @(require_results) lessThanEqual_uint   :: proc "c" (a, b: uint) -> bool { return a <= b }
+@(require_results) lessThanEqual_half2  :: proc "c" (a, b: half2) -> bool2 { return {a.x <= b.x, a.y <= b.y} }
 @(require_results) lessThanEqual_float2  :: proc "c" (a, b: float2) -> bool2 { return {a.x <= b.x, a.y <= b.y} }
 @(require_results) lessThanEqual_double2  :: proc "c" (a, b: double2) -> bool2 { return {a.x <= b.x, a.y <= b.y} }
 @(require_results) lessThanEqual_int2 :: proc "c" (a, b: int2) -> bool2 { return {a.x <= b.x, a.y <= b.y} }
 @(require_results) lessThanEqual_uint2 :: proc "c" (a, b: uint2) -> bool2 { return {a.x <= b.x, a.y <= b.y} }
+@(require_results) lessThanEqual_half3  :: proc "c" (a, b: half3) -> bool3 { return {a.x <= b.x, a.y <= b.y, a.z <= b.z} }
 @(require_results) lessThanEqual_float3  :: proc "c" (a, b: float3) -> bool3 { return {a.x <= b.x, a.y <= b.y, a.z <= b.z} }
 @(require_results) lessThanEqual_double3  :: proc "c" (a, b: double3) -> bool3 { return {a.x <= b.x, a.y <= b.y, a.z <= b.z} }
 @(require_results) lessThanEqual_int3 :: proc "c" (a, b: int3) -> bool3 { return {a.x <= b.x, a.y <= b.y, a.z <= b.z} }
 @(require_results) lessThanEqual_uint3 :: proc "c" (a, b: uint3) -> bool3 { return {a.x <= b.x, a.y <= b.y, a.z <= b.z} }
+@(require_results) lessThanEqual_half4  :: proc "c" (a, b: half4) -> bool4 { return {a.x <= b.x, a.y <= b.y, a.z <= b.z, a.w <= b.w} }
 @(require_results) lessThanEqual_float4  :: proc "c" (a, b: float4) -> bool4 { return {a.x <= b.x, a.y <= b.y, a.z <= b.z, a.w <= b.w} }
 @(require_results) lessThanEqual_double4  :: proc "c" (a, b: double4) -> bool4 { return {a.x <= b.x, a.y <= b.y, a.z <= b.z, a.w <= b.w} }
 @(require_results) lessThanEqual_int4 :: proc "c" (a, b: int4) -> bool4 { return {a.x <= b.x, a.y <= b.y, a.z <= b.z, a.w <= b.w} }
@@ -1319,35 +1728,43 @@ lessThanEqual :: proc{
 
 
 greaterThan :: proc{
+	greaterThan_half,
 	greaterThan_float,
 	greaterThan_double,
 	greaterThan_int,
 	greaterThan_uint,
+	greaterThan_half2,
 	greaterThan_float2,
 	greaterThan_double2,
 	greaterThan_int2,
 	greaterThan_uint2,
+	greaterThan_half3,
 	greaterThan_float3,
 	greaterThan_double3,
 	greaterThan_int3,
 	greaterThan_uint3,
+	greaterThan_half4,
 	greaterThan_float4,
 	greaterThan_double4,
 	greaterThan_int4,
 	greaterThan_uint4,
 }
+@(require_results) greaterThan_half   :: proc "c" (a, b: half) -> bool { return a > b }
 @(require_results) greaterThan_float   :: proc "c" (a, b: float) -> bool { return a > b }
 @(require_results) greaterThan_double   :: proc "c" (a, b: double) -> bool { return a > b }
 @(require_results) greaterThan_int   :: proc "c" (a, b: int) -> bool { return a > b }
 @(require_results) greaterThan_uint   :: proc "c" (a, b: uint) -> bool { return a > b }
+@(require_results) greaterThan_half2  :: proc "c" (a, b: half2) -> bool2 { return {a.x > b.x, a.y > b.y} }
 @(require_results) greaterThan_float2  :: proc "c" (a, b: float2) -> bool2 { return {a.x > b.x, a.y > b.y} }
 @(require_results) greaterThan_double2  :: proc "c" (a, b: double2) -> bool2 { return {a.x > b.x, a.y > b.y} }
 @(require_results) greaterThan_int2 :: proc "c" (a, b: int2) -> bool2 { return {a.x > b.x, a.y > b.y} }
 @(require_results) greaterThan_uint2 :: proc "c" (a, b: uint2) -> bool2 { return {a.x > b.x, a.y > b.y} }
+@(require_results) greaterThan_half3  :: proc "c" (a, b: half3) -> bool3 { return {a.x > b.x, a.y > b.y, a.z > b.z} }
 @(require_results) greaterThan_float3  :: proc "c" (a, b: float3) -> bool3 { return {a.x > b.x, a.y > b.y, a.z > b.z} }
 @(require_results) greaterThan_double3  :: proc "c" (a, b: double3) -> bool3 { return {a.x > b.x, a.y > b.y, a.z > b.z} }
 @(require_results) greaterThan_int3 :: proc "c" (a, b: int3) -> bool3 { return {a.x > b.x, a.y > b.y, a.z > b.z} }
 @(require_results) greaterThan_uint3 :: proc "c" (a, b: uint3) -> bool3 { return {a.x > b.x, a.y > b.y, a.z > b.z} }
+@(require_results) greaterThan_half4  :: proc "c" (a, b: half4) -> bool4 { return {a.x > b.x, a.y > b.y, a.z > b.z, a.w > b.w} }
 @(require_results) greaterThan_float4  :: proc "c" (a, b: float4) -> bool4 { return {a.x > b.x, a.y > b.y, a.z > b.z, a.w > b.w} }
 @(require_results) greaterThan_double4  :: proc "c" (a, b: double4) -> bool4 { return {a.x > b.x, a.y > b.y, a.z > b.z, a.w > b.w} }
 @(require_results) greaterThan_int4 :: proc "c" (a, b: int4) -> bool4 { return {a.x > b.x, a.y > b.y, a.z > b.z, a.w > b.w} }
@@ -1355,35 +1772,43 @@ greaterThan :: proc{
 
 
 greaterThanEqual :: proc{
+	greaterThanEqual_half,
 	greaterThanEqual_float,
 	greaterThanEqual_double,
 	greaterThanEqual_int,
 	greaterThanEqual_uint,
+	greaterThanEqual_half2,
 	greaterThanEqual_float2,
 	greaterThanEqual_double2,
 	greaterThanEqual_int2,
 	greaterThanEqual_uint2,
+	greaterThanEqual_half3,
 	greaterThanEqual_float3,
 	greaterThanEqual_double3,
 	greaterThanEqual_int3,
 	greaterThanEqual_uint3,
+	greaterThanEqual_half4,
 	greaterThanEqual_float4,
 	greaterThanEqual_double4,
 	greaterThanEqual_int4,
 	greaterThanEqual_uint4,
 }
+@(require_results) greaterThanEqual_half   :: proc "c" (a, b: half) -> bool { return a >= b }
 @(require_results) greaterThanEqual_float   :: proc "c" (a, b: float) -> bool { return a >= b }
 @(require_results) greaterThanEqual_double   :: proc "c" (a, b: double) -> bool { return a >= b }
 @(require_results) greaterThanEqual_int   :: proc "c" (a, b: int) -> bool { return a >= b }
 @(require_results) greaterThanEqual_uint   :: proc "c" (a, b: uint) -> bool { return a >= b }
+@(require_results) greaterThanEqual_half2  :: proc "c" (a, b: half2) -> bool2 { return {a.x >= b.x, a.y >= b.y} }
 @(require_results) greaterThanEqual_float2  :: proc "c" (a, b: float2) -> bool2 { return {a.x >= b.x, a.y >= b.y} }
 @(require_results) greaterThanEqual_double2  :: proc "c" (a, b: double2) -> bool2 { return {a.x >= b.x, a.y >= b.y} }
 @(require_results) greaterThanEqual_int2 :: proc "c" (a, b: int2) -> bool2 { return {a.x >= b.x, a.y >= b.y} }
 @(require_results) greaterThanEqual_uint2 :: proc "c" (a, b: uint2) -> bool2 { return {a.x >= b.x, a.y >= b.y} }
+@(require_results) greaterThanEqual_half3  :: proc "c" (a, b: half3) -> bool3 { return {a.x >= b.x, a.y >= b.y, a.z >= b.z} }
 @(require_results) greaterThanEqual_float3  :: proc "c" (a, b: float3) -> bool3 { return {a.x >= b.x, a.y >= b.y, a.z >= b.z} }
 @(require_results) greaterThanEqual_double3  :: proc "c" (a, b: double3) -> bool3 { return {a.x >= b.x, a.y >= b.y, a.z >= b.z} }
 @(require_results) greaterThanEqual_int3 :: proc "c" (a, b: int3) -> bool3 { return {a.x >= b.x, a.y >= b.y, a.z >= b.z} }
 @(require_results) greaterThanEqual_uint3 :: proc "c" (a, b: uint3) -> bool3 { return {a.x >= b.x, a.y >= b.y, a.z >= b.z} }
+@(require_results) greaterThanEqual_half4  :: proc "c" (a, b: half4) -> bool4 { return {a.x >= b.x, a.y >= b.y, a.z >= b.z, a.w >= b.w} }
 @(require_results) greaterThanEqual_float4  :: proc "c" (a, b: float4) -> bool4 { return {a.x >= b.x, a.y >= b.y, a.z >= b.z, a.w >= b.w} }
 @(require_results) greaterThanEqual_double4  :: proc "c" (a, b: double4) -> bool4 { return {a.x >= b.x, a.y >= b.y, a.z >= b.z, a.w >= b.w} }
 @(require_results) greaterThanEqual_int4 :: proc "c" (a, b: int4) -> bool4 { return {a.x >= b.x, a.y >= b.y, a.z >= b.z, a.w >= b.w} }
@@ -1391,70 +1816,86 @@ greaterThanEqual :: proc{
 
 
 equal :: proc{
+	equal_half,
 	equal_float,
 	equal_double,
 	equal_int,
 	equal_uint,
+	equal_half2,
 	equal_float2,
 	equal_double2,
 	equal_int2,
 	equal_uint2,
+	equal_half3,
 	equal_float3,
 	equal_double3,
 	equal_int3,
 	equal_uint3,
+	equal_half4,
 	equal_float4,
 	equal_double4,
 	equal_int4,
 	equal_uint4,
 }
+@(require_results) equal_half   :: proc "c" (a, b: half) -> bool { return a == b }
 @(require_results) equal_float   :: proc "c" (a, b: float) -> bool { return a == b }
 @(require_results) equal_double   :: proc "c" (a, b: double) -> bool { return a == b }
 @(require_results) equal_int   :: proc "c" (a, b: int) -> bool { return a == b }
 @(require_results) equal_uint   :: proc "c" (a, b: uint) -> bool { return a == b }
+@(require_results) equal_half2  :: proc "c" (a, b: half2) -> bool2 { return {a.x == b.x, a.y == b.y} }
 @(require_results) equal_float2  :: proc "c" (a, b: float2) -> bool2 { return {a.x == b.x, a.y == b.y} }
 @(require_results) equal_double2  :: proc "c" (a, b: double2) -> bool2 { return {a.x == b.x, a.y == b.y} }
 @(require_results) equal_int2 :: proc "c" (a, b: int2) -> bool2 { return {a.x == b.x, a.y == b.y} }
 @(require_results) equal_uint2 :: proc "c" (a, b: uint2) -> bool2 { return {a.x == b.x, a.y == b.y} }
+@(require_results) equal_half3  :: proc "c" (a, b: half3) -> bool3 { return {a.x == b.x, a.y == b.y, a.z == b.z} }
 @(require_results) equal_float3  :: proc "c" (a, b: float3) -> bool3 { return {a.x == b.x, a.y == b.y, a.z == b.z} }
 @(require_results) equal_double3  :: proc "c" (a, b: double3) -> bool3 { return {a.x == b.x, a.y == b.y, a.z == b.z} }
 @(require_results) equal_int3 :: proc "c" (a, b: int3) -> bool3 { return {a.x == b.x, a.y == b.y, a.z == b.z} }
 @(require_results) equal_uint3 :: proc "c" (a, b: uint3) -> bool3 { return {a.x == b.x, a.y == b.y, a.z == b.z} }
+@(require_results) equal_half4  :: proc "c" (a, b: half4) -> bool4 { return {a.x == b.x, a.y == b.y, a.z == b.z, a.w == b.w} }
 @(require_results) equal_float4  :: proc "c" (a, b: float4) -> bool4 { return {a.x == b.x, a.y == b.y, a.z == b.z, a.w == b.w} }
 @(require_results) equal_double4  :: proc "c" (a, b: double4) -> bool4 { return {a.x == b.x, a.y == b.y, a.z == b.z, a.w == b.w} }
 @(require_results) equal_int4 :: proc "c" (a, b: int4) -> bool4 { return {a.x == b.x, a.y == b.y, a.z == b.z, a.w == b.w} }
 @(require_results) equal_uint4 :: proc "c" (a, b: uint4) -> bool4 { return {a.x == b.x, a.y == b.y, a.z == b.z, a.w == b.w} }
 
 notEqual :: proc{
+	notEqual_half,
 	notEqual_float,
 	notEqual_double,
 	notEqual_int,
 	notEqual_uint,
+	notEqual_half2,
 	notEqual_float2,
 	notEqual_double2,
 	notEqual_int2,
 	notEqual_uint2,
+	notEqual_half3,
 	notEqual_float3,
 	notEqual_double3,
 	notEqual_int3,
 	notEqual_uint3,
+	notEqual_half4,
 	notEqual_float4,
 	notEqual_double4,
 	notEqual_int4,
 	notEqual_uint4,
 }
+@(require_results) notEqual_half   :: proc "c" (a, b: half) -> bool { return a != b }
 @(require_results) notEqual_float   :: proc "c" (a, b: float) -> bool { return a != b }
 @(require_results) notEqual_double   :: proc "c" (a, b: double) -> bool { return a != b }
 @(require_results) notEqual_int   :: proc "c" (a, b: int) -> bool { return a != b }
 @(require_results) notEqual_uint   :: proc "c" (a, b: uint) -> bool { return a != b }
+@(require_results) notEqual_half2  :: proc "c" (a, b: half2) -> bool2 { return {a.x != b.x, a.y != b.y} }
 @(require_results) notEqual_float2  :: proc "c" (a, b: float2) -> bool2 { return {a.x != b.x, a.y != b.y} }
 @(require_results) notEqual_double2  :: proc "c" (a, b: double2) -> bool2 { return {a.x != b.x, a.y != b.y} }
 @(require_results) notEqual_int2 :: proc "c" (a, b: int2) -> bool2 { return {a.x != b.x, a.y != b.y} }
 @(require_results) notEqual_uint2 :: proc "c" (a, b: uint2) -> bool2 { return {a.x != b.x, a.y != b.y} }
+@(require_results) notEqual_half3  :: proc "c" (a, b: half3) -> bool3 { return {a.x != b.x, a.y != b.y, a.z != b.z} }
 @(require_results) notEqual_float3  :: proc "c" (a, b: float3) -> bool3 { return {a.x != b.x, a.y != b.y, a.z != b.z} }
 @(require_results) notEqual_double3  :: proc "c" (a, b: double3) -> bool3 { return {a.x != b.x, a.y != b.y, a.z != b.z} }
 @(require_results) notEqual_int3 :: proc "c" (a, b: int3) -> bool3 { return {a.x != b.x, a.y != b.y, a.z != b.z} }
 @(require_results) notEqual_uint3 :: proc "c" (a, b: uint3) -> bool3 { return {a.x != b.x, a.y != b.y, a.z != b.z} }
+@(require_results) notEqual_half4  :: proc "c" (a, b: half4) -> bool4 { return {a.x != b.x, a.y != b.y, a.z != b.z, a.w != b.w} }
 @(require_results) notEqual_float4  :: proc "c" (a, b: float4) -> bool4 { return {a.x != b.x, a.y != b.y, a.z != b.z, a.w != b.w} }
 @(require_results) notEqual_double4  :: proc "c" (a, b: double4) -> bool4 { return {a.x != b.x, a.y != b.y, a.z != b.z, a.w != b.w} }
 @(require_results) notEqual_int4 :: proc "c" (a, b: int4) -> bool4 { return {a.x != b.x, a.y != b.y, a.z != b.z, a.w != b.w} }
@@ -1497,6 +1938,10 @@ not :: proc{
 
 
 
+@(require_results) inverse_half1x1  :: proc "c" (m: half1x1)  -> half1x1  { return inverse_matrix1x1(m) }
+@(require_results) inverse_half2x2  :: proc "c" (m: half2x2)  -> half2x2  { return inverse_matrix2x2(m) }
+@(require_results) inverse_half3x3  :: proc "c" (m: half3x3)  -> half3x3  { return inverse_matrix3x3(m) }
+@(require_results) inverse_half4x4  :: proc "c" (m: half4x4)  -> half4x4  { return inverse_matrix4x4(m) }
 @(require_results) inverse_float1x1  :: proc "c" (m: float1x1)  -> float1x1  { return inverse_matrix1x1(m) }
 @(require_results) inverse_float2x2  :: proc "c" (m: float2x2)  -> float2x2  { return inverse_matrix2x2(m) }
 @(require_results) inverse_float3x3  :: proc "c" (m: float3x3)  -> float3x3  { return inverse_matrix3x3(m) }
@@ -1507,6 +1952,10 @@ not :: proc{
 @(require_results) inverse_double4x4 :: proc "c" (m: double4x4) -> double4x4 { return inverse_matrix4x4(m) }
 
 inverse :: proc{
+	inverse_half1x1,
+	inverse_half2x2,
+	inverse_half3x3,
+	inverse_half4x4,
 	inverse_float1x1,
 	inverse_float2x2,
 	inverse_float3x3,
@@ -1832,12 +2281,176 @@ inverse_matrix4x4 :: proc "contextless" (x: $M/matrix[4, 4]$T) -> (y: M) #no_bou
 
 
 
+ashalf :: proc{
+	ashalf_half,
+	ashalf_float,
+	ashalf_double,
+	ashalf_int,
+	ashalf_uint,
+	ashalf_half1x1,
+	ashalf_half2x2,
+	ashalf_half3x3,
+	ashalf_half4x4,
+	ashalf_half1x2,
+	ashalf_half1x3,
+	ashalf_half1x4,
+	ashalf_half2x1,
+	ashalf_half2x3,
+	ashalf_half2x4,
+	ashalf_half3x1,
+	ashalf_half3x2,
+	ashalf_half3x4,
+	ashalf_half4x1,
+	ashalf_half4x2,
+	ashalf_half4x3,
+	ashalf_half2,
+	ashalf_half3,
+	ashalf_half4,
+	ashalf_float1x1,
+	ashalf_float2x2,
+	ashalf_float3x3,
+	ashalf_float4x4,
+	ashalf_float1x2,
+	ashalf_float1x3,
+	ashalf_float1x4,
+	ashalf_float2x1,
+	ashalf_float2x3,
+	ashalf_float2x4,
+	ashalf_float3x1,
+	ashalf_float3x2,
+	ashalf_float3x4,
+	ashalf_float4x1,
+	ashalf_float4x2,
+	ashalf_float4x3,
+	ashalf_float2,
+	ashalf_float3,
+	ashalf_float4,
+	ashalf_int2,
+	ashalf_int3,
+	ashalf_int4,
+	ashalf_uint2,
+	ashalf_uint3,
+	ashalf_uint4,
+	ashalf_bool2,
+	ashalf_bool3,
+	ashalf_bool4,
+	ashalf_double1x1,
+	ashalf_double2x2,
+	ashalf_double3x3,
+	ashalf_double4x4,
+	ashalf_double1x2,
+	ashalf_double1x3,
+	ashalf_double1x4,
+	ashalf_double2x1,
+	ashalf_double2x3,
+	ashalf_double2x4,
+	ashalf_double3x1,
+	ashalf_double3x2,
+	ashalf_double3x4,
+	ashalf_double4x1,
+	ashalf_double4x2,
+	ashalf_double4x3,
+	ashalf_double2,
+	ashalf_double3,
+	ashalf_double4,
+}
+@(require_results) ashalf_half     :: proc "c" (v: half)       -> half    { return half(v) }
+@(require_results) ashalf_float     :: proc "c" (v: float)     -> half    { return half(v) }
+@(require_results) ashalf_double    :: proc "c" (v: double)    -> half    { return half(v) }
+@(require_results) ashalf_int       :: proc "c" (v: int)       -> half    { return half(v) }
+@(require_results) ashalf_uint      :: proc "c" (v: uint)      -> half    { return half(v) }
+@(require_results) ashalf_half1x1  :: proc "c" (v: half1x1)   -> half1x1 { return half1x1(v) }
+@(require_results) ashalf_half2x2  :: proc "c" (v: half2x2)   -> half2x2 { return half2x2(v) }
+@(require_results) ashalf_half3x3  :: proc "c" (v: half3x3)   -> half3x3 { return half3x3(v) }
+@(require_results) ashalf_half4x4  :: proc "c" (v: half4x4)   -> half4x4 { return half4x4(v) }
+@(require_results) ashalf_half1x2  :: proc "c" (v: half1x2)   -> half1x2 { return half1x2(v) }
+@(require_results) ashalf_half1x3  :: proc "c" (v: half1x3)   -> half1x3 { return half1x3(v) }
+@(require_results) ashalf_half1x4  :: proc "c" (v: half1x4)   -> half1x4 { return half1x4(v) }
+@(require_results) ashalf_half2x1  :: proc "c" (v: half2x1)   -> half2x1 { return half2x1(v) }
+@(require_results) ashalf_half2x3  :: proc "c" (v: half2x3)   -> half2x3 { return half2x3(v) }
+@(require_results) ashalf_half2x4  :: proc "c" (v: half2x4)   -> half2x4 { return half2x4(v) }
+@(require_results) ashalf_half3x1  :: proc "c" (v: half3x1)   -> half3x1 { return half3x1(v) }
+@(require_results) ashalf_half3x2  :: proc "c" (v: half3x2)   -> half3x2 { return half3x2(v) }
+@(require_results) ashalf_half3x4  :: proc "c" (v: half3x4)   -> half3x4 { return half3x4(v) }
+@(require_results) ashalf_half4x1  :: proc "c" (v: half4x1)   -> half4x1 { return half4x1(v) }
+@(require_results) ashalf_half4x2  :: proc "c" (v: half4x2)   -> half4x2 { return half4x2(v) }
+@(require_results) ashalf_half4x3  :: proc "c" (v: half4x3)   -> half4x3 { return half4x3(v) }
+@(require_results) ashalf_half2    :: proc "c" (v: half2)     -> half2   { return half2(v) }
+@(require_results) ashalf_half3    :: proc "c" (v: half3)     -> half3   { return half3(v) }
+@(require_results) ashalf_half4    :: proc "c" (v: half4)     -> half4   { return half4(v) }
+@(require_results) ashalf_float1x1  :: proc "c" (v: float1x1)   -> half1x1 { return half1x1(v) }
+@(require_results) ashalf_float2x2  :: proc "c" (v: float2x2)   -> half2x2 { return half2x2(v) }
+@(require_results) ashalf_float3x3  :: proc "c" (v: float3x3)   -> half3x3 { return half3x3(v) }
+@(require_results) ashalf_float4x4  :: proc "c" (v: float4x4)   -> half4x4 { return half4x4(v) }
+@(require_results) ashalf_float1x2  :: proc "c" (v: float1x2)   -> half1x2 { return half1x2(v) }
+@(require_results) ashalf_float1x3  :: proc "c" (v: float1x3)   -> half1x3 { return half1x3(v) }
+@(require_results) ashalf_float1x4  :: proc "c" (v: float1x4)   -> half1x4 { return half1x4(v) }
+@(require_results) ashalf_float2x1  :: proc "c" (v: float2x1)   -> half2x1 { return half2x1(v) }
+@(require_results) ashalf_float2x3  :: proc "c" (v: float2x3)   -> half2x3 { return half2x3(v) }
+@(require_results) ashalf_float2x4  :: proc "c" (v: float2x4)   -> half2x4 { return half2x4(v) }
+@(require_results) ashalf_float3x1  :: proc "c" (v: float3x1)   -> half3x1 { return half3x1(v) }
+@(require_results) ashalf_float3x2  :: proc "c" (v: float3x2)   -> half3x2 { return half3x2(v) }
+@(require_results) ashalf_float3x4  :: proc "c" (v: float3x4)   -> half3x4 { return half3x4(v) }
+@(require_results) ashalf_float4x1  :: proc "c" (v: float4x1)   -> half4x1 { return half4x1(v) }
+@(require_results) ashalf_float4x2  :: proc "c" (v: float4x2)   -> half4x2 { return half4x2(v) }
+@(require_results) ashalf_float4x3  :: proc "c" (v: float4x3)   -> half4x3 { return half4x3(v) }
+@(require_results) ashalf_float2    :: proc "c" (v: float2)     -> half2   { return half2{half(v.x), half(v.y)} }
+@(require_results) ashalf_float3    :: proc "c" (v: float3)     -> half3   { return half3{half(v.x), half(v.y), half(v.z)}  }
+@(require_results) ashalf_float4    :: proc "c" (v: float4)     -> half4   { return half4{half(v.x), half(v.y), half(v.z), half(v.w)} }
+@(require_results) ashalf_int2      :: proc "c" (v: int2)      -> half2   { return half2{half(v.x), half(v.y)} }
+@(require_results) ashalf_int3      :: proc "c" (v: int3)      -> half3   { return half3{half(v.x), half(v.y), half(v.z)} }
+@(require_results) ashalf_int4      :: proc "c" (v: int4)      -> half4   { return half4{half(v.x), half(v.y), half(v.z), half(v.w)} }
+@(require_results) ashalf_uint2     :: proc "c" (v: uint2)     -> half2   { return half2{half(v.x), half(v.y)} }
+@(require_results) ashalf_uint3     :: proc "c" (v: uint3)     -> half3   { return half3{half(v.x), half(v.y), half(v.z)} }
+@(require_results) ashalf_uint4     :: proc "c" (v: uint4)     -> half4   { return half4{half(v.x), half(v.y), half(v.z), half(v.w)} }
+@(require_results) ashalf_bool2     :: proc "c" (v: bool2)     -> half2   { return half2{half(int(v.x)), half(int(v.y))} }
+@(require_results) ashalf_bool3     :: proc "c" (v: bool3)     -> half3   { return half3{half(int(v.x)), half(int(v.y)), half(int(v.z))} }
+@(require_results) ashalf_bool4     :: proc "c" (v: bool4)     -> half4   { return half4{half(int(v.x)), half(int(v.y)), half(int(v.z)), half(int(v.w))} }
+@(require_results) ashalf_double1x1 :: proc "c" (v: double1x1) -> half1x1 { return half1x1(v) }
+@(require_results) ashalf_double2x2 :: proc "c" (v: double2x2) -> half2x2 { return half2x2(v) }
+@(require_results) ashalf_double3x3 :: proc "c" (v: double3x3) -> half3x3 { return half3x3(v) }
+@(require_results) ashalf_double4x4 :: proc "c" (v: double4x4) -> half4x4 { return half4x4(v) }
+@(require_results) ashalf_double1x2 :: proc "c" (v: double1x2) -> half1x2 { return half1x2(v) }
+@(require_results) ashalf_double1x3 :: proc "c" (v: double1x3) -> half1x3 { return half1x3(v) }
+@(require_results) ashalf_double1x4 :: proc "c" (v: double1x4) -> half1x4 { return half1x4(v) }
+@(require_results) ashalf_double2x1 :: proc "c" (v: double2x1) -> half2x1 { return half2x1(v) }
+@(require_results) ashalf_double2x3 :: proc "c" (v: double2x3) -> half2x3 { return half2x3(v) }
+@(require_results) ashalf_double2x4 :: proc "c" (v: double2x4) -> half2x4 { return half2x4(v) }
+@(require_results) ashalf_double3x1 :: proc "c" (v: double3x1) -> half3x1 { return half3x1(v) }
+@(require_results) ashalf_double3x2 :: proc "c" (v: double3x2) -> half3x2 { return half3x2(v) }
+@(require_results) ashalf_double3x4 :: proc "c" (v: double3x4) -> half3x4 { return half3x4(v) }
+@(require_results) ashalf_double4x1 :: proc "c" (v: double4x1) -> half4x1 { return half4x1(v) }
+@(require_results) ashalf_double4x2 :: proc "c" (v: double4x2) -> half4x2 { return half4x2(v) }
+@(require_results) ashalf_double4x3 :: proc "c" (v: double4x3) -> half4x3 { return half4x3(v) }
+@(require_results) ashalf_double2   :: proc "c" (v: double2)   -> half2   { return half2{half(v.x), half(v.y)} }
+@(require_results) ashalf_double3   :: proc "c" (v: double3)   -> half3   { return half3{half(v.x), half(v.y), half(v.z)} }
+@(require_results) ashalf_double4   :: proc "c" (v: double4)   -> half4   { return half4{half(v.x), half(v.y), half(v.z), half(v.w)} }
 
 asfloat :: proc{
+	asfloat_half,
 	asfloat_float,
 	asfloat_double,
 	asfloat_int,
 	asfloat_uint,
+	asfloat_half1x1,
+	asfloat_half2x2,
+	asfloat_half3x3,
+	asfloat_half4x4,
+	asfloat_half1x2,
+	asfloat_half1x3,
+	asfloat_half1x4,
+	asfloat_half2x1,
+	asfloat_half2x3,
+	asfloat_half2x4,
+	asfloat_half3x1,
+	asfloat_half3x2,
+	asfloat_half3x4,
+	asfloat_half4x1,
+	asfloat_half4x2,
+	asfloat_half4x3,
+	asfloat_half2,
+	asfloat_half3,
+	asfloat_half4,
 	asfloat_float1x1,
 	asfloat_float2x2,
 	asfloat_float3x3,
@@ -1886,10 +2499,30 @@ asfloat :: proc{
 	asfloat_double3,
 	asfloat_double4,
 }
+@(require_results) asfloat_half     :: proc "c" (v: half)     -> float    { return float(v) }
 @(require_results) asfloat_float     :: proc "c" (v: float)     -> float    { return float(v) }
 @(require_results) asfloat_double    :: proc "c" (v: double)    -> float    { return float(v) }
 @(require_results) asfloat_int       :: proc "c" (v: int)       -> float    { return float(v) }
 @(require_results) asfloat_uint      :: proc "c" (v: uint)      -> float    { return float(v) }
+@(require_results) asfloat_half1x1  :: proc "c" (v: half1x1)  -> float1x1 { return float1x1(v) }
+@(require_results) asfloat_half2x2  :: proc "c" (v: half2x2)  -> float2x2 { return float2x2(v) }
+@(require_results) asfloat_half3x3  :: proc "c" (v: half3x3)  -> float3x3 { return float3x3(v) }
+@(require_results) asfloat_half4x4  :: proc "c" (v: half4x4)  -> float4x4 { return float4x4(v) }
+@(require_results) asfloat_half1x2  :: proc "c" (v: half1x2)  -> float1x2 { return float1x2(v) }
+@(require_results) asfloat_half1x3  :: proc "c" (v: half1x3)  -> float1x3 { return float1x3(v) }
+@(require_results) asfloat_half1x4  :: proc "c" (v: half1x4)  -> float1x4 { return float1x4(v) }
+@(require_results) asfloat_half2x1  :: proc "c" (v: half2x1)  -> float2x1 { return float2x1(v) }
+@(require_results) asfloat_half2x3  :: proc "c" (v: half2x3)  -> float2x3 { return float2x3(v) }
+@(require_results) asfloat_half2x4  :: proc "c" (v: half2x4)  -> float2x4 { return float2x4(v) }
+@(require_results) asfloat_half3x1  :: proc "c" (v: half3x1)  -> float3x1 { return float3x1(v) }
+@(require_results) asfloat_half3x2  :: proc "c" (v: half3x2)  -> float3x2 { return float3x2(v) }
+@(require_results) asfloat_half3x4  :: proc "c" (v: half3x4)  -> float3x4 { return float3x4(v) }
+@(require_results) asfloat_half4x1  :: proc "c" (v: half4x1)  -> float4x1 { return float4x1(v) }
+@(require_results) asfloat_half4x2  :: proc "c" (v: half4x2)  -> float4x2 { return float4x2(v) }
+@(require_results) asfloat_half4x3  :: proc "c" (v: half4x3)  -> float4x3 { return float4x3(v) }
+@(require_results) asfloat_half2    :: proc "c" (v: half2)    -> float2   { return float2{float(v.x), float(v.y)} }
+@(require_results) asfloat_half3    :: proc "c" (v: half3)    -> float3   { return float3{float(v.x), float(v.y), float(v.z)} }
+@(require_results) asfloat_half4    :: proc "c" (v: half4)    -> float4   { return float4{float(v.x), float(v.y), float(v.z), float(v.w)} }
 @(require_results) asfloat_float1x1  :: proc "c" (v: float1x1)  -> float1x1 { return float1x1(v) }
 @(require_results) asfloat_float2x2  :: proc "c" (v: float2x2)  -> float2x2 { return float2x2(v) }
 @(require_results) asfloat_float3x3  :: proc "c" (v: float3x3)  -> float3x3 { return float3x3(v) }
@@ -1939,10 +2572,30 @@ asfloat :: proc{
 @(require_results) asfloat_double4   :: proc "c" (v: double4)   -> float4   { return float4{float(v.x), float(v.y), float(v.z), float(v.w)} }
 
 asdouble :: proc{
+	asdouble_half,
 	asdouble_float,
 	asdouble_double,
 	asdouble_int,
 	asdouble_uint,
+	asdouble_half1x1,
+	asdouble_half2x2,
+	asdouble_half3x3,
+	asdouble_half4x4,
+	asdouble_half1x2,
+	asdouble_half1x3,
+	asdouble_half1x4,
+	asdouble_half2x1,
+	asdouble_half2x3,
+	asdouble_half2x4,
+	asdouble_half3x1,
+	asdouble_half3x2,
+	asdouble_half3x4,
+	asdouble_half4x1,
+	asdouble_half4x2,
+	asdouble_half4x3,
+	asdouble_half2,
+	asdouble_half3,
+	asdouble_half4,
 	asdouble_float1x1,
 	asdouble_float2x2,
 	asdouble_float3x3,
@@ -1991,10 +2644,30 @@ asdouble :: proc{
 	asdouble_double3,
 	asdouble_double4,
 }
+@(require_results) asdouble_half     :: proc "c" (v: half)     -> double    { return double(v) }
 @(require_results) asdouble_float     :: proc "c" (v: float)     -> double    { return double(v) }
 @(require_results) asdouble_double    :: proc "c" (v: double)    -> double    { return double(v) }
 @(require_results) asdouble_int       :: proc "c" (v: int)       -> double    { return double(v) }
 @(require_results) asdouble_uint      :: proc "c" (v: uint)      -> double    { return double(v) }
+@(require_results) asdouble_half1x1  :: proc "c" (v: half1x1)  -> double1x1 { return double1x1(v) }
+@(require_results) asdouble_half2x2  :: proc "c" (v: half2x2)  -> double2x2 { return double2x2(v) }
+@(require_results) asdouble_half3x3  :: proc "c" (v: half3x3)  -> double3x3 { return double3x3(v) }
+@(require_results) asdouble_half4x4  :: proc "c" (v: half4x4)  -> double4x4 { return double4x4(v) }
+@(require_results) asdouble_half1x2  :: proc "c" (v: half1x2)  -> double1x2 { return double1x2(v) }
+@(require_results) asdouble_half1x3  :: proc "c" (v: half1x3)  -> double1x3 { return double1x3(v) }
+@(require_results) asdouble_half1x4  :: proc "c" (v: half1x4)  -> double1x4 { return double1x4(v) }
+@(require_results) asdouble_half2x1  :: proc "c" (v: half2x1)  -> double2x1 { return double2x1(v) }
+@(require_results) asdouble_half2x3  :: proc "c" (v: half2x3)  -> double2x3 { return double2x3(v) }
+@(require_results) asdouble_half2x4  :: proc "c" (v: half2x4)  -> double2x4 { return double2x4(v) }
+@(require_results) asdouble_half3x1  :: proc "c" (v: half3x1)  -> double3x1 { return double3x1(v) }
+@(require_results) asdouble_half3x2  :: proc "c" (v: half3x2)  -> double3x2 { return double3x2(v) }
+@(require_results) asdouble_half3x4  :: proc "c" (v: half3x4)  -> double3x4 { return double3x4(v) }
+@(require_results) asdouble_half4x1  :: proc "c" (v: half4x1)  -> double4x1 { return double4x1(v) }
+@(require_results) asdouble_half4x2  :: proc "c" (v: half4x2)  -> double4x2 { return double4x2(v) }
+@(require_results) asdouble_half4x3  :: proc "c" (v: half4x3)  -> double4x3 { return double4x3(v) }
+@(require_results) asdouble_half2    :: proc "c" (v: half2)    -> double2   { return double2{double(v.x), double(v.y)} }
+@(require_results) asdouble_half3    :: proc "c" (v: half3)    -> double3   { return double3{double(v.x), double(v.y), double(v.z)} }
+@(require_results) asdouble_half4    :: proc "c" (v: half4)    -> double4   { return double4{double(v.x), double(v.y), double(v.z), double(v.w)} }
 @(require_results) asdouble_float1x1  :: proc "c" (v: float1x1)  -> double1x1 { return double1x1(v) }
 @(require_results) asdouble_float2x2  :: proc "c" (v: float2x2)  -> double2x2 { return double2x2(v) }
 @(require_results) asdouble_float3x3  :: proc "c" (v: float3x3)  -> double3x3 { return double3x3(v) }
@@ -2044,10 +2717,30 @@ asdouble :: proc{
 @(require_results) asdouble_double4   :: proc "c" (v: double4)   -> double4   { return double4{double(v.x), double(v.y), double(v.z), double(v.w)} }
 
 asint :: proc{
+	asint_half,
 	asint_float,
 	asint_double,
 	asint_int,
 	asint_uint,
+	asint_half1x1,
+	asint_half2x2,
+	asint_half3x3,
+	asint_half4x4,
+	asint_half1x2,
+	asint_half1x3,
+	asint_half1x4,
+	asint_half2x1,
+	asint_half2x3,
+	asint_half2x4,
+	asint_half3x1,
+	asint_half3x2,
+	asint_half3x4,
+	asint_half4x1,
+	asint_half4x2,
+	asint_half4x3,
+	asint_half2,
+	asint_half3,
+	asint_half4,
 	asint_float1x1,
 	asint_float2x2,
 	asint_float3x3,
@@ -2096,10 +2789,30 @@ asint :: proc{
 	asint_double3,
 	asint_double4,
 }
+@(require_results) asint_half     :: proc "c" (v: half)     -> int    { return int(v) }
 @(require_results) asint_float     :: proc "c" (v: float)     -> int    { return int(v) }
 @(require_results) asint_double    :: proc "c" (v: double)    -> int    { return int(v) }
 @(require_results) asint_int       :: proc "c" (v: int)       -> int    { return int(v) }
 @(require_results) asint_uint      :: proc "c" (v: uint)      -> int    { return int(v) }
+@(require_results) asint_half1x1  :: proc "c" (v: half1x1)  -> int1x1 { return int1x1(v) }
+@(require_results) asint_half2x2  :: proc "c" (v: half2x2)  -> int2x2 { return int2x2(v) }
+@(require_results) asint_half3x3  :: proc "c" (v: half3x3)  -> int3x3 { return int3x3(v) }
+@(require_results) asint_half4x4  :: proc "c" (v: half4x4)  -> int4x4 { return int4x4(v) }
+@(require_results) asint_half1x2  :: proc "c" (v: half1x2)  -> int1x2 { return int1x2(v) }
+@(require_results) asint_half1x3  :: proc "c" (v: half1x3)  -> int1x3 { return int1x3(v) }
+@(require_results) asint_half1x4  :: proc "c" (v: half1x4)  -> int1x4 { return int1x4(v) }
+@(require_results) asint_half2x1  :: proc "c" (v: half2x1)  -> int2x1 { return int2x1(v) }
+@(require_results) asint_half2x3  :: proc "c" (v: half2x3)  -> int2x3 { return int2x3(v) }
+@(require_results) asint_half2x4  :: proc "c" (v: half2x4)  -> int2x4 { return int2x4(v) }
+@(require_results) asint_half3x1  :: proc "c" (v: half3x1)  -> int3x1 { return int3x1(v) }
+@(require_results) asint_half3x2  :: proc "c" (v: half3x2)  -> int3x2 { return int3x2(v) }
+@(require_results) asint_half3x4  :: proc "c" (v: half3x4)  -> int3x4 { return int3x4(v) }
+@(require_results) asint_half4x1  :: proc "c" (v: half4x1)  -> int4x1 { return int4x1(v) }
+@(require_results) asint_half4x2  :: proc "c" (v: half4x2)  -> int4x2 { return int4x2(v) }
+@(require_results) asint_half4x3  :: proc "c" (v: half4x3)  -> int4x3 { return int4x3(v) }
+@(require_results) asint_half2    :: proc "c" (v: half2)    -> int2   { return int2{int(v.x), int(v.y)} }
+@(require_results) asint_half3    :: proc "c" (v: half3)    -> int3   { return int3{int(v.x), int(v.y), int(v.z)} }
+@(require_results) asint_half4    :: proc "c" (v: half4)    -> int4   { return int4{int(v.x), int(v.y), int(v.z), int(v.w)} }
 @(require_results) asint_float1x1  :: proc "c" (v: float1x1)  -> int1x1 { return int1x1(v) }
 @(require_results) asint_float2x2  :: proc "c" (v: float2x2)  -> int2x2 { return int2x2(v) }
 @(require_results) asint_float3x3  :: proc "c" (v: float3x3)  -> int3x3 { return int3x3(v) }
@@ -2150,10 +2863,14 @@ asint :: proc{
 
 
 asuint :: proc{
+	asuint_half,
 	asuint_float,
 	asuint_double,
 	asuint_int,
 	asuint_uint,
+	asuint_half2,
+	asuint_half3,
+	asuint_half4,
 	asuint_float2,
 	asuint_float3,
 	asuint_float4,
@@ -2170,10 +2887,14 @@ asuint :: proc{
 	asuint_double3,
 	asuint_double4,
 }
+@(require_results) asuint_half     :: proc "c" (v: half)     -> uint    { return uint(v) }
 @(require_results) asuint_float     :: proc "c" (v: float)     -> uint    { return uint(v) }
 @(require_results) asuint_double    :: proc "c" (v: double)    -> uint    { return uint(v) }
 @(require_results) asuint_int       :: proc "c" (v: int)       -> uint    { return uint(v) }
 @(require_results) asuint_uint      :: proc "c" (v: uint)      -> uint    { return uint(v) }
+@(require_results) asuint_half2    :: proc "c" (v: half2)    -> uint2   { return uint2{uint(v.x), uint(v.y)} }
+@(require_results) asuint_half3    :: proc "c" (v: half3)    -> uint3   { return uint3{uint(v.x), uint(v.y), uint(v.z)} }
+@(require_results) asuint_half4    :: proc "c" (v: half4)    -> uint4   { return uint4{uint(v.x), uint(v.y), uint(v.z), uint(v.w)} }
 @(require_results) asuint_float2    :: proc "c" (v: float2)    -> uint2   { return uint2{uint(v.x), uint(v.y)} }
 @(require_results) asuint_float3    :: proc "c" (v: float3)    -> uint3   { return uint3{uint(v.x), uint(v.y), uint(v.z)} }
 @(require_results) asuint_float4    :: proc "c" (v: float4)    -> uint4   { return uint4{uint(v.x), uint(v.y), uint(v.z), uint(v.w)} }

--- a/core/math/linalg/hlsl/linalg_hlsl_math.odin
+++ b/core/math/linalg/hlsl/linalg_hlsl_math.odin
@@ -2,6 +2,42 @@ package math_linalg_hlsl
 
 import "core:math"
 
+@(require_results) cos_half         :: proc "c" (x: half)    -> half { return math.cos(x) }
+@(require_results) sin_half         :: proc "c" (x: half)    -> half { return math.sin(x) }
+@(require_results) tan_half         :: proc "c" (x: half)    -> half { return math.tan(x) }
+@(require_results) acos_half        :: proc "c" (x: half)    -> half { return math.acos(x) }
+@(require_results) asin_half        :: proc "c" (x: half)    -> half { return math.asin(x) }
+@(require_results) atan_half        :: proc "c" (x: half)    -> half { return math.atan(x) }
+@(require_results) atan2_half       :: proc "c" (y, x: half) -> half { return math.atan2(y, x) }
+@(require_results) cosh_half        :: proc "c" (x: half)    -> half { return math.cosh(x) }
+@(require_results) sinh_half        :: proc "c" (x: half)    -> half { return math.sinh(x) }
+@(require_results) tanh_half        :: proc "c" (x: half)    -> half { return math.tanh(x) }
+@(require_results) acosh_half       :: proc "c" (x: half)    -> half { return math.acosh(x) }
+@(require_results) asinh_half       :: proc "c" (x: half)    -> half { return math.asinh(x) }
+@(require_results) atanh_half       :: proc "c" (x: half)    -> half { return math.atanh(x) }
+@(require_results) sqrt_half        :: proc "c" (x: half)    -> half { return math.sqrt(x) }
+@(require_results) rsqrt_half       :: proc "c" (x: half)    -> half { return 1.0/math.sqrt(x) }
+@(require_results) rcp_half         :: proc "c" (x: half)    -> half { return 1.0/x }
+@(require_results) pow_half         :: proc "c" (x, y: half) -> half { return math.pow(x, y) }
+@(require_results) exp_half         :: proc "c" (x: half)    -> half { return math.exp(x) }
+@(require_results) log_half         :: proc "c" (x: half)    -> half { return math.ln(x) }
+@(require_results) log2_half        :: proc "c" (x: half)    -> half { return math.log(x, 2) }
+@(require_results) log10_half       :: proc "c" (x: half)    -> half { return math.log(x, 10) }
+@(require_results) exp2_half        :: proc "c" (x: half)    -> half { return math.pow(half(2), x) }
+@(require_results) sign_half        :: proc "c" (x: half)    -> half { return math.sign(x) }
+@(require_results) floor_half       :: proc "c" (x: half)    -> half { return math.floor(x) }
+@(require_results) round_half       :: proc "c" (x: half)    -> half { return math.round(x) }
+@(require_results) ceil_half        :: proc "c" (x: half)    -> half { return math.ceil(x) }
+@(require_results) isnan_half       :: proc "c" (x: half)    -> bool  { return math.classify(x) == .NaN}
+@(require_results) fmod_half        :: proc "c" (x, y: half) -> half { return math.mod(x, y) }
+@(require_results)
+frac_half :: proc "c" (x: half) -> half {
+	if x >= 0 {
+		return x - math.trunc(x)
+	}
+	return math.trunc(-x) + x
+}
+
 @(require_results) cos_float         :: proc "c" (x: float)    -> float { return math.cos(x) }
 @(require_results) sin_float         :: proc "c" (x: float)    -> float { return math.sin(x) }
 @(require_results) tan_float         :: proc "c" (x: float)    -> float { return math.tan(x) }


### PR DESCRIPTION
Addresses #5434 

My first contribution to Odin so I started with something simple. Every relevant `half` type has been added, along with the relevant additions to proc groups and the addition of the `ashalf` proc group.