### PR TITLE
Fix misleading error messages for init, fini and test attributes

### DIFF
--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -3581,7 +3581,7 @@ gb_internal DECL_ATTRIBUTE_PROC(proc_decl_attribute) {
 		return true;
 	} else if (name == "test") {
 		if (value != nullptr) {
-			error(value, "'%.*s' expects no parameter, or a string literal containing \"file\" or \"package\"", LIT(name));
+			error(value, "Expected no value for '%.*s'", LIT(name));
 		}
 		ac->test = true;
 		return true;
@@ -3629,13 +3629,13 @@ gb_internal DECL_ATTRIBUTE_PROC(proc_decl_attribute) {
 		return true;
 	} else if (name == "init") {
 		if (value != nullptr) {
-			error(value, "'%.*s' expects no parameter, or a string literal containing \"file\" or \"package\"", LIT(name));
+			error(value, "Expected no value for '%.*s'", LIT(name));
 		}
 		ac->init = true;
 		return true;
 	} else if (name == "fini") {
 		if (value != nullptr) {
-			error(value, "'%.*s' expects no parameter, or a string literal containing \"file\" or \"package\"", LIT(name));
+			error(value, "Expected no value for '%.*s'", LIT(name));
 		}
 		ac->fini = true;
 		return true;


### PR DESCRIPTION
These look like copy-pasta from the private attribute.

Despite what error message says, a procedure like following still does not compile:

```odin
// same for init or fini
@(test="package")
some_proc :: proc "contextless" () {}
```

output generated by current master:

```
…/main.odin(8:8) Error: 'test' expects no parameter, or a string literal containing "file" or "package" 
	@(test="package") 
	       ^~~~~~~~^ 
 
```

The fixed error reporting looks like:

```
…/main.odin(8:8) Error: Expected no value for 'test' 
	@(test="package") 
	       ^~~~~~~~^ 
 
```

I wasn't sure if the `error` call should point to the whole attribute or to its value only - it's a bit inconsistent (see `require_results` and `instrumentation_enter`).