### PR TITLE
core:container/handle_map: fix dynamic_add not updating indicies nor …

### DIFF
--- a/core/container/handle_map/dynamic_handle_map.odin
+++ b/core/container/handle_map/dynamic_handle_map.odin
@@ -50,10 +50,10 @@ dynamic_add :: proc(m: ^$D/Dynamic_Handle_Map($T, $Handle_Type), item: T, loc :=
 
 	i := xar.append(&m.items, item, loc) or_return
 
-	ptr := xar.get_ptr_unsafe(&m.items, i)
+	ptr := xar.get_ptr_unsafe(&m.items, m.items.len-1)
 	ptr^ = item
 
-	ptr.handle.idx = auto_cast i
+	ptr.handle.idx = auto_cast m.items.len-1
 	ptr.handle.gen = 1
 	return ptr.handle, nil
 }


### PR DESCRIPTION
…keeping track of pointers

dynamic_add was using the return from xar.append() (which always returns 1) to get the pointer and set the idx for the handle