### PR TITLE
Fix `is_pointer_internally` not handling Named Types.

### DIFF
--- a/core/reflect/types.odin
+++ b/core/reflect/types.odin
@@ -328,7 +328,7 @@ is_soa_pointer :: proc(info: ^Type_Info) -> bool {
 @(require_results)
 is_pointer_internally :: proc(info: ^Type_Info) -> bool {
 	if info == nil { return false }
-	#partial switch v in info.variant {
+	#partial switch v in type_info_base(info).variant {
 	case Type_Info_Pointer, Type_Info_Multi_Pointer,
 	     Type_Info_Procedure:
 		return true


### PR DESCRIPTION
Currently unlike all other `is_*` procs, `reflect.is_pointer_internally` doesn't handle for named types. This causes issues with pure maybe's. Namely an OOB in `fmt.fmt_union` as `reflect.type_info_union_is_pure_maybe` returns `false`.

Example code of the current behavior.
```odin
package example
import "core:fmt"
import "core:reflect"

main :: proc() {
    CB :: distinct ^int // Named pointer type
    // CB :: proc()     // Named pointer type
    v: Maybe(CB)        // Pure maybe
    ti := reflect.type_info_base(type_info_of(type_of(v))).variant.(reflect.Type_Info_Union)

    fmt.println(reflect.is_pointer_internally(type_info_of(CB))) // false
    fmt.println(reflect.type_info_union_is_pure_maybe(ti))       // false
    fmt.println(v) // OOB crash at `core/fmt/fmt.odin(2608:23)`
}
```