### PR TITLE
Fix TGA header detection

### DIFF
--- a/core/image/general.odin
+++ b/core/image/general.odin
@@ -86,7 +86,7 @@ which_bytes :: proc(data: []byte) -> Which_File_Type {
 			return v
 		}
 		get16le :: #force_inline  proc(s: ^string) -> u16 {
-			v := u16(s[0]) | u16(s[1])<<16
+			v := u16(s[0]) | u16(s[1])<<8
 			s^ = s[2:]
 			return v
 		}


### PR DESCRIPTION
Here `u16` is shifted by 16. Because of it any TGA image with the size of k*256 is reported as `Unsupported_Format`.

In [stb_image.h](https://github.com/nothings/stb/blob/f1c79c02822848a9bed4315b12c8c8f3761e1296/stb_image.h#L1714) it is shifted by 8.