### PR TITLE
vendor/x11/xlib: Fix XSetWindowBackgroundPixmap binding name

### DIFF
--- a/vendor/x11/xlib/xlib_procs.odin
+++ b/vendor/x11/xlib/xlib_procs.odin
@@ -241,7 +241,7 @@ foreign xlib {
 		window:    Window,
 		pixel:     uint,
 		) ---
-	SetWindowBackgroundMap :: proc(
+	SetWindowBackgroundPixmap :: proc(
 		display:   ^Display,
 		window:    Window,
 		pixmap:    Pixmap,


### PR DESCRIPTION
Changed SetWindowBackgroundMap to SetWindowBackgroundPixmap to match the actual X11 C function name. The incorrect name caused linker errors.

Fixes #6149