### PR TITLE
Implement missing device properties function

### DIFF
--- a/vendor/sdl3/sdl3_gpu.odin
+++ b/vendor/sdl3/sdl3_gpu.odin
@@ -824,6 +824,7 @@ foreign lib {
 	GetGPUDriver                          :: proc(index: c.int) -> cstring ---
 	GetGPUDeviceDriver                    :: proc(device: ^GPUDevice) -> cstring ---
 	GetGPUShaderFormats                   :: proc(device: ^GPUDevice) -> GPUShaderFormat ---
+	GetGPUDeviceProperties                :: proc(device: ^GPUDevice) -> PropertiesID ---
 	CreateGPUComputePipeline              :: proc(device: ^GPUDevice, #by_ptr createinfo: GPUComputePipelineCreateInfo) -> ^GPUComputePipeline ---
 	CreateGPUGraphicsPipeline             :: proc(device: ^GPUDevice, #by_ptr createinfo: GPUGraphicsPipelineCreateInfo) -> ^GPUGraphicsPipeline ---
 	CreateGPUSampler                      :: proc(device: ^GPUDevice, #by_ptr createinfo: GPUSamplerCreateInfo) -> ^GPUSampler ---


### PR DESCRIPTION
Very minor fix, just implements a function that got missed in the 3.4.0 update. Should be located in the correct spot relative to other functions like in the original file.