### PR TITLE
Fix duplicate code emission in type assertions.

### DIFF
--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -5785,11 +5785,11 @@ gb_internal lbAddr lb_build_addr_internal(lbProcedure *p, Ast *expr) {
 		if (is_type_union(t)) {
 			Type *type = type_of_expr(expr);
 			lbAddr v = lb_add_local_generated(p, type, false);
-			lb_addr_store(p, v, lb_emit_union_cast(p, lb_build_expr(p, ta->expr), type, pos));
+			lb_addr_store(p, v, lb_emit_union_cast(p, e, type, pos));
 			return v;
 		} else if (is_type_any(t)) {
 			Type *type = type_of_expr(expr);
-			return lb_emit_any_cast_addr(p, lb_build_expr(p, ta->expr), type, pos);
+			return lb_emit_any_cast_addr(p, e, type, pos);
 		} else {
 			GB_PANIC("TODO(bill): type assertion %s", type_to_string(e.type));
 		}

--- a/tests/issues/run.bat
+++ b/tests/issues/run.bat
@@ -25,6 +25,7 @@ set COMMON=-define:ODIN_TEST_FANCY=false -file -vet -strict-style
 ..\..\..\odin build ..\test_issue_5097.odin %COMMON% || exit /b
 ..\..\..\odin build ..\test_issue_5097-2.odin %COMMON% || exit /b
 ..\..\..\odin build ..\test_issue_5265.odin %COMMON% || exit /b
+..\..\..\odin test ..\test_issue_5699.odin %COMMON%  || exit /b
 
 @echo off
 

--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -32,6 +32,7 @@ $ODIN build ../test_issue_5043.odin $COMMON
 $ODIN build ../test_issue_5097.odin $COMMON
 $ODIN build ../test_issue_5097-2.odin $COMMON
 $ODIN build ../test_issue_5265.odin $COMMON
+$ODIN test ../test_issue_5699.odin $COMMON
 
 set +x
 

--- a/tests/issues/test_issue_5699.odin
+++ b/tests/issues/test_issue_5699.odin
@@ -1,0 +1,36 @@
+// Tests issue #5699 https://github.com/odin-lang/Odin/issues/5699
+package test_issues
+
+import "core:testing"
+
+Issue5699_Value :: struct {
+    value: i32,
+}
+
+Issue5699_Result :: union {
+    Issue5699_Value,
+}
+
+test_issue_5699_increment_union :: proc(counter: ^i32) -> Issue5699_Result {
+    counter^ += 1
+    return Issue5699_Value{0}
+}
+
+@test
+test_issue_5699_union :: proc(t: ^testing.T) {
+    counter: i32 = 0
+    _ = test_issue_5699_increment_union(&counter).(Issue5699_Value).value
+    testing.expectf(t, counter == 1, "\n\texpected: 1\n\tgot:      %d", counter)
+}
+
+test_issue_5699_increment_any :: proc(counter: ^i32) -> any {
+    counter^ += 1
+    return Issue5699_Value{0}
+}
+
+@test
+test_issue_5699_any :: proc(t: ^testing.T) {
+    counter: i32 = 0
+    _ = test_issue_5699_increment_any(&counter).(Issue5699_Value).value
+    testing.expectf(t, counter == 1, "\n\texpected: 1\n\tgot:      %d", counter)
+}


### PR DESCRIPTION
Fixes #5699.

Before:

```
Finished 2 tests in 294.8┬╡s. All tests failed.
 - test_issues.test_issue_5699_any
        expected: 1
        got:      2
 - test_issues.test_issue_5699_union
        expected: 1
        got:      2
```

After:

```
Finished 2 tests in 193.1┬╡s. All tests were successful.
```
