### PR TITLE
vendor/x11/xlib: Fix signature of XChangeWindowAttributes

### DIFF
--- a/vendor/x11/xlib/xlib_procs.odin
+++ b/vendor/x11/xlib/xlib_procs.odin
@@ -234,7 +234,7 @@ foreign xlib {
 		display:   ^Display,
 		window:    Window,
 		attr_mask: WindowAttributeMask,
-		attr:      ^XWindowAttributes,
+		attr:      ^XSetWindowAttributes,
 		) ---
 	SetWindowBackground :: proc(
 		display:   ^Display,


### PR DESCRIPTION
Actually fixes #5139

Seems e3fe733 attempted to fix it but it didn't fix the (very similarly named) struct being the wrong one

References:
* https://github.com/mirror/libX11/blob/ff8706a5eae25b8bafce300527079f68a201d27f/src/ChWAttrs.c#L43