### PR TITLE
undetected type declaration cycles work-around

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -4279,7 +4279,7 @@ gb_internal bool type_set_offsets(Type *t) {
 	t = base_type(t);
 	if (t->kind == Type_Struct) {
 		if (t->Struct.are_offsets_being_processed.load()) {
-			return true
+			return true;
 		}
 		MUTEX_GUARD(&t->Struct.offset_mutex);
 		if (!t->Struct.are_offsets_set) {


### PR DESCRIPTION
fixes: https://github.com/odin-lang/Odin/issues/5713

issue stems from MUTEX_GUARD in type_set_offsets hanging due to a thread trying to re-enter the mutex. Cycle is caused by type_set_offsets -> type_set_offsets_of -> type_align_of_internal -> type_set_offsets. This minor work around doesn't produce a neat error message however, i haven't been able to figure out how to implement that. Should still be an upgrade to the compiler crashing/hanging

Some notes from looking into this:

type_set_offsets_of initializes the typepath, which is walked in type_align_of_internal *after* it already calls type_set_offsets (since they're needed for computing the alignment). There might also be some complexities related to unnamed types not being pushed to the path complicating the cycle detection.