### PR TITLE
Show `-target` flag usage examples in the help

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2971,6 +2971,10 @@ gb_internal int print_show_help(String const arg0, String command, String option
 	if (check) {
 		if (print_flag("-target:<string>")) {
 			print_usage_line(2, "Sets the target for the executable to be built in.");
+			print_usage_line(2, "Examples:");
+				print_usage_line(3, "-target:linux_amd64");
+				print_usage_line(3, "-target:windows_amd64");
+				print_usage_line(3, "-target:\"?\" for a list");
 		}
 
 		if (print_flag("-terse-errors")) {


### PR DESCRIPTION
This PR fixes #4709 confusion.

It was not obvious that you can list all the available targets using `-target:"?"` just like with `-target-features:"?"`, now it is mentioned in the `odin build/run/check --help` help message.

```
-target:<string>
        Sets the target for the executable to be built in.
        Examples:
                -target:linux_amd64
                -target:windows_amd64
                -target:"?" for a list
```

But you still have to provide a path to a package. (e.g. `odin build <package> -target:"?"`)

Would be cool if you could just supply the flag without a package `odin build -target:"?"`. But this feature is for another PR...
