### PR TITLE
Don't build log allocator file on freestanding.

### DIFF
--- a/core/log/log_allocator.odin
+++ b/core/log/log_allocator.odin
@@ -1,3 +1,5 @@
+#+build !freestanding
+
 package log
 
 import "base:runtime"


### PR DESCRIPTION
This makes core:log compile on freestanding again. Closes #5948