### PR TITLE
Stop silently ignoring unknown directives on an inline asm expression

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -3130,6 +3130,8 @@ gb_internal Ast *parse_operand(AstFile *f, bool lhs) {
 					} else {
 						dialect = InlineAsmDialect_Intel;
 					}
+				} else {
+					syntax_error(token, "Invalid directive on inline asm expression: '#%.*s'", LIT(token.string));
 				}
 			} else {
 				syntax_error(f->curr_token, "Expected an identifier after hash");


### PR DESCRIPTION
The code like below will fail to build with this PR.

```odin
package p

main :: proc() {
    asm #intel #ajwaj { "", "" }()
}
```