### PR TITLE
Do not allow duplicated #partial directives on switch statements

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -5427,9 +5427,15 @@ gb_internal Ast *parse_stmt(AstFile *f) {
 			s = parse_stmt(f);
 			switch (s->kind) {
 			case Ast_SwitchStmt:
+				if (s->SwitchStmt.partial) {
+					syntax_error(token, "#partial already applied to a switch statement");
+				}
 				s->SwitchStmt.partial = true;
 				break;
 			case Ast_TypeSwitchStmt:
+				if (s->TypeSwitchStmt.partial) {
+					syntax_error(token, "#partial already applied to a switch statement");
+				}
 				s->TypeSwitchStmt.partial = true;
 				break;
 			case Ast_EmptyStmt:


### PR DESCRIPTION
The code with duplicated `#partial` directive on a switch statement currently compiles fine, whereas duplicated `#reverse` directive on a "for in" statement fails to build. Since the compiler is already catching a bunch of duplicated directives in other places, I suppose that the `#partial` directive should not be an exception.

```odin
package foo

main :: proc() {
    Stuff :: enum u8 {
        A, B, C,
    }

    s := Stuff.B

    // Currently compiles. Fails to build with this PR.
    #partial sl: #partial switch s {
    case .A:
        break sl
    }

    a := []int{1, 2, 3}
    // Currently fails to build.
    #reverse fl: #reverse for i in a {
        break fl
    }
}
```