### PR TITLE
core:sys/linux Add timerfd syscall wrappers

### DIFF
--- a/core/sys/linux/sys.odin
+++ b/core/sys/linux/sys.odin
@@ -2992,15 +2992,36 @@ epoll_pwait :: proc(epfd: Fd, events: [^]EPoll_Event, count: i32, timeout: i32, 
 
 // TODO(flysand): signalfd
 
-// TODO(flysand): timerfd_create
+/*
+	Create Linux file descriptor based timer.
+	Available since Linux 2.6.25
+*/
+timerfd_create :: proc "contextless" (clock_id: Clock_Id, flags: Open_Flags) -> (Fd, Errno) {
+	ret := syscall(SYS_timerfd_create, clock_id, transmute(u32)flags)
+	return errno_unwrap2(ret, Fd)
+}
 
 // TODO(flysand): eventfd
 
 // TODO(flysand): fallocate
 
-// TODO(flysand): timerfd_settime
+/*
+	Arm/disarm the state of the Linux file descriptor based timer.
+	Available since Linux 2.6.25
+*/
+timerfd_settime :: proc "contextless" (fd: Fd, flags: ITimer_Flags, new_value: ^ITimer_Spec, old_value: ^ITimer_Spec) -> Errno {
+	ret := syscall(SYS_timerfd_settime, fd, transmute(u32)flags, new_value, old_value)
+	return Errno(-ret)
+}
 
-// TODO(flysand): timerfd_gettime
+/*
+	Get the state of the Linux file descriptor based timer.
+	Available since Linux 2.6.25
+*/
+timerfd_gettime :: proc "contextless" (fd: Fd, curr_value: ^ITimer_Spec) -> Errno {
+	ret := syscall(SYS_timerfd_gettime, fd, curr_value)
+	return Errno(-ret)
+}
 
 // TODO(flysand): accept4
 


### PR DESCRIPTION
Needed those syscalls in one of my projects, so just added them as they were not present before. 

Below is also a file to test the functionality of the syscall
```odin
package main

import "core:fmt"
import "core:os"
import "core:sys/linux"

main :: proc() {
	timer_fd, _ := linux.timerfd_create(.MONOTONIC, {.NONBLOCK})
	timer_spec := linux.ITimer_Spec {
		interval = {time_nsec = 500 * 1000 * 1000},
		value = {time_sec = 1},
	}
	linux.timerfd_settime(timer_fd, nil, &timer_spec, nil)
	pollfds := []linux.Poll_Fd{{fd = cast(linux.Fd)timer_fd, events = {.IN}}}

	for {
		if ret, err := linux.poll(pollfds, -1); err != nil || ret < 0 {
			if err == .EINTR {
				continue
			}

			fmt.eprintln("poll error:", err)
			break
		}
		if .IN in pollfds[0].revents {
			buf := [8]byte{}
			size, _ := os.read(cast(os.Handle)timer_fd, buf[:])

			fmt.println("received timer", transmute(u64)buf)
		}
	}
}
```