### PR TITLE
encoding/base32: Fix padding validation for malformed input

### DIFF
--- a/core/encoding/base32/base32.odin
+++ b/core/encoding/base32/base32.odin
@@ -153,15 +153,15 @@ decode :: proc(
 		padding_count += 1
 	}
 
+	// Verify no padding in the middle
+	for i := 0; i < data_len - padding_count; i += 1 {
+		if data[i] == byte(PADDING) {
+			return nil, .Malformed_Input
+		}
+	}
+
 	// Check for proper padding and length combinations
 	if padding_count > 0 {
-		// Verify no padding in the middle
-		for i := 0; i < data_len - padding_count; i += 1 {
-			if data[i] == byte(PADDING) {
-				return nil, .Malformed_Input
-			}
-		}
-
 		content_len := data_len - padding_count
 		mod8 := content_len % 8
 		required_padding: int

--- a/tests/core/encoding/base32/base32.odin
+++ b/tests/core/encoding/base32/base32.odin
@@ -1,4 +1,3 @@
-#+test
 package test_encoding_base32
 
 import "core:testing"
@@ -83,7 +82,16 @@ test_base32_decode_invalid :: proc(t: ^testing.T) {
 
 	// Section 3.2 - Padding requirements
 	{
-		// Padding must only be at end
+		// Padding in middle without trailing padding
+		input := "MZ===YTBMZXW6YTB" // '===' in middle, no trailing padding
+		output, err := base32.decode(input)
+		if output != nil {
+			defer delete(output)
+		}
+		testing.expect_value(t, err, Error.Malformed_Input)
+	}
+	{
+		// Padding must only be at end (with trailing padding)
 		input := "MZ=Q===="
 		output, err := base32.decode(input)
 		if output != nil {


### PR DESCRIPTION
This PR fixes a bug in the error handling where padding characters in the middle of input were not detected when there was no trailing padding.

### Problem Description

The "verify no padding in middle" check was inside `if padding_count > 0`, which meant it only ran when trailing padding was present.

For input `"MZ===YTBMZXW6YTB"` (padding in middle, no trailing padding):
1. `padding_count` is counted from the end -> `padding_count = 0`
2. `if padding_count > 0` is false -> middle padding check is skipped
3. Input incorrectly passes validation with `.None`

### Fix

Move the loop outside the conditional so it always runs:

```odin
// Verify no padding in the middle
for i := 0; i < data_len - padding_count; i += 1 {
    if data[i] == byte(PADDING) {
        return nil, .Malformed_Input
    }
}

// Check for proper padding and length combinations
if padding_count > 0 {
    // ...
}
```

### Testing

Added test case for this edge case:
```odin
{
    // Padding in middle without trailing padding
    input := "MZ===YTBMZXW6YTB"
    output, err := base32.decode(input)
    if output != nil {
        defer delete(output)
    }
    testing.expect_value(t, err, Error.Malformed_Input)
}
```

All tests pass.