### PR TITLE
Fix automatic `objc_msgSend` on static methods via selector expression not resolving aliased types

### DIFF
--- a/src/llvm_backend_utility.cpp
+++ b/src/llvm_backend_utility.cpp
@@ -2868,9 +2868,13 @@ gb_internal lbValue lb_handle_objc_auto_send(lbProcedure *p, Ast *expr, Slice<lb
 			GB_ASSERT(se->expr->tav.mode == Addressing_Type && se->expr->tav.type->kind == Type_Named);
 
 			objc_class = entity_from_expr(se->expr);
-
 			GB_ASSERT(objc_class);
 			GB_ASSERT(objc_class->kind == Entity_TypeName);
+
+			if (objc_class->TypeName.is_type_alias) {
+				objc_class = objc_class->type->Named.type_name;
+			}
+
 			GB_ASSERT(objc_class->TypeName.objc_class_name != "");
 		}
 


### PR DESCRIPTION
This fixes an assert triggered when an during emission of automatic `objc_msgSend` when a selector expression on an alias to an Objective-C-classed struct was used:

```odin

Obj :: NS.Object

main :: proc() {
    // this would trigger the compiler assert as it expected that the objc_class name was not an empty string
    Obj.alloc()
}
```
