### PR TITLE
Fix `in`/`not_in` on constant `bit_set`s

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -4125,15 +4125,19 @@ gb_internal void check_binary_expr(CheckerContext *c, Operand *x, Ast *node, Typ
 				i64 upper = yt->BitSet.upper;
 
 				if (lower <= key && key <= upper) {
-					i64 bit = 1ll<<key;
-					i64 bits = big_int_to_i64(&v.value_integer);
+					BigInt idx = big_int_make_i64(key - lower);
+					BigInt bit = big_int_make_i64(1);
+					big_int_shl_eq(&bit, &idx);
+
+					BigInt mask = {};
+					big_int_and(&mask, &bit, &v.value_integer);
 
 					x->mode = Addressing_Constant;
 					x->type = t_untyped_bool;
 					if (op.kind == Token_in) {
-						x->value = exact_value_bool((bit & bits) != 0);
+						x->value = exact_value_bool(!big_int_is_zero(&mask));
 					} else {
-						x->value = exact_value_bool((bit & bits) == 0);
+						x->value = exact_value_bool(big_int_is_zero(&mask));
 					}
 					x->expr = node;
 					return;


### PR DESCRIPTION
This addresses two niche issues with `in`/`not_in` on `bit_set`s evaluated at compile-time:
- With a `bit_set` having a non-zero lower bound, `in` and `not_in` were returning incorrect results when done at compile-time.
- With a `bit_set` of more than 128 bits, `in` always returns false on values that fall within the upper 64 bits.

These issues can be demonstrated with the following snippet:
```odin
#assert(5 in bit_set[1..<128]{5})
#assert(4 not_in bit_set[1..<128]{5})
#assert(100 in bit_set[0..<128]{100})

// also with an enum
E :: enum { A = 1, B, C = 100 }
#assert(.B in bit_set[E]{.B})
#assert(.A not_in bit_set[E]{.B})
#assert(.C in bit_set[E]{.C})
```

On the current `master`, all of these `#assert`s fail. On this branch, they succeed (as expected).