### PR TITLE
Fix typo in NS.String_initWithCString

### DIFF
--- a/core/sys/darwin/Foundation/NSString.odin
+++ b/core/sys/darwin/Foundation/NSString.odin
@@ -81,7 +81,7 @@ String_initWithString :: proc "c" (self: ^String, other: ^String) -> ^String {
 
 @(objc_type=String, objc_name="initWithCString")
 String_initWithCString :: proc "c" (self: ^String, pString: cstring, encoding: StringEncoding) -> ^String {
-	return msgSend(^String, self, "initWithCstring:encoding:", pString, encoding)
+	return msgSend(^String, self, "initWithCString:encoding:", pString, encoding)
 }
 
 @(objc_type=String, objc_name="initWithBytesNoCopy")


### PR DESCRIPTION
Was getting an unknown selector error whenever I called `NS.String_initWithCString`. Turns out there was a typo in the binding. I have tested this change to make sure it works.