### PR TITLE
Add `@builtin` to missing builtin procedure group procs

### DIFF
--- a/base/runtime/core_builtin.odin
+++ b/base/runtime/core_builtin.odin
@@ -267,7 +267,10 @@ non_zero_resize :: proc{
 
 // Shrinks the capacity of a dynamic array or map down to the current length, or the given capacity.
 @builtin
-shrink :: proc{shrink_dynamic_array, shrink_map}
+shrink :: proc{
+	shrink_dynamic_array,
+	shrink_map,
+}
 
 // `free` will try to free the passed pointer, with the given `allocator` if the allocator supports this operation.
 @builtin
@@ -794,7 +797,11 @@ inject_at_elem_string :: proc(array: ^$T/[dynamic]$E/u8, #any_int index: int, ar
 }
 
 // `inject_at` injects something into a dynamic array at a specified index and moves the previous elements after that index "across"
-@builtin inject_at :: proc{inject_at_elem, inject_at_elems, inject_at_elem_string}
+@builtin inject_at :: proc{
+	inject_at_elem,
+	inject_at_elems,
+	inject_at_elem_string,
+}
 
 
 
@@ -858,7 +865,6 @@ assign_at :: proc{
 	assign_at_elems,
 	assign_at_elem_string,
 }
-
 
 
 
@@ -1000,6 +1006,7 @@ non_zero_resize_dynamic_array :: proc(array: ^$T/[dynamic]$E, #any_int length: i
 // If `len(array) < new_cap`, then `len(array)` will be left unchanged.
 //
 // Note: Prefer the procedure group `shrink`
+@builtin
 shrink_dynamic_array :: proc(array: ^$T/[dynamic]$E, #any_int new_cap := -1, loc := #caller_location) -> (did_shrink: bool, err: Allocator_Error) {
 	return _shrink_dynamic_array((^Raw_Dynamic_Array)(array), size_of(E), align_of(E), new_cap, loc)
 }

--- a/base/runtime/core_builtin_soa.odin
+++ b/base/runtime/core_builtin_soa.odin
@@ -615,7 +615,7 @@ inject_at_elems_soa :: proc(array: ^$T/#soa[dynamic]$E, #any_int index: int, #no
 // `inject_at_soa` injects something into a dynamic SOA array at a specified index and moves the previous elements after that index "across"
 @builtin inject_at_soa :: proc{inject_at_elem_soa, inject_at_elems_soa}
 
-
+@builtin
 delete_soa_slice :: proc(array: $T/#soa[]$E, allocator := context.allocator, loc := #caller_location) -> Allocator_Error {
 	field_count :: len(E) when intrinsics.type_is_array(E) else intrinsics.type_struct_field_count(E)
 	when field_count != 0 {
@@ -626,6 +626,7 @@ delete_soa_slice :: proc(array: $T/#soa[]$E, allocator := context.allocator, loc
 	return nil
 }
 
+@builtin
 delete_soa_dynamic_array :: proc(array: $T/#soa[dynamic]$E, loc := #caller_location) -> Allocator_Error {
 	field_count :: len(E) when intrinsics.type_is_array(E) else intrinsics.type_struct_field_count(E)
 	when field_count != 0 {
@@ -644,7 +645,7 @@ delete_soa :: proc{
 	delete_soa_dynamic_array,
 }
 
-
+@builtin
 clear_soa_dynamic_array :: proc(array: ^$T/#soa[dynamic]$E) {
 	field_count :: len(E) when intrinsics.type_is_array(E) else intrinsics.type_struct_field_count(E)
 	when field_count != 0 {

--- a/base/runtime/internal.odin
+++ b/base/runtime/internal.odin
@@ -148,6 +148,7 @@ mem_alloc_non_zeroed :: #force_no_inline proc(size: int, alignment: int = DEFAUL
 	return allocator.procedure(allocator.data, .Alloc_Non_Zeroed, size, alignment, nil, 0, loc)
 }
 
+@builtin
 mem_free :: #force_no_inline proc(ptr: rawptr, allocator := context.allocator, loc := #caller_location) -> Allocator_Error {
 	if ptr == nil || allocator.procedure == nil {
 		return nil
@@ -172,7 +173,7 @@ mem_free_bytes :: #force_no_inline proc(bytes: []byte, allocator := context.allo
 	return err
 }
 
-
+@builtin
 mem_free_all :: #force_no_inline proc(allocator := context.allocator, loc := #caller_location) -> (err: Allocator_Error) {
 	if allocator.procedure != nil {
 		_, err = allocator.procedure(allocator.data, .Free_All, 0, 0, nil, 0, loc)
@@ -341,7 +342,7 @@ memory_compare :: proc "contextless" (x, y: rawptr, n: int) -> int #no_bounds_ch
 	case y == nil: return +1
 	}
 	a, b := cast([^]byte)x, cast([^]byte)y
-	
+
 	n := uint(n)
 	i := uint(0)
 	m := uint(0)
@@ -1409,4 +1410,3 @@ when .Address in ODIN_SANITIZER_FLAGS {
 		__asan_unpoison_memory_region :: proc "system" (address: rawptr, size: uint) ---
 	}
 }
-


### PR DESCRIPTION
As discussed on Discord, this PR adds the missing `@builtin` attributes to builtin procedures in procedure groups that were missing it.

Only procedures that are part of a procedure group were changed.