### PR TITLE
Fix out of bounds access when parsing end_pos

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -99,19 +99,15 @@ end_pos :: proc(tok: tokenizer.Token) -> tokenizer.Pos {
 	pos := tok.pos
 	pos.offset += len(tok.text)
 
-	if tok.kind == .Comment || tok.kind == .String {
-		if tok.text[:2] == "/*" || tok.text[:1] == "`" {
-			for i := 0; i < len(tok.text); i += 1 {
-				c := tok.text[i]
-				if c == '\n' {
-					pos.line += 1
-					pos.column = 1
-				} else {
-					pos.column += 1
-				}
+	if (tok.kind == .Comment && tok.text[:2] == "/*") || (tok.kind == .String && tok.text[:1] == "`") {
+		for i := 0; i < len(tok.text); i += 1 {
+			c := tok.text[i]
+			if c == '\n' {
+				pos.line += 1
+				pos.column = 1
+			} else {
+				pos.column += 1
 			}
-		} else {
-			pos.column += len(tok.text)
 		}
 	} else {
 		pos.column += len(tok.text)


### PR DESCRIPTION
We got an error reported in `ols`:
```sh
".../ols/ols"  "stderr"        ".../odin/core/odin/parser/parser.odin(103:14) Invalid slice indices 0:2 is out of range 0..<1\n"
```

My guess is we have a string with the tokenizer text only being 1 character, though I'm not really sure how that happens.

Edit: I changed it to just explicitly verify the length as I'm not even sure how it got into the state of having this error.