### PR TITLE
[encoding/json] Fix Unicode Output When Marshalling

### DIFF
--- a/core/encoding/json/marshal.odin
+++ b/core/encoding/json/marshal.odin
@@ -122,9 +122,9 @@ marshal_to_writer :: proc(w: io.Writer, v: any, opt: ^Marshal_Options) -> (err: 
 
 	case runtime.Type_Info_Rune:
 		r := a.(rune)
-		io.write_byte(w, '"')                  or_return
-		io.write_escaped_rune(w, r, '"', true) or_return
-		io.write_byte(w, '"')                  or_return
+		io.write_byte(w, '"')                             or_return
+		io.write_escaped_rune(w, r, '"', for_json = true) or_return
+		io.write_byte(w, '"')                             or_return
 
 	case runtime.Type_Info_Float:
 		switch f in a {


### PR DESCRIPTION
Fixes https://github.com/odin-lang/Odin/issues/6060 and https://github.com/odin-lang/Odin/issues/6075 
The boolean "true" was setting `html_safe` instead of `for_json`.
Chalk one up for the "use enums instead of booleans" crowd.