### PR TITLE
Allow test names to be specified as a command line option for tests executable

### DIFF
--- a/core/testing/runner.odin
+++ b/core/testing/runner.odin
@@ -213,7 +213,7 @@ parse_cli_options :: proc(argv: []string, opts: ^Options, stdout, stderr: io.Wri
 				os.exit(-1)
 			}
 
-			if len(test_names.buf) > 0 {
+			if strings.builder_len(test_names) > 0 {
 				strings.write_byte(&test_names, ',')
 			}
 			strings.write_string(&test_names, tests)


### PR DESCRIPTION
When running the tests executable generated by `odin build -build-mode:test`, this allows to optionally specify a  set of tests to run at runtime via the command line, instead of being limited only to specifying them as compile-time definitions.

Compile-time definitions still allowed, but the cli list, if present, takes precedence.
