### PR TITLE
use xar.len instead of len for accessing length of items

### DIFF
--- a/core/container/handle_map/dynamic_handle_map.odin
+++ b/core/container/handle_map/dynamic_handle_map.odin
@@ -49,7 +49,7 @@ dynamic_add :: proc(m: ^$D/Dynamic_Handle_Map($T, $Handle_Type), item: T, loc :=
 	}
 
 	_ = xar.append(&m.items, item, loc) or_return
-	i := len(m.items)-1
+	i := xar.len(m.items)-1
 
 	ptr := xar.get_ptr_unsafe(&m.items, i)
 	ptr^ = item


### PR DESCRIPTION
Fixes `dynamic_add` in `handle_map` package