### PR TITLE
[tz_unix] added additional search paths to match musl

### DIFF
--- a/core/time/timezone/tz_unix.odin
+++ b/core/time/timezone/tz_unix.odin
@@ -81,6 +81,18 @@ _region_load :: proc(_reg_str: string, allocator := context.allocator) -> (out_r
 	}
 	defer if _reg_str == "local" { delete(reg_str, allocator) }
 
+	tzdir_str, tzdir_ok := os.lookup_env("TZDIR", allocator)
+	defer if tzdir_ok { delete(tzdir_str, allocator) }
+
+	if tzdir_ok {
+		region_path := filepath.join({tzdir_str, reg_str}, allocator)
+		defer delete(region_path, allocator)
+		
+		if tz_reg, ok := load_tzif_file(region_path, reg_str, allocator); ok {
+			return tz_reg, true
+		}
+	}
+
 	db_paths := []string{"/usr/share/zoneinfo", "/share/zoneinfo", "/etc/zoneinfo"}
 	for db_path in db_paths {
 		region_path := filepath.join({db_path, reg_str}, allocator)


### PR DESCRIPTION
adds additional timezone search paths to bring things in line with musl [source link](https://git.musl-libc.org/cgit/musl/tree/src/time/__tz.c?id=0ccaf0572e9cccda2cced0f7ee659af4c1c6679a#n131). this should improve distribution support across the various linux/unix flavors