### PR TITLE
Don't check proc signature similarity for imported Objective-C methods

### DIFF
--- a/src/check_decl.cpp
+++ b/src/check_decl.cpp
@@ -1607,8 +1607,7 @@ gb_internal void check_proc_decl(CheckerContext *ctx, Entity *e, DeclInfo *d) {
 		if (is_arch_wasm() && foreign_library != nullptr) {
 			// NOTE(bill): this must be delayed because the foreign import paths might not be evaluated yet until much later
 			mpsc_enqueue(&ctx->info->foreign_decls_to_check, e);
-		} else {
-			// TODO(harold): Check if it's an objective-C foreign, if so, I don't think we need to check it.
+		} else if (!e->Procedure.is_objc_impl_or_import) {
 			check_foreign_procedure(ctx, e, d);
 		}
 	} else {


### PR DESCRIPTION
It is inappropriate to perform a signature check as Objective-C procedures imported from external libraries (under a `foreign` block) are loaded via the Objective-C runtime and not as linked functions, therefore this collision check does not apply to them.

I had initially left as a `TODO` but I did run into this issue yesterday with `QuartzCore` and `AppKit` where `CAAnimationDelegate.animationDidStop` and `NSAnimationDelegate.animationDidStop` collided.

