### PR TITLE
implement #override_foreign_library

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -295,7 +295,8 @@ gb_internal void error_operand_no_value(Operand *o) {
 			if (p->kind == Ast_BasicDirective) {
 				String tag = p->BasicDirective.name.string;
 				if (tag == "panic" ||
-				    tag == "assert") {
+				    tag == "assert" ||
+				    tag == "override_foreign_library") {
 					return;
 				}
 			}
@@ -8226,7 +8227,8 @@ gb_internal ExprKind check_call_expr(CheckerContext *c, Operand *operand, Ast *c
 		    name == "load_directory" ||
 		    name == "load_hash" ||
 		    name == "hash" ||
-		    name == "caller_expression"
+		    name == "caller_expression" ||
+		    name == "override_foreign_library"
 		) {
 			operand->mode = Addressing_Builtin;
 			operand->builtin_id = BuiltinProc_DIRECTIVE;
@@ -9170,7 +9172,8 @@ gb_internal ExprKind check_basic_directive_expr(CheckerContext *c, Operand *o, A
 		    name == "load" ||
 		    name == "load_hash" ||
 		    name == "load_directory" ||
-		    name == "load_or"
+		    name == "load_or" ||
+		    name == "override_foreign_library"
 		) {
 			error(node, "'#%.*s' must be used as a call", LIT(name));
 			o->type = t_invalid;

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -288,6 +288,7 @@ struct Entity {
 			String name;
 			i64 priority_index;
 			bool ignore_duplicates;
+			bool is_overridden;
 			String extra_linker_flags;
 		} LibraryName;
 		i32 Nil;


### PR DESCRIPTION
I've attempted to implement the feature requested and described in this discussion: https://github.com/odin-lang/Odin/discussions/1390

Essentially, someone should be able to custom override a foreign import declaration. For example, if a library (`otherlib`) sets up a foreign import like this:
`foreign import lib "system:mylib"`

You should then be able to override that import like so:
```
import "otherlib"

#override_foreign_library otherlib.lib "system:adifferentlib"
```

This is slightly different than the way suggested by @gingerBill in the above discussion. I found that depending on whether or not I was linking with a static library, I needed to include other libraries/frameworks as well, so just swapping out a single library definition (i.e. "system:somelib" -> "myownlib.a") wasn't flexible enough.

I've tested this locally (M series MacOS) and it seems to work for my purposes. I have a few tests cases written to ensure that it works with compound literals, exported libs, and aliasing the library (i.e. `import o "otherlib"`), but I don't know how to integrate those tests into the existing test system. If you'd like I can add another commit including the tests and the little bash script I wrote to run them. I have not tested this feature on Windows or Linux at all.

There's two "design" decisions of note:
1. In the case where a library is overridden multiple times I've chosen to fail compilation
2. The directive optionally allows for `()` calling syntax: `#override_foreign_library(a, "b")` == `#override_foreign_library a "b"`. I wasn't sure which way to go - most directives use parentheses, but not requiring parentheses makes it match `foreign import` syntax more closely and matches the original design in the linked discussion.

I've never contributed to Odin before, so feel free to chuck the code in the bin if it sucks, or just take little bits of it and implement it yourself in an actually good way. Or just put it on the back burner.