### PR TITLE
Use shared partial return memory

### DIFF
--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -17,6 +17,7 @@
 
 #define LLVM_SET_INTERNAL_WEAK_LINKAGE(value) LLVMSetLinkage(value, USE_SEPARATE_MODULES ? LLVMWeakAnyLinkage : LLVMInternalLinkage);
 
+#define LB_TUPLE_FIX_USE_PARTIAL_RETURN_CACHE true
 
 #include "llvm_backend.hpp"
 #include "llvm_abi.cpp"

--- a/src/llvm_backend.hpp
+++ b/src/llvm_backend.hpp
@@ -329,6 +329,10 @@ struct lbGlobalVariable {
 	bool is_initialized;
 };
 
+struct lbReturnTypeCache {
+	Type * type;
+	lbAddr addr;
+};
 
 struct lbProcedure {
 	u32 flags;
@@ -390,6 +394,8 @@ struct lbProcedure {
 	PtrMap<Ast *, lbValue> selector_values;
 	PtrMap<Ast *, lbAddr>  selector_addr;
 	PtrMap<LLVMValueRef, lbTupleFix> tuple_fix_map;
+
+	Array<lbReturnTypeCache> partial_return_type_cache;
 
 	Array<lbValue> asan_stack_locals;
 

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -1196,7 +1196,7 @@ gb_internal lbValue lb_emit_call(lbProcedure *p, lbValue value, Array<lbValue> c
 			GB_ASSERT(rt->kind == Type_Tuple);
 			for (isize j = 0; j < rt->Tuple.variables.count-1; j++) {
 				Type *partial_return_type = rt->Tuple.variables[j]->type;
-				lbValue partial_return_ptr = lb_get_partial_return_local(p, partial_return_type, &partial_return_stack, /*use_stack*/true);
+				lbValue partial_return_ptr = lb_get_partial_return_local(p, partial_return_type, &partial_return_stack, /*use_stack*/LB_TUPLE_FIX_USE_PARTIAL_RETURN_CACHE);
 				array_add(&processed_args, partial_return_ptr);
 			}
 			rt = reduce_tuple_to_single_type(rt->Tuple.variables[rt->Tuple.variables.count-1]->type);

--- a/src/llvm_backend_utility.cpp
+++ b/src/llvm_backend_utility.cpp
@@ -1151,11 +1151,15 @@ gb_internal lbValue lb_emit_tuple_ep(lbProcedure *p, lbValue ptr, i32 index) {
 		lbValue res = tf->values[index];
 		GB_ASSERT(are_types_identical(res.type, result_type));
 
-		// NOTE(bill): make an explicit copy because partial return values are sharing memory
-		// See: lb_get_partial_return_local
-		lbAddr addr = lb_add_local_generated(p, res.type, false);
-		lb_addr_store(p, addr, res);
-		return addr.addr;
+		if (LB_TUPLE_FIX_USE_PARTIAL_RETURN_CACHE) {
+			// NOTE(bill): make an explicit copy because partial return values are sharing memory
+			// See: lb_get_partial_return_local
+			lbAddr addr = lb_add_local_generated(p, res.type, false);
+			lb_addr_store(p, addr, res);
+			return addr.addr;
+		} else {
+			return lb_address_from_load_or_generate_local(p, res);
+		}
 	} else {
 		return lb_emit_struct_ep_internal(p, ptr, index, result_type);
 	}


### PR DESCRIPTION
To minimize the stack usage for partial return values requiring `alloca`, try to reuse it where possible.

**Note:** this will need a lot of proofing to make sure there are no aliasing issues with this. If aliasing issues do exist, they will definitely be subtle.