### PR TITLE
Fix `core:unicode/utf8.decode_grapheme_iterate` returning wrong text

### DIFF
--- a/core/unicode/utf8/grapheme.odin
+++ b/core/unicode/utf8/grapheme.odin
@@ -23,7 +23,7 @@ normalized_east_asian_width       :: unicode.normalized_east_asian_width
 Grapheme :: struct {
 	byte_index: int,
 	rune_index: int,
-	width:      int,
+	width:      int, // The width of the Grapheme in number of monospace cells
 }
 
 
@@ -40,7 +40,7 @@ Grapheme_Iterator :: struct {
 
 	grapheme_count: int, // The number of graphemes in the string
 	rune_count:     int, // The number of runes in the string
-	width:          int, // The widrth of the string in number of monospace cells
+	width:          int, // The width of the string in number of monospace cells
 
 	last_rune:                  rune,
 	last_rune_breaks_forward:   bool,
@@ -152,7 +152,7 @@ decode_grapheme_iterate :: proc(it: ^Grapheme_Iterator) -> (text: string, graphe
 					it.rune_count,
 					it.width - it.last_width,
 				}
-				text = it.str[byte_index:][:grapheme.width]
+				text = it.str[byte_index:it.curr_offset]
 				ok = true
 
 


### PR DESCRIPTION
The current behavior uses the monospace width of a grapheme, which isn't the same as the data width.

This PR also fixes a typo & adds documentation to `Grapheme.width`, to help people not assume it's the data width. Though it should be renamed to something more explicate like `monospace_width` or `cell_count`, but I couldn't decided which is better.

Example of current behavior:
```odin
package __test_bug
 
import "core:fmt"
import "core:unicode/utf8"

main :: proc() { 
    base := "子猫"
    iter := utf8.decode_grapheme_iterator_make(base)
    for str, g in utf8.decode_grapheme_iterate(&iter) {
        fmt.println(str, transmute([]u8)str, g)
    }
}
```
This should give:
```
子 [229, 173, 144] Grapheme{byte_index = 0, rune_index = 0, width = 2}
猫 [231, 140, 171] Grapheme{byte_index = 3, rune_index = 1, width = 2}
```
but instead gives (output of `str` may be nothing depending on your term):
```
σ¡ [229, 173] Grapheme{byte_index = 0, rune_index = 0, width = 2}
τî [231, 140] Grapheme{byte_index = 3, rune_index = 1, width = 2}
```