### PR TITLE
Adding missing build flags in jpeg loader to avoid load proc collision

### DIFF
--- a/core/image/bmp/bmp_js.odin
+++ b/core/image/bmp/bmp_js.odin
@@ -1,4 +1,3 @@
-#+build js
 package core_image_bmp
 
 load :: proc{load_from_bytes, load_from_context}

--- a/core/image/general_js.odin
+++ b/core/image/general_js.odin
@@ -1,4 +1,3 @@
-#+build js
 package image
 
 load :: proc{

--- a/core/image/jpeg/jpeg_js.odin
+++ b/core/image/jpeg/jpeg_js.odin
@@ -1,4 +1,3 @@
-#+build js
 package jpeg
 
 load :: proc{load_from_bytes, load_from_context}

--- a/core/image/netpbm/netpbm_js.odin
+++ b/core/image/netpbm/netpbm_js.odin
@@ -1,4 +1,3 @@
-#+build js
 package netpbm
 
 load :: proc {

--- a/core/image/png/png_js.odin
+++ b/core/image/png/png_js.odin
@@ -1,4 +1,3 @@
-#+build js
 package png
 
 load :: proc{load_from_bytes, load_from_context}

--- a/core/image/qoi/qoi_js.odin
+++ b/core/image/qoi/qoi_js.odin
@@ -1,4 +1,3 @@
-#+build js
 package qoi
 
 save :: proc{save_to_buffer}

--- a/core/image/tga/tga_js.odin
+++ b/core/image/tga/tga_js.odin
@@ -1,4 +1,3 @@
-#+build js
 package tga
 
 save :: proc{save_to_buffer}


### PR DESCRIPTION
This brings the jpeg loader in-line with the other core:image/* loaders, resolving the following compilation error when targeting js/wasm:

> /Odin/core/image/jpeg/jpeg_os.odin(5:1) Error: Redeclaration of 'load' in this scope 
        at /Odin/core/image/jpeg/jpeg_js.odin(3:1) 
        load :: proc{load_from_file, load_from_bytes, load_from_context} 

