### PR TITLE
fix LTO on MacOS

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1728,6 +1728,29 @@ gb_internal char *token_pos_to_string(TokenPos const &pos) {
 	return s;
 }
 
+gb_internal String normalize_minimum_os_version_string(String version) {
+	GB_ASSERT(version.len > 0);
+
+	gbString normalized = gb_string_make(permanent_allocator(), "");
+
+	int granularity = 0;
+	String_Iterator it = {version, 0};
+	for (;; granularity++) {
+		String str = string_split_iterator(&it, '.');
+		if (str == "") break;
+		if (granularity > 0) {
+			normalized = gb_string_appendc(normalized, ".");
+		}
+		normalized = gb_string_append_length(normalized, str.text, str.len);
+	}
+
+	for (; granularity < 3; granularity++) {
+		normalized = gb_string_appendc(normalized, ".0");
+	}
+
+	return make_string_c(normalized);
+}
+
 gb_internal void init_build_context(TargetMetrics *cross_target, Subtarget subtarget) {
 	BuildContext *bc = &build_context;
 
@@ -1997,9 +2020,11 @@ gb_internal void init_build_context(TargetMetrics *cross_target, Subtarget subta
 			} else if (subtarget == Subtarget_iPhone || subtarget == Subtarget_iPhoneSimulator) {
 				// NOTE(harold): We default to 17.4 on iOS because that's when os_sync_wait_on_address was added and
 				//               we'd like to avoid any potential App Store issues by using the private ulock_* there.
-				bc->minimum_os_version_string = str_lit("17.4");
+				bc->minimum_os_version_string = str_lit("17.4.0");
 			}
 		}
+
+		bc->minimum_os_version_string = normalize_minimum_os_version_string(bc->minimum_os_version_string);
 
 		if (subtarget == Subtarget_iPhoneSimulator) {
 			// For the iPhoneSimulator subtarget, the version must be between 'ios' and '-simulator'.

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -978,6 +978,10 @@ try_cross_linking:;
 			if (build_context.lto_kind != LTO_None) {
 				link_command_line = gb_string_appendc(link_command_line, " -flto=thin");
 				link_command_line = gb_string_append_fmt(link_command_line, " -flto-jobs=%d ", build_context.thread_count);
+
+				if (is_osx && !build_context.minimum_os_version_string_given) {
+					link_command_line = gb_string_appendc(link_command_line, " -Wno-override-module ");
+				}
 			}
 
 			link_command_line = gb_string_appendc(link_command_line, object_files);


### PR DESCRIPTION
If no `-minimum-os-version` is given, ignore the `override-module` warnings. The user not using `-minimum-os-version` opts you out of linker warnings about target versions.

If a `-minimum-os-version` is provided, normalize it to a full version `11` to `11.0.0` for example. The linker seems to want that when doing LTO.