### PR TITLE
Fix default temp allocator under flow bug

### DIFF
--- a/base/runtime/default_temp_allocator_arena.odin
+++ b/base/runtime/default_temp_allocator_arena.odin
@@ -235,6 +235,7 @@ arena_allocator_proc :: proc(allocator_data: rawptr, mode: Allocator_Mode,
 				if start < old_end && old_end == block.used && new_end <= block.capacity {
 					// grow data in-place, adjusting next allocation
 					block.used = uint(new_end)
+					arena.total_used = uint(new_end)
 					data = block.base[start:new_end]
 					// sanitizer.address_unpoison(data)
 					return


### PR DESCRIPTION
Example code:

```odin
package alloc

import "base:runtime"

main :: proc()
{
	// example of default temp_allocator total_used under flow
	{
		runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
		ptr0, error0 := context.temp_allocator.procedure(context.temp_allocator.data, .Alloc,  1, 1, nil, 0)
		ptr1, error1 := context.temp_allocator.procedure(context.temp_allocator.data, .Resize, 2, 1, raw_data(ptr0), 1)
	}
	{
		runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
		ptr0, error0 := context.temp_allocator.procedure(context.temp_allocator.data, .Alloc,  1, 1, nil, 0)
		ptr1, error1 := context.temp_allocator.procedure(context.temp_allocator.data, .Resize, 3, 1, raw_data(ptr0), 1)
	}
}

```