### PR TITLE
Fix NetBSD CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     name: NetBSD Build, Check, and Test
     runs-on: ubuntu-latest
     env:
-      PKGSRC_BRANCH: 2025Q2
+      PKGSRC_BRANCH: 2025Q4
     steps:
     - uses: actions/checkout@v4
     - name: Build, Check, and Test


### PR DESCRIPTION
`10.0_2025Q2` seems to be gone from https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/x86_64/. I can only see `10.0_2025Q3` and `10.0_2025Q4`, so went with the latter here.