### PR TITLE
os\os2 windows: fix truncate-clamp op order when determining to_read size

### DIFF
--- a/core/os/os2/file_windows.odin
+++ b/core/os/os2/file_windows.odin
@@ -377,7 +377,7 @@ _read_internal :: proc(f: ^File_Impl, p: []byte) -> (n: i64, err: Error) {
 	sync.shared_guard(&f.rw_mutex) // multiple readers
 
 	if sync.guard(&f.p_mutex) {
-		to_read := min(win32.DWORD(length), MAX_RW)
+		to_read := win32.DWORD(min(length, MAX_RW))
 		switch f.kind {
 		case .Console:
 			// NOTE(laytan): at least for now, just use ReadFile, it seems to work fine,


### PR DESCRIPTION
```
to_read := min(win32.DWORD(length), MAX_RW)
// changed to
to_read := win32.DWORD(min(length, MAX_RW))

// DWORD :: c_ulong :: u32
```
Now we first clamp by `MAX_RW :: 1<<30`, then truncate to u32.
This allows to read files larger than U32_MAX.