### PR TITLE
[core:thread] Ensure creating a low priority thread with SCHED_OTHER policy does not assert

### DIFF
--- a/core/thread/thread_unix.odin
+++ b/core/thread/thread_unix.odin
@@ -107,7 +107,11 @@ _create :: proc(procedure: Thread_Proc, priority: Thread_Priority) -> ^Thread {
 	high := posix.sched_get_priority_max(policy)
 	switch priority {
 	case .Normal: // Okay
-	case .Low:  params.sched_priority = low + 1
+	case .Low:
+		params.sched_priority = low + 1
+		if params.sched_priority >= high {
+			params.sched_priority = low
+		}
 	case .High: params.sched_priority = high
 	}
 	res = posix.pthread_attr_setschedparam(&attrs, &params)


### PR DESCRIPTION
For Linux users whose kernel is using the Completely Fair Scheduler (CFS), creating a thread with priority `.Low` will yield a runtime assert:

```
/Odin/core/thread/thread_unix.odin(114:2) runtime assertion: res == nil
```

This is because the pthread scheduler priority we're trying to set for `.Low` is actually out of bounds. For Linux users using CFS, the pthread scheduler policy will be `SCHED_OTHER` with both the min and max priority both being 0.

<img width="416" height="83" alt="Screenshot_20260113_145857" src="https://github.com/user-attachments/assets/6d4fbe48-5c85-4c67-a4ac-4a30fc74a0a4" />

<img width="327" height="130" alt="Screenshot_20260113_150006" src="https://github.com/user-attachments/assets/682d286f-6508-4a97-9f37-9fa8212283e6" />

In order to keep the existing behavior of having `.Low` represent a priority that is slightly higher than the minimum, we check to see if the incremented priority is equal to or exceeds the max priority. If so, we set the scheduler priority to the minimum.

I wonder if there is merit in simply having `.Low` just represent the min priority in all cases.

Further reading: https://linuxvox.com/blog/linux-sched-other-sched-fifo-and-sched-rr-differences/#sched_other-the-default-fair-scheduler

