### PR TITLE
runtime: replace default RNG with xoshiro256** + splitmix64; SOLVE: #5881

### DIFF
--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -22,6 +22,7 @@ $ODIN test ../test_issue_3435.odin $COMMON
 $ODIN test ../test_issue_4210.odin $COMMON
 $ODIN test ../test_issue_4364.odin $COMMON
 $ODIN test ../test_issue_4584.odin $COMMON
+$ODIN test ../test_issue_5881.odin $COMMON
 if [[ $($ODIN build ../test_issue_2395.odin $COMMON 2>&1 >/dev/null | grep -c "Error:") -eq 2 ]] ; then
 	echo "SUCCESSFUL 1/1"
 else

--- a/tests/issues/test_issue_5881.odin
+++ b/tests/issues/test_issue_5881.odin
@@ -1,0 +1,93 @@
+// Tests issue #5881 https://github.com/odin-lang/Odin/issues/5881
+package test_issues
+
+import "core:math"
+import "core:math/rand"
+import "core:testing"
+import "base:runtime"
+
+// Helper: compute chi-square statistic for counts vs equal-expected across k bins
+chi_square_equal :: proc(counts: []int) -> f64 {
+	n := 0
+	for c in counts {
+		n += c
+	}
+	if n == 0 {
+		return 0
+	}
+	k := len(counts)
+	exp := f64(n) / f64(k)
+	stat := f64(0)
+	for c in counts {
+		d := f64(c) - exp
+		stat += (d * d) / exp
+	}
+	return stat
+}
+
+// Helper: check bit balance on u64 across many samples
+expect_u64_bit_balance :: proc(t: ^testing.T, gen: rand.Generator, samples: int, sigma_k: f64 = 6) {
+	ones: [64]int
+	for i := 0; i < samples; i += 1 {
+		v := rand.uint64(gen)
+		for b := 0; b < 64; b += 1 {
+			ones[b] += int((v >> u64(b)) & 1)
+		}
+	}
+	mu := f64(samples) * 0.5
+	sigma := math.sqrt(f64(samples) * 0.25)
+	limit := sigma_k * sigma
+	for b := 0; b < 64; b += 1 {
+		diff := math.abs(f64(ones[b]) - mu)
+		if diff > limit {
+			testing.expectf(t, false, "u64 bit %d imbalance: ones=%d samples=%d diff=%.1f limit=%.1f", b, ones[b], samples, diff, limit)
+			return
+		}
+	}
+}
+
+// Uniformity sanity via 4D sign orthant chi-square with modest sample size.
+expect_quaternion_sign_uniformity :: proc(t: ^testing.T, gen: rand.Generator, iterations: int) {
+	counts: [16]int
+	for _ in 0..<iterations {
+		// Map 4D signs to 0..15 index
+		x := rand.float64_range(-10, 10, gen)
+		y := rand.float64_range(-10, 10, gen)
+		z := rand.float64_range(-10, 10, gen)
+		w := rand.float64_range(-10, 10, gen)
+		idx := 0
+		if x >= 0 { idx |= 1 }
+		if y >= 0 { idx |= 2 }
+		if z >= 0 { idx |= 4 }
+		if w >= 0 { idx |= 8 }
+		counts[idx] += 1
+	}
+	// df = 15. For a modest sample size, use a generous cutoff to reduce flakiness.
+	// Chi-square critical values (df=15): p=0.001 -> ~37.7, p=0.0001 -> ~43.8
+	// We accept < 55 as a conservative stability bound across platforms.
+	chi := chi_square_equal(counts[:])
+	testing.expectf(t, chi < 55.0, "4D sign chi-square too high: %.3f (counts=%v)", chi, counts)
+}
+
+@test
+test_runtime_default_rng_properties :: proc(t: ^testing.T) {
+	// Determinism with same seed
+	state1 := rand.create(123456789)
+	state2 := rand.create(123456789)
+	gen1 := rand.default_random_generator(&state1)
+	gen2 := rand.default_random_generator(&state2)
+	a1 := rand.uint64(gen1)
+	a2 := rand.uint64(gen2)
+	testing.expect(t, a1 == a2, "default RNG not deterministic with same seed")
+
+	// Info flags
+	info := rand.query_info(gen1)
+	testing.expect(t, runtime.Random_Generator_Query_Info_Flag.Uniform in info, "default RNG must be Uniform")
+	testing.expect(t, runtime.Random_Generator_Query_Info_Flag.Resettable in info, "default RNG must be Resettable")
+
+	// Bit balance and sign uniformity (modest samples to keep CI fast)
+	expect_u64_bit_balance(t, gen1, 200_000)
+	expect_quaternion_sign_uniformity(t, gen1, 200_000)
+}
+
+


### PR DESCRIPTION
runtime: replace default RNG with xoshiro256** + splitmix64; deterministic seeding

- Replace custom RNG with xoshiro256** (rotl(s1*5,7)*9) and standard state transition for high-quality, unbiased 64-bit outputs.
- Seed via splitmix64 expansion into 4×u64; `.Reset(seed)` is deterministic for all seeds, including 0.
- Use cycle-counter seeding only on first use when state is all-zero and no explicit `.Reset` was called.

BREAKING CHANGE: Default RNG sequences for a given seed have changed.
Refs: #5881

---

# Odin default RNG bias

## Background: original RNG and observed bias

The previous default RNG in `Odin/base/runtime/random_generator.odin` implemented a custom 64‑bit generator that:
- updated a 64‑bit internal `state` with a linear recurrence,
- constructed the output by combining bitwise operations (including a dependency on the highest bits of `state`), and
- used that same top‑bit region to parameterize a rotation of the mixed value.

Symptoms reported by @SOBEX (issue #5881):
- A simple 4D sign test (counting in which orthant uniformly sampled points fall) showed large deviations from uniformity with the default RNG.
- The bias was visible across specific bit positions within each group of generated 64‑bit outputs (e.g., the 2nd, 65th/66th, etc.), impacting floating‑point generation significantly.
- Substituting `core:crypto.random_generator()` (OS entropy) produced nearly uniform results in the same test.

Example reproduction (20,000,000 iterations; expected per cell ≈ 1,250,000):

Default RNG (old):
```
[[[[6211079, 6217687], [7032779, 7032439]], [[5512272, 5520713], [6234779, 6233805]]],
 [[[6235810, 6236637], [7089622, 7077973]], [[5466182, 5474363], [6216283, 6207577]]]]
```

Crypto RNG (OS entropy):
```
[[[[6249432, 6247440], [6254894, 6246002]], [[6249059, 6250686], [6246800, 6245386]]],
 [[[6252428, 6252212], [6252157, 6246725]], [[6249742, 6250116], [6253940, 6252981]]]]
```

The default RNG’s orthant counts (old) show pronounced skew not seen under the crypto RNG.

---

## Root cause

Two interacting issues in the original algorithm caused structural bias:
1) Non‑standard mixing and rotation:
   - The output transform used a rotation amount derived from the same high bits that also guided other parts of the mixing function.
   - Reusing the same bit slice for both "how much to rotate" and "what to rotate" creates correlations that systematically favor or disfavor particular bit positions in the output word.
2) Weak low‑order statistics carried into float sampling:
   - Odin’s `float64()` draws from integer output and maps to the unit interval (with rejection for bounds), assuming the integer generator is uniform over its bit width.
   - Any per‑bit skew in the generator leaks into sign tests and floating‑point sampling, manifesting as quadrant/orthant bias in simple geometric tests.

Together these produced the observed, reproducible deviations from uniformity and bit balance.

---

## Chosen algorithms

### Core generator: xoshiro256**

I replaced the previous custom transform with xoshiro256**:
- State: 256 bits (4 × u64)
- Output function ("star‑star"): `rotl(s1 * 5, 7) * 9`
- Transition: xorshifts and fixed rotations on the state words

This generator is widely used and extremely fast. 

### Seeding: splitmix64 expansion

Seed the 256‑bit xoshiro state by expanding a single 64‑bit seed with splitmix64:
- On `.Reset(seed)`, we run splitmix64 four times to fill `[4]u64`. This is fully deterministic for any 64‑bit seed value, including `0`.
- If no seed is explicitly provided by the user (i.e., the generator is used without a prior `.Reset` and the internal state is all‑zero), we fallback to a platform cycle counter to produce a non‑zero state via splitmix64.
- We defensively guard against the extremely unlikely all‑zero state.

Splitmix64 is fast, simple, and purpose‑built for turning a small seed into a well‑distributed stream suitable for seeding other PRNGs.

---

## Testing and validation

I added a targeted test (see `Odin/tests/issues/test_issue_5881.odin`) that check:
- Determinism: two RNGs reset with the same seed produce the same first value.
- Flags: `.Uniform` and `.Resettable` are reported by the default RNG.
- Bit balance: for 200,000 samples of `uint64`, each bit’s count of ones is within a 6σ bound around 50%.
- 4D sign uniformity: we sample signs of 4 independent `float64_range(-10, 10)` draws, bin into 16 orthants, and check the chi‑square statistic against a generous threshold. The fixed generator passes; the old version did not.

Example runs (20,000,000 iterations; expected per cell ≈ 1,250,000) after the fix:
```
default random generator:
[[[[1250162, 1250442], [1250820, 1251092]], [[1250518, 1250322], [1248821, 1249426]]],
 [[[1250280, 1250451], [1249173, 1248935]], [[1249642, 1250723], [1249094, 1250099]]]]

crypto random generator:
[[[[1250161, 1249435], [1252261, 1249551]], [[1249452, 1252756], [1249809, 1249990]]],
 [[[1247632, 1250246], [1248428, 1250507]], [[1250048, 1247982], [1251448, 1250294]]]]
```

Both sets are close to uniform. The new default generator exhibits no visible skew in this test.

---

## Compatibility

- API compatibility: unchanged. The default RNG is still exposed through the same `Random_Generator` surface, with `.Reset` accepting a `u64` seed (now expanded via splitmix64).
- Sequence compatibility: changed. The bit sequences for a given seed will differ from prior releases due to the new algorithm and seeding method. This is expected. Users relying on exact historical sequences should pin to an older compiler version or provide their own PRNG implementation.
- Cryptography: unchanged guidance. 

---

## Acknowledgements

This fix draws on research and practice around the xoshiro family (Sebastiano Vigna, David Blackman) and splitmix64.

---

## Reproduction snippet (4D sign orthant)

```odin
import "core:math/rand"
import "core:fmt"

random_generator_period_quat256 :: proc(iterations := 100_000_000, gen := context.random_generator) {
    counts: [2][2][2][2]int
    for _ in 0..<iterations {
        x := rand.float64_range(-10, 10, gen)
        y := rand.float64_range(-10, 10, gen)
        z := rand.float64_range(-10, 10, gen)
        w := rand.float64_range(-10, 10, gen)
        counts[w >= 0 ? 1 : 0][z >= 0 ? 1 : 0][y >= 0 ? 1 : 0][x >= 0 ? 1 : 0] += 1
    }
    fmt.println(counts)
}
```

## How it can break in theory (general stuff)

  - Deterministic sequences change: Any code that assert exact numbers from a given seed will fail.
  - Procedural generation reproducibility: Worlds/levels/assets keyed by a seed won’t reproduce identically across compiler versions.
  - Replays/snapshots: Simulations or game replays that depend on "same seed => same evolution" across versions will diverge.
  - Serialized/checkpointed RNG state: If only the seed (not full internal state) is saved, resumed runs will diverge from pre-change behavior.

- What won’t break
  - Tests checking properties/statistics (distribution, bounds, determinism per run) rather than exact values.
  - Code that only needs determinism within the same version while providing its own seed.
  - Users who don’t rely on cross-version reproducibility.

- Additional to be aware of
  - Seed 0 is now a valid deterministic seed. If anyone passed 0 expecting "randomize" behavior, they’ll now get a stable sequence. Randomized seeding still happens but only when no Reset occurred and the state is all-zero.

CI building fine is expected (I hope): this is a behavioral change, not an API/ABI change.

## Why changing in theory

A biased default RNG might cause subtle errors that would be hard to diagnose.

- **Statistical correctness**: Monte Carlo, simulations, p-values, and estimators get skewed; results can be systematically uncorrect rather than just noisy.
- **Procedural generation**: Symmetry-breaking artifacts, uneven distributions, and reproducibility that "works" but yields the wrong distribution.
- **Security-adjacent** (non-crypto): More predictable patterns and worse behavior in randomized algorithms (hash seeding, randomized quicksort pivoting), increasing worst-case risks.

Even small biases become visible with large samples and propagate widely. Fixing the default (as done or with any other PR) is the right call.

---

@gingerBill , what do you think? 



