### PR TITLE
Add "contextless" to procs in slice package

### DIFF
--- a/core/slice/slice.odin
+++ b/core/slice/slice.odin
@@ -41,7 +41,7 @@ to_bytes :: proc "contextless" (s: []$T) -> []byte {
 	Turns a byte slice into a type.
 */
 @(require_results)
-to_type :: proc(buf: []u8, $T: typeid) -> (T, bool) #optional_ok {
+to_type :: proc "contextless" (buf: []u8, $T: typeid) -> (T, bool) #optional_ok {
 	if len(buf) < size_of(T) {
 		return {}, false
 	}
@@ -97,7 +97,7 @@ reinterpret :: proc "contextless" ($T: typeid/[]$U, s: []$V) -> []U {
 }
 
 
-swap :: proc(array: $T/[]$E, a, b: int) {
+swap :: proc "contextless" (array: $T/[]$E, a, b: int) {
 	when size_of(E) > 8 {
 		ptr_swap_non_overlapping(&array[a], &array[b], size_of(E))
 	} else {
@@ -105,7 +105,7 @@ swap :: proc(array: $T/[]$E, a, b: int) {
 	}
 }
 
-swap_between :: proc(a, b: $T/[]$E) {
+swap_between :: proc "contextless" (a, b: $T/[]$E) {
 	n := builtin.min(len(a), len(b))
 	if n >= 0 {
 		ptr_swap_overlapping(&a[0], &b[0], size_of(E)*n)
@@ -113,7 +113,7 @@ swap_between :: proc(a, b: $T/[]$E) {
 }
 
 
-reverse :: proc(array: $T/[]$E) {
+reverse :: proc "contextless" (array: $T/[]$E) {
 	n := len(array)/2
 	for i in 0..<n {
 		swap(array, i, len(array)-i-1)
@@ -122,7 +122,7 @@ reverse :: proc(array: $T/[]$E) {
 
 
 @(require_results)
-contains :: proc(array: $T/[]$E, value: E) -> bool where intrinsics.type_is_comparable(E) {
+contains :: proc "contextless" (array: $T/[]$E, value: E) -> bool where intrinsics.type_is_comparable(E) {
 	_, found := linear_search(array, value)
 	return found
 }
@@ -156,7 +156,7 @@ Example:
 	assert(index == 1 && found == true)
 */
 @(require_results)
-linear_search :: proc(array: $A/[]$T, key: T) -> (index: int, found: bool)
+linear_search :: proc "contextless" (array: $A/[]$T, key: T) -> (index: int, found: bool)
 	where intrinsics.type_is_comparable(T) {
 	for x, i in array {
 		if x == key {
@@ -219,7 +219,7 @@ Example:
 	assert(index == 1 && found == true)
 */
 @(require_results)
-linear_search_reverse :: proc(array: $A/[]$T, key: T) -> (index: int, found: bool)
+linear_search_reverse :: proc "contextless" (array: $A/[]$T, key: T) -> (index: int, found: bool)
 	where intrinsics.type_is_comparable(T) {
 	#reverse for x, i in array {
 		if x == key {
@@ -327,7 +327,7 @@ binary_search_by :: proc(array: $A/[]$T, key: $K, f: proc(T, K) -> Ordering) -> 
 }
 
 @(require_results)
-equal :: proc(a, b: $T/[]$E) -> bool where intrinsics.type_is_comparable(E) #no_bounds_check {
+equal :: proc "contextless" (a, b: $T/[]$E) -> bool where intrinsics.type_is_comparable(E) #no_bounds_check {
 	if len(a) != len(b) {
 		return false
 	}
@@ -355,7 +355,7 @@ equal :: proc(a, b: $T/[]$E) -> bool where intrinsics.type_is_comparable(E) #no_
 }
 
 @(require_results)
-simple_equal :: proc(a, b: $T/[]$E) -> bool where intrinsics.type_is_simple_compare(E) {
+simple_equal :: proc "contextless" (a, b: $T/[]$E) -> bool where intrinsics.type_is_simple_compare(E) {
 	if len(a) != len(b) {
 		return false
 	}
@@ -370,7 +370,7 @@ simple_equal :: proc(a, b: $T/[]$E) -> bool where intrinsics.type_is_simple_comp
 	slice.prefix_length([]u8{1, 2, 3, 4}, []u8{2, 3, 4}) -> 0
 */
 @(require_results)
-prefix_length :: proc(a, b: $T/[]$E) -> (n: int) where intrinsics.type_is_comparable(E) {
+prefix_length :: proc "contextless" (a, b: $T/[]$E) -> (n: int) where intrinsics.type_is_comparable(E) {
 	_len := builtin.min(len(a), len(b))
 
 	#no_bounds_check for n < _len && a[n] == b[n] {
@@ -380,7 +380,7 @@ prefix_length :: proc(a, b: $T/[]$E) -> (n: int) where intrinsics.type_is_compar
 }
 
 @(require_results)
-has_prefix :: proc(array: $T/[]$E, needle: T) -> bool where intrinsics.type_is_comparable(E) {
+has_prefix :: proc "contextless" (array: $T/[]$E, needle: T) -> bool where intrinsics.type_is_comparable(E) {
 	n := len(needle)
 	if len(array) >= n {
 		return equal(array[:n], needle)
@@ -398,7 +398,7 @@ has_prefix :: proc(array: $T/[]$E, needle: T) -> bool where intrinsics.type_is_c
 	slice.suffix_length([]u8{3, 4, 5}, []u8{3, 5}) -> 1
 */
 @(require_results)
-suffix_length :: proc(a, b: $T/[]$E) -> (n: int) where intrinsics.type_is_comparable(E) {
+suffix_length :: proc "contextless" (a, b: $T/[]$E) -> (n: int) where intrinsics.type_is_comparable(E) {
 	len_a, len_b := len(a), len(b)
 	_len := builtin.min(len_a, len_b)
 
@@ -409,7 +409,7 @@ suffix_length :: proc(a, b: $T/[]$E) -> (n: int) where intrinsics.type_is_compar
 }
 
 @(require_results)
-has_suffix :: proc(array: $T/[]$E, needle: T) -> bool where intrinsics.type_is_comparable(E) {
+has_suffix :: proc "contextless" (array: $T/[]$E, needle: T) -> bool where intrinsics.type_is_comparable(E) {
 	array := array
 	m, n := len(array), len(needle)
 	if m >= n {
@@ -418,13 +418,13 @@ has_suffix :: proc(array: $T/[]$E, needle: T) -> bool where intrinsics.type_is_c
 	return false
 }
 
-zero :: proc(array: $T/[]$E) #no_bounds_check {
+zero :: proc "contextless" (array: $T/[]$E) #no_bounds_check {
 	if len(array) > 0 {
 		intrinsics.mem_zero(raw_data(array), size_of(E)*len(array))
 	}
 }
 
-fill :: proc(array: $T/[]$E, value: E) #no_bounds_check {
+fill :: proc "contextless" (array: $T/[]$E, value: E) #no_bounds_check {
 	if len(array) <= 0 {
 		return
 	}
@@ -434,7 +434,7 @@ fill :: proc(array: $T/[]$E, value: E) #no_bounds_check {
 	}
 }
 
-rotate_left :: proc(array: $T/[]$E, mid: int) {
+rotate_left :: proc "contextless" (array: $T/[]$E, mid: int) {
 	n := len(array)
 	m := mid %% n
 	k := n - m
@@ -443,7 +443,7 @@ rotate_left :: proc(array: $T/[]$E, mid: int) {
 	p := cast(^E)raw_data(array)
 	ptr_rotate(m, ptr_add(p, m), k)
 }
-rotate_right :: proc(array: $T/[]$E, k: int) {
+rotate_right :: proc "contextless" (array: $T/[]$E, k: int) {
 	rotate_left(array, -k)
 }
 
@@ -502,11 +502,11 @@ into_dynamic :: proc(a: $T/[]$E) -> [dynamic]E {
 
 
 @(require_results)
-length :: proc(a: $T/[]$E) -> int {
+length :: proc "contextless" (a: $T/[]$E) -> int {
 	return len(a)
 }
 @(require_results)
-is_empty :: proc(a: $T/[]$E) -> bool {
+is_empty :: proc "contextless" (a: $T/[]$E) -> bool {
 	return len(a) == 0
 }
 
@@ -519,40 +519,40 @@ size :: proc "contextless" (a: $T/[]$E) -> int {
 
 
 @(require_results)
-split_at :: proc(array: $T/[]$E, index: int) -> (a, b: T) {
+split_at :: proc "contextless" (array: $T/[]$E, index: int) -> (a, b: T) {
 	return array[:index], array[index:]
 }
 
 
 @(require_results)
-split_first :: proc(array: $T/[]$E) -> (first: E, rest: T) {
+split_first :: proc "contextless" (array: $T/[]$E) -> (first: E, rest: T) {
 	return array[0], array[1:]
 }
 @(require_results)
-split_last :: proc(array: $T/[]$E) -> (rest: T, last: E) {
+split_last :: proc "contextless" (array: $T/[]$E) -> (rest: T, last: E) {
 	n := len(array)-1
 	return array[:n], array[n]
 }
 
 @(require_results)
-first :: proc(array: $T/[]$E) -> E {
+first :: proc "contextless" (array: $T/[]$E) -> E {
 	return array[0]
 }
 @(require_results)
-last :: proc(array: $T/[]$E) -> E {
+last :: proc "contextless" (array: $T/[]$E) -> E {
 	return array[len(array)-1]
 }
 
 
 @(require_results)
-first_ptr :: proc(array: $T/[]$E) -> ^E {
+first_ptr :: proc "contextless" (array: $T/[]$E) -> ^E {
 	if len(array) != 0 {
 		return &array[0]
 	}
 	return nil
 }
 @(require_results)
-last_ptr :: proc(array: $T/[]$E) -> ^E {
+last_ptr :: proc "contextless" (array: $T/[]$E) -> ^E {
 	if len(array) != 0 {
 		return &array[len(array)-1]
 	}
@@ -560,7 +560,7 @@ last_ptr :: proc(array: $T/[]$E) -> ^E {
 }
 
 @(require_results)
-get :: proc(array: $T/[]$E, index: int) -> (value: E, ok: bool) {
+get :: proc "contextless" (array: $T/[]$E, index: int) -> (value: E, ok: bool) {
 	if uint(index) < len(array) {
 		value = array[index]
 		ok = true
@@ -568,7 +568,7 @@ get :: proc(array: $T/[]$E, index: int) -> (value: E, ok: bool) {
 	return
 }
 @(require_results)
-get_ptr :: proc(array: $T/[]$E, index: int) -> (value: ^E, ok: bool) {
+get_ptr :: proc "contextless" (array: $T/[]$E, index: int) -> (value: ^E, ok: bool) {
 	if uint(index) < len(array) {
 		value = &array[index]
 		ok = true
@@ -577,7 +577,7 @@ get_ptr :: proc(array: $T/[]$E, index: int) -> (value: ^E, ok: bool) {
 }
 
 @(require_results)
-as_ptr :: proc(array: $T/[]$E) -> [^]E {
+as_ptr :: proc "contextless" (array: $T/[]$E) -> [^]E {
 	return raw_data(array)
 }
 
@@ -672,7 +672,7 @@ repeat :: proc(s: $S/[]$U, count: int, allocator := context.allocator) -> (b: S,
 // 'unique' replaces consecutive runs of equal elements with a single copy.
 // The procedures modifies the slice in-place and returns the modified slice.
 @(require_results)
-unique :: proc(s: $S/[]$T) -> S where intrinsics.type_is_comparable(T) #no_bounds_check {
+unique :: proc "contextless" (s: $S/[]$T) -> S where intrinsics.type_is_comparable(T) #no_bounds_check {
 	if len(s) < 2 {
 		return s
 	}
@@ -711,7 +711,7 @@ unique_proc :: proc(s: $S/[]$T, eq: proc(T, T) -> bool) -> S #no_bounds_check {
 
 
 @(require_results)
-min :: proc(s: $S/[]$T) -> (res: T, ok: bool) where intrinsics.type_is_ordered(T) #optional_ok {
+min :: proc "contextless" (s: $S/[]$T) -> (res: T, ok: bool) where intrinsics.type_is_ordered(T) #optional_ok {
 	if len(s) != 0 {
 		res = s[0]
 		ok = true
@@ -722,7 +722,7 @@ min :: proc(s: $S/[]$T) -> (res: T, ok: bool) where intrinsics.type_is_ordered(T
 	return
 }
 @(require_results)
-max :: proc(s: $S/[]$T) -> (res: T, ok: bool) where intrinsics.type_is_ordered(T) #optional_ok {
+max :: proc "contextless" (s: $S/[]$T) -> (res: T, ok: bool) where intrinsics.type_is_ordered(T) #optional_ok {
 	if len(s) != 0 {
 		res = s[0]
 		ok = true
@@ -734,7 +734,7 @@ max :: proc(s: $S/[]$T) -> (res: T, ok: bool) where intrinsics.type_is_ordered(T
 }
 
 @(require_results)
-min_max :: proc(s: $S/[]$T) -> (min, max: T, ok: bool) where intrinsics.type_is_ordered(T) {
+min_max :: proc "contextless" (s: $S/[]$T) -> (min, max: T, ok: bool) where intrinsics.type_is_ordered(T) {
 	if len(s) != 0 {
 		min, max = s[0], s[0]
 		ok = true
@@ -748,7 +748,7 @@ min_max :: proc(s: $S/[]$T) -> (min, max: T, ok: bool) where intrinsics.type_is_
 
 // Find the index of the (first) minimum element in a slice.
 @(require_results)
-min_index :: proc(s: $S/[]$T) -> (min_index: int, ok: bool) where intrinsics.type_is_ordered(T) #optional_ok {
+min_index :: proc "contextless" (s: $S/[]$T) -> (min_index: int, ok: bool) where intrinsics.type_is_ordered(T) #optional_ok {
 	if len(s) == 0 {
 		return -1, false
 	}
@@ -765,7 +765,7 @@ min_index :: proc(s: $S/[]$T) -> (min_index: int, ok: bool) where intrinsics.typ
 
 // Find the index of the (first) maximum element in a slice.
 @(require_results)
-max_index :: proc(s: $S/[]$T) -> (max_index: int, ok: bool) where intrinsics.type_is_ordered(T) #optional_ok {
+max_index :: proc "contextless" (s: $S/[]$T) -> (max_index: int, ok: bool) where intrinsics.type_is_ordered(T) #optional_ok {
 	if len(s) == 0 {
 		return -1, false
 	}
@@ -781,7 +781,7 @@ max_index :: proc(s: $S/[]$T) -> (max_index: int, ok: bool) where intrinsics.typ
 }
 
 @(require_results)
-any_of :: proc(s: $S/[]$T, value: T) -> bool where intrinsics.type_is_comparable(T) {
+any_of :: proc "contextless" (s: $S/[]$T, value: T) -> bool where intrinsics.type_is_comparable(T) {
 	for v in s {
 		if v == value {
 			return true
@@ -791,7 +791,7 @@ any_of :: proc(s: $S/[]$T, value: T) -> bool where intrinsics.type_is_comparable
 }
 
 @(require_results)
-none_of :: proc(s: $S/[]$T, value: T) -> bool where intrinsics.type_is_comparable(T) {
+none_of :: proc "contextless" (s: $S/[]$T, value: T) -> bool where intrinsics.type_is_comparable(T) {
 	for v in s {
 		if v == value {
 			return false
@@ -801,7 +801,7 @@ none_of :: proc(s: $S/[]$T, value: T) -> bool where intrinsics.type_is_comparabl
 }
 
 @(require_results)
-all_of :: proc(s: $S/[]$T, value: T) -> bool where intrinsics.type_is_comparable(T) {
+all_of :: proc "contextless" (s: $S/[]$T, value: T) -> bool where intrinsics.type_is_comparable(T) {
 	if len(s) == 0 {
 		return false
 	}
@@ -849,7 +849,7 @@ all_of_proc :: proc(s: $S/[]$T, f: proc(T) -> bool) -> bool {
 
 
 @(require_results)
-count :: proc(s: $S/[]$T, value: T) -> (n: int) where intrinsics.type_is_comparable(T) {
+count :: proc "contextless" (s: $S/[]$T, value: T) -> (n: int) where intrinsics.type_is_comparable(T) {
 	for v in s {
 		if v == value {
 			n += 1
@@ -870,7 +870,7 @@ count_proc :: proc(s: $S/[]$T, f: proc(T) -> bool) -> (n: int) {
 
 
 @(require_results)
-dot_product :: proc(a, b: $S/[]$T) -> (r: T, ok: bool)
+dot_product :: proc "contextless" (a, b: $S/[]$T) -> (r: T, ok: bool)
 	where intrinsics.type_is_numeric(T) {
 	if len(a) != len(b) {
 		return
@@ -884,7 +884,7 @@ dot_product :: proc(a, b: $S/[]$T) -> (r: T, ok: bool)
 
 // Convert a pointer to an enumerated array to a slice of the element type
 @(require_results)
-enumerated_array :: proc(ptr: ^$T) -> []intrinsics.type_elem_type(T)
+enumerated_array :: proc "contextless" (ptr: ^$T) -> []intrinsics.type_elem_type(T)
 	where intrinsics.type_is_enumerated_array(T) {
 	return ([^]intrinsics.type_elem_type(T))(ptr)[:len(T)]
 }
@@ -893,7 +893,7 @@ enumerated_array :: proc(ptr: ^$T) -> []intrinsics.type_elem_type(T)
 // e.g.:
 //    bs := slice.enum_slice_to_bitset(my_flag_slice, rl.ConfigFlags)
 @(require_results)
-enum_slice_to_bitset :: proc(enums: []$E, $T: typeid/bit_set[E]) -> (bits: T) where intrinsics.type_is_enum(E), intrinsics.type_bit_set_elem_type(T) == E {
+enum_slice_to_bitset :: proc "contextless" (enums: []$E, $T: typeid/bit_set[E]) -> (bits: T) where intrinsics.type_is_enum(E), intrinsics.type_bit_set_elem_type(T) == E {
 	for v in enums {
 		bits += {v}
 	}
@@ -904,7 +904,7 @@ enum_slice_to_bitset :: proc(enums: []$E, $T: typeid/bit_set[E]) -> (bits: T) wh
 // e.g.:
 //    sl := slice.bitset_to_enum_slice(flag_buf[:], bs)
 @(require_results)
-bitset_to_enum_slice_with_buffer :: proc(buf: []$E, bs: $T) -> (slice: []E) where intrinsics.type_is_enum(E), intrinsics.type_bit_set_elem_type(T) == E {
+bitset_to_enum_slice_with_buffer :: proc "contextless" (buf: []$E, bs: $T) -> (slice: []E) where intrinsics.type_is_enum(E), intrinsics.type_bit_set_elem_type(T) == E {
 	count := 0
 	for v in bs {
 		buf[count] = v


### PR DESCRIPTION
Looks like a lot of procedures in the `slice` package could use a `"contextless"` calling convention as most don't require context. Some procedures there already were contextless, but it was applied inconsistently—why would `to_bytes` be contextless, but not `to_type`.
Let me know if some of these should require context by design or something.