### PR TITLE
encoding/xml: pass allocator on destroy

### DIFF
--- a/core/encoding/xml/xml_reader.odin
+++ b/core/encoding/xml/xml_reader.odin
@@ -386,7 +386,8 @@ load_from_file :: proc(filename: string, options := DEFAULT_OPTIONS, error_handl
 	return parse_bytes(data, options, filename, error_handler, allocator)
 }
 
-destroy :: proc(doc: ^Document) {
+destroy :: proc(doc: ^Document, allocator := context.allocator) {
+	context.allocator = allocator
 	if doc == nil { return }
 
 	for el in doc.elements {


### PR DESCRIPTION
was getting some memory errors when using temp_allocator to parse a file. this is due to slices not having a reference to the owning allocator.