### PR TITLE
core/fmt: fix incorrect string padding

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -1495,12 +1495,13 @@ fmt_string :: proc(fi: ^Info, s: string, verb: rune) {
 	switch verb {
 	case 's', 'v':
 		if fi.width_set {
-			if fi.width > len(s) {
+			length := utf8.rune_count_in_string(s)
+			if fi.width > length {
 				if fi.minus {
 					io.write_string(fi.writer, s, &fi.n)
 				}
 
-				for _ in 0..<fi.width - len(s) {
+				for _ in 0..<fi.width - length {
 					io.write_byte(fi.writer, ' ', &fi.n)
 				}
 


### PR DESCRIPTION
Padding for format strings such as "% -6s" incorrectly calculated the length of the argument string - bytes instead of UTF-8 runes - resulting in the padding not being present for input such as "μμμμμ".