### PR TITLE
Fix standard json parsing / unmarshalling issue for pure arrays

### DIFF
--- a/core/encoding/json/parser.odin
+++ b/core/encoding/json/parser.odin
@@ -38,7 +38,7 @@ parse_string :: proc(data: string, spec := DEFAULT_SPECIFICATION, parse_integers
 
 	switch p.spec {
 	case .JSON:
-		return parse_object(&p, loc)
+		return parse_value(&p, loc)
 	case .JSON5:
 		return parse_value(&p, loc)
 	case .SJSON:
@@ -84,7 +84,7 @@ expect_token :: proc(p: ^Parser, kind: Token_Kind) -> Error {
 
 
 parse_colon :: proc(p: ^Parser) -> (err: Error) {
-	colon_err := expect_token(p, .Colon) 
+	colon_err := expect_token(p, .Colon)
 	if colon_err == nil {
 		return nil
 	}
@@ -133,13 +133,13 @@ parse_value :: proc(p: ^Parser, loc := #caller_location) -> (value: Value, err: 
 		f, _ := strconv.parse_f64(token.text)
 		value = Float(f)
 		return
-		
+
 	case .Ident:
 		if p.spec == .MJSON {
 			advance_token(p)
 			return clone_string(token.text, p.allocator, loc)
 		}
-		
+
 	case .String:
 		advance_token(p)
 		return unquote_string(token, p.spec, p.allocator, loc)
@@ -192,7 +192,7 @@ parse_array :: proc(p: ^Parser, loc := #caller_location) -> (value: Value, err: 
 	for p.curr_token.kind != .Close_Bracket {
 		elem := parse_value(p, loc) or_return
 		append(&array, elem, loc)
-		
+
 		if parse_comma(p) {
 			break
 		}
@@ -278,7 +278,7 @@ parse_object_body :: proc(p: ^Parser, end_token: Token_Kind, loc := #caller_loca
 		if parse_comma(p) {
 			break
 		}
-	}	
+	}
 	return obj, .None
 }
 

--- a/core/encoding/json/validator.odin
+++ b/core/encoding/json/validator.odin
@@ -5,10 +5,10 @@ import "core:mem"
 // NOTE(bill): is_valid will not check for duplicate keys
 is_valid :: proc(data: []byte, spec := DEFAULT_SPECIFICATION, parse_integers := false) -> bool {
 	p := make_parser(data, spec, parse_integers, mem.nil_allocator())
-	
+
 	switch p.spec {
 	case .JSON:
-		return validate_object(&p)
+		return validate_value(&p)
 	case .JSON5:
 		return validate_value(&p)
 	case .MJSON:
@@ -52,7 +52,7 @@ validate_object :: proc(p: ^Parser) -> bool {
 	if err := expect_token(p, .Open_Brace); err != .None {
 		return false
 	}
-	
+
 	validate_object_body(p, .Close_Brace) or_return
 
 	if err := expect_token(p, .Close_Brace); err != .None {
@@ -102,7 +102,7 @@ validate_value :: proc(p: ^Parser) -> bool {
 
 	case .Open_Bracket:
 		return validate_array(p)
-		
+
 	case .Ident:
 		if p.spec == .MJSON {
 			advance_token(p)


### PR DESCRIPTION
Fixes https://github.com/odin-lang/Odin/issues/6077

The root element need not be an object, even in the standard json specification, it can be an array as well, so parsing it as a value is appropriate.

I did not add a test case for this. Should I?

---

Aparte: marshaling pure arrays has worked already, which leads to the following behaviour (currently), this PR remedies it.
```odin
x := [3]int{1, 2, 3}
marshalled, _ := json.marshal(x, {spec = .JSON}, context.temp_allocator)
fmt.printfln("%#v", string(marshalled))

parsed, _ := json.parse(marshalled, .JSON)
fmt.printfln("%#v", parsed) // Nil, could not parse the output produced by `json.marshal`.
```