### PR TITLE
core/net: fix `map_to_ip6` offset

### DIFF
--- a/core/net/addr.odin
+++ b/core/net/addr.odin
@@ -495,8 +495,8 @@ map_to_ip6 :: proc(addr: Address) -> Address {
 	addr4 := addr.(IP4_Address)
 	addr4_u16 := transmute([2]u16be) addr4
 	addr6: IP6_Address
-	addr6[4] = 0xffff
-	copy(addr6[5:], addr4_u16[:])
+	addr6[5] = 0xffff
+	copy(addr6[6:], addr4_u16[:])
 	return addr6
 }
 


### PR DESCRIPTION
`map_to_ip6` currently fills `addr6[4:7]`, leaving the last element empty, which shouldn't be the case afaict (https://en.wikipedia.org/wiki/Reserved_IP_addresses#IPv6)
This PR just changes range to `addr6[5:8]`