### PR TITLE
Fix front-end threading bugs and remove unnecessary serialization

### DIFF
--- a/src/exact_value.cpp
+++ b/src/exact_value.cpp
@@ -1,7 +1,6 @@
 #include <math.h>
 #include <stdlib.h>
 
-gb_global BlockingMutex hash_exact_value_mutex;
 
 struct Ast;
 struct HashKey;
@@ -54,9 +53,6 @@ struct ExactValue {
 gb_global ExactValue const empty_exact_value = {};
 
 gb_internal uintptr hash_exact_value(ExactValue v) {
-	mutex_lock(&hash_exact_value_mutex);
-	defer (mutex_unlock(&hash_exact_value_mutex));
-
 	uintptr res = 0;
 	
 	switch (v.kind) {

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -4308,17 +4308,14 @@ gb_internal i64 *type_set_offsets_of(Slice<Entity *> const &fields, bool is_pack
 gb_internal bool type_set_offsets(Type *t) {
 	t = base_type(t);
 	if (t->kind == Type_Struct) {
-		if (t->Struct.are_offsets_being_processed.load()) {
-			return true;
-		}
 		MUTEX_GUARD(&t->Struct.offset_mutex);
 		if (!t->Struct.are_offsets_set) {
 			t->Struct.are_offsets_being_processed.store(true);
 			t->Struct.offsets = type_set_offsets_of(t->Struct.fields, t->Struct.is_packed, t->Struct.is_raw_union, t->Struct.custom_min_field_align, t->Struct.custom_max_field_align);
 			t->Struct.are_offsets_being_processed.store(false);
 			t->Struct.are_offsets_set = true;
-			return true;
 		}
+		return true;
 	} else if (is_type_tuple(t)) {
 		MUTEX_GUARD(&t->Tuple.mutex);
 		if (!t->Tuple.are_offsets_set) {
@@ -4326,8 +4323,8 @@ gb_internal bool type_set_offsets(Type *t) {
 			t->Tuple.offsets = type_set_offsets_of(t->Tuple.variables, t->Tuple.is_packed, false, 1, 0);
 			t->Tuple.are_offsets_being_processed.store(false);
 			t->Tuple.are_offsets_set = true;
-			return true;
 		}
+		return true;
 	} else {
 		GB_PANIC("Invalid type for setting offsets");
 	}


### PR DESCRIPTION
This is another PR for tsan related fixes but should be completely independent and not collide.  

- Remove broken are_offsets_being_processed early-return in type_set_offsets that let concurrent threads read uninitialized struct offsets
- Fix type_set_offsets fall-through returning false when offsets already set
- Add shared lock on parent scope in scope_insert_with_name to prevent data race when reading parent's elements map
- Remove unnecessary global mutex from hash_exact_value (pure function)
- Convert error collector curr_error_value_set from atomic to plain bool (all access already under mutex)
- Add threading-safety comments for phase-ordered traversals