### PR TITLE
Fix #6279

### DIFF
--- a/tests/core/os/path.odin
+++ b/tests/core/os/path.odin
@@ -100,6 +100,17 @@ test_clean_path :: proc(t: ^testing.T) {
 }
 
 @(test)
+replace_path_separators :: proc(t: ^testing.T) {
+	P :: "W:/Odin/core/os/path.odin"
+
+	p1, _ := os.replace_path_separators(P, '😀', context.temp_allocator)
+	testing.expect_value(t, p1, "W:😀Odin😀core😀os😀path.odin")
+
+	p2, _ := os.replace_path_separators(P, '|', context.temp_allocator)
+	testing.expect_value(t, p2, "W:|Odin|core|os|path.odin")
+}
+
+@(test)
 test_is_absolute_path :: proc(t: ^testing.T) {
 	when ODIN_OS == .Windows {
 		testing.expect(t, os.is_absolute_path(`C:\Windows`))


### PR DESCRIPTION
If the replacement rune was multi-byte, `os.replace_path_separators` would silently fail to replace anything.

Now it properly handles a non-ASCII separator. Additionally added a fast path for when all runes in the input path as well as the replacement separator are simple ASCII.

Test added.