### PR TITLE
#lazy imports

### DIFF
--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -5136,6 +5136,9 @@ gb_internal void add_import_dependency_node(Checker *c, Ast *decl, PtrMap<AstPac
 		}
 		AstPackage **found = string_map_get(&c->info.packages, path);
 		if (found == nullptr) {
+			if (id->is_lazy) {
+				return;
+			}
 			Token token = ast_token(decl);
 			error(token, "Unable to find package: %.*s", LIT(path));
 			exit_with_errors();
@@ -5323,7 +5326,14 @@ gb_internal void check_add_import_decl(CheckerContext *ctx, Ast *decl) {
 
 	bool force_use = false;
 
-	if (id->fullpath == "builtin") {
+	if (id->is_lazy) {
+		AstPackage **found = string_map_get(pkgs, id->fullpath);
+		if (found == nullptr) {
+			return;
+		}
+		AstPackage *pkg = *found;
+		scope = pkg->scope;
+	} else if (id->fullpath == "builtin") {
 		scope = builtin_pkg->scope;
 		force_use = true;
 	} else if (id->fullpath == "intrinsics") {

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -671,6 +671,7 @@ AST_KIND(_DeclBegin,      "", bool) \
 		Token    relpath;       \
 		String   fullpath;      \
 		Token    import_name;   \
+		bool     is_lazy;       \
 		Array<Ast *> attributes;  \
 		CommentGroup *docs;     \
 		CommentGroup *comment;  \


### PR DESCRIPTION
If you import a package to use a single struct definition, you are forced to (supposedly) inherit its entire dependency tree, its @(init) overhead, and its impact on the linker

I propose `#lazy` import, which tells the compiler to completely skip the parsing, type-checking, and initialization of a package unless a symbol from that package is explicitly referenced in the code


Btw, I am not looking to replace the "file suffixes" for platform logic, i"m looking for a way to keep the dependency graph as lean as posible for when simplicity matters more than the overhead of managing a thousand tiny, fragmented files