### PR TITLE
Add ThinLTO support via -lto:thin and -lto:thin-files flags

### DIFF
--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -163,7 +163,7 @@ gb_internal bool lb_init_generator(lbGenerator *gen, Checker *c) {
 	map_init(&gen->modules_through_ctx, gen->info->packages.count*2);
 
 	if (USE_SEPARATE_MODULES) {
-		bool module_per_file = build_context.module_per_file && build_context.optimization_level <= 0;
+		bool module_per_file = build_context.module_per_file && (build_context.optimization_level <= 0 || build_context.lto_kind != LTO_None);
 		for (auto const &entry : gen->info->packages) {
 			AstPackage *pkg = entry.value;
 			auto m = gb_alloc_item(permanent_allocator(), lbModule);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -413,6 +413,7 @@ enum BuildFlagKind {
 	BuildFlag_Tilde,
 
 	BuildFlag_Sanitize,
+	BuildFlag_LTO,
 
 #if defined(GB_SYSTEM_WINDOWS)
 	BuildFlag_IgnoreVsSearch,
@@ -643,6 +644,7 @@ gb_internal bool parse_build_flags(Array<String> args) {
 #endif
 
 	add_flag(&build_flags, BuildFlag_Sanitize,                str_lit("sanitize"),                  BuildFlagParam_String,  Command__does_build, true);
+	add_flag(&build_flags, BuildFlag_LTO,                     str_lit("lto"),                       BuildFlagParam_String,  Command__does_build);
 
 
 #if defined(GB_SYSTEM_WINDOWS)
@@ -1632,6 +1634,18 @@ gb_internal bool parse_build_flags(Array<String> args) {
 								build_context.sanitizer_flags |= SanitizerFlag_Thread;
 							} else {
 								gb_printf_err("-sanitize:<string> options are 'address', 'memory', and 'thread'\n");
+								bad_flags = true;
+							}
+							break;
+
+						case BuildFlag_LTO:
+							GB_ASSERT(value.kind == ExactValue_String);
+							if (str_eq_ignore_case(value.value_string, str_lit("thin"))) {
+								build_context.lto_kind = LTO_Thin;
+							} else if (str_eq_ignore_case(value.value_string, str_lit("thin-files"))) {
+								build_context.lto_kind = LTO_Thin_Files;
+							} else {
+								gb_printf_err("-lto:<string> options are 'thin' and 'thin-files'\n");
 								bad_flags = true;
 							}
 							break;


### PR DESCRIPTION
I asked Claude to implement thin-lto into the compiler, with support at the Package and individual file level.  On my system, this results in a wall clock reduction of 40% in 'odin run' for the tests and demo, largely through parallel compilation gains from LLVM.

- Add -lto:thin and -lto:thin-files CLI flags with validation
- Emit LLVM bitcode (.bc) instead of object files when LTO is enabled
- Pass -flto=thin and -flto-jobs to clang/lld linkers
- Guard linkage corrections to skip declarations without definitions (required for LTO where declarations appear across modules)
- Allow module-per-file with LTO even at higher optimization levels