### PR TITLE
change STBI resize alpha_channel parameter type to c.int

### DIFF
--- a/vendor/stb/image/stb_image_resize.odin
+++ b/vendor/stb/image/stb_image_resize.odin
@@ -79,13 +79,13 @@ edge :: enum c.int {
 foreign lib {
 	resize_uint8_srgb :: proc(input_pixels: [^]u8, input_w, input_h, input_stride_in_bytes: c.int,
 	                          output_pixels: [^]u8, output_w, output_h, output_stride_in_bytes: c.int,
-	                          num_channels: c.int, alpha_channel: b32, flags: c.int) -> c.int ---
+	                          num_channels: c.int, alpha_channel: c.int, flags: c.int) -> c.int ---
 
 
 	// This function adds the ability to specify how requests to sample off the edge of the image are handled.
 	resize_uint8_srgb_edgemode :: proc(input_pixels:  [^]u8, input_w,  input_h,  input_stride_in_bytes: c.int,
 	                                   output_pixels: [^]u8, output_w, output_h, output_stride_in_bytes: c.int,
-	                                   num_channels: c.int, alpha_channel: b32, flags: c.int,
+	                                   num_channels: c.int, alpha_channel: c.int, flags: c.int,
 	                                   edge_wrap_mode: edge) -> c.int ---
 
 }
@@ -126,25 +126,25 @@ colorspace :: enum c.int {
 @(default_calling_convention="c", link_prefix="stbir_")
 foreign lib {
 	// The following functions are all identical except for the type of the image data
-	
+
 	resize_uint8_generic :: proc(input_pixels:  [^]u8, input_w,  input_h,  input_stride_in_bytes:  c.int,
 	                             output_pixels: [^]u8, output_w, output_h, output_stride_in_bytes: c.int,
-	                             num_channels: c.int, alpha_channel: b32, flags: c.int,
+	                             num_channels: c.int, alpha_channel: c.int, flags: c.int,
 	                             edge_wrap_mode: edge, filter: filter, space: colorspace,
 	                             alloc_context: rawptr) -> c.int ---
 
 	resize_uint16_generic :: proc(input_pixels:  [^]u16, input_w,  input_h,  input_stride_in_bytes:  c.int,
 	                              output_pixels: [^]u16, output_w, output_h, output_stride_in_bytes: c.int,
-	                              num_channels: c.int, alpha_channel: b32, flags: c.int,
+	                              num_channels: c.int, alpha_channel: c.int, flags: c.int,
 	                              edge_wrap_mode: edge, filter: filter, space: colorspace,
 	                              alloc_context: rawptr) -> c.int ---
 
 	resize_float_generic :: proc(input_pixels:  [^]f32, input_w,  input_h,  input_stride_in_bytes:  c.int,
 	                             output_pixels: [^]f32, output_w, output_h, output_stride_in_bytes: c.int,
-	                             num_channels: c.int, alpha_channel: b32, flags: c.int,
+	                             num_channels: c.int, alpha_channel: c.int, flags: c.int,
 	                             edge_wrap_mode: edge, filter: filter, space: colorspace,
-	                             alloc_context: rawptr) -> c.int ---	
-	
+	                             alloc_context: rawptr) -> c.int ---
+
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -173,11 +173,11 @@ datatype :: enum c.int {
 @(default_calling_convention="c", link_prefix="stbir_")
 foreign lib {
 	// (s0, t0) & (s1, t1) are the top-left and bottom right corner (uv addressing style: [0, 1]x[0, 1]) of a region of the input image to use.
-	
+
 	resize :: proc(input_pixels:  rawptr, input_w,  input_h,  input_stride_in_bytes:  c.int,
 	               output_pixels: rawptr, output_w, output_h, output_stride_in_bytes: c.int,
 	               datatype: datatype,
-	               num_channels: c.int, alpha_channel: b32, flags: c.int,
+	               num_channels: c.int, alpha_channel: c.int, flags: c.int,
 	               edge_mode_horizontal, edge_mode_vertical: edge,
 	               filter_horizontal, filter_vertical: filter,
 	               space: colorspace, alloc_context: rawptr) -> c.int ---
@@ -185,7 +185,7 @@ foreign lib {
 	resize_subpixel :: proc(input_pixels:  rawptr, input_w,  input_h,  input_stride_in_bytes:  c.int,
 	                        output_pixels: rawptr, output_w, output_h, output_stride_in_bytes: c.int,
 	                        datatype: datatype,
-	                        num_channels: c.int, alpha_channel: b32, flags: c.int,
+	                        num_channels: c.int, alpha_channel: c.int, flags: c.int,
 	                        edge_mode_horizontal, edge_mode_vertical: edge,
 	                        filter_horizontal, filter_vertical: filter,
 	                        space: colorspace, alloc_context: rawptr,
@@ -195,10 +195,10 @@ foreign lib {
 	resize_region :: proc(input_pixels:  rawptr, input_w,  input_h,  input_stride_in_bytes:  c.int,
 	                      output_pixels: rawptr, output_w, output_h, output_stride_in_bytes: c.int,
 	                      datatype: datatype,
-	                      num_channels: c.int, alpha_channel: b32, flags: c.int,
+	                      num_channels: c.int, alpha_channel: c.int, flags: c.int,
 	                      edge_mode_horizontal, edge_mode_vertical: edge,
 	                      filter_horizontal,  filter_vertical: filter,
 	                      space: colorspace, alloc_context: rawptr,
 	                      s0, t0, s1, t1: f32) -> c.int ---
-	
+
 }


### PR DESCRIPTION
I think the `alpha_channel` parameters in the `stb_image_resize` bindings are confusingly typed as `b32`. 

Initially, `b32` led me to believe it's a simple true vs false for presence of an alpha channel, but when resizing images with alpha, I noticed a magenta tint on the resulting images (see test images below). 

The R and B channels behave strangely in areas of high contrast, while G is fine, which i think is due to having b32 true interpreted as 1 for `alpha_channel`.  

Looking at the bindings & stb_image_resize.h, it seems the int represents the channel index, e.g. 
- `-1` (ALPHA_CHANNEL_NONE) for no alpha channel
- `0-3` for the index of the alpha channel, RGBA, ARGB etc..

this seems to be especially important depending on the flags used as part of the resize: 
```
//       * If alpha_channel is not STBIR_ALPHA_CHANNEL_NONE
//         * Alpha channel will not be gamma corrected (unless flags&STBIR_FLAG_GAMMA_CORRECT)
//         * Filters will be weighted by alpha channel (unless flags&STBIR_FLAG_ALPHA_PREMULTIPLIED)
```

I do realize that `transmute(b32)` can solve any issues here, but IMO `c.int` better represents how `alpha_channel` is being used. 
It took me a bit of time to work out what was going wrong, so just using `c.int` may be more helpful for users. 

### Fix
Just changed the 8 occurrances of `b32` to `c.int` where `alpha_channel` is used. 

incorrect result:
![stbi-alpha-bug](https://github.com/user-attachments/assets/7ef8c153-9cef-455d-9316-b69cf871cdb5)

correct result:
![stbi-alpha-fix](https://github.com/user-attachments/assets/a4fc865f-b343-4c2b-9a6b-5e47561e1c63)