### PR TITLE
Feature: Allow compound literals for unions with one variant (eg. `Maybe`)

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -10838,6 +10838,20 @@ gb_internal ExprKind check_compound_literal(CheckerContext *c, Operand *o, Ast *
 		}
 		break;
 	}
+	case Type_Union: {
+		if (cl->elems.count == 0) {
+			break; // NOTE(bill): No need to init
+		}
+		TypeUnion *u = &t->Union;
+		if (u->variants.count != 1) {
+			gbString str = type_to_string(type);
+			error(node, "'%s' ('union') compound literals are only allowed for unions with a single variant", str);
+			gb_string_free(str);
+			return kind;
+		}
+
+		return check_compound_literal(c, o, node, u->variants[0]);
+	}
 
 
 	default: {


### PR DESCRIPTION
I find this to be quite the enhancement in some cases, especially when having `Maybe(struct)`, `Maybe(bit_set)` and `Maybe(bit_field)` parameters to procedures