### PR TITLE
`text/scanner`: Add missing switch case for octal prefix (fixes #5239)

### DIFF
--- a/core/text/scanner/scanner.odin
+++ b/core/text/scanner/scanner.odin
@@ -341,8 +341,10 @@ scan_number :: proc(s: ^Scanner, ch: rune, seen_dot: bool) -> (rune, rune) {
 				case 'x':
 					ch = advance(s)
 					base, prefix = 16, 'x'
-				case:
+				case 'o':
+					ch = advance(s)
 					base, prefix = 8, 'o'
+				case:
 					digsep = 1 // Leading zero
 				}
 			} else {


### PR DESCRIPTION
Fix #5239 by adding missing switch case for octal prefix.

Code below prints `Float 0.0` without an error message, as expected.
```odin
package main

import "core:fmt"
import sc "core:text/scanner"

main :: proc() {
    s: sc.Scanner
    sc.init(&s, "0.0")
    s.flags = sc.C_Like_Tokens
    tok := sc.scan(&s)
    fmt.printfln(
        "%v %v",
        sc.token_string(tok, context.temp_allocator),
        sc.token_text(&s),
    )
}
```