### PR TITLE
Fix typo in xar.array_linear_search() return

### DIFF
--- a/core/container/xar/xar.odin
+++ b/core/container/xar/xar.odin
@@ -410,7 +410,7 @@ array_linear_search :: proc(x: ^$X/Array($T, $SHIFT), elem: T) -> (index: int, f
 			return i, true
 		}
 	}
-	return -1, flase
+	return -1, false
 }
 
 


### PR DESCRIPTION
Fix typo flase -> false