### PR TITLE
Fixing code example, trace_ctx variable was renamed

### DIFF
--- a/core/debug/trace/doc.odin
+++ b/core/debug/trace/doc.odin
@@ -19,7 +19,7 @@ Example:
 		}
 		runtime.print_byte('\n')
 
-		ctx := &trace_ctx
+		ctx := &global_trace_ctx
 		if !trace.in_resolve(ctx) {
 			buf: [64]trace.Frame
 			runtime.print_string("Debug Trace:\n")


### PR DESCRIPTION
`trace_ctx` should actually be `global_trace_ctx`, as declared on line 10