### PR TITLE
Prefer LPCSTR/LPCWSTR types in DirectX bindings

### DIFF
--- a/vendor/directx/d3d11/d3d11.odin
+++ b/vendor/directx/d3d11/d3d11.odin
@@ -20,6 +20,7 @@ BOOL    :: dxgi.BOOL
 UINT    :: dxgi.UINT
 INT     :: dxgi.INT
 
+LPCSTR   :: windows.LPCSTR
 LPCWSTR  :: windows.LPCWSTR
 
 RECT :: dxgi.RECT
@@ -950,7 +951,7 @@ INPUT_CLASSIFICATION :: enum i32 {
 }
 
 INPUT_ELEMENT_DESC :: struct {
-	SemanticName:         cstring,
+	SemanticName:         LPCSTR,
 	SemanticIndex:        u32,
 	Format:               dxgi.FORMAT,
 	InputSlot:            u32,
@@ -972,7 +973,7 @@ CULL_MODE :: enum i32 {
 
 SO_DECLARATION_ENTRY :: struct {
 	Stream:         u32,
-	SemanticName:   cstring,
+	SemanticName:   LPCSTR,
 	SemanticIndex:  u32,
 	StartComponent: u8,
 	ComponentCount: u8,
@@ -2172,8 +2173,8 @@ IClassLinkage :: struct #raw_union {
 }
 IClassLinkage_VTable :: struct {
 	using id3d11devicechild_vtable: IDeviceChild_VTable,
-	GetClassInstance:    proc "system" (this: ^IClassLinkage, pClassInstanceName: cstring, InstanceIndex: u32, ppInstance: ^^IClassInstance) -> HRESULT,
-	CreateClassInstance: proc "system" (this: ^IClassLinkage, pClassTypeName: cstring, ConstantBufferOffset: u32, ConstantVectorOffset: u32, TextureOffset: u32, SamplerOffset: u32, ppInstance: ^^IClassInstance) -> HRESULT,
+	GetClassInstance:    proc "system" (this: ^IClassLinkage, pClassInstanceName: LPCSTR, InstanceIndex: u32, ppInstance: ^^IClassInstance) -> HRESULT,
+	CreateClassInstance: proc "system" (this: ^IClassLinkage, pClassTypeName: LPCSTR, ConstantBufferOffset: u32, ConstantVectorOffset: u32, TextureOffset: u32, SamplerOffset: u32, ppInstance: ^^IClassInstance) -> HRESULT,
 }
 
 
@@ -3407,7 +3408,7 @@ SHADER_VERSION_TYPE :: enum i32 {
 }
 
 SIGNATURE_PARAMETER_DESC :: struct {
-	SemanticName:    cstring,
+	SemanticName:    LPCSTR,
 	SemanticIndex:   u32,
 	Register:        u32,
 	SystemValueType: NAME,
@@ -3421,7 +3422,7 @@ SIGNATURE_PARAMETER_DESC :: struct {
 }
 
 SHADER_BUFFER_DESC :: struct {
-	Name:      cstring,
+	Name:      LPCSTR,
 	Type:      CBUFFER_TYPE,
 	Variables: u32,
 	Size:      u32,
@@ -3429,7 +3430,7 @@ SHADER_BUFFER_DESC :: struct {
 }
 
 SHADER_VARIABLE_DESC :: struct {
-	Name:         cstring,
+	Name:         LPCSTR,
 	StartOffset:  u32,
 	Size:         u32,
 	uFlags:       SHADER_VARIABLE_FLAGS,
@@ -3448,12 +3449,12 @@ SHADER_TYPE_DESC :: struct {
 	Elements: u32,
 	Members:  u32,
 	Offset:   u32,
-	Name:     cstring,
+	Name:     LPCSTR,
 }
 
 SHADER_DESC :: struct {
 	Version:                     u32,
-	Creator:                     cstring,
+	Creator:                     LPCSTR,
 	Flags:                       u32,
 
 	ConstantBuffers:             u32,
@@ -3496,7 +3497,7 @@ SHADER_DESC :: struct {
 }
 
 SHADER_INPUT_BIND_DESC :: struct {
-	Name:       cstring,
+	Name:       LPCSTR,
 	Type:       SHADER_INPUT_TYPE,
 	BindPoint:  u32,
 	BindCount:  u32,
@@ -3508,14 +3509,14 @@ SHADER_INPUT_BIND_DESC :: struct {
 }
 
 LIBRARY_DESC :: struct {
-	Creator:       cstring,
+	Creator:       LPCSTR,
 	Flags:         u32,
 	FunctionCount: u32,
 }
 
 FUNCTION_DESC :: struct {
 	Version:                     u32,
-	Creator:                     cstring,
+	Creator:                     LPCSTR,
 	Flags:                       u32,
 
 	ConstantBuffers:             u32,
@@ -3545,7 +3546,7 @@ FUNCTION_DESC :: struct {
 	MinFeatureLevel:             FEATURE_LEVEL,
 	RequiredFeatureFlags:        SHADER_REQUIRES_FLAGS,
 
-	Name:                        cstring,
+	Name:                        LPCSTR,
 	FunctionParameterCount:      i32,
 	HasReturn:                   BOOL,
 	Has10Level9VertexShader:     BOOL,
@@ -3553,8 +3554,8 @@ FUNCTION_DESC :: struct {
 }
 
 PARAMETER_DESC :: struct {
-	Name:              cstring,
-	SemanticName:      cstring,
+	Name:              LPCSTR,
+	SemanticName:      LPCSTR,
 	Type:              SHADER_VARIABLE_TYPE,
 	Class:             SHADER_VARIABLE_CLASS,
 	Rows:              u32,
@@ -3576,8 +3577,8 @@ IShaderReflectionType :: struct {
 IShaderReflectionType_VTable :: struct {
 	GetDesc:              proc "system" (this: ^IShaderReflectionType, pDesc: ^SHADER_TYPE_DESC) -> HRESULT,
 	GetMemberTypeByIndex: proc "system" (this: ^IShaderReflectionType, Index: u32) -> ^IShaderReflectionType,
-	GetMemberTypeByName:  proc "system" (this: ^IShaderReflectionType, Name: cstring) -> ^IShaderReflectionType,
-	GetMemberTypeName:    proc "system" (this: ^IShaderReflectionType, Index: u32) -> cstring,
+	GetMemberTypeByName:  proc "system" (this: ^IShaderReflectionType, Name: LPCSTR) -> ^IShaderReflectionType,
+	GetMemberTypeName:    proc "system" (this: ^IShaderReflectionType, Index: u32) -> LPCSTR,
 	IsEqual:              proc "system" (this: ^IShaderReflectionType, pType: ^IShaderReflectionType) -> HRESULT,
 	GetSubType:           proc "system" (this: ^IShaderReflectionType) -> ^IShaderReflectionType,
 	GetBaseClass:         proc "system" (this: ^IShaderReflectionType) -> ^IShaderReflectionType,
@@ -3607,7 +3608,7 @@ IShaderReflectionConstantBuffer :: struct {
 IShaderReflectionConstantBuffer_VTable :: struct {
 	GetDesc: proc "system" (this: ^IShaderReflectionConstantBuffer, pDesc: ^SHADER_BUFFER_DESC) -> HRESULT,
 	GetVariableByIndex: proc "system" (this: ^IShaderReflectionConstantBuffer, Index: u32) -> ^IShaderReflectionVariable,
-	GetVariableByName: proc "system" (this: ^IShaderReflectionConstantBuffer, Name: cstring) -> ^IShaderReflectionVariable,
+	GetVariableByName: proc "system" (this: ^IShaderReflectionConstantBuffer, Name: LPCSTR) -> ^IShaderReflectionVariable,
 }
 
 
@@ -3621,13 +3622,13 @@ IShaderReflection_VTable :: struct {
 	using iunknown_vtable: IUnknown_VTable,
 	GetDesc:                       proc "system" (this: ^IShaderReflection, pDesc: ^SHADER_DESC) -> HRESULT,
 	GetConstantBufferByIndex:      proc "system" (this: ^IShaderReflection, Index: u32) -> ^IShaderReflectionConstantBuffer,
-	GetConstantBufferByName:       proc "system" (this: ^IShaderReflection, Name: cstring) -> ^IShaderReflectionConstantBuffer,
+	GetConstantBufferByName:       proc "system" (this: ^IShaderReflection, Name: LPCSTR) -> ^IShaderReflectionConstantBuffer,
 	GetResourceBindingDesc:        proc "system" (this: ^IShaderReflection, ResourceIndex: u32, pDesc: ^SHADER_INPUT_BIND_DESC) -> HRESULT,
 	GetInputParameterDesc:         proc "system" (this: ^IShaderReflection, ParameterIndex: u32, pDesc: ^SIGNATURE_PARAMETER_DESC) -> HRESULT,
 	GetOutputParameterDesc:        proc "system" (this: ^IShaderReflection, ParameterIndex: u32, pDesc: ^SIGNATURE_PARAMETER_DESC) -> HRESULT,
 	GetPatchConstantParameterDesc: proc "system" (this: ^IShaderReflection, ParameterIndex: u32, pDesc: ^SIGNATURE_PARAMETER_DESC) -> HRESULT,
-	GetVariableByName:             proc "system" (this: ^IShaderReflection, Name: cstring) -> ^IShaderReflectionVariable,
-	GetResourceBindingDescByName:  proc "system" (this: ^IShaderReflection, Name: cstring, pDesc: ^SHADER_INPUT_BIND_DESC) -> HRESULT,
+	GetVariableByName:             proc "system" (this: ^IShaderReflection, Name: LPCSTR) -> ^IShaderReflectionVariable,
+	GetResourceBindingDescByName:  proc "system" (this: ^IShaderReflection, Name: LPCSTR, pDesc: ^SHADER_INPUT_BIND_DESC) -> HRESULT,
 	GetMovInstructionCount:        proc "system" (this: ^IShaderReflection) -> u32,
 	GetMovcInstructionCount:       proc "system" (this: ^IShaderReflection) -> u32,
 	GetConversionInstructionCount: proc "system" (this: ^IShaderReflection) -> u32,
@@ -3661,10 +3662,10 @@ IFunctionReflection :: struct {
 IFunctionReflection_VTable :: struct {
 	GetDesc:                      proc "system" (this: ^IFunctionReflection, pDesc: ^FUNCTION_DESC) -> HRESULT,
 	GetConstantBufferByIndex:     proc "system" (this: ^IFunctionReflection, BufferIndex: u32) -> ^IShaderReflectionConstantBuffer,
-	GetConstantBufferByName:      proc "system" (this: ^IFunctionReflection, Name: cstring) -> ^IShaderReflectionConstantBuffer,
+	GetConstantBufferByName:      proc "system" (this: ^IFunctionReflection, Name: LPCSTR) -> ^IShaderReflectionConstantBuffer,
 	GetResourceBindingDesc:       proc "system" (this: ^IFunctionReflection, ResourceIndex: u32, pDesc: ^SHADER_INPUT_BIND_DESC) -> HRESULT,
-	GetVariableByName:            proc "system" (this: ^IFunctionReflection, Name: cstring) -> ^IShaderReflectionVariable,
-	GetResourceBindingDescByName: proc "system" (this: ^IFunctionReflection, Name: cstring, pDesc: ^SHADER_INPUT_BIND_DESC) -> HRESULT,
+	GetVariableByName:            proc "system" (this: ^IFunctionReflection, Name: LPCSTR) -> ^IShaderReflectionVariable,
+	GetResourceBindingDescByName: proc "system" (this: ^IFunctionReflection, Name: LPCSTR, pDesc: ^SHADER_INPUT_BIND_DESC) -> HRESULT,
 	GetFunctionParameter:         proc "system" (this: ^IFunctionReflection, ParameterIndex: i32) -> ^IFunctionParameterReflection,
 }
 
@@ -3691,7 +3692,7 @@ IFunctionLinkingGraph_VTable :: struct {
 	CreateModuleInstance: proc "system" (this: ^IFunctionLinkingGraph, ppModuleInstance: ^^IModuleInstance, ppErrorBuffer: ^^IBlob) -> HRESULT,
 	SetInputSignature:    proc "system" (this: ^IFunctionLinkingGraph, pInputParameters: [^]PARAMETER_DESC, cInputParameters: u32, ppInputNode: ^^ILinkingNode) -> HRESULT,
 	SetOutputSignature:   proc "system" (this: ^IFunctionLinkingGraph, pOutputParameters: [^]PARAMETER_DESC, cOutputParameters: u32, ppOutputNode: ^^ILinkingNode) -> HRESULT,
-	CallFunction:         proc "system" (this: ^IFunctionLinkingGraph, pModuleInstanceNamespace: cstring, pModuleWithFunctionPrototype: ^IModule, pFunctionName: cstring, ppCallNode: ^^ILinkingNode) -> HRESULT,
+	CallFunction:         proc "system" (this: ^IFunctionLinkingGraph, pModuleInstanceNamespace: LPCSTR, pModuleWithFunctionPrototype: ^IModule, pFunctionName: LPCSTR, ppCallNode: ^^ILinkingNode) -> HRESULT,
 	PassValue:            proc "system" (this: ^IFunctionLinkingGraph, pSrcNode: ^ILinkingNode, SrcParameterIndex: i32, pDstNode: ^ILinkingNode, DstParameterIndex: i32) -> HRESULT,
 	PassValueWithSwizzle: proc "system" (this: ^IFunctionLinkingGraph, pSrcNode: ^ILinkingNode, SrcParameterIndex: i32, pSrcSwizzle: ^u8, pDstNode: ^ILinkingNode, DstParameterIndex: i32, pDstSwizzle: ^u8) -> HRESULT,
 	GetLastError:         proc "system" (this: ^IFunctionLinkingGraph, ppErrorBuffer: ^^IBlob) -> HRESULT,
@@ -3814,8 +3815,8 @@ IInfoQueue_VTable :: struct {
 	PushRetrievalFilter:                          proc "system" (this: ^IInfoQueue, pFilter: ^INFO_QUEUE_FILTER) -> HRESULT,
 	PopRetrievalFilter:                           proc "system" (this: ^IInfoQueue),
 	GetRetrievalFilterStackSize:                  proc "system" (this: ^IInfoQueue) -> u64,
-	AddMessage:                                   proc "system" (this: ^IInfoQueue, Category: MESSAGE_CATEGORY, Severity: MESSAGE_SEVERITY, ID: MESSAGE_ID, pDescription: cstring) -> HRESULT,
-	AddApplicationMessage:                        proc "system" (this: ^IInfoQueue, Severity: MESSAGE_SEVERITY, pDescription: cstring) -> HRESULT,
+	AddMessage:                                   proc "system" (this: ^IInfoQueue, Category: MESSAGE_CATEGORY, Severity: MESSAGE_SEVERITY, ID: MESSAGE_ID, pDescription: LPCSTR) -> HRESULT,
+	AddApplicationMessage:                        proc "system" (this: ^IInfoQueue, Severity: MESSAGE_SEVERITY, pDescription: LPCSTR) -> HRESULT,
 	SetBreakOnCategory:                           proc "system" (this: ^IInfoQueue, Category: MESSAGE_CATEGORY, bEnable: BOOL) -> HRESULT,
 	SetBreakOnSeverity:                           proc "system" (this: ^IInfoQueue, Severity: MESSAGE_SEVERITY, bEnable: BOOL) -> HRESULT,
 	SetBreakOnID:                                 proc "system" (this: ^IInfoQueue, ID: MESSAGE_ID, bEnable: BOOL) -> HRESULT,

--- a/vendor/directx/d3d12/d3d12.odin
+++ b/vendor/directx/d3d12/d3d12.odin
@@ -23,6 +23,7 @@ BOOL    :: dxgi.BOOL
 
 RECT :: dxgi.RECT
 
+LPCSTR  :: win32.LPCSTR
 LPCWSTR :: win32.LPCWSTR
 
 IModuleInstance :: d3d_compiler.ID3D11ModuleInstance
@@ -467,7 +468,7 @@ INPUT_CLASSIFICATION :: enum i32 {
 }
 
 INPUT_ELEMENT_DESC :: struct {
-	SemanticName:         cstring,
+	SemanticName:         LPCSTR,
 	SemanticIndex:        u32,
 	Format:               dxgi.FORMAT,
 	InputSlot:            u32,
@@ -489,7 +490,7 @@ CULL_MODE :: enum i32 {
 
 SO_DECLARATION_ENTRY :: struct {
 	Stream:         u32,
-	SemanticName:   cstring,
+	SemanticName:   LPCSTR,
 	SemanticIndex:  u32,
 	StartComponent: u8,
 	ComponentCount: u8,
@@ -3153,13 +3154,13 @@ EXISTING_COLLECTION_DESC :: struct {
 SUBOBJECT_TO_EXPORTS_ASSOCIATION :: struct {
 	pSubobjectToAssociate: ^STATE_SUBOBJECT,
 	NumExports:            u32,
-	pExports:              [^]cstring16 `fmt:"v,NumExports"`,
+	pExports:              [^]LPCWSTR `fmt:"v,NumExports"`,
 }
 
 DXIL_SUBOBJECT_TO_EXPORTS_ASSOCIATION :: struct {
-	SubobjectToAssociate: cstring16,
+	SubobjectToAssociate: LPCWSTR,
 	NumExports:           u32,
-	pExports:             [^]cstring16 `fmt:"v,NumExports"`,
+	pExports:             [^]LPCWSTR `fmt:"v,NumExports"`,
 }
 
 HIT_GROUP_TYPE :: enum i32 {
@@ -3168,11 +3169,11 @@ HIT_GROUP_TYPE :: enum i32 {
 }
 
 HIT_GROUP_DESC :: struct {
-	HitGroupExport:           cstring16,
+	HitGroupExport:           LPCWSTR,
 	Type:                     HIT_GROUP_TYPE,
-	AnyHitShaderImport:       cstring16,
-	ClosestHitShaderImport:   cstring16,
-	IntersectionShaderImport: cstring16,
+	AnyHitShaderImport:       LPCWSTR,
+	ClosestHitShaderImport:   LPCWSTR,
+	IntersectionShaderImport: LPCWSTR,
 }
 
 RAYTRACING_SHADER_CONFIG :: struct {
@@ -5222,8 +5223,8 @@ IInfoQueue_VTable :: struct {
 	PushRetrievalFilter:                          proc "system" (this: ^IInfoQueue, pFilter: ^INFO_QUEUE_FILTER) -> HRESULT,
 	PopRetrievalFilter:                           proc "system" (this: ^IInfoQueue),
 	GetRetrievalFilterStackSize:                  proc "system" (this: ^IInfoQueue) -> u32,
-	AddMessage:                                   proc "system" (this: ^IInfoQueue, Category: MESSAGE_CATEGORY, Severity: MESSAGE_SEVERITY, ID: MESSAGE_ID, pDescription: cstring) -> HRESULT,
-	AddApplicationMessage:                        proc "system" (this: ^IInfoQueue, Severity: MESSAGE_SEVERITY, pDescription: cstring) -> HRESULT,
+	AddMessage:                                   proc "system" (this: ^IInfoQueue, Category: MESSAGE_CATEGORY, Severity: MESSAGE_SEVERITY, ID: MESSAGE_ID, pDescription: LPCSTR) -> HRESULT,
+	AddApplicationMessage:                        proc "system" (this: ^IInfoQueue, Severity: MESSAGE_SEVERITY, pDescription: LPCSTR) -> HRESULT,
 	SetBreakOnCategory:                           proc "system" (this: ^IInfoQueue, Category: MESSAGE_CATEGORY, bEnable: BOOL) -> HRESULT,
 	SetBreakOnSeverity:                           proc "system" (this: ^IInfoQueue, Severity: MESSAGE_SEVERITY, bEnable: BOOL) -> HRESULT,
 	SetBreakOnID:                                 proc "system" (this: ^IInfoQueue, ID: MESSAGE_ID, bEnable: BOOL) -> HRESULT,
@@ -5239,7 +5240,7 @@ MESSAGE_CALLBACK_FLAG :: enum {
 	IGNORE_FILTERS = 0,
 }
 
-PFN_MESSAGE_CALLBACK :: #type proc "c" (Category: MESSAGE_CATEGORY, Severity: MESSAGE_SEVERITY, ID: MESSAGE_ID, pDescription: cstring, pContext: rawptr)
+PFN_MESSAGE_CALLBACK :: #type proc "c" (Category: MESSAGE_CATEGORY, Severity: MESSAGE_SEVERITY, ID: MESSAGE_ID, pDescription: LPCSTR, pContext: rawptr)
 
 IInfoQueue1_UUID_STRING :: "2852dd88-b484-4c0c-b6b1-67168500e600"
 IInfoQueue1_UUID := &IID{0x2852dd88, 0xb484, 0x4c0c, {0xb6, 0xb1, 0x67, 0x16, 0x85, 0x00, 0xe6, 0x00}}
@@ -5262,7 +5263,7 @@ ISDKConfiguration :: struct #raw_union {
 }
 ISDKConfiguration_VTable :: struct {
 	using iunknown_vtable: IUnknown_VTable,
-	SetSDKVersion: proc "system" (this: ^ISDKConfiguration, SDKVersion: u32, SDKPath: cstring) -> HRESULT,
+	SetSDKVersion: proc "system" (this: ^ISDKConfiguration, SDKVersion: u32, SDKPath: LPCSTR) -> HRESULT,
 }
 
 
@@ -5361,7 +5362,7 @@ shver_get_minor :: proc "contextless" (version: u32) -> u8 {
 }
 
 SIGNATURE_PARAMETER_DESC :: struct {
-	SemanticName:    cstring,
+	SemanticName:    LPCSTR,
 	SemanticIndex:   u32,
 	Register:        u32,
 	SystemValueType: NAME,
@@ -5375,7 +5376,7 @@ SIGNATURE_PARAMETER_DESC :: struct {
 }
 
 SHADER_BUFFER_DESC :: struct {
-	Name:      cstring,
+	Name:      LPCSTR,
 	Type:      CBUFFER_TYPE,
 	Variables: u32,
 	Size:      u32,
@@ -5383,7 +5384,7 @@ SHADER_BUFFER_DESC :: struct {
 }
 
 SHADER_VARIABLE_DESC :: struct {
-	Name:         cstring,
+	Name:         LPCSTR,
 	StartOffset:  u32,
 	Size:         u32,
 	uFlags:       u32,
@@ -5402,12 +5403,12 @@ SHADER_TYPE_DESC :: struct {
 	Elements: u32,
 	Members:  u32,
 	Offset:   u32,
-	Name:     cstring,
+	Name:     LPCSTR,
 }
 
 SHADER_DESC :: struct {
 	Version:                     u32,
-	Creator:                     cstring,
+	Creator:                     LPCSTR,
 	Flags:                       u32,
 
 	ConstantBuffers:             u32,
@@ -5450,7 +5451,7 @@ SHADER_DESC :: struct {
 }
 
 SHADER_INPUT_BIND_DESC :: struct {
-	Name:       cstring,
+	Name:       LPCSTR,
 	Type:       SHADER_INPUT_TYPE,
 	BindPoint:  u32,
 	BindCount:  u32,
@@ -5497,14 +5498,14 @@ SHADER_REQUIRES :: enum u64 {
 }
 
 LIBRARY_DESC :: struct {
-	Creator:       cstring,
+	Creator:       LPCSTR,
 	Flags:         u32,
 	FunctionCount: u32,
 }
 
 FUNCTION_DESC :: struct {
 	Version:                     u32,
-	Creator:                     cstring,
+	Creator:                     LPCSTR,
 	Flags:                       u32,
 
 	ConstantBuffers:             u32,
@@ -5534,7 +5535,7 @@ FUNCTION_DESC :: struct {
 	MinFeatureLevel:             FEATURE_LEVEL,
 	RequiredFeatureFlags:        u64,
 
-	Name:                        cstring,
+	Name:                        LPCSTR,
 	FunctionParameterCount:      i32,
 	HasReturn:                   BOOL,
 	Has10Level9VertexShader:     BOOL,
@@ -5542,8 +5543,8 @@ FUNCTION_DESC :: struct {
 }
 
 PARAMETER_DESC :: struct {
-	Name:              cstring,
-	SemanticName:      cstring,
+	Name:              LPCSTR,
+	SemanticName:      LPCSTR,
 	Type:              SHADER_VARIABLE_TYPE,
 	Class:             SHADER_VARIABLE_CLASS,
 	Rows:              u32,
@@ -5565,8 +5566,8 @@ IShaderReflectionType :: struct {
 IShaderReflectionType_VTable :: struct {
 	GetDesc:              proc "system" (this: ^IShaderReflectionType, pDesc: ^SHADER_TYPE_DESC) -> HRESULT,
 	GetMemberTypeByIndex: proc "system" (this: ^IShaderReflectionType, Index: u32) -> ^IShaderReflectionType,
-	GetMemberTypeByName:  proc "system" (this: ^IShaderReflectionType, Name: cstring) -> ^IShaderReflectionType,
-	GetMemberTypeName:    proc "system" (this: ^IShaderReflectionType, Index: u32) -> cstring,
+	GetMemberTypeByName:  proc "system" (this: ^IShaderReflectionType, Name: LPCSTR) -> ^IShaderReflectionType,
+	GetMemberTypeName:    proc "system" (this: ^IShaderReflectionType, Index: u32) -> LPCSTR,
 	IsEqual:              proc "system" (this: ^IShaderReflectionType, pType: ^IShaderReflectionType) -> HRESULT,
 	GetSubType:           proc "system" (this: ^IShaderReflectionType) -> ^IShaderReflectionType,
 	GetBaseClass:         proc "system" (this: ^IShaderReflectionType) -> ^IShaderReflectionType,
@@ -5596,7 +5597,7 @@ IShaderReflectionConstantBuffer :: struct {
 IShaderReflectionConstantBuffer_VTable :: struct {
 	GetDesc:            proc "system" (this: ^IShaderReflectionConstantBuffer, pDesc: ^SHADER_BUFFER_DESC) -> HRESULT,
 	GetVariableByIndex: proc "system" (this: ^IShaderReflectionConstantBuffer, Index: u32) -> ^IShaderReflectionVariable,
-	GetVariableByName:  proc "system" (this: ^IShaderReflectionConstantBuffer, Name: cstring) -> ^IShaderReflectionVariable,
+	GetVariableByName:  proc "system" (this: ^IShaderReflectionConstantBuffer, Name: LPCSTR) -> ^IShaderReflectionVariable,
 }
 
 IShaderReflection_UUID_STRING :: "5A58797D-A72C-478D-8BA2-EFC6B0EFE88E"
@@ -5609,13 +5610,13 @@ IShaderReflection_VTable :: struct {
 	using iunknown_vtable: IUnknown_VTable,
 	GetDesc:                       proc "system" (this: ^IShaderReflection, pDesc: ^SHADER_DESC) -> HRESULT,
 	GetConstantBufferByIndex:      proc "system" (this: ^IShaderReflection, Index: u32) -> ^IShaderReflectionConstantBuffer,
-	GetConstantBufferByName:       proc "system" (this: ^IShaderReflection, Name: cstring) -> ^IShaderReflectionConstantBuffer,
+	GetConstantBufferByName:       proc "system" (this: ^IShaderReflection, Name: LPCSTR) -> ^IShaderReflectionConstantBuffer,
 	GetResourceBindingDesc:        proc "system" (this: ^IShaderReflection, ResourceIndex: u32, pDesc: ^SHADER_INPUT_BIND_DESC) -> HRESULT,
 	GetInputParameterDesc:         proc "system" (this: ^IShaderReflection, ParameterIndex: u32, pDesc: ^SIGNATURE_PARAMETER_DESC) -> HRESULT,
 	GetOutputParameterDesc:        proc "system" (this: ^IShaderReflection, ParameterIndex: u32, pDesc: ^SIGNATURE_PARAMETER_DESC) -> HRESULT,
 	GetPatchConstantParameterDesc: proc "system" (this: ^IShaderReflection, ParameterIndex: u32, pDesc: ^SIGNATURE_PARAMETER_DESC) -> HRESULT,
-	GetVariableByName:             proc "system" (this: ^IShaderReflection, Name: cstring) -> ^IShaderReflectionVariable,
-	GetResourceBindingDescByName:  proc "system" (this: ^IShaderReflection, Name: cstring, pDesc: ^SHADER_INPUT_BIND_DESC) -> HRESULT,
+	GetVariableByName:             proc "system" (this: ^IShaderReflection, Name: LPCSTR) -> ^IShaderReflectionVariable,
+	GetResourceBindingDescByName:  proc "system" (this: ^IShaderReflection, Name: LPCSTR, pDesc: ^SHADER_INPUT_BIND_DESC) -> HRESULT,
 	GetMovInstructionCount:        proc "system" (this: ^IShaderReflection) -> u32,
 	GetMovcInstructionCount:       proc "system" (this: ^IShaderReflection) -> u32,
 	GetConversionInstructionCount: proc "system" (this: ^IShaderReflection) -> u32,
@@ -5648,10 +5649,10 @@ IFunctionReflection :: struct {
 IFunctionReflection_VTable :: struct {
 	GetDesc:                      proc "system" (this: ^IFunctionReflection, pDesc: ^FUNCTION_DESC) -> HRESULT,
 	GetConstantBufferByIndex:     proc "system" (this: ^IFunctionReflection, BufferIndex: u32) -> ^IShaderReflectionConstantBuffer,
-	GetConstantBufferByName:      proc "system" (this: ^IFunctionReflection, Name: cstring) -> ^IShaderReflectionConstantBuffer,
+	GetConstantBufferByName:      proc "system" (this: ^IFunctionReflection, Name: LPCSTR) -> ^IShaderReflectionConstantBuffer,
 	GetResourceBindingDesc:       proc "system" (this: ^IFunctionReflection, ResourceIndex: u32, pDesc: ^SHADER_INPUT_BIND_DESC) -> HRESULT,
-	GetVariableByName:            proc "system" (this: ^IFunctionReflection, Name: cstring) -> ^IShaderReflectionVariable,
-	GetResourceBindingDescByName: proc "system" (this: ^IFunctionReflection, Name: cstring, pDesc: ^SHADER_INPUT_BIND_DESC) -> HRESULT,
+	GetVariableByName:            proc "system" (this: ^IFunctionReflection, Name: LPCSTR) -> ^IShaderReflectionVariable,
+	GetResourceBindingDescByName: proc "system" (this: ^IFunctionReflection, Name: LPCSTR, pDesc: ^SHADER_INPUT_BIND_DESC) -> HRESULT,
 	GetFunctionParameter:         proc "system" (this: ^IFunctionReflection, ParameterIndex: i32) -> ^IFunctionParameterReflection,
 }
 

--- a/vendor/directx/d3d_compiler/d3d_compiler.odin
+++ b/vendor/directx/d3d_compiler/d3d_compiler.odin
@@ -2,6 +2,7 @@
 package directx_d3d_compiler
 
 foreign import d3dcompiler "d3dcompiler_47.lib"
+import win32 "core:sys/windows"
 
 D3DCOMPILER_DLL_A :: "d3dcompiler_47.dll"
 COMPILER_VERSION :: 47
@@ -16,19 +17,22 @@ HRESULT         :: dxgi.HRESULT
 IUnknown        :: dxgi.IUnknown
 IUnknown_VTable :: dxgi.IUnknown_VTable
 
+LPCSTR   :: win32.LPCSTR
+LPCWSTR  :: win32.LPCWSTR
+
 @(default_calling_convention="system", link_prefix="D3D")
 foreign d3dcompiler {
-	ReadFileToBlob                 :: proc(pFileName: [^]u16, ppContents: ^^ID3DBlob) -> HRESULT ---
-	WriteBlobToFile                :: proc(pBlob: ^ID3DBlob, pFileName: [^]u16, bOverwrite: BOOL) -> HRESULT ---
-	Compile                        :: proc(pSrcData: rawptr, SrcDataSize: SIZE_T, pSourceName: cstring, pDefines: ^SHADER_MACRO, pInclude: ^ID3DInclude, pEntrypoint: cstring, pTarget: cstring, Flags1: u32, Flags2: u32, ppCode: ^^ID3DBlob, ppErrorMsgs: ^^ID3DBlob) -> HRESULT ---
-	Compile2                       :: proc(pSrcData: rawptr, SrcDataSize: SIZE_T, pSourceName: cstring, pDefines: ^SHADER_MACRO, pInclude: ^ID3DInclude, pEntrypoint: cstring, pTarget: cstring, Flags1: u32, Flags2: u32, SecondaryDataFlags: u32, pSecondaryData: rawptr, SecondaryDataSize: SIZE_T, ppCode: ^^ID3DBlob, ppErrorMsgs: ^^ID3DBlob) -> HRESULT ---
-	CompileFromFile                :: proc(pFileName: [^]u16, pDefines: ^SHADER_MACRO, pInclude: ^ID3DInclude, pEntrypoint: cstring, pTarget: cstring, Flags1: u32, Flags2: u32, ppCode: ^^ID3DBlob, ppErrorMsgs: ^^ID3DBlob) -> HRESULT ---
-	Preprocess                     :: proc(pSrcData: rawptr, SrcDataSize: SIZE_T, pSourceName: cstring, pDefines: ^SHADER_MACRO, pInclude: ^ID3DInclude, ppCodeText: ^^ID3DBlob, ppErrorMsgs: ^^ID3DBlob) -> HRESULT ---
+	ReadFileToBlob                 :: proc(pFileName: LPCWSTR, ppContents: ^^ID3DBlob) -> HRESULT ---
+	WriteBlobToFile                :: proc(pBlob: ^ID3DBlob, pFileName: LPCWSTR, bOverwrite: BOOL) -> HRESULT ---
+	Compile                        :: proc(pSrcData: rawptr, SrcDataSize: SIZE_T, pSourceName: LPCSTR, pDefines: ^SHADER_MACRO, pInclude: ^ID3DInclude, pEntrypoint: LPCSTR, pTarget: LPCSTR, Flags1: u32, Flags2: u32, ppCode: ^^ID3DBlob, ppErrorMsgs: ^^ID3DBlob) -> HRESULT ---
+	Compile2                       :: proc(pSrcData: rawptr, SrcDataSize: SIZE_T, pSourceName: LPCSTR, pDefines: ^SHADER_MACRO, pInclude: ^ID3DInclude, pEntrypoint: LPCSTR, pTarget: LPCSTR, Flags1: u32, Flags2: u32, SecondaryDataFlags: u32, pSecondaryData: rawptr, SecondaryDataSize: SIZE_T, ppCode: ^^ID3DBlob, ppErrorMsgs: ^^ID3DBlob) -> HRESULT ---
+	CompileFromFile                :: proc(pFileName: LPCWSTR, pDefines: ^SHADER_MACRO, pInclude: ^ID3DInclude, pEntrypoint: LPCSTR, pTarget: LPCSTR, Flags1: u32, Flags2: u32, ppCode: ^^ID3DBlob, ppErrorMsgs: ^^ID3DBlob) -> HRESULT ---
+	Preprocess                     :: proc(pSrcData: rawptr, SrcDataSize: SIZE_T, pSourceName: LPCSTR, pDefines: ^SHADER_MACRO, pInclude: ^ID3DInclude, ppCodeText: ^^ID3DBlob, ppErrorMsgs: ^^ID3DBlob) -> HRESULT ---
 	GetDebugInfo                   :: proc(pSrcData: rawptr, SrcDataSize: SIZE_T, ppDebugInfo: ^^ID3DBlob) -> HRESULT ---
 	Reflect                        :: proc(pSrcData: rawptr, SrcDataSize: SIZE_T, pInterface: ^IID, ppReflector: ^rawptr) -> HRESULT ---
 	ReflectLibrary                 :: proc(pSrcData: rawptr, SrcDataSize: SIZE_T, riid: ^IID, ppReflector: ^rawptr) -> HRESULT ---
-	Disassemble                    :: proc(pSrcData: rawptr, SrcDataSize: SIZE_T, Flags: u32, szComments: cstring, ppDisassembly: ^^ID3DBlob) -> HRESULT ---
-	DisassembleRegion              :: proc(pSrcData: rawptr, SrcDataSize: SIZE_T, Flags: u32, szComments: cstring, StartByteOffset: SIZE_T, NumInsts: SIZE_T, pFinishByteOffset: ^SIZE_T, ppDisassembly: ^^ID3DBlob) -> HRESULT ---
+	Disassemble                    :: proc(pSrcData: rawptr, SrcDataSize: SIZE_T, Flags: u32, szComments: LPCSTR, ppDisassembly: ^^ID3DBlob) -> HRESULT ---
+	DisassembleRegion              :: proc(pSrcData: rawptr, SrcDataSize: SIZE_T, Flags: u32, szComments: LPCSTR, StartByteOffset: SIZE_T, NumInsts: SIZE_T, pFinishByteOffset: ^SIZE_T, ppDisassembly: ^^ID3DBlob) -> HRESULT ---
 	CreateLinker                   :: proc(ppLinker: ^^ID3D11Linker) -> HRESULT ---
 	LoadModule                     :: proc(pSrcData: rawptr, cbSrcDataSize: SIZE_T, ppModule: ^^ID3D11Module) -> HRESULT ---
 	GetTraceInstructionOffsets     :: proc(pSrcData: rawptr, SrcDataSize: SIZE_T, Flags: u32, StartInstIndex: SIZE_T, NumInsts: SIZE_T, pOffsets: ^SIZE_T, pTotalInsts: ^SIZE_T) -> HRESULT ---
@@ -113,8 +117,8 @@ GET_INST_OFFSETS_INCLUDE_NON_EXECUTABLE :: 0x00000001
 COMPRESS_SHADER_KEEP_ALL_PARTS :: 0x00000001
 
 SHADER_MACRO :: struct {
-	Name:       cstring,
-	Definition: cstring,
+	Name:       LPCSTR,
+	Definition: LPCSTR,
 }
 
 ID3D10Blob_UUID_STRING :: "8BA5FB08-5195-40E2-AC58-0D989C3A0102"
@@ -146,7 +150,7 @@ ID3DInclude :: struct {
 	vtable: ^ID3DInclude_VTable,
 }
 ID3DInclude_VTable :: struct {
-	Open:  proc "system" (this: ^ID3DInclude, IncludeType: INCLUDE_TYPE, pFileName: cstring, pParentData: rawptr, ppData: ^rawptr, pBytes: ^u32) -> HRESULT,
+	Open:  proc "system" (this: ^ID3DInclude, IncludeType: INCLUDE_TYPE, pFileName: LPCSTR, pParentData: rawptr, ppData: ^rawptr, pBytes: ^u32) -> HRESULT,
 	Close: proc "system" (this: ^ID3DInclude, pData: rawptr) -> HRESULT,
 }
 
@@ -160,7 +164,7 @@ ID3D11Module :: struct #raw_union {
 }
 ID3D11Module_VTable :: struct {
 	using iunknown_vtable: IUnknown_VTable,
-	CreateInstance: proc "system" (this: ^ID3D11Module, pNamespace: cstring, ppModuleInstance: ^^ID3D11ModuleInstance) -> HRESULT,
+	CreateInstance: proc "system" (this: ^ID3D11Module, pNamespace: LPCSTR, ppModuleInstance: ^^ID3D11ModuleInstance) -> HRESULT,
 }
 
 
@@ -171,15 +175,15 @@ ID3D11ModuleInstance :: struct #raw_union {
 ID3D11ModuleInstance_VTable :: struct {
 	using iunknown_vtable: IUnknown_VTable,
 	BindConstantBuffer:                      proc "system" (this: ^ID3D11ModuleInstance, uSrcSlot: u32, uDstSlot: u32, cbDstOffset: u32) -> HRESULT,
-	BindConstantBufferByName:                proc "system" (this: ^ID3D11ModuleInstance, pName: cstring, uDstSlot: u32, cbDstOffset: u32) -> HRESULT,
+	BindConstantBufferByName:                proc "system" (this: ^ID3D11ModuleInstance, pName: LPCSTR, uDstSlot: u32, cbDstOffset: u32) -> HRESULT,
 	BindResource:                            proc "system" (this: ^ID3D11ModuleInstance, uSrcSlot: u32, uDstSlot: u32, uCount: u32) -> HRESULT,
-	BindResourceByName:                      proc "system" (this: ^ID3D11ModuleInstance, pName: cstring, uDstSlot: u32, uCount: u32) -> HRESULT,
+	BindResourceByName:                      proc "system" (this: ^ID3D11ModuleInstance, pName: LPCSTR, uDstSlot: u32, uCount: u32) -> HRESULT,
 	BindSampler:                             proc "system" (this: ^ID3D11ModuleInstance, uSrcSlot: u32, uDstSlot: u32, uCount: u32) -> HRESULT,
-	BindSamplerByName:                       proc "system" (this: ^ID3D11ModuleInstance, pName: cstring, uDstSlot: u32, uCount: u32) -> HRESULT,
+	BindSamplerByName:                       proc "system" (this: ^ID3D11ModuleInstance, pName: LPCSTR, uDstSlot: u32, uCount: u32) -> HRESULT,
 	BindUnorderedAccessView:                 proc "system" (this: ^ID3D11ModuleInstance, uSrcSlot: u32, uDstSlot: u32, uCount: u32) -> HRESULT,
-	BindUnorderedAccessViewByName:           proc "system" (this: ^ID3D11ModuleInstance, pName: cstring, uDstSlot: u32, uCount: u32) -> HRESULT,
+	BindUnorderedAccessViewByName:           proc "system" (this: ^ID3D11ModuleInstance, pName: LPCSTR, uDstSlot: u32, uCount: u32) -> HRESULT,
 	BindResourceAsUnorderedAccessView:       proc "system" (this: ^ID3D11ModuleInstance, uSrcSrvSlot: u32, uDstUavSlot: u32, uCount: u32) -> HRESULT,
-	BindResourceAsUnorderedAccessViewByName: proc "system" (this: ^ID3D11ModuleInstance, pSrvName: cstring, uDstUavSlot: u32, uCount: u32) -> HRESULT,
+	BindResourceAsUnorderedAccessViewByName: proc "system" (this: ^ID3D11ModuleInstance, pSrvName: LPCSTR, uDstUavSlot: u32, uCount: u32) -> HRESULT,
 }
 
 
@@ -189,15 +193,15 @@ ID3D11Linker :: struct #raw_union {
 }
 ID3D11Linker_VTable :: struct {
 	using iunknown_vtable: IUnknown_VTable,
-	Link:                    proc "system" (this: ^ID3D11Linker, pEntry: ^ID3D11ModuleInstance, pEntryName: cstring, pTargetName: cstring, uFlags: u32, ppShaderBlob: ^^ID3DBlob, ppErrorBuffer: ^^ID3DBlob) -> HRESULT,
+	Link:                    proc "system" (this: ^ID3D11Linker, pEntry: ^ID3D11ModuleInstance, pEntryName: LPCSTR, pTargetName: LPCSTR, uFlags: u32, ppShaderBlob: ^^ID3DBlob, ppErrorBuffer: ^^ID3DBlob) -> HRESULT,
 	UseLibrary:              proc "system" (this: ^ID3D11Linker, pLibraryMI: ^ID3D11ModuleInstance) -> HRESULT,
 	AddClipPlaneFromCBuffer: proc "system" (this: ^ID3D11Linker, uCBufferSlot: u32, uCBufferEntry: u32) -> HRESULT,
 }
 
 
-pD3DCompile     :: #type proc "c" (a0: rawptr, a1: SIZE_T, a2: cstring, a3: ^SHADER_MACRO, a4: ^ID3DInclude, a5: cstring, a6: cstring, a7: u32, a8: u32, a9: ^^ID3DBlob, a10: ^^ID3DBlob) -> HRESULT
-pD3DPreprocess  :: #type proc "c" (a0: rawptr, a1: SIZE_T, a2: cstring, a3: ^SHADER_MACRO, a4: ^ID3DInclude, a5: ^^ID3DBlob, a6: ^^ID3DBlob) -> HRESULT
-pD3DDisassemble :: #type proc "c" (a0: rawptr, a1: SIZE_T, a2: u32, a3: cstring, a4: ^^ID3DBlob) -> HRESULT
+pD3DCompile     :: #type proc "c" (a0: rawptr, a1: SIZE_T, a2: LPCSTR, a3: ^SHADER_MACRO, a4: ^ID3DInclude, a5: LPCSTR, a6: LPCSTR, a7: u32, a8: u32, a9: ^^ID3DBlob, a10: ^^ID3DBlob) -> HRESULT
+pD3DPreprocess  :: #type proc "c" (a0: rawptr, a1: SIZE_T, a2: LPCSTR, a3: ^SHADER_MACRO, a4: ^ID3DInclude, a5: ^^ID3DBlob, a6: ^^ID3DBlob) -> HRESULT
+pD3DDisassemble :: #type proc "c" (a0: rawptr, a1: SIZE_T, a2: u32, a3: LPCSTR, a4: ^^ID3DBlob) -> HRESULT
 
 D3DCOMPILER_STRIP_FLAGS :: distinct bit_set[D3DCOMPILER_STRIP_FLAG; u32]
 D3DCOMPILER_STRIP_FLAG :: enum u32 {


### PR DESCRIPTION
- Replaces [^]u16 parameter types because they are not directly compatible with result of `win32.utf8_to_wstring()`
- Replaces some string/wstring types for consistency, similarly as other packages do to match original C declarations and documentation