### PR TITLE
Add broadcasting to strings (fix #1837)

### DIFF
--- a/src/llvm_backend_const.cpp
+++ b/src/llvm_backend_const.cpp
@@ -678,6 +678,22 @@ LLVMValueRef llvm_const_pad_to_size(lbModule *m, LLVMValueRef val, LLVMTypeRef d
 }
 #endif
 
+gb_internal void lb_const_array_spread(lbModule *m, lbConstContext cc, Type *array, ExactValue value, lbValue *res) {
+	GB_ASSERT(array->kind == Type_Array);
+	
+	i64 count  = array->Array.count;
+	Type *elem = array->Array.elem;
+
+	lbValue single_elem = lb_const_value(m, elem, value, cc);
+
+	LLVMValueRef *elems = gb_alloc_array(permanent_allocator(), LLVMValueRef, cast(isize)count);
+	for (i64 i = 0; i < count; i++) {
+		elems[i] = single_elem.value;
+	}
+
+	res->value = llvm_const_array(m, lb_type(m, elem), elems, cast(unsigned)count);
+}
+
 gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, lbConstContext cc, Type *value_type) {
 	if (cc.allow_local) {
 		cc.is_rodata = false;
@@ -967,34 +983,29 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, lb
 
 
 		}
-	} else if (is_type_array(type) && value.kind == ExactValue_String && !is_type_u8(core_array_type(type))) {
-		if (is_type_rune_array(type)) {
-			i64 count  = type->Array.count;
-			Type *elem = type->Array.elem;
-			LLVMTypeRef et = lb_type(m, elem);
+	} else if (is_type_rune_array(type) && value.kind == ExactValue_String && !is_type_u8(core_array_type(type))) {
+		i64 count  = type->Array.count;
+		Type *elem = type->Array.elem;
+		LLVMTypeRef et = lb_type(m, elem);
 
-			Rune rune;
-			isize offset = 0;
-			isize width = 1;
-			String s = value.value_string;
+		Rune rune;
+		isize offset = 0;
+		isize width = 1;
+		String s = value.value_string;
 
-			LLVMValueRef *elems = gb_alloc_array(permanent_allocator(), LLVMValueRef, cast(isize)count);
+		LLVMValueRef *elems = gb_alloc_array(permanent_allocator(), LLVMValueRef, cast(isize)count);
 
-			for (i64 i = 0; i < count && offset < s.len; i++) {
-				width = utf8_decode(s.text+offset, s.len-offset, &rune);
-				offset += width;
+		for (i64 i = 0; i < count && offset < s.len; i++) {
+			width = utf8_decode(s.text+offset, s.len-offset, &rune);
+			offset += width;
 
-				elems[i] = LLVMConstInt(et, rune, true);
+			elems[i] = LLVMConstInt(et, rune, true);
 
-			}
-			GB_ASSERT(offset == s.len);
-
-			res.value = llvm_const_array(m, et, elems, cast(unsigned)count);
-			return res;
 		}
-		// NOTE(bill, 2021-10-07): Allow for array programming value constants
-		Type *core_elem = core_array_type(type);
-		return lb_const_value(m, core_elem, value, cc);
+		GB_ASSERT(offset == s.len);
+
+		res.value = llvm_const_array(m, et, elems, cast(unsigned)count);
+		return res;
 	} else if (is_type_u8_array(type) && value.kind == ExactValue_String) {
 		GB_ASSERT(type->Array.count == value.value_string.len);
 		LLVMValueRef data = LLVMConstStringInContext(ctx,
@@ -1005,21 +1016,9 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, lb
 		return res;
 	} else if (is_type_array(type) &&
 		value.kind != ExactValue_Invalid &&
-		value.kind != ExactValue_String &&
 		value.kind != ExactValue_Compound) {
-
-		i64 count  = type->Array.count;
-		Type *elem = type->Array.elem;
-
-
-		lbValue single_elem = lb_const_value(m, elem, value, cc);
-
-		LLVMValueRef *elems = gb_alloc_array(permanent_allocator(), LLVMValueRef, cast(isize)count);
-		for (i64 i = 0; i < count; i++) {
-			elems[i] = single_elem.value;
-		}
-
-		res.value = llvm_const_array(m, lb_type(m, elem), elems, cast(unsigned)count);
+			
+		lb_const_array_spread(m, cc, type, value, &res);
 		return res;
 	} else if (is_type_matrix(type) &&
 		value.kind != ExactValue_Invalid &&
@@ -2009,4 +2008,3 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, lb
 
 	return lb_const_nil(m, original_type);
 }
-


### PR DESCRIPTION
Made string path with `[]rune <- string` on top level, moved string broadcasting to basic type broadcasting.


---


**Side note**: When debugging why `x: [2]string = "abcdef"` worked, but `x: [][2]string = {"abcdef"}` didn't, I found that `x :: cast([2]string)"abcdef"` yielded just `"abcdef"` when used in expressions:

```odin
x :: cast([2]string)"abcdef"
fmt.printf("%v", x) // prints "abcdef" instead of ["abcdef", "abcdef"]
``` 

Assigning to a variable "fixed" it:

```odin
x :: cast([2]string)"abcdef"
y := x
fmt.printf("%v", y) // prints ["abcdef", "abcdef"] as intended
``` 

So I found that there's a conversion done after assignment here: https://github.com/odin-lang/Odin/blob/71cf7f59a923c8f2ece1dbe6e725225b1e68c313/src/llvm_backend_stmt.cpp#L3077 (`lb_addr_store` called `lb_emit_conv`)

That conversion also happens to handle array programming cases, so when doing `x: [2]string = "abcdef"`, even though while emitting for the right hand side, knowing that the expected type is `[2]string`, `lb_const_value` emitted a simple `string`, but it happened to work because `lb_emit_conv` also emits an array broadcast operation here: https://github.com/odin-lang/Odin/blob/71cf7f59a923c8f2ece1dbe6e725225b1e68c313/src/llvm_backend_expr.cpp#L2706-L2730

So there's 2 places where array spreading happens. Is this a deliberate decision, and would it make sense to remove spreading from `lb_const_value` and perform a cast to avoid duplicate code instead?

