### PR TITLE
removes the darwin specific paths from thread_unix

### DIFF
--- a/core/thread/thread_unix.odin
+++ b/core/thread/thread_unix.odin
@@ -22,11 +22,6 @@ _create :: proc(procedure: Thread_Proc, priority: Thread_Priority) -> ^Thread {
 	__unix_thread_entry_proc :: proc "c" (t: rawptr) -> rawptr {
 		t := (^Thread)(t)
 
-		// We need to give the thread a moment to start up before we enable cancellation.
-		// NOTE(laytan): setting to .DISABLE on darwin, with .ENABLE pthread_cancel would deadlock
-		// most of the time, don't ask me why.
-		can_set_thread_cancel_state := posix.pthread_setcancelstate(.DISABLE when ODIN_OS == .Darwin else .ENABLE, nil) == nil
-
 		t.id = sync.current_thread_id()
 
 		for (.Started not_in sync.atomic_load(&t.flags)) {
@@ -34,16 +29,14 @@ _create :: proc(procedure: Thread_Proc, priority: Thread_Priority) -> ^Thread {
 		}
 
 		// Enable thread's cancelability.
-		// NOTE(laytan): Darwin does not correctly/fully support all of this, not doing this does
-		// actually make pthread_cancel work in the capacity of my tests, while executing this would
-		// basically always make it deadlock.
-		if ODIN_OS != .Darwin && can_set_thread_cancel_state {
-			err := posix.pthread_setcancelstate(.ENABLE, nil)
-			assert_contextless(err == nil)
+		err := posix.pthread_setcancelstate(.ENABLE, nil)
+		assert_contextless(err == nil)
 
-			err = posix.pthread_setcanceltype(.ASYNCHRONOUS, nil)
-			assert_contextless(err == nil)
-		}
+		// NOTE(laytan): .ASYNCHRONOUS should make `pthread_cancel` cancel immediately
+		// instead of waiting for a cancellation point.
+		// This does not seem to work on at least Darwin and NetBSD though.
+		err = posix.pthread_setcanceltype(.ASYNCHRONOUS, nil)
+		assert_contextless(err == nil)
 
 		{
 			init_context := t.init_context


### PR DESCRIPTION
I know I left a note there about deadlocks but it doesn't seem to happen anymore, especially now that the test runner creates cancellation points.

Also, what was this `can_set_thread_cancel_state` for? It does not make sense to me that it enables cancellation, and then does it again later. With the comment it seems like it should be `.DISABLE` to first disable and then wait for the thread to start. But even that seems weird, why do you need to do that? I removed it.