### PR TITLE
Add missing 'caller_location' to several procedures in 'slice' package

### DIFF
--- a/core/slice/map.odin
+++ b/core/slice/map.odin
@@ -6,8 +6,8 @@ import "base:runtime"
 _ :: intrinsics
 _ :: runtime
 
-map_keys :: proc(m: $M/map[$K]$V, allocator := context.allocator) -> (keys: []K, err: runtime.Allocator_Error) {
-	keys = make(type_of(keys), len(m), allocator) or_return
+map_keys :: proc(m: $M/map[$K]$V, allocator := context.allocator, loc := #caller_location) -> (keys: []K, err: runtime.Allocator_Error) {
+	keys = make(type_of(keys), len(m), allocator, loc) or_return
 	i := 0
 	for key in m {
 		keys[i] = key
@@ -15,8 +15,8 @@ map_keys :: proc(m: $M/map[$K]$V, allocator := context.allocator) -> (keys: []K,
 	}
 	return
 }
-map_values :: proc(m: $M/map[$K]$V, allocator := context.allocator) -> (values: []V, err: runtime.Allocator_Error) {
-	values = make(type_of(values), len(m), allocator) or_return
+map_values :: proc(m: $M/map[$K]$V, allocator := context.allocator, loc := #caller_location) -> (values: []V, err: runtime.Allocator_Error) {
+	values = make(type_of(values), len(m), allocator, loc) or_return
 	i := 0
 	for _, value in m {
 		values[i] = value
@@ -37,8 +37,8 @@ Map_Entry_Info :: struct($Key, $Value: typeid) {
 }
 
 
-map_entries :: proc(m: $M/map[$K]$V, allocator := context.allocator) -> (entries: []Map_Entry(K, V), err: runtime.Allocator_Error) {
-	entries = make(type_of(entries), len(m), allocator) or_return
+map_entries :: proc(m: $M/map[$K]$V, allocator := context.allocator, loc := #caller_location) -> (entries: []Map_Entry(K, V), err: runtime.Allocator_Error) {
+	entries = make(type_of(entries), len(m), allocator, loc) or_return
 	i := 0
 	for key, value in m {
 		entries[i].key   = key
@@ -48,13 +48,13 @@ map_entries :: proc(m: $M/map[$K]$V, allocator := context.allocator) -> (entries
 	return
 }
 
-map_entry_infos :: proc(m: $M/map[$K]$V, allocator := context.allocator) -> (entries: []Map_Entry_Info(K, V), err: runtime.Allocator_Error) #no_bounds_check {
+map_entry_infos :: proc(m: $M/map[$K]$V, allocator := context.allocator, loc := #caller_location) -> (entries: []Map_Entry_Info(K, V), err: runtime.Allocator_Error) #no_bounds_check {
 	m := m
 	rm := (^runtime.Raw_Map)(&m)
 
 	info := runtime.type_info_base(type_info_of(M)).variant.(runtime.Type_Info_Map)
 	if info.map_info != nil {
-		entries = make(type_of(entries), len(m), allocator) or_return
+		entries = make(type_of(entries), len(m), allocator, loc) or_return
 
 		map_cap := uintptr(cap(m))
 		ks, vs, hs, _, _ := runtime.map_kvh_data_dynamic(rm^, info.map_info)

--- a/core/slice/permute.odin
+++ b/core/slice/permute.odin
@@ -29,12 +29,13 @@ Returns:
 make_permutation_iterator :: proc(
 	slice: []$T,
 	allocator := context.allocator,
+	loc := #caller_location,
 ) -> (
 	iter: Permutation_Iterator(T),
 	error: runtime.Allocator_Error,
 ) #optional_allocator_error {
 	iter.slice = slice
-	iter.counters = make([]int, len(iter.slice), allocator) or_return
+	iter.counters = make([]int, len(iter.slice), allocator, loc) or_return
 
 	return
 }

--- a/core/slice/sort.odin
+++ b/core/slice/sort.odin
@@ -54,9 +54,9 @@ sort :: proc(data: $T/[]$E) where ORD(E) {
 
 sort_by_indices :: proc{ sort_by_indices_allocate, _sort_by_indices}
 
-sort_by_indices_allocate :: proc(data: $T/[]$E, indices: []int, allocator := context.allocator) -> (sorted: T) {
+sort_by_indices_allocate :: proc(data: $T/[]$E, indices: []int, allocator := context.allocator, loc := #caller_location) -> (sorted: T) {
 	assert(len(data) == len(indices))
-	sorted = make(T, len(data), allocator)
+	sorted = make(T, len(data), allocator, loc)
 	for v, i in indices {
 		sorted[i] = data[v]
 	}
@@ -100,8 +100,8 @@ sort_from_permutation_indices :: proc(data: $T/[]$E, indices: []int) {
 
 // sort sorts a slice and returns a slice of the original indices
 // This sort is not guaranteed to be stable
-sort_with_indices :: proc(data: $T/[]$E, allocator := context.allocator) -> (indices: []int) where ORD(E) {
-	indices = make([]int, len(data), allocator)
+sort_with_indices :: proc(data: $T/[]$E, allocator := context.allocator, loc := #caller_location) -> (indices: []int) where ORD(E) {
+	indices = make([]int, len(data), allocator, loc)
 	when size_of(E) != 0 {
 		if n := len(data); n > 1 {
 			for _, idx in indices {
@@ -173,8 +173,8 @@ sort_by_with_data :: proc(data: $T/[]$E, less: proc(i, j: E, user_data: rawptr) 
 
 // sort_by sorts a slice with a given procedure to test whether two values are ordered "i < j"
 // This sort is not guaranteed to be stable
-sort_by_with_indices :: proc(data: $T/[]$E, less: proc(i, j: E) -> bool, allocator := context.allocator) -> (indices : []int) {
-	indices = make([]int, len(data), allocator)
+sort_by_with_indices :: proc(data: $T/[]$E, less: proc(i, j: E) -> bool, allocator := context.allocator, loc := #caller_location) -> (indices : []int) {
+	indices = make([]int, len(data), allocator, loc)
 	when size_of(E) != 0 {
 		if n := len(data); n > 1 {
 			for _, idx in indices {
@@ -205,8 +205,8 @@ sort_by_with_indices :: proc(data: $T/[]$E, less: proc(i, j: E) -> bool, allocat
 	return indices
 }
 
-sort_by_with_indices_with_data :: proc(data: $T/[]$E, less: proc(i, j: E, user_data: rawptr) -> bool, user_data: rawptr, allocator := context.allocator) -> (indices : []int) {
-	indices = make([]int, len(data), allocator)
+sort_by_with_indices_with_data :: proc(data: $T/[]$E, less: proc(i, j: E, user_data: rawptr) -> bool, user_data: rawptr, allocator := context.allocator, loc := #caller_location) -> (indices : []int) {
+	indices = make([]int, len(data), allocator, loc)
 	when size_of(E) != 0 {
 		if n := len(data); n > 1 {
 			for _, idx in indices {


### PR DESCRIPTION
I noticed that some of the calls to allocating functions in the 'slice' package don't use the caller's code line when printing messages, so in keeping with the standard elsewhere in the package and the rest of 'core', I've added an optional location `loc` argument.