### PR TITLE
[core:container/pool]  Fix pool parapoly type error when using multiple Pool types

### DIFF
--- a/core/container/pool/pool.odin
+++ b/core/container/pool/pool.odin
@@ -113,28 +113,30 @@ _set_next :: proc(p: ^Pool($T), elem: ^T, next: ^T) {
 	(^^T)(uintptr(elem) + p.link_off)^ = next
 }
 
-@(disabled=.Address not_in ODIN_SANITIZER_FLAGS)
 _poison_elem :: proc(p: ^Pool($T), elem: ^T) {
-	if p.link_off > 0 {
-		sanitizer.address_poison_rawptr(elem, int(p.link_off))
-	}
+	when .Address in ODIN_SANITIZER_FLAGS {
+		if p.link_off > 0 {
+			sanitizer.address_poison_rawptr(elem, int(p.link_off))
+		}
 
-	len := size_of(T) - p.link_off - size_of(rawptr)
-	if len > 0 {
-		ptr := rawptr(uintptr(elem) + p.link_off + size_of(rawptr))
-		sanitizer.address_poison_rawptr(ptr, int(len))
+		len := size_of(T) - p.link_off - size_of(rawptr)
+		if len > 0 {
+			ptr := rawptr(uintptr(elem) + p.link_off + size_of(rawptr))
+			sanitizer.address_poison_rawptr(ptr, int(len))
+		}
 	}
 }
 
-@(disabled=.Address not_in ODIN_SANITIZER_FLAGS)
 _unpoison_elem :: proc(p: ^Pool($T), elem: ^T) {
-	if p.link_off > 0 {
-		sanitizer.address_unpoison_rawptr(elem, int(p.link_off))
-	}
+	when .Address in ODIN_SANITIZER_FLAGS {
+		if p.link_off > 0 {
+			sanitizer.address_unpoison_rawptr(elem, int(p.link_off))
+		}
 
-	len := size_of(T) - p.link_off - size_of(rawptr)
-	if len > 0 {
-		ptr := rawptr(uintptr(elem) + p.link_off + size_of(rawptr))
-		sanitizer.address_unpoison_rawptr(ptr, int(len))
+		len := size_of(T) - p.link_off - size_of(rawptr)
+		if len > 0 {
+			ptr := rawptr(uintptr(elem) + p.link_off + size_of(rawptr))
+			sanitizer.address_unpoison_rawptr(ptr, int(len))
+		}
 	}
 }


### PR DESCRIPTION
## Summary
  - Fix #6219
  - Replace @(disabled=...) attribute on _poison_elem and _unpoison_elem with when blocks inside the procedure body
  - The @(disabled) attribute causes the compiler's type inference to confuse generic parameters across different Pool instantiations

 I'm not sure if this is the intended behavior of @(disabled) on parapoly procedures or a compiler bug, but the when block approach avoids the issue and is consistent with how destroy already handles it in the same file.