### PR TITLE
Add warning for `size_of(&x)` expressions

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -2701,7 +2701,7 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 				ERROR_BLOCK();
 
 				warning(ce->args[0], "'size_of(&x)' returns the size of a pointer, not the size of x");
-		        error_line("\tSuggestion: Use 'size_of(rawptr)' if you want the size of the pointer");
+				error_line("\tSuggestion: Use 'size_of(rawptr)' if you want the size of the pointer");
 			}
 		}
 


### PR DESCRIPTION
This is a very simple check based on the AST, that should have very few false positives (none across all of my code and the odin core library).
`size_of(&x)` is just pretty much always a mistake in my experience, with `size_of(rawptr/uintptr/some other pointer type)` communicating the intent much more clearly.