### PR TITLE
virtual.memory_block_allocation().  Fix reserve size calculation.

### DIFF
--- a/core/mem/virtual/virtual.odin
+++ b/core/mem/virtual/virtual.odin
@@ -89,7 +89,7 @@ memory_block_alloc :: proc(committed, reserved: uint, alignment: uint = 0, flags
 	reserved  = align_formula(reserved, page_size)
 	committed = clamp(committed, 0, reserved)
 	
-	total_size     := reserved + alignment + size_of(Platform_Memory_Block)
+	total_size     := reserved + size_of(Platform_Memory_Block)
 	base_offset    := mem.align_forward_uintptr(size_of(Platform_Memory_Block), max(uintptr(alignment), align_of(Platform_Memory_Block)))
 	protect_offset := uintptr(0)
 	


### PR DESCRIPTION
Remove alignment from the reserve size calculation. It leads to committing more than has been reserved and trips an assert.  virtual.odin(177:2) runtime assertion: block.committed <= block.reserved
Any alignment that needs to happen has to be done within the reserved memory region.

To reproduce this try `virtual.arena_init_growing(m_arena, 16 * 1024 * 1024).`
Some reserved sizes work by chance with your allocation pattern.

Fixes #5821 