### PR TITLE
vendor/x11/xlib: Fix returntype of some procs

### DIFF
--- a/vendor/x11/xlib/xlib_procs.odin
+++ b/vendor/x11/xlib/xlib_procs.odin
@@ -1112,15 +1112,15 @@ foreign xlib {
 	SetAfterFunction :: proc(
 		display:   ^Display,
 		procedure: #type proc "c" (display: ^Display) -> i32,
-		) -> i32 ---
+		) -> proc "c" (display: ^Display) -> i32 ---
 	Synchronize :: proc(
 		display: ^Display,
 		onoff: b32,
-		) -> i32 ---
+		) -> proc "c" (display: ^Display) -> i32 ---
 	// Error handling
 	SetErrorHandler :: proc(
 		handler: #type proc "c" (display: ^Display, event: ^XErrorEvent) -> i32,
-		) -> i32 ---
+		) -> proc "c" (display: ^Display, event: ^XErrorEvent) -> i32 ---
 	GetErrorText :: proc(
 		display: ^Display,
 		code: i32,
@@ -1138,7 +1138,7 @@ foreign xlib {
 	DisplayName :: proc(string: cstring) -> cstring ---
 	SetIOErrorHandler :: proc(
 		handler: #type proc "c" (display: ^Display) -> i32,
-		) -> i32 ---
+		) -> proc "c" (display: ^Display) -> i32 ---
 	// Pointer grabbing
 	GrabPointer :: proc(
 		display:       ^Display,


### PR DESCRIPTION
Returntype of a few procs was incorrectly set to i32 rather than a proc that returns i32.

These just seem to be functions that return the previous handler upon setting a new one.

Not sure whether this is all of them, I just grep'd for `(*` in https://github.com/mirror/libX11/blob/master/include/X11/Xlib.h

References:
* https://github.com/mirror/libX11/blob/master/include/X11/Xlib.h#L1522
* https://github.com/mirror/libX11/blob/master/include/X11/Xlib.h#L1852
* https://www.x.org/releases/X11R7.5/doc/man/man3/XSetAfterFunction.3.html
* https://www.x.org/releases/X11R7.5/doc/man/man3/XSetErrorHandler.3.html