### PR TITLE
core/fmt: Second attempt at improving number formatting

### DIFF
--- a/core/math/bits/bits.odin
+++ b/core/math/bits/bits.odin
@@ -79,7 +79,7 @@ Example:
 
 	log2_example :: proc() {
 		for i in u8(1)..=8 {
-			fmt.printfln("{0} ({0:4b}): {1}", i, bits.log2(i))
+			fmt.printfln("{0} ({0:04b}): {1}", i, bits.log2(i))
 		}
 		assert(bits.log2(  u8(0)) == max(u8))
 		assert(bits.log2( u16(0)) == max(u16))
@@ -127,7 +127,7 @@ Example:
 	rotate_left8_example :: proc() {
 		x := u8(13)
 		for k in 0..<8 {
-			fmt.printfln("{0:8b}: {1}", bits.rotate_left8(x, k), k)
+			fmt.printfln("{0:08b}: {1}", bits.rotate_left8(x, k), k)
 		}
 	}
 

--- a/tests/core/fmt/test_core_fmt.odin
+++ b/tests/core/fmt/test_core_fmt.odin
@@ -17,7 +17,8 @@ test_fmt_memory :: proc(t: ^testing.T) {
 	check(t, "3KiB",      "%.0M",  mem.Kilobyte * 3)
 	check(t, "3.000 mib", "%#.3m", mem.Megabyte * 3)
 	check(t, "3.50 gib",  "%#m",   u32(mem.Gigabyte * 3.5))
-	check(t, "01tib",     "%5.0m", mem.Terabyte)
+	check(t, " 1tib",     "%5.0m", mem.Terabyte)
+	check(t, "01tib",     "%05.0m", mem.Terabyte)
 	check(t, "-1tib",     "%5.0m", -mem.Terabyte)
 	check(t, "2 pib",     "%#5.m", uint(mem.Petabyte * 2.5))
 	check(t, "1.00 EiB",  "%#M",   mem.Exabyte)
@@ -60,7 +61,7 @@ test_fmt_complex_quaternion :: proc(t: ^testing.T) {
 	cptr^ = {1, 1}
 	check(t, "+1+1i",     "%+v", c)
 	cptr^ = {nan, nan}
-	check(t, "NaNNaNi",   "%+v", c)
+	check(t, " NaN NaNi",   "%+v", c)
 	cptr^ = {pos_inf, pos_inf}
 	check(t, "+Inf+Infi", "%+v", c)
 	cptr^ = {neg_inf, neg_inf}
@@ -93,13 +94,17 @@ test_fmt_complex_quaternion :: proc(t: ^testing.T) {
 test_fmt_doc_examples :: proc(t: ^testing.T) {
 	// C-like syntax
 	check(t, "37 13",  "%[1]d %[0]d",    13,   37)
-	check(t, "017.00", "%*[2].*[1][0]f", 17.0, 2, 6)
-	check(t, "017.00", "%6.2f",          17.0)
+	check(t, " 17.00", "%*[2].*[1][0]f", 17.0, 2, 6)
+	check(t, " 17.00", "%6.2f",          17.0)
+	check(t, "017.00", "%0*[2].*[1][0]f", 17.0, 2, 6)
+	check(t, "017.00", "%06.2f",          17.0)
 
 	 // Python-like syntax
 	check(t, "37 13",  "{1:d} {0:d}",    13,   37)
-	check(t, "017.00", "{0:*[2].*[1]f}", 17.0, 2, 6)
-	check(t, "017.00", "{:6.2f}",        17.0)
+	check(t, " 17.00", "{0:*[2].*[1]f}", 17.0, 2, 6)
+	check(t, " 17.00", "{:6.2f}",        17.0)
+	check(t, "017.00", "{0:0*[2].*[1]f}", 17.0, 2, 6)
+	check(t, "017.00", "{:06.2f}",        17.0)
 }
 
 @(test)
@@ -110,7 +115,8 @@ test_fmt_escaping_prefixes :: proc(t: ^testing.T) {
 	// Prefixes
 	check(t, "+3.000", "%+f",   3.0 )
 	check(t, "0003",   "%04i",  3 )
-	check(t, "3   ",   "% -4i", 3 )
+	check(t, " 3  ",   "% -4i", 3 )
+	check(t, "3   ",   "%-4i", 3 )
 	check(t, "+3",     "%+i",   3 )
 	check(t, "0b11",   "%#b",   3 )
 	check(t, "0xA",    "%#X",   10 )
@@ -134,7 +140,8 @@ test_fmt_width_precision :: proc(t: ^testing.T) {
 	check(t, "3.140",  "%f",  3.14)
 	check(t, "3.140",  "%4f", 3.14)
 	check(t, "3.140",  "%5f", 3.14)
-	check(t, "03.140", "%6f", 3.14)
+	check(t, " 3.140", "%6f", 3.14)
+	check(t, "03.140", "%06f", 3.14)
 
 	// Precision
 	check(t, "3",       "%.f",  3.14)
@@ -235,28 +242,28 @@ test_pointers :: proc(t: ^testing.T) {
 	check(t, "0x0", "%p", c)
 	check(t, "0xFFFF", "%p", d)
 
-	check(t, "0x0", "%#p", a)
-	check(t, "0x0", "%#p", b)
-	check(t, "0x0", "%#p", c)
-	check(t, "0xFFFF", "%#p", d)
+	check(t, "0", "%#p", a)
+	check(t, "0", "%#p", b)
+	check(t, "0", "%#p", c)
+	check(t, "FFFF", "%#p", d)
 
 	check(t, "0x0",   "%v", a)
 	check(t, "0x0",   "%v", b)
 	check(t, "<nil>", "%v", c)
 
-	check(t, "0x0",   "%#v", a)
-	check(t, "0x0",   "%#v", b)
+	check(t, "0",   "%#v", a)
+	check(t, "0",   "%#v", b)
 	check(t, "<nil>", "%#v", c)
 
-	check(t, "0x0000", "%4p", a)
-	check(t, "0x0000", "%4p", b)
-	check(t, "0x0000", "%4p", c)
-	check(t, "0xFFFF", "%4p", d)
+	check(t, "0x0000", "%06p", a)
+	check(t, "0x0000", "%06p", b)
+	check(t, "0x0000", "%06p", c)
+	check(t, "0xFFFF", "%06p", d)
 
-	check(t, "0x0000", "%#4p", a)
-	check(t, "0x0000", "%#4p", b)
-	check(t, "0x0000", "%#4p", c)
-	check(t, "0xFFFF", "%#4p", d)
+	check(t, "   0", "%#4p", a)
+	check(t, "   0", "%#4p", b)
+	check(t, "   0", "%#4p", c)
+	check(t, "FFFF", "%#4p", d)
 }
 
 @(test)

--- a/tests/core/fmt/test_core_fmt.odin
+++ b/tests/core/fmt/test_core_fmt.odin
@@ -20,6 +20,8 @@ test_fmt_memory :: proc(t: ^testing.T) {
 	check(t, " 1tib",     "%5.0m", mem.Terabyte)
 	check(t, "01tib",     "%05.0m", mem.Terabyte)
 	check(t, "-1tib",     "%5.0m", -mem.Terabyte)
+	check(t, " -1tib",     "%6.0m", -mem.Terabyte)
+	check(t, "-01tib",     "%06.0m", -mem.Terabyte)
 	check(t, "2 pib",     "%#5.m", uint(mem.Petabyte * 2.5))
 	check(t, "1.00 EiB",  "%#M",   mem.Exabyte)
 	check(t, "255 B",     "%#M",   u8(255))
@@ -167,6 +169,12 @@ test_fmt_width_precision :: proc(t: ^testing.T) {
 	check(t, "3.06e+01",     "%.2e", 30.56)
 	check(t, "3.056e+01",    "%.3e", 30.56)
 
+	check(t, "  3.056e+01",    "%11.3e",   30.56)
+	check(t, " -3.056e+01",    "%11.3e",  -30.56)
+	check(t, "003.056e+01",    "%011.3e",  30.56)
+	check(t, "-03.056e+01",    "%011.3e", -30.56)
+	check(t, "3.056e+01  ",    "%-11.3e",  30.56)
+
 	// Width and precision
 	check(t, "3.140", "%5.3f",          3.14)
 	check(t, "3.140", "%*[1].3f",       3.14, 5)
@@ -264,6 +272,77 @@ test_pointers :: proc(t: ^testing.T) {
 	check(t, "   0", "%#4p", b)
 	check(t, "   0", "%#4p", c)
 	check(t, "FFFF", "%#4p", d)
+}
+
+@(test)
+test_fmt_inf :: proc(t: ^testing.T) {
+	check(t, "+Inf", "%.3f", math.inf_f64(1))
+	check(t, "-Inf", "%.3f", math.inf_f64(-1))
+
+	check(t, "  +Inf", "%6.3f", math.inf_f64(1))
+	check(t, "  -Inf", "%6.3f", math.inf_f64(-1))
+
+	check(t, "  +Inf", "%06.3f", math.inf_f64(1))
+	check(t, "  -Inf", "%06.3f", math.inf_f64(-1))
+
+	check(t, "+Inf  ", "%-6.3f", math.inf_f64(1))
+	check(t, "-Inf  ", "%-6.3f", math.inf_f64(-1))
+}
+
+@(test)
+test_fmt_nan :: proc(t: ^testing.T) {
+	check(t, "NaN", "%.3f", math.nan_f64())
+	check(t, "   NaN", "%6.3f", math.nan_f64())
+	check(t, "   NaN", "%06.3f", math.nan_f64())
+	check(t, "NaN   ", "%-6.3f", math.nan_f64())
+}
+
+@(test)
+test_fmt_hex :: proc(t: ^testing.T) {
+	check(t, "0x000a", "%#06x", 10)
+	check(t, "-0x00a", "%#06x", -10)
+
+	check(t, "+0x00a", "%#+06x", 10)
+	check(t, "-0x00a", "%#+06x", -10)
+
+	check(t, "0xa   ", "%#-06x", 10)
+	check(t, "-0xa  ", "%#-06x", -10)
+
+	check(t, "0xa   ", "%#-6x", 10)
+	check(t, "-0xa  ", "%#-6x", -10)
+
+	check(t, " 0x00a", "%# 06x", 10)
+	check(t, "-0x00a", "%# 06x", -10)
+
+	check(t, "+0x00a", "%# +06x", 10)
+	check(t, "-0x00a", "%# +06x", -10)
+
+	check(t, " 0xa  ", "%# -06x", 10)
+	check(t, "-0xa  ", "%# -06x", -10)
+}
+
+@(test)
+test_fmt_hex_128 :: proc(t: ^testing.T) {
+	check(t, "0x000a", "%#06x", i128(10))
+	check(t, "-0x00a", "%#06x", i128(-10))
+
+	check(t, "+0x00a", "%#+06x", i128(10))
+	check(t, "-0x00a", "%#+06x", i128(-10))
+
+	check(t, "0xa   ", "%#-06x", i128(10))
+	check(t, "-0xa  ", "%#-06x", i128(-10))
+
+	check(t, "0xa   ", "%#-6x", i128(10))
+	check(t, "-0xa  ", "%#-6x", i128(-10))
+
+	check(t, " 0x00a", "%# 06x", i128(10))
+	check(t, "-0x00a", "%# 06x", i128(-10))
+
+	check(t, "+0x00a", "%# +06x", i128(10))
+	check(t, "-0x00a", "%# +06x", i128(-10))
+
+	check(t, " 0xa  ", "%# -06x", i128(10))
+	check(t, "-0xa  ", "%# -06x", i128(-10))
 }
 
 @(test)

--- a/tests/core/net/test_core_net.odin
+++ b/tests/core/net/test_core_net.odin
@@ -665,7 +665,7 @@ address_to_binstr :: proc(address: net.Address) -> (binstr: string) {
 		return fmt.tprintf("%08x", b)
 	case net.IP6_Address:
 		b := transmute(u128be)t
-		return fmt.tprintf("%32x", b)
+		return fmt.tprintf("%032x", b)
 	case:
 		return ""
 	}


### PR DESCRIPTION
This pull request tries to improve the number formatting of the core/fmt package to do what the docs say it should.

Notable changes are:
- default padding is now " " instead of "0" (fixes #3112)
- right padding is now always done with spaces, to keep the formatted number correct
- the space flag now adds a space, when there is no sign
- the plus flag now also adds a space before NaN
- the hash flag now correctly adds a base prefix (eg. "0x") to number and removes it from pointers
- the base prefix is now counted towards the total width

I didn't use the suggestion from https://github.com/odin-lang/Odin/pull/3115#issuecomment-1899369363, because I didn't want to change the formatting syntax.
This is my second attempt at improving number formatting, I'm closing the first one (#6148), because I found a few other problems afterwards that needed more extensive changes.

Here are a few formatting examples that are changed by this pull request.

```odin
// format                        old           new
// ------------------------------------------------

fmt.printf("%.0i",  0)         //  ""       ->   "0"

fmt.printf("% i",  1)          //  "1"      ->   " 1"
fmt.printf("% i", -1)          //  "-1"     ->   "-1"

fmt.printf("%4i",  1)          //  "0001"   ->   "   1"
fmt.printf("%4i", -1)          //  "-001"   ->   "  -1"

fmt.printf("% 4i",  1234)      //  "1234"   ->   " 1234"
fmt.printf("% 4i", -1234)      //  "-1234"  ->   "-1234"

fmt.printf("%-4i",  1)         //  "1000"   ->   "1   "
fmt.printf("%-4i", -1)         //  "-100"   ->   "-1  "

fmt.printf("%- 4i",  1)        //  "1   "   ->   " 1  "
fmt.printf("%- 4i", -1)        //  "-1  "   ->   "-1  "

fmt.printf("%+4i",  1)         //  "+001"   ->   "  +1"
fmt.printf("%+4i", -1)         //  "-001"   ->   "  -1"

fmt.printf("%+0 4i",  1)       //  "  +1"   ->   "+001"
fmt.printf("%+0 4i", -1)       //  "  -1"   ->   "-001"

fmt.printf("% 04i",  1)        //  "   1"   ->   " 001"
fmt.printf("% 04i", -1)        //  "  -1"   ->   "-001"

fmt.printf("%-04i",  1)        //  "1000"   ->   "1   "
fmt.printf("%-04i", -1)        //  "-100"   ->   "-1  "

fmt.printf("%- 04i",  1)       //  "1   "   ->   " 1  "
fmt.printf("%- 04i", -1)       //  "-1  "   ->   "-1  "

fmt.printf("%#04x",  10)       //  "000a"   ->   "0x0a"
fmt.printf("%#04x", -10)       //  "-00a"   ->   "-0xa"

fmt.printf("%#+04x",  10)      //  "+00a"   ->   "+0xa"
fmt.printf("%#+04x", -10)      //  "-00a"   ->   "-0xa"

fmt.printf("%#-04x",  10)      //  "0xa0"   ->   "0xa "
fmt.printf("%#-04x", -10)      //  "-0xa"   ->   "-0xa"

fmt.printf("%#-4x",  10)       //  "0xa0"   ->   "0xa "
fmt.printf("%#-4x", -10)       //  "-0xa"   ->   "-0xa"

fmt.printf("%# 04x",  10)      //  "   a"   ->   " 0xa"
fmt.printf("%# 04x", -10)      //  "  -a"   ->   "-0xa"

fmt.printf("%# +04x",  10)     //  "  +a"   ->   "+0xa"
fmt.printf("%# +04x", -10)     //  "  -a"   ->   "-0xa"

fmt.printf("%# -04x",  10)     //  "0xa "   ->   " 0xa"
fmt.printf("%# -04x", -10)     //  "-0xa"   ->   "-0xa"

fmt.printf("%+f",  NaN)        //  "NaN"    ->   " NaN"

fmt.printf("% f",  3.14)       //  "3.140"  ->   " 3.140"
fmt.printf("% f",  NaN)        //  "NaN"    ->   " NaN"

fmt.printf("%7.3f",  3.14)     //  "003.140"  ->   "  3.140"
fmt.printf("%7.3f", -3.14)     //  "-03.140"  ->   " -3.140"
fmt.printf("%7.3f", +Inf)      //  "+000Inf"  ->   "   +Inf"
fmt.printf("%7.3f", -Inf)      //  "-000Inf"  ->   "   -Inf"
fmt.printf("%7.3f",  NaN)      //  "0000NaN"  ->   "    NaN"

fmt.printf("%07.3f", +Inf)     //  "+000Inf"  ->   "   +Inf"
fmt.printf("%07.3f", -Inf)     //  "-000Inf"  ->   "   -Inf"
fmt.printf("%07.3f",  NaN)     //  "0000NaN"  ->   "    NaN"

fmt.printf("%-7.3f",  3.14)    //  "3.14000"  ->   "3.140  "
fmt.printf("%-7.3f", -3.14)    //  "-3.1400"  ->   "-3.140 "
fmt.printf("%-7.3f", +Inf)     //  "+Inf000"  ->   "+Inf   "
fmt.printf("%-7.3f", -Inf)     //  "-Inf000"  ->   "-Inf   "
fmt.printf("%-7.3f",  NaN)     //  "NaN0000"  ->   "NaN    "

fmt.printf("%- 7.3f",  3.14)   //  "3.140  "  ->   " 3.140 "
fmt.printf("%- 7.3f",  NaN)    //  "NaN    "  ->   " NaN   "

fmt.printf("%-07.3f",  3.14)   //  "3.14000"  ->   "3.140  "
fmt.printf("%-07.3f", -3.14)   //  "-3.1400"  ->   "-3.140 "
fmt.printf("%-07.3f", +Inf)    //  "+Inf000"  ->   "+Inf   "
fmt.printf("%-07.3f", -Inf)    //  "-Inf000"  ->   "-Inf   "
fmt.printf("%-07.3f",  NaN)    //  "NaN0000"  ->   "NaN    "

fmt.printf("%- 07.3f",  3.14)  //  "3.140  "  ->   " 3.140 "
fmt.printf("%- 07.3f",  NaN)   //  "NaN    "  ->   " NaN   "
```