### PR TITLE
Fix minor issues within `curl` bindings

### DIFF
--- a/vendor/curl/curl.odin
+++ b/vendor/curl/curl.odin
@@ -2502,7 +2502,7 @@ foreign lib {
 	 * Appends a string to a linked list. If no list exists, it will be created
 	 * first. Returns the new list, after appending.
 	 */
-	slist_append :: proc(list: ^slist, data: [^]byte) -> ^slist ---
+	slist_append :: proc(list: ^slist, data: cstring) -> ^slist ---
 
 	/*
 	 * NAME curl_slist_free_all()

--- a/vendor/curl/curl_multi.odin
+++ b/vendor/curl/curl_multi.odin
@@ -410,7 +410,7 @@ foreign lib {
 	 *
 	 * Returns: NULL on failure, otherwise a CURL **array pointer
 	 */
-	multi_get_handles :: proc(multi_handle: ^CURLM) -> ^^CURL ---
+	multi_get_handles :: proc(multi_handle: ^CURLM) -> [^]^CURL ---
 
 	/*
 	 * Name:    curl_multi_get_offt()


### PR DESCRIPTION
## `slist_append`:
https://curl.se/libcurl/c/curl_slist_append.html
> Appends a string to a linked list of strings. The existing list should be passed as the first argument and the new list is returned from this function. Pass in NULL in the list argument to create a new list. The specified string has been appended when this function returns. [curl_slist_append](https://curl.se/libcurl/c/curl_slist_append.html) copies the string. The string argument must be a valid string pointer and cannot be NULL. [...]

## `multi_get_handles`:
https://curl.se/libcurl/c/curl_multi_get_handles.html
> Returns an array with pointers to all added easy handles. The end of the list is marked with a NULL pointer.  [...]