### PR TITLE
Address issue identifying CDATA in XML file

### DIFF
--- a/core/encoding/xml/xml_reader.odin
+++ b/core/encoding/xml/xml_reader.odin
@@ -308,6 +308,7 @@ parse_bytes :: proc(data: []u8, options := DEFAULT_OPTIONS, path := "", error_ha
 				case .Open_Bracket:
 					// This could be a CDATA tag part of a tag's body. Unread the `<![`
 					t.offset -= 3
+					t.read_offset = t.offset
 
 					// Instead of calling `parse_body` here, we could also `continue loop`
 					// and fall through to the `case:` at the bottom of the outer loop.


### PR DESCRIPTION
This pull request address [issue 6062](https://github.com/odin-lang/Odin/issues/6062)

The XML library isn't identifying CDATA and skipping over it. This was found when CDATA contained a < resulting in an error being thrown. This patch addresses the issue.