### PR TITLE
Bulk-write to a slice in xoshiro/pcg_random_generator_proc

### DIFF
--- a/core/math/rand/rand_pcg.odin
+++ b/core/math/rand/rand_pcg.odin
@@ -55,16 +55,20 @@ pcg_random_generator_proc :: proc(data: rawptr, mode: runtime.Random_Generator_M
 			intrinsics.unaligned_store((^u64)(raw_data(p)), read_u64(r))
 		case:
 			// All other cases.
-			pos := i8(0)
-			val := u64(0)
-			for &v in p {
-				if pos == 0 {
-					val = read_u64(r)
-					pos = 8
+			n := len(p) / size_of(u64)
+			buff := ([^]u64)(raw_data(p))[:n]
+			for &e in buff {
+				intrinsics.unaligned_store(&e, read_u64(r))
+			}
+			// Handle remaining bytes
+			rem := len(p) % size_of(u64)
+			if rem > 0 {
+				val := read_u64(r)
+				tail := p[len(p) - rem:]
+				for &b in tail {
+					b = byte(val)
+					val >>= 8
 				}
-				v = byte(val)
-				val >>= 8
-				pos -= 1
 			}
 		}
 

--- a/core/math/rand/rand_xoshiro256.odin
+++ b/core/math/rand/rand_xoshiro256.odin
@@ -74,16 +74,20 @@ xoshiro256_random_generator_proc :: proc(data: rawptr, mode: runtime.Random_Gene
 			intrinsics.unaligned_store((^u64)(raw_data(p)), read_u64(r))
 		case:
 			// All other cases.
-			pos := i8(0)
-			val := u64(0)
-			for &v in p {
-				if pos == 0 {
-					val = read_u64(r)
-					pos = 8
+			n := len(p) / size_of(u64)
+			buff := ([^]u64)(raw_data(p))[:n]
+			for &e in buff {
+				intrinsics.unaligned_store(&e, read_u64(r))
+			}
+			// Handle remaining bytes
+			rem := len(p) % size_of(u64)
+			if rem > 0 {
+				val := read_u64(r)
+				tail := p[len(p) - rem:]
+				for &b in tail {
+					b = byte(val)
+					val >>= 8
 				}
-				v = byte(val)
-				val >>= 8
-				pos -= 1
 			}
 		}
 


### PR DESCRIPTION
Funnily, I tried to do this a few months ago, and it was slower than filling byte-by-byte. Guess codegen improved. 

Before:

```
+---------------------------------------------+
|                     RNG                     |
+-------------+------+----------+-------------+
|    Algorithm|  Size|      Time|   Throughput|
+-------------+------+----------+-------------+
|  chacha8rand|uint64|      61ns|123.946 MiB/s|
|  chacha8rand| 1 MiB|2.739109ms|356.793 MiB/s|
|             |      |          |             |
|        pcg64|uint64|      24ns|311.575 MiB/s|
|        pcg64| 1 MiB|3.092009ms|316.071 MiB/s|
|             |      |          |             |
|xorshiro256**|uint64|      29ns|261.596 MiB/s|
|xorshiro256**| 1 MiB|3.548303ms|275.426 MiB/s|
+-------------+------+----------+-------------+
```
After:

```
+----------------------------------------------+
|                     RNG                      |
+-------------+------+----------+--------------+
|    Algorithm|  Size|      Time|    Throughput|
+-------------+------+----------+--------------+
|  chacha8rand|uint64|      57ns| 132.659 MiB/s|
|  chacha8rand| 1 MiB|2.595776ms| 376.494 MiB/s|
|             |      |          |              |
|        pcg64|uint64|      24ns| 314.554 MiB/s|
|        pcg64| 1 MiB| 817.083µs|1196.077 MiB/s|
|             |      |          |              |
|xorshiro256**|uint64|      29ns| 254.739 MiB/s|
|xorshiro256**| 1 MiB|1.445885ms| 675.915 MiB/s|
+-------------+------+----------+--------------+
```