### PR TITLE
Clean-up some imports and dependencies

### DIFF
--- a/core/slice/slice.odin
+++ b/core/slice/slice.odin
@@ -3,12 +3,10 @@ package slice
 
 import "base:intrinsics"
 import "base:builtin"
-import "core:math/bits"
 import "base:runtime"
 
 _ :: intrinsics
 _ :: builtin
-_ :: bits
 _ :: runtime
 
 /*
@@ -933,7 +931,7 @@ If `elems` is out of bounds (more than the total) this will trigger a bounds che
 Example:
 	import "core:fmt"
 	import "core:slice"
-	
+
 	advance_slices_example :: proc() {
 		slices := [][]byte {
 			{1, 2, 3, 4},

--- a/core/sort/sort.odin
+++ b/core/sort/sort.odin
@@ -2,11 +2,9 @@
 package sort
 
 import "core:mem"
-import _slice "core:slice"
 import "base:intrinsics"
 
 _ :: intrinsics
-_ :: _slice
 ORD :: intrinsics.type_is_ordered
 
 Interface :: struct {
@@ -639,7 +637,7 @@ compare_f64s :: proc(a, b: f64) -> int {
 compare_strings :: proc(a, b: string) -> int {
 	x := transmute(mem.Raw_String)a
 	y := transmute(mem.Raw_String)b
-	
+
 	ret := mem.compare_byte_ptrs(x.data, y.data, min(x.len, y.len))
 	if ret == 0 && x.len != y.len {
 		return -1 if x.len < y.len else +1

--- a/core/sys/wasm/js/memory_all_targets.odin
+++ b/core/sys/wasm/js/memory_all_targets.odin
@@ -1,14 +1,14 @@
 #+build !js
 package wasm_js_interface
 
-import "core:mem"
+import "base:runtime"
 
 PAGE_SIZE :: 64 * 1024
-page_alloc :: proc(page_count: int) -> (data: []byte, err: mem.Allocator_Error) {
+page_alloc :: proc(page_count: int) -> (data: []byte, err: runtime.Allocator_Error) {
 	panic("vendor:wasm/js not supported on non-js targets")
 }
 
-page_allocator :: proc() -> mem.Allocator {
+page_allocator :: proc() -> runtime.Allocator {
 	panic("vendor:wasm/js not supported on non-js targets")
 }
 

--- a/core/sys/wasm/js/memory_js.odin
+++ b/core/sys/wasm/js/memory_js.odin
@@ -1,11 +1,11 @@
 #+build js wasm32, js wasm64p32
 package wasm_js_interface
 
-import "core:mem"
+import "base:runtime"
 import "base:intrinsics"
 
 PAGE_SIZE :: 64 * 1024
-page_alloc :: proc(page_count: int) -> (data: []byte, err: mem.Allocator_Error) {
+page_alloc :: proc(page_count: int) -> (data: []byte, err: runtime.Allocator_Error) {
 	prev_page_count := intrinsics.wasm_memory_grow(0, uintptr(page_count))
 	if prev_page_count < 0 {
 		return nil, .Out_Of_Memory
@@ -15,11 +15,11 @@ page_alloc :: proc(page_count: int) -> (data: []byte, err: mem.Allocator_Error) 
 	return ptr[:page_count * PAGE_SIZE], nil
 }
 
-page_allocator :: proc() -> mem.Allocator {
-	procedure :: proc(allocator_data: rawptr, mode: mem.Allocator_Mode,
+page_allocator :: proc() -> runtime.Allocator {
+	procedure :: proc(allocator_data: rawptr, mode: runtime.Allocator_Mode,
 	                  size, alignment: int,
 	                  old_memory: rawptr, old_size: int,
-	                  location := #caller_location) -> ([]byte, mem.Allocator_Error) {
+	                  location := #caller_location) -> ([]byte, runtime.Allocator_Error) {
 		switch mode {
 		case .Alloc, .Alloc_Non_Zeroed:
 			assert(size % PAGE_SIZE == 0)
@@ -27,7 +27,7 @@ page_allocator :: proc() -> mem.Allocator {
 		case .Resize, .Free, .Free_All, .Query_Info, .Resize_Non_Zeroed:
 			return nil, .Mode_Not_Implemented
 		case .Query_Features:
-			set := (^mem.Allocator_Mode_Set)(old_memory)
+			set := (^runtime.Allocator_Mode_Set)(old_memory)
 			if set != nil {
 				set^ = {.Alloc, .Query_Features}
 			}

--- a/core/sys/windows/gdi32.odin
+++ b/core/sys/windows/gdi32.odin
@@ -1,8 +1,6 @@
 #+build windows
 package sys_windows
 
-import "core:math/fixed"
-
 foreign import gdi32 "system:Gdi32.lib"
 
 @(default_calling_convention="system")
@@ -100,7 +98,7 @@ PALETTEINDEX :: #force_inline proc "contextless" (#any_int i: int) -> COLORREF {
 	return COLORREF(DWORD(0x01000000) | DWORD(WORD(i)))
 }
 
-FXPT2DOT30 :: distinct fixed.Fixed(i32, 30)
+FXPT2DOT30 :: distinct i32 // fixed.Fixed(i32, 30)
 
 CIEXYZ :: struct {
 	ciexyzX, ciexyzY, ciexyzZ: FXPT2DOT30,

--- a/vendor/raylib/raylib.odin
+++ b/vendor/raylib/raylib.odin
@@ -91,9 +91,6 @@ import "core:c"
 import "core:fmt"
 import "core:mem"
 
-import "core:math/linalg"
-_ :: linalg
-
 MAX_TEXTFORMAT_BUFFERS :: #config(RAYLIB_MAX_TEXTFORMAT_BUFFERS, 4)
 MAX_TEXT_BUFFER_LENGTH :: #config(RAYLIB_MAX_TEXT_BUFFER_LENGTH, 1024)
 MAX_MATERIAL_MAPS      :: #config(RAYLIB_MAX_MATERIAL_MAPS, 12)
@@ -128,7 +125,7 @@ when ODIN_OS == .Windows {
 		"system:Cocoa.framework",
 		"system:OpenGL.framework",
 		"system:IOKit.framework",
-	} 
+	}
 } else when ODIN_ARCH == .wasm32 || ODIN_ARCH == .wasm64p32 {
 	foreign import lib {
 		RAYLIB_WASM_LIB,
@@ -142,7 +139,7 @@ VERSION_MINOR :: 5
 VERSION_PATCH :: 0
 VERSION :: "5.5"
 
-PI :: 3.14159265358979323846 
+PI :: 3.14159265358979323846
 DEG2RAD :: PI/180.0
 RAD2DEG :: 180.0/PI
 
@@ -235,7 +232,7 @@ RenderTexture :: struct {
 	id:       c.uint,             // OpenGL framebuffer object id
 	texture: Texture,             // Color buffer attachment texture
 	depth:   Texture,             // Depth buffer attachment texture
-} 
+}
 
 // RenderTexture2D type, same as RenderTexture
 RenderTexture2D :: RenderTexture
@@ -257,7 +254,7 @@ GlyphInfo :: struct {
 	offsetY:  c.int,              // Character offset Y when drawing
 	advanceX: c.int,              // Character advance position X
 	image:    Image,              // Character image data
-} 
+}
 
 // Font type, includes texture and charSet array data
 Font :: struct {
@@ -851,7 +848,7 @@ Gesture :: enum c.uint {
 }
 Gestures :: distinct bit_set[Gesture; c.uint]
 
-// Camera speed values 
+// Camera speed values
 CAMERA_MOVE_SPEED :: 5.4
 CAMERA_ROTATION_SPEED :: 0.03
 CAMERA_PAN_SPEED :: 0.2
@@ -1029,7 +1026,7 @@ foreign lib {
 	GetScreenToWorld2D    :: proc(position: Vector2, camera: Camera2D) -> Vector2 ---                            // Get the world space position for a 2d camera screen space position
 	GetCameraMatrix       :: proc(camera: Camera) -> Matrix ---                                                  // Get camera transform matrix (view matrix)
 	GetCameraMatrix2D     :: proc(camera: Camera2D) -> Matrix ---                                                // Get camera 2d transform matrix
-	
+
 	// Timing-related functions
 
 	SetTargetFPS :: proc(fps: c.int) --- // Set target FPS (maximum)
@@ -1110,7 +1107,7 @@ foreign lib {
 	ComputeMD5       :: proc (data: rawptr,    dataSize: c.int) -> [^]c.uint ---                               // Compute MD5 hash code, returns static int[4] (16 bytes)
 	ComputeSHA1      :: proc(data: rawptr,     dataSize: c.int) -> [^]c.uint ---                               // Compute SHA1 hash code, returns static int[5] (20 bytes)
 
-	
+
 	// Automation events functionality
 
 	LoadAutomationEventList       :: proc(fileName: cstring) -> AutomationEventList ---             // Load automation events list from file, NULL for empty list, capacity = MAX_AUTOMATION_EVENTS
@@ -1151,14 +1148,14 @@ foreign lib {
 	SetGamepadMappings       :: proc(mappings: cstring) -> c.int ---                                     // Set internal gamepad mappings (SDL_GameControllerDB)
 	SetGamepadVibration      :: proc(gamepad: c.int, leftMotor: f32, rightMotor: f32, duration: f32) --- // Set gamepad vibration for both motors (duration in seconds)
 
-	
+
 	// Input-related functions: mouse
 
 	IsMouseButtonPressed  :: proc(button: MouseButton) -> bool ---    // Detect if a mouse button has been pressed once
 	IsMouseButtonDown     :: proc(button: MouseButton) -> bool ---    // Detect if a mouse button is being pressed
 	IsMouseButtonReleased :: proc(button: MouseButton) -> bool ---    // Detect if a mouse button has been released once
 	IsMouseButtonUp       :: proc(button: MouseButton) -> bool ---
-	
+
 	GetMouseX             :: proc() -> c.int ---                      // Returns mouse position X
 	GetMouseY             :: proc() -> c.int ---                      // Returns mouse position Y
 	GetMousePosition      :: proc() -> Vector2 ---                    // Returns mouse position XY
@@ -1226,7 +1223,7 @@ foreign lib {
 	GetShapesTexture :: proc() -> Texture2D ---                             // Get texture that is used for shapes drawing
 	GetShapesTextureRectangle :: proc() -> Rectangle ---                    // Get texture source rectangle that is used for shapes drawing
 
-	
+
 	// Basic shapes drawing functions
 
 	DrawPixel                   :: proc(posX, posY: c.int, color: Color) ---                                                                          // Draw a pixel using geometry [Can be slow, use with care]
@@ -1422,7 +1419,7 @@ foreign lib {
 	DrawTextureNPatch :: proc(texture: Texture2D, nPatchInfo: NPatchInfo, dest: Rectangle, origin: Vector2, rotation: f32, tint: Color) --- // Draws a texture (or part of it) that stretches or shrinks nicely
 
 	// Color/pixel related functions
-	
+
 	@(deprecated="Prefer col1 == col2")
 	ColorIsEqual        :: proc(col1, col2: Color) ---                                  // Check if two colors are equal
 	Fade                :: proc(color: Color, alpha: f32) -> Color ---                  // Get color with alpha applied, alpha goes from 0.0f to 1.0f
@@ -1730,15 +1727,15 @@ IsGestureDetected :: proc "c" (gesture: Gesture) -> bool {
 TextFormat :: proc(text: cstring, args: ..any) -> cstring {
 	@static buffers: [MAX_TEXTFORMAT_BUFFERS][MAX_TEXT_BUFFER_LENGTH]byte
 	@static index: u32
-	
+
 	buffer := buffers[index][:]
 	mem.zero_slice(buffer)
-	
+
 	index = (index+1)%MAX_TEXTFORMAT_BUFFERS
-	
+
 	str := fmt.bprintf(buffer[:len(buffer)-1], string(text), ..args)
 	buffer[len(str)] = 0
-	
+
 	return cstring(raw_data(buffer))
 }
 
@@ -1785,7 +1782,7 @@ MemAllocatorProc :: proc(allocator_data: rawptr, mode: mem.Allocator_Mode,
 	case .Free:
 		MemFree(old_memory)
 		return nil, nil
-	
+
 	case .Resize, .Resize_Non_Zeroed:
 		ptr := MemRealloc(old_memory, c.uint(size))
 		if ptr == nil {
@@ -1794,10 +1791,10 @@ MemAllocatorProc :: proc(allocator_data: rawptr, mode: mem.Allocator_Mode,
 		}
 		data = mem.byte_slice(ptr, size)
 		return
-	
+
 	case .Free_All, .Query_Features, .Query_Info:
 		return nil, .Mode_Not_Implemented
-	}	
+	}
 	return nil, .Mode_Not_Implemented
 }
 


### PR DESCRIPTION
I was looking at some import graphs within my project and noticed a few dependencies in core which seem very unnecessary.

Overview:
- `core:math` had a dependency on the `bits` package literally just for 5 lines of trivial code, used within one procedure. So now the code calls directly to `intrinsics`.
- `core:sys/wasm/js` had a dependency on `core:mem` just for `mem.Allocator_Error`, which is defined in `base:runtime` already. Since sys is a low-level package I think it makes sense to try to make it as independent as possible.
- `core:sys/windows` had a dependency on `core:math/fixed` for a single definition, which isn't even very important. Just use a transmute.

There were also a number of unused imports which were unnoticed just because of the `_ :: pkg` thing. `sort` now doesn't import `slice`, `slice` doesn't need `bits` and raylib doesn't use `linalg`.

As an example, here's my project import graph before this change:

<img width="1253" height="608" alt="image" src="https://github.com/user-attachments/assets/3423372e-6818-4880-b98d-b82895d3dc87" />

And here is the after:

<img width="683" height="239" alt="image" src="https://github.com/user-attachments/assets/2a494d3a-57ca-43c8-9f22-cadfcdddb9e7" />

This looks WAY more reasonable, I'm literally just pulling in parts of `core:sys` so why the heck should it import half of `core`.

In my personal projects I've been trying to stay aware of what are my actual dependencies, and sticking to only `base:` when it makes sense. Unfortunately a lot of the core packages are tangled in weird and unexpected ways. So usually importing a regular package pulls in almost the entire core, which I'm not a big fan of. I understand why it's that way, how it evolved naturally over time and how sometimes it's just convenient. I still think it's worth getting the low-hanging fruit.

Oh also, some of the trailing whitespace got stripped, I can get rid of that if necessary.