### PR TITLE
[core:io/utils]: fix buffer size in `write_*` procs

### DIFF
--- a/core/io/util.odin
+++ b/core/io/util.odin
@@ -21,12 +21,12 @@ write_ptr_at :: proc(w: Writer_At, p: rawptr, byte_size: int, offset: i64, n_wri
 }
 
 write_u64 :: proc(w: Writer, i: u64, base: int = 10, n_written: ^int = nil) -> (n: int, err: Error) {
-	buf: [32]byte
+	buf: [64]byte
 	s := strconv.write_bits(buf[:], i, base, false, 64, strconv.digits, nil)
 	return write_string(w, s, n_written)
 }
 write_i64 :: proc(w: Writer, i: i64, base: int = 10, n_written: ^int = nil) -> (n: int, err: Error) {
-	buf: [32]byte
+	buf: [65]byte
 	s := strconv.write_bits(buf[:], u64(i), base, true, 64, strconv.digits, nil)
 	return write_string(w, s, n_written)
 }
@@ -39,12 +39,12 @@ write_int :: proc(w: Writer, i: int, base: int = 10, n_written: ^int = nil) -> (
 }
 
 write_u128 :: proc(w: Writer, i: u128, base: int = 10, n_written: ^int = nil) -> (n: int, err: Error) {
-	buf: [39]byte
+	buf: [128]byte
 	s := strconv.write_bits_128(buf[:], i, base, false, 128, strconv.digits, nil)
 	return write_string(w, s, n_written)
 }
 write_i128 :: proc(w: Writer, i: i128, base: int = 10, n_written: ^int = nil) -> (n: int, err: Error) {
-	buf: [40]byte
+	buf: [129]byte
 	s := strconv.write_bits_128(buf[:], u128(i), base, true, 128, strconv.digits, nil)
 	return write_string(w, s, n_written)
 }


### PR DESCRIPTION
For some reason these procs used very small buffers, causing a panic when trying to write large numbers in base 2.

```odin
io.write_int(io.to_writer(os.stream_from_handle(os.stdout)), min(int), 2)
// .../odin/core/strconv/integers.odin(104:19) Invalid slice indices 0:65 is out of range 0..<32

io.write_u128(io.to_writer(os.stream_from_handle(os.stdout)), 1<<64, 2)
// .../odin/core/strconv/integers.odin(209:19) Invalid slice indices 0:65 is out of range 0..<39
```