### PR TITLE
vendor:compress/lz4 wasn't finding lz4 for Non-Windows targets.

### DIFF
--- a/vendor/compress/lz4/lz4.odin
+++ b/vendor/compress/lz4/lz4.odin
@@ -4,6 +4,8 @@ package vendor_compress_lz4
 when ODIN_OS == .Windows {
 	@(extra_linker_flags="/NODEFAULTLIB:libcmt")
 	foreign import lib { "lib/liblz4_static.lib", "system:ucrt.lib" }
+} else {
+	foreign import lib "system:lz4"
 }
 
 import "core:c"


### PR DESCRIPTION
On Arch Linux LZ4 wasn't being found.  Giving this error:

```
/usr/lib/odin/vendor/compress/lz4/lz4.odin(36:9) Error: Undeclared name: lib foreign lib {
/usr/lib/odin/vendor/compress/lz4/lz4.odin(424:9) Error: Undeclared name: lib foreign lib {
```

Added else foreign import to system lz4.