### PR TITLE
Remove core:mem dependency from core:container/xar

### DIFF
--- a/core/container/xar/xar.odin
+++ b/core/container/xar/xar.odin
@@ -26,7 +26,6 @@
 */
 package container_xar
 
-@(require) import "core:mem"
 @(require) import "base:intrinsics"
 @(require) import "base:runtime"
 
@@ -73,7 +72,7 @@ MAX_SHIFT :: PLATFORM_BITS>>1
 Array :: struct($T: typeid, $SHIFT: uint) where 0 < SHIFT, SHIFT <= MAX_SHIFT {
 	chunks:    [(1 << (_LOG2_PLATFORM_BITS - intrinsics.constant_log2(SHIFT))) + 1][^]T,
 	len:       int,
-	allocator: mem.Allocator,
+	allocator: runtime.Allocator,
 }
 
 
@@ -99,7 +98,7 @@ destroy :: proc(x: ^$X/Array($T, $SHIFT)) {
 		if c != nil {
 			n := 1 << (SHIFT + uint(i if i > 0 else 1) - 1)
 			size_in_bytes := n * size_of(T)
-			mem.free_with_size(c, size_in_bytes, x.allocator)
+			runtime.mem_free_with_size(c, size_in_bytes, x.allocator)
 		}
 	}
 	x^ = {}
@@ -257,7 +256,7 @@ Example:
 		fmt.println(xar.get(&x, 1))  // world
 	}
 */
-push_back_elem :: proc(x: ^$X/Array($T, $SHIFT), value: T, loc := #caller_location) -> (n: int, err: mem.Allocator_Error) {
+push_back_elem :: proc(x: ^$X/Array($T, $SHIFT), value: T, loc := #caller_location) -> (n: int, err: runtime.Allocator_Error) {
 	if x.allocator.procedure == nil {
 		// to minic `[dynamic]T` behaviour
 		x.allocator = context.allocator
@@ -284,7 +283,7 @@ Append multiple elements to the end of the exponential array.
 - number of elements successfully added
 - allocation error if chunk allocation failed (partial append possible)
 */
-push_back_elems :: proc(x: ^$X/Array($T, $SHIFT), values: ..T, loc := #caller_location) -> (n: int, err: mem.Allocator_Error) {
+push_back_elems :: proc(x: ^$X/Array($T, $SHIFT), values: ..T, loc := #caller_location) -> (n: int, err: runtime.Allocator_Error) {
 	for value in values {
 		n += push_back_elem(x, value, loc) or_return
 	}
@@ -318,7 +317,7 @@ Example:
 	}
 */
 @(require_results)
-push_back_elem_and_get_ptr :: proc(x: ^$X/Array($T, $SHIFT), value: T, loc := #caller_location) -> (ptr: ^T, err: mem.Allocator_Error) {
+push_back_elem_and_get_ptr :: proc(x: ^$X/Array($T, $SHIFT), value: T, loc := #caller_location) -> (ptr: ^T, err: runtime.Allocator_Error) {
 	if x.allocator.procedure == nil {
 		// to minic `[dynamic]T` behaviour
 		x.allocator = context.allocator


### PR DESCRIPTION
Xar is already importing base:runtime so use it directly.
Inspired by recent commits.