### PR TITLE
Minor x11/xlib bindings fixes (KeySym + Xutf8LookupString)

### DIFF
--- a/vendor/x11/xlib/xlib_keysym.odin
+++ b/vendor/x11/xlib/xlib_keysym.odin
@@ -1,7 +1,7 @@
 #+build linux, freebsd, openbsd
 package xlib
 
-KeySym :: enum u32 {
+KeySym :: enum uint {
 	XK_BackSpace                     = 0xff08,  /* Back space, back char */
 	XK_Tab                           = 0xff09,
 	XK_Linefeed                      = 0xff0a,  /* Linefeed, LF */

--- a/vendor/x11/xlib/xlib_procs.odin
+++ b/vendor/x11/xlib/xlib_procs.odin
@@ -2068,7 +2068,7 @@ foreign xlib {
 	Xutf8LookupString :: proc(
 		ic: XIC,
 		event: ^XKeyPressedEvent,
-		buffer_return: ^cstring,
+		buffer_return: cstring,
 		bytes_buffer: i32,
 		keysym_return: ^KeySym,
 		status_return: ^LookupStringStatus,


### PR DESCRIPTION
### 1. Fix Xutf8LookupString signature

This one is pretty straight-forward.

`^cstring` -> `cstring`

Ref: https://github.com/mirror/libX11/blob/master/include/X11/Xlib.h#L3930-L3937

### 2. Fix type of KeySym

This one was trickier. `Xutf8LookupString` was failing to fill the buffer with data, and [Barinzaya on discord helped](https://discord.com/channels/568138951836172421/1461842553174495323) figure out that it was being clobbered by a mismatch between the size of `KeySym` in C vs the bindings.

`u32` -> `uint`

Refs:

- Here you can see it's `unsigned long` in C: https://github.com/mirror/libX11/blob/ff8706a5eae25b8bafce300527079f68a201d27f/src/util/makekeys.c#L47
- Here in the bindings we assert that `uint` is the same size as `c.ulong`: https://github.com/odin-lang/Odin/blob/master/vendor/x11/xlib/xlib_types.odin#L7