### PR TITLE
Fix regression for #6118 in #6104

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -3528,7 +3528,7 @@ gb_internal bool check_cast_internal(CheckerContext *c, Operand *x, Type *type) 
 		if (core_type(bt)->kind == Type_Basic) {
 			return check_representable_as_constant(c, x->value, type, &x->value) ||
 			       (is_type_pointer(type) && check_is_castable_to(c, x, type));
-		} else if (!are_types_identical(elem, bt) && elem->kind == Type_Basic) {
+		} else if (!are_types_identical(elem, bt) && elem->kind == Type_Basic && x->type->kind == Type_Basic) {
 			return check_representable_as_constant(c, x->value, elem, &x->value) || 
 			       (is_type_pointer(elem) && check_is_castable_to(c, x, elem));
 		} else if (check_is_castable_to(c, x, type)) {


### PR DESCRIPTION
I'm very sorry. This branch was only supposed to execute when operand is a basic type (vector expansion). This adds a check for it. I made sure to check the examples now and in the future.