### PR TITLE
Fix debug info sizes, endian flags, and add debug locations for loops / defer

### DIFF
--- a/src/llvm_backend.hpp
+++ b/src/llvm_backend.hpp
@@ -186,7 +186,7 @@ struct lbModule {
 	LLVMMetadataRef debug_compile_unit;
 
 	RecursiveMutex debug_values_mutex;
-	PtrMap<void *, LLVMMetadataRef> debug_values; 
+	PtrMap<void *, LLVMMetadataRef> debug_values;
 
 
 	StringMap<lbAddr> objc_classes;
@@ -290,6 +290,7 @@ struct lbDefer {
 	isize       scope_index;
 	isize       context_stack_count;
 	lbBlock *   block;
+	TokenPos    pos;
 	union {
 		Ast *stmt;
 		struct {

--- a/src/llvm_backend_const.cpp
+++ b/src/llvm_backend_const.cpp
@@ -736,13 +736,12 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, lb
 				}
 				LLVMValueRef tag = LLVMConstInt(LLVMStructGetTypeAtIndex(llvm_type, 1), tag_value, false);
 				LLVMValueRef padding = nullptr;
-				LLVMValueRef values[3] = {cv.value, tag, padding};
-
 				isize value_count = 2;
 				if (LLVMCountStructElementTypes(llvm_type) > 2) {
 					value_count = 3;
 					padding = LLVMConstNull(LLVMStructGetTypeAtIndex(llvm_type, 2));
 				}
+				LLVMValueRef values[3] = {cv.value, tag, padding};
 				res.value = llvm_const_named_struct_internal(m, llvm_type, values, value_count);
 				res.type = original_type;
 				return res;

--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -1377,6 +1377,8 @@ gb_internal LLVMValueRef lb_integer_modulo(lbProcedure *p, LLVMValueRef lhs, LLV
 	if (LLVMIsConstant(rhs)) {
 		if (LLVMIsNull(rhs)) {
 			switch (behaviour) {
+			case IntegerDivisionByZero_Trap:
+				break; // fall through to runtime path which emits trap
 			case IntegerDivisionByZero_Self:
 				return zero;
 			case IntegerDivisionByZero_Zero:

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -703,8 +703,6 @@ gb_internal void lb_begin_procedure_body(lbProcedure *p) {
 								lbValue ptr = {};
 								ptr.value = LLVMGetParam(p->value, cast(unsigned)the_offset);
 								ptr.type = alloc_type_pointer(e->type);
-
-
 							}
 						} else if (has_return_ptr) {
 							lbValue ptr = p->return_ptr.addr;
@@ -1288,7 +1286,7 @@ gb_internal lbValue lb_emit_call(lbProcedure *p, lbValue value, Array<lbValue> c
 				}
 			}
 
-			lb_add_defer_proc(p, p->scope_index, deferred, result_as_args);
+			lb_add_defer_proc(p, p->scope_index, deferred, result_as_args, e->token.pos);
 		}
 	}
 


### PR DESCRIPTION
This I feel the least confident regarding correctness.  But there may be ideas here worth grabbing.

- Fix big-endian float debug types using wrong DI flag (LittleEndian→BigEndian)
- Fix complex32/quaternion64 debug info sizes (were doubled)
- Fix complex64 imag field offset (2*32→1*32)
- Fix quaternion256 debug alignment (32→64)
- Fix string/string16/any debug info to use ptr_bits for field offsets
- Fix SoaPointer debug type to use ptr_bits instead of int_bits
- Add debug locations at loop back-edges and switch cases
- Track source position in deferred procedure calls for accurate debug info
- Fix union constant VLA initialization order
- Fix integer division-by-zero trap fallthrough for constant zero divisor