### PR TITLE
core/os, core/os/os2: fix lookup_env_buf only working with empty buffer

### DIFF
--- a/core/os/os2/env_linux.odin
+++ b/core/os/os2/env_linux.odin
@@ -282,6 +282,7 @@ when ODIN_NO_CRT {
 			return "", .Buffer_Full
 		} else {
 			copy(buf, key)
+			buf[len(key)] = 0
 		}
 
 		cval := posix.getenv(cstring(raw_data(buf)))

--- a/core/os/os2/env_posix.odin
+++ b/core/os/os2/env_posix.odin
@@ -35,6 +35,7 @@ _lookup_env_buf :: proc(buf: []u8, key: string) -> (value: string, error: Error)
 		return "", .Buffer_Full
 	} else {
 		copy(buf, key)
+		buf[len(key)] = 0
 	}
 
 	cval := posix.getenv(cstring(raw_data(buf)))

--- a/core/os/os2/env_wasi.odin
+++ b/core/os/os2/env_wasi.odin
@@ -88,6 +88,7 @@ _lookup_env_buf :: proc(buf: []u8, key: string) -> (value: string, error: Error)
 		return "", .Buffer_Full
 	} else {
 		copy(buf, key)
+		buf[len(key)] = 0
 	}
 
 	sync.shared_guard(&g_env_mutex)

--- a/core/os/os_darwin.odin
+++ b/core/os/os_darwin.odin
@@ -1072,6 +1072,7 @@ lookup_env_buffer :: proc(buf: []u8, key: string) -> (value: string, err: Error)
 		return "", .Buffer_Full
 	} else {
 		copy(buf, key)
+		buf[len(key)] = 0
 	}
 
 	if value = string(_unix_getenv(cstring(raw_data(buf)))); value == "" {

--- a/core/os/os_freebsd.odin
+++ b/core/os/os_freebsd.odin
@@ -844,6 +844,7 @@ lookup_env_buffer :: proc(buf: []u8, key: string) -> (value: string, err: Error)
 		return "", .Buffer_Full
 	} else {
 		copy(buf, key)
+		buf[len(key)] = 0
 	}
 
 	if value = string(_unix_getenv(cstring(raw_data(buf)))); value == "" {

--- a/core/os/os_haiku.odin
+++ b/core/os/os_haiku.odin
@@ -487,6 +487,7 @@ lookup_env_buffer :: proc(buf: []u8, key: string) -> (value: string, err: Error)
 		return "", .Buffer_Full
 	} else {
 		copy(buf, key)
+		buf[len(key)] = 0
 	}
 
 	if value = string(_unix_getenv(cstring(raw_data(buf)))); value == "" {

--- a/core/os/os_linux.odin
+++ b/core/os/os_linux.odin
@@ -963,6 +963,7 @@ lookup_env_buffer :: proc(buf: []u8, key: string) -> (value: string, err: Error)
 		return "", .Buffer_Full
 	} else {
 		copy(buf, key)
+		buf[len(key)] = 0
 	}
 
 	if value = string(_unix_getenv(cstring(raw_data(buf)))); value == "" {

--- a/core/os/os_netbsd.odin
+++ b/core/os/os_netbsd.odin
@@ -891,6 +891,7 @@ lookup_env_buffer :: proc(buf: []u8, key: string) -> (value: string, err: Error)
 		return "", .Buffer_Full
 	} else {
 		copy(buf, key)
+		buf[len(key)] = 0
 	}
 
 	if value = string(_unix_getenv(cstring(raw_data(buf)))); value == "" {

--- a/core/os/os_openbsd.odin
+++ b/core/os/os_openbsd.odin
@@ -804,6 +804,7 @@ lookup_env_buffer :: proc(buf: []u8, key: string) -> (value: string, err: Error)
 		return "", .Buffer_Full
 	} else {
 		copy(buf, key)
+		buf[len(key)] = 0
 	}
 
 	if value = string(_unix_getenv(cstring(raw_data(buf)))); value == "" {


### PR DESCRIPTION
`os.lookup_env_buffer()` and `os2._lookup_env_buf()` only work reliably with an empty buffer on most systems: They copy the key to the buffer without ensuring that it is null terminated for the following syscall. This means that subsequent calls with the same buffer will probably wrongly fail with `.Env_Var_Not_Found`.
I fixed that by adding a 0-byte to the buffer after the key. It is already checked that the buffer is large enough.