### PR TITLE
Parse empty idents after selector as a selector expr with an empty field

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -3210,6 +3210,17 @@ parse_call_expr :: proc(p: ^Parser, operand: ^ast.Expr) -> ^ast.Expr {
 	return ce
 }
 
+empty_selector_expr :: proc(tok: tokenizer.Token, operand: ^ast.Expr) -> ^ast.Selector_Expr {
+	field := ast.new(ast.Ident, tok.pos, end_pos(tok))
+	field.name = ""
+
+	sel := ast.new(ast.Selector_Expr, operand.pos, field)
+	sel.expr  = operand
+	sel.op = tok
+	sel.field = field
+
+	return sel
+}
 
 parse_atom_expr :: proc(p: ^Parser, value: ^ast.Expr, lhs: bool) -> (operand: ^ast.Expr) {
 	operand = value
@@ -3343,8 +3354,7 @@ parse_atom_expr :: proc(p: ^Parser, value: ^ast.Expr, lhs: bool) -> (operand: ^a
 
 			case:
 				error(p, p.curr_tok.pos, "expected a selector")
-				advance_token(p)
-				operand = ast.new(ast.Bad_Expr, operand.pos, end_pos(tok))
+				operand = empty_selector_expr(tok, operand)
 			}
 
 		case .Arrow_Right:
@@ -3361,8 +3371,7 @@ parse_atom_expr :: proc(p: ^Parser, value: ^ast.Expr, lhs: bool) -> (operand: ^a
 				operand = sel
 			case:
 				error(p, p.curr_tok.pos, "expected a selector")
-				advance_token(p)
-				operand = ast.new(ast.Bad_Expr, operand.pos, end_pos(tok))
+				operand = empty_selector_expr(tok, operand)
 			}
 
 		case .Pointer:


### PR DESCRIPTION
As part of the work with `ols`, we are often parsing incomplete programs as people are typing their code. One particular pain point we have with this is with selector expressions with empty fields. For example:

```odin
package main

Foo :: struct {
    x: int,
}

main :: proc() {
    foo: Foo
    foo. // <- we're now prompted for completions here
}
```

Currently this is parsed in the ast as a `Bad_Expr`, and so we need to do some extensive checks to see if we're actually dealing with a selector expr with an empty field. This works relatively well, however there are some cases that don't work, as outlined in this issue raised here https://github.com/DanielGavin/ols/issues/1002. The simple solution for us is to parse this as a regular `Selector_Expr`, with some way to identify that we have an empty field. This PR would simply use an `Ident` with an empty identifier.

This is more of a proposal or suggestion than anything. The main goal is to have a way to identify selectors with empty fields, we could change the identifier to something else. I did see that the c++ parser used to use a selector expr with a null field but that was changed a while ago now. If this is something that is desirable, then I'll make a similar change to the c++ parser as well. Anyways, let me know what you think of a change like this. Thanks!