### PR TITLE
Adjust docs links for satellite SDL libraries

### DIFF
--- a/vendor/sdl2/image/sdl_image.odin
+++ b/vendor/sdl2/image/sdl_image.odin
@@ -1,4 +1,4 @@
-// Bindings for [[ SDL2 Image; https://wiki.libsdl.org/SDL2/FrontPage ]].
+// Bindings for [[ SDL2 Image; https://wiki.libsdl.org/SDL2_image/FrontPage ]].
 package sdl2_image
 
 import "core:c"

--- a/vendor/sdl2/mixer/sdl_mixer.odin
+++ b/vendor/sdl2/mixer/sdl_mixer.odin
@@ -1,4 +1,4 @@
-// Bindings for [[ SDL2 Mixer ; https://wiki.libsdl.org/SDL2/FrontPage ]].
+// Bindings for [[ SDL2 Mixer ; https://wiki.libsdl.org/SDL2_mixer/FrontPage ]].
 package sdl2_mixer
 
 import "core:c"

--- a/vendor/sdl2/net/sdl_net.odin
+++ b/vendor/sdl2/net/sdl_net.odin
@@ -1,4 +1,4 @@
-// Bindings for [[ SDL2 Net ; https://wiki.libsdl.org/SDL2/FrontPage ]].
+// Bindings for [[ SDL2 Net ; https://wiki.libsdl.org/SDL2_net/FrontPage ]].
 package sdl2_net
 
 import "core:c"

--- a/vendor/sdl2/ttf/sdl_ttf.odin
+++ b/vendor/sdl2/ttf/sdl_ttf.odin
@@ -1,4 +1,4 @@
-// Bindings for [[ SDL2 TTF ; https://wiki.libsdl.org/SDL2/FrontPage ]].
+// Bindings for [[ SDL2 TTF ; https://wiki.libsdl.org/SDL2_ttf/FrontPage ]].
 package sdl2_ttf
 
 import "core:c"

--- a/vendor/sdl3/image/sdl_image.odin
+++ b/vendor/sdl3/image/sdl_image.odin
@@ -1,4 +1,4 @@
-// Bindings for [[ SDL3 Image ; https://wiki.libsdl.org/SDL3/FrontPage ]].
+// Bindings for [[ SDL3 Image ; https://wiki.libsdl.org/SDL3_image/FrontPage ]].
 package sdl3_image
 
 import "core:c"

--- a/vendor/sdl3/ttf/sdl3_ttf.odin
+++ b/vendor/sdl3/ttf/sdl3_ttf.odin
@@ -1,4 +1,4 @@
-// Bindings for [[ SDL3 TTF ; https://wiki.libsdl.org/SDL3/FrontPage ]].
+// Bindings for [[ SDL3 TTF ; https://wiki.libsdl.org/SDL3_ttf/FrontPage ]].
 package sdl3_ttf
 
 import "core:c"


### PR DESCRIPTION
I was reading docs at https://pkg.odin-lang.org/vendor/sdl3/ttf/ , clicked on the `SDL3 TTF` URL in the Overview section expecting it to lead to a page specific to SDL3 TTF, instead, it led to SDL3 front page requiring extra navigation.

I suggest we link directly to the wiki pages specific for each sattelite library.