### PR TITLE
Add JSON5/SJSON Comments When Marshalling

### DIFF
--- a/core/encoding/json/marshal.odin
+++ b/core/encoding/json/marshal.odin
@@ -413,13 +413,13 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 				}
 
 				opt_write_iteration(w, opt, first_iteration) or_return
+				first_iteration = false
 
 				if opt.pretty {
 					comment := reflect.struct_tag_get(reflect.Struct_Tag(info.tags[i]), "jsoncomment")
 					opt_write_comment(w, opt, &comment) or_return
 				}
 
-				first_iteration = false
 				if json_name != "" {
 					opt_write_key(w, opt, json_name) or_return
 				} else {


### PR DESCRIPTION
Allows user-facing JSON5/SJSON to have comments explaining field usage.
- `json.Marshal_Options.pretty` must be enabled since we only use single-line comments (not to mention it wouldn't be terribly useful without `pretty` set anyways)
- We don't escape anything, so `\n` will display as "\n", but you're still able to enter in a proper newline character and it'll be marshalled into multiple lines of comments