### PR TITLE
Fix typo in atomic.odin documentation

### DIFF
--- a/core/sync/atomic.odin
+++ b/core/sync/atomic.odin
@@ -27,7 +27,7 @@ multiple memory locations between two cores. Which is why CPU's allow for
 stronger memory ordering guarantees if certain instructions or instruction
 variants are used.
 
-In Odin there are 5 different memory ordering guaranties that can be provided
+In Odin there are 5 different memory ordering guarantees that can be provided
 to an atomic operation:
 
 - `Relaxed`: The memory access (load or store) is unordered with respect to


### PR DESCRIPTION
## Summary
- Fixed typo: "guaranties" → "guarantees" in the memory ordering documentation
- Added missing newline at end of file

## Test plan
- [x] No code changes, documentation-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)