### PR TITLE
remove terminate from demo

### DIFF
--- a/examples/demo/demo.odin
+++ b/examples/demo/demo.odin
@@ -1215,19 +1215,6 @@ threading_example :: proc() {
 		}
 
 		thread.pool_start(&pool)
-
-		{
-			// Wait a moment before we cancel a thread
-			time.sleep(5 * time.Millisecond)
-
-			// Allow one thread to print at a time.
-			for !did_acquire(&print_mutex) { thread.yield() }
-
-			thread.terminate(pool.threads[N - 1], 0)
-			fmt.println("Canceled last thread")
-			print_mutex = false
-		}
-
 		thread.pool_finish(&pool)
 	}
 }


### PR DESCRIPTION
This was causing deadlocks because:

1. The main thread would `thread.terminate` a running thread
2. `thread.terminate` does not mean termination happens immediately
3. The thread that was terminated would see that the main thread released `print_mutex` and acquire it
4. The worker would execute `fmt.printf` which is a cancellation point
5. Cancellation point reached, cancelled
6. Deadlock because the thread was holding `print_mutex`

You would usually solve this with `pthread_cleanup_push` that would release the mutex in case it is cancelled, or use
`pthread_setcancelstate` to disable cancellation while the mutex is held. But the real fix is just not using forced termination and using a flag or other mechanism to indicate to the thread it should stop.

`thread.terminate` shouldn't even be a thing IMO.
It is way to dangerous and if somebody knows what they are doing they can use the core:sys procedures to achieve it.

And we certainly shouldn't be using it in the demo as an example.