### PR TITLE
[core:sys/windows] ReadDirectoryChangesExW

### DIFF
--- a/core/sys/windows/kernel32.odin
+++ b/core/sys/windows/kernel32.odin
@@ -474,6 +474,17 @@ foreign kernel32 {
 		lpOverlapped: LPOVERLAPPED,
 		lpCompletionRoutine: LPOVERLAPPED_COMPLETION_ROUTINE,
 	) -> BOOL ---
+	ReadDirectoryChangesExW :: proc(
+		hDirectory: HANDLE,
+		lpBuffer: LPVOID,
+		nBufferLength: DWORD,
+		bWatchSubtree: BOOL,
+		dwNotifyFilter: DWORD,
+		lpBytesReturned: LPDWORD,
+		lpOverlapped: LPOVERLAPPED,
+		lpCompletionRoutine: LPOVERLAPPED_COMPLETION_ROUTINE,
+		ReadDirectoryNotifyInformationClass: READ_DIRECTORY_NOTIFY_INFORMATION_CLASS,
+	) -> BOOL ---
 	FindFirstChangeNotificationW :: proc(
 		lpPathName: LPWSTR,
 		bWatchSubtree: BOOL,

--- a/core/sys/windows/types.odin
+++ b/core/sys/windows/types.odin
@@ -3176,6 +3176,13 @@ LPOVERLAPPED_COMPLETION_ROUTINE :: #type proc "system" (
 	lpOverlapped:              LPOVERLAPPED,
 )
 
+READ_DIRECTORY_NOTIFY_INFORMATION_CLASS :: enum c_int {
+	ReadDirectoryNotifyInformation = 1,
+	ReadDirectoryNotifyExtendedInformation,
+	ReadDirectoryNotifyFullInformation,
+	ReadDirectoryNotifyMaximumInformation,
+}
+
 ADDRESS_MODE :: enum c_int {
 	AddrMode1616,
 	AddrMode1632,


### PR DESCRIPTION
Adds `ReadDirectoryChangesExW`, used to get extended file information in file watchers, for example.

https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-readdirectorychangesexw
https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ne-minwinbase-read_directory_notify_information_class

Hope I put things in the right place.