### PR TITLE
Fix all ThreadSanitizer data races (227 warnings → 0)

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -2124,7 +2124,7 @@ gb_internal bool check_builtin_procedure_directive(CheckerContext *c, Operand *o
 				if (e == nullptr || (e->flags & EntityFlag_Param) == 0) {
 					error(arg, "'#caller_expression' expected a valid earlier parameter name");
 				}
-				arg->Ident.entity = e;
+				ident_entity_store(arg, e);
 			}
 		}
 
@@ -6947,7 +6947,7 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 			
 			operand->mode = Addressing_Constant;
 			operand->type = t_untyped_integer;
-			operand->value = exact_value_i64(u->Union.variant_block_size);
+			operand->value = exact_value_i64(reinterpret_cast<std::atomic<i64>*>(&u->Union.variant_block_size)->load(std::memory_order_relaxed));
 		}
 		break;
 

--- a/src/checker.hpp
+++ b/src/checker.hpp
@@ -222,13 +222,13 @@ struct DeclInfo {
 	Entity *     para_poly_original;
 
 	bool          is_using;
-	bool          where_clauses_evaluated;
+	std::atomic<bool> where_clauses_evaluated;
 	bool          foreign_require_results;
 	std::atomic<ProcCheckedState> proc_checked_state;
 
 	BlockingMutex proc_checked_mutex;
 	isize         defer_used;
-	bool          defer_use_checked;
+	std::atomic<bool> defer_use_checked;
 
 	CommentGroup *comment;
 	CommentGroup *docs;
@@ -631,7 +631,7 @@ gb_internal void    scope_lookup_parent (Scope *s, String const &name, Scope **s
 gb_internal Entity *scope_insert (Scope *s, Entity *entity);
 
 
-gb_internal void      add_type_and_value      (CheckerContext *c, Ast *expression, AddressingMode mode, Type *type, ExactValue const &value, bool use_mutex=true);
+gb_internal void      add_type_and_value      (CheckerContext *c, Ast *expression, AddressingMode mode, Type *type, ExactValue const &value);
 gb_internal ExprInfo *check_get_expr_info     (CheckerContext *c, Ast *expr);
 gb_internal void      add_untyped             (CheckerContext *c, Ast *expression, AddressingMode mode, Type *basic_type, ExactValue const &value);
 gb_internal void      add_entity_use          (CheckerContext *c, Ast *identifier, Entity *entity);

--- a/src/llvm_backend_const.cpp
+++ b/src/llvm_backend_const.cpp
@@ -763,7 +763,7 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, lb
 
 			GB_ASSERT_MSG(value_type != nullptr, "%s :: %s", type_to_string(original_type), exact_value_to_string(value));
 
-			i64 block_size = bt->Union.variant_block_size;
+			i64 block_size = reinterpret_cast<std::atomic<i64>*>(&bt->Union.variant_block_size)->load(std::memory_order_relaxed);
 
 			if (are_types_identical(value_type, original_type)) {
 				if (value.kind == ExactValue_Compound) {

--- a/src/llvm_backend_debug.cpp
+++ b/src/llvm_backend_debug.cpp
@@ -446,7 +446,7 @@ gb_internal LLVMMetadataRef lb_debug_union(lbModule *m, Type *type, String name,
 
 	if (index_offset > 0) {
 		Type *tag_type = union_tag_type(bt);
-		u64 offset_in_bits = 8*cast(u64)bt->Union.variant_block_size;
+		u64 offset_in_bits = 8*cast(u64)reinterpret_cast<std::atomic<i64>*>(&bt->Union.variant_block_size)->load(std::memory_order_relaxed);
 
 		elements[0] = LLVMDIBuilderCreateMemberType(
 			m->debug_builder, member_scope,

--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -1573,7 +1573,7 @@ gb_internal void lb_emit_store_union_variant(lbProcedure *p, lbValue parent, lbV
 	} else {
 		if (type_size_of(variant_type) == 0) {
 			unsigned alignment = 1;
-			lb_mem_zero_ptr_internal(p, parent.value, pt->Union.variant_block_size, alignment, false);
+			lb_mem_zero_ptr_internal(p, parent.value, reinterpret_cast<std::atomic<i64>*>(&pt->Union.variant_block_size)->load(std::memory_order_relaxed), alignment, false);
 		} else {
 			lbValue underlying = lb_emit_conv(p, parent, alloc_type_pointer(variant_type));
 			lb_emit_store(p, underlying, variant);
@@ -1760,7 +1760,7 @@ gb_internal LLVMTypeRef lb_type_internal_union_block_type(lbModule *m, Type *typ
 
 	i64 align = type_align_of(type);
 
-	unsigned block_size = cast(unsigned)type->Union.variant_block_size;
+	unsigned block_size = cast(unsigned)reinterpret_cast<std::atomic<i64>*>(&type->Union.variant_block_size)->load(std::memory_order_relaxed);
 	if (block_size == 0) {
 		return lb_type_padding_filler(m, block_size, align);
 	}

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -102,8 +102,8 @@ gb_internal lbProcedure *lb_create_procedure(lbModule *m, Entity *entity, bool i
 	lbProcedure *p = gb_alloc_item(permanent_allocator(), lbProcedure);
 
 	p->module = m;
-	entity->code_gen_module = m;
-	entity->code_gen_procedure = p;
+	reinterpret_cast<std::atomic<lbModule*>*>(&entity->code_gen_module)->store(m, std::memory_order_relaxed);
+	reinterpret_cast<std::atomic<lbProcedure*>*>(&entity->code_gen_procedure)->store(p, std::memory_order_relaxed);
 	p->entity = entity;
 	p->name = link_name;
 
@@ -676,7 +676,7 @@ gb_internal void lb_begin_procedure_body(lbProcedure *p) {
 
 					lbAddr res = {};
 					if (p->entity && p->entity->decl_info &&
-					    p->entity->decl_info->defer_use_checked &&
+					    p->entity->decl_info->defer_use_checked.load(std::memory_order_relaxed) &&
 					    p->entity->decl_info->defer_used == 0) {
 
 						// NOTE(bill): this is a bodge to get around the issue of the problem BELOW

--- a/src/llvm_backend_type.cpp
+++ b/src/llvm_backend_type.cpp
@@ -189,7 +189,7 @@ gb_internal LLVMTypeRef *lb_setup_modified_types_for_type_info(lbModule *m, isiz
 	GB_ASSERT(Typeid__COUNT == ut->Union.variants.count);
 	modified_types[0] = element_types[0];
 
-	i64 tag_offset = ut->Union.variant_block_size;
+	i64 tag_offset = reinterpret_cast<std::atomic<i64>*>(&ut->Union.variant_block_size)->load(std::memory_order_relaxed);
 	LLVMTypeRef tag = lb_type(m, union_tag_type(ut));
 
 	for_array(i, ut->Union.variants) {
@@ -782,7 +782,7 @@ gb_internal void lb_setup_type_info_data_giant_array(lbModule *m, i64 global_typ
 
 				i64 tag_size = union_tag_size(t);
 				if (tag_size > 0) {
-					i64 tag_offset = align_formula(t->Union.variant_block_size, tag_size);
+					i64 tag_offset = align_formula(reinterpret_cast<std::atomic<i64>*>(&t->Union.variant_block_size)->load(std::memory_order_relaxed), tag_size);
 					vals[1] = lb_const_int(m, t_uintptr, tag_offset).value;
 					vals[2] = get_type_info_ptr(m, union_tag_type(t));
 				} else {

--- a/src/llvm_backend_utility.cpp
+++ b/src/llvm_backend_utility.cpp
@@ -2419,7 +2419,7 @@ gb_internal lbValue lb_handle_objc_block(lbProcedure *p, Ast *expr) {
 
 	Ast *proc_lit = unparen_expr(ce->args[capture_arg_count]);
 	if (proc_lit->kind == Ast_Ident) {
-		proc_lit = proc_lit->Ident.entity->decl_info->proc_lit;
+		proc_lit = ident_entity_load(proc_lit)->decl_info->proc_lit;
 	}
 	GB_ASSERT(proc_lit->kind == Ast_ProcLit);
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -192,7 +192,7 @@ gb_internal Ast *clone_ast(Ast *node, AstFile *f) {
 
 	case Ast_Invalid:        break;
 	case Ast_Ident:
-		n->Ident.entity = nullptr;
+		ident_entity_store(n, nullptr);
 		break;
 	case Ast_Implicit:       break;
 	case Ast_Uninit:         break;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -889,6 +889,20 @@ struct Ast {
 	}
 };
 
+static inline Entity *ident_entity_load(Ast *node) {
+	return reinterpret_cast<std::atomic<Entity*>*>(&node->Ident.entity)->load(std::memory_order_relaxed);
+}
+static inline void ident_entity_store(Ast *node, Entity *e) {
+	reinterpret_cast<std::atomic<Entity*>*>(&node->Ident.entity)->store(e, std::memory_order_relaxed);
+}
+
+static inline u8 ast_viral_flags_load(Ast *node) {
+	return reinterpret_cast<std::atomic<u8>*>(&node->viral_state_flags)->load(std::memory_order_relaxed);
+}
+static inline void ast_viral_flags_or(Ast *node, u8 val) {
+	reinterpret_cast<std::atomic<u8>*>(&node->viral_state_flags)->fetch_or(val, std::memory_order_relaxed);
+}
+
 
 #define ast_node(n_, Kind_, node_) GB_JOIN2(Ast, Kind_) *n_ = &(node_)->Kind_; gb_unused(n_); GB_ASSERT_MSG((node_)->kind == GB_JOIN2(Ast_, Kind_), \
 	"expected '%.*s' got '%.*s'", \

--- a/src/threading.cpp
+++ b/src/threading.cpp
@@ -375,8 +375,8 @@ gb_internal void semaphore_wait(Semaphore *s) {
 	}
 	gb_internal bool mutex_try_lock(BlockingMutex *m) {
 		ANNOTATE_LOCK_PRE(m, 1);
-		i32 v = m->state().exchange(Internal_Mutex_State_Locked, std::memory_order_acquire);
-		if (v == Internal_Mutex_State_Unlocked) {
+		i32 expected = Internal_Mutex_State_Unlocked;
+		if (m->state().compare_exchange_strong(expected, Internal_Mutex_State_Locked, std::memory_order_acquire)) {
 			ANNOTATE_LOCK_POST(m);
 			return true;
 		}

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -3332,8 +3332,9 @@ gb_internal i64 union_variant_index(Type *u, Type *v) {
 gb_internal i64 union_tag_size(Type *u) {
 	u = base_type(u);
 	GB_ASSERT(u->kind == Type_Union);
-	if (u->Union.tag_size > 0) {
-		return u->Union.tag_size;
+	i16 cached_tag_size = reinterpret_cast<std::atomic<i16>*>(&u->Union.tag_size)->load(std::memory_order_relaxed);
+	if (cached_tag_size > 0) {
+		return cached_tag_size;
 	}
 
 	u64 n = cast(u64)u->Union.variants.count;
@@ -3365,8 +3366,9 @@ gb_internal i64 union_tag_size(Type *u) {
 		}
 	}
 
-	u->Union.tag_size = cast(i16)gb_min3(max_align, build_context.max_align, 8);
-	return u->Union.tag_size;
+	i16 result = cast(i16)gb_min3(max_align, build_context.max_align, 8);
+	reinterpret_cast<std::atomic<i16>*>(&u->Union.tag_size)->store(result, std::memory_order_relaxed);
+	return result;
 }
 
 gb_internal Type *union_tag_type(Type *u) {
@@ -4467,15 +4469,15 @@ gb_internal i64 type_size_of_internal(Type *t, TypePath *path) {
 
 		if (is_type_union_maybe_pointer(t)) {
 			size = max;
-			t->Union.tag_size = 0;
-			t->Union.variant_block_size = size;
+			reinterpret_cast<std::atomic<i16>*>(&t->Union.tag_size)->store(cast(i16)0, std::memory_order_relaxed);
+			reinterpret_cast<std::atomic<i64>*>(&t->Union.variant_block_size)->store(size, std::memory_order_relaxed);
 		} else {
 			// NOTE(bill): Align to tag
 			i64 tag_size = union_tag_size(t);
 			size = align_formula(max, tag_size);
 			// NOTE(bill): Calculate the padding between the common fields and the tag
-			t->Union.tag_size = cast(i16)tag_size;
-			t->Union.variant_block_size = size;
+			reinterpret_cast<std::atomic<i16>*>(&t->Union.tag_size)->store(cast(i16)tag_size, std::memory_order_relaxed);
+			reinterpret_cast<std::atomic<i64>*>(&t->Union.variant_block_size)->store(size, std::memory_order_relaxed);
 
 			size += tag_size;
 		}
@@ -4650,7 +4652,7 @@ gb_internal i64 type_offset_of(Type *t, i64 index, Type **field_type_) {
 			case -1:
 				if (field_type_) *field_type_ = union_tag_type(t);
 				union_tag_size(t);
-				return t->Union.variant_block_size;
+				return reinterpret_cast<std::atomic<i64>*>(&t->Union.variant_block_size)->load(std::memory_order_relaxed);
 			}
 		}
 		break;


### PR DESCRIPTION
I had Claude address TSAN warnings as they would occur running the compiler on loop running the odin tests and demo on various optimization modes until they went silent on Linux Mint x64 for a duration of 5 minutes.  Claude checked its  work several times along the way.

Replace non-thread-safe patterns with proper atomic operations and synchronization across the concurrent checker and LLVM codegen phases.

Changes by category:

1. Thread pool (Chase-Lev deque) TSan annotations
   - Add TSAN_RELEASE/TSAN_ACQUIRE on ring buffer slots in push/take/steal
   - Annotations establish happens-before for the work-stealing protocol

2. Entity flags: std::atomic<u64> with fetch_or/fetch_and
   - EntityFlag_Used, EntityFlag_Cold, EntityFlag_Disabled, etc.
   - Replaces racy compound assignment (|=, &=~) from concurrent checkers

3. Ident.entity pointer: atomic load/store helpers via std::atomic reinterpret_cast
   - ident_entity_load/ident_entity_store in parser.hpp
   - All read/write sites converted across checker and codegen

4. AST type-and-value (tav): striped locks (64 stripes, cache-line aligned)
   - add_type_and_value always acquires stripe lock keyed by node address
   - Protects memcpy-based tav writes from concurrent tav reads

5. DeclInfo atomic bools: where_clauses_evaluated, defer_use_checked
   - Changed from bool to std::atomic<bool> in checker.hpp

6. viral_state_flags: atomic load/fetch_or helpers
   - ast_viral_flags_load/ast_viral_flags_or in parser.hpp
   - All 29 access sites converted

7. Union type cache fields: atomic load/store via std::atomic reinterpret_cast
   - tag_size and variant_block_size in types.cpp and all LLVM backend readers
   - Idempotent cache writes that race with concurrent readers

8. mutex_try_lock correctness: exchange → compare_exchange_strong
   - Old code could spuriously "succeed" when mutex was already locked

9. parent_proc_decl: atomic load/store via std::atomic reinterpret_cast

All helpers use std::atomic reinterpret_cast (not __atomic_* builtins) because clang's TSan instrumentation does not properly track GCC-style __atomic_load_n/__atomic_store_n with __ATOMIC_RELAXED.