### PR TITLE
Fix #packed #all_or_none

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2803,7 +2803,7 @@ gb_internal Ast *parse_operand(AstFile *f, bool lhs) {
 				}
 				is_packed = true;
 			} else if (tag.string == "all_or_none") {
-				if (is_packed) {
+				if (is_all_or_none) {
 					syntax_error(tag, "Duplicate struct tag '#%.*s'", LIT(tag.string));
 				}
 				is_all_or_none = true;


### PR DESCRIPTION
Compiling the code with odin `dev-2025-12:3567c64d7` below results in an error like:

```
…/main.odin(3:22) Syntax Error: Duplicate struct tag '#all_or_none' 
	S :: struct #packed #all_or_none { 
	                     ^ 
 
```

I assume that this is just a copy-pasta error.

The code:

```odin
package foo

S :: struct #packed #all_or_none {
    c : u8,
    i: i32,
}

main :: proc() {}
```