### PR TITLE
Strengthen binary_search return properties.

### DIFF
--- a/core/slice/slice.odin
+++ b/core/slice/slice.odin
@@ -255,7 +255,7 @@ Searches the given slice for the given element.
 If the slice is not sorted, the returned index is unspecified and meaningless.
 
 If the value is found then the returned int is the index of the matching element.
-If there are multiple matches, then any one of the matches could be returned.
+If there are multiple matches, then the returned int is the index of the first matching element.
 
 If the value is not found then the returned int is the index where a matching
 element could be inserted while maintaining sorted order.
@@ -266,7 +266,8 @@ Example:
 	/*
 	Looks up a series of four elements. The first is found, with a
 	uniquely determined position; the second and third are not
-	found; the fourth could match any position in `[1, 4]`.
+	found; the fourth matches a uniquely determined position being
+	the first match at index 1.
 	*/
 
 	index: int
@@ -284,7 +285,7 @@ Example:
 	assert(index == 13 && found == false)
 
 	index, found = slice.binary_search(s, 1)
-	assert(index >= 1 && index <= 4 && found == true)
+	assert(index == 1 && found == true)
 */
 @(require_results)
 binary_search :: proc(array: $A/[]$T, key: T) -> (index: int, found: bool)
@@ -297,7 +298,7 @@ Searches the given slice for the given element.
 If the slice is not sorted, the returned index is unspecified and meaningless.
 
 If the value is found then the returned int is the index of the matching element.
-If there are multiple matches, then any one of the matches could be returned.
+If there are multiple matches, then the returned int is the index of the first matching element.
 
 If the value is not found then the returned int is the index where a matching
 element could be inserted while maintaining sorted order.

--- a/tests/core/slice/test_core_slice.odin
+++ b/tests/core/slice/test_core_slice.odin
@@ -160,7 +160,7 @@ test_binary_search :: proc(t: ^testing.T) {
 	testing.expect(t, found == false, "Expected found to be false.")
 
 	index, found = slice.binary_search(s, 1)
-	testing.expect(t, index >= 1 && index <= 4, "Expected index to be 1, 2, 3, or 4.")
+	testing.expect(t, index == 1, "Expected index to be 1.")
 	testing.expect(t, found == true, "Expected found to be true.")
 
 	index, found = slice.binary_search(s, -1)


### PR DESCRIPTION
Prior to this commit, the guarantee is that if the element does not exist, then a uniquely determined position is returned (which is where the element *would* go) according to the documentation and tests.

However, if the element exists, the documentation states that there is no uniquely determined position that gets returned.

1. We can make a stronger statement on the returned value when there are multiple matches given the existing implementation.

2. We can also make our statement more consistent where both cases of finding and not finding the desired element results in a uniquely determined return position.

The binary_search and binary_search_by implementations are basically equivalent to what `std::lower_bound` does in C++. We can examine the code for the case where the range `[left, right)` is looking at a range of equal numbers and see that we set `right = mid` which moves the `right)` interval towards the left (aka an earlier match). The loop terminates without `[left` ever moving and with `right)` shifting all the way to equal `[left`, which is at the first match.

I doubt changing the statement from returning anything within a range to a specific element would break a lot of existing code for a binary search implementation, but this change would result in clearer understanding of the behavior and more consistency within the documentation.