### PR TITLE
Fix function signature for memmove in vendor:libc

### DIFF
--- a/vendor/libc/include/string.h
+++ b/vendor/libc/include/string.h
@@ -8,7 +8,7 @@ extern "C" {
 
 void *memcpy(void *, const void *, size_t);
 void *memset(void *, int, size_t);
-void *memmove(void *, void *, size_t);
+void *memmove(void *, const void *, size_t);
 int memcmp(const void *, const void *, size_t);
 void *memchr(const void *, int, size_t);
 


### PR DESCRIPTION
Fix function signature for memmove to prevent errors when compiling C++ while targeting wasm (specifically when building [L4/odin-imgui](https://gitlab.com/L-4/odin-imgui.git)).

From my limited research, this *appears* to be the correct signature for most (if not all) modern platforms:

https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/memmove-wmemmove?view=msvc-170
http://git.musl-libc.org/cgit/musl/tree/src/string/memmove.c
https://man.freebsd.org/cgi/man.cgi?query=memmove&sektion=3
https://man7.org/linux/man-pages/man3/memmove.3.html