### PR TITLE
Fix some tools and examples after core:os update and using-stmt feature

### DIFF
--- a/core/crypto/_edwards25519/tools/edwards_gen_tables.odin
+++ b/core/crypto/_edwards25519/tools/edwards_gen_tables.odin
@@ -80,7 +80,7 @@ main :: proc() {
 
 	fn, err := path.join({ODIN_ROOT, "core", "crypto", "_edwards25519", "edwards25519_table.odin"}, context.allocator)
 	if err != .None {
-		fmt.printfln("Join path error for edwards25519_table.odin: %v", err);
+		fmt.eprintfln("Join path error for edwards25519_table.odin: %v", err);
 		os.exit(1);
 	}
 	bld: strings.Builder

--- a/core/crypto/_weierstrass/tools/ecc_gen_tables.odin
+++ b/core/crypto/_weierstrass/tools/ecc_gen_tables.odin
@@ -70,7 +70,7 @@ gen_tables :: proc($CURVE: string) {
 	fn_ := "sec" + CURVE + "_table.odin"
 	fn, err := path.join({ODIN_ROOT, "core", "crypto", "_weierstrass", fn_}, context.allocator)
 	if err != .None {
-		fmt.printfln("Join path error for %s: %v", fn_, err);
+		fmt.eprintfln("Join path error for %s: %v", fn_, err);
 		os.exit(1);
 	}
 	bld: strings.Builder

--- a/core/encoding/xml/example/xml_example.odin
+++ b/core/encoding/xml/example/xml_example.odin
@@ -57,9 +57,9 @@ example :: proc() {
 	fmt.printf("[Average]: %v bytes in %.2f ms (%.2f MiB/s).\n", len(input), average_ms, average_speed)
 
 	if errs[0] != .None {
-		fmt.printf("Load/Parse error: %v\n", errs[0])
+		fmt.eprintf("Load/Parse error: %v\n", errs[0])
 		if errs[0] == .File_Error {
-			fmt.println("\"unicode.xml\" not found. Did you run \"tests\\download_assets.py\"?")
+			fmt.eprintln("\"unicode.xml\" not found. Did you run \"tests\\download_assets.py\"?")
 		}
 		return
 	}

--- a/core/unicode/tools/generate_entity_table.odin
+++ b/core/unicode/tools/generate_entity_table.odin
@@ -24,7 +24,7 @@ main :: proc() {
 	defer delete(filename)
 
 	if err_xml != .None {
-		fmt.printfln("Join path error for unicode.xml: %v", err_xml);
+		fmt.eprintfln("Join path error for unicode.xml: %v", err_xml);
 		os.exit(1);
 	}
 
@@ -32,7 +32,7 @@ main :: proc() {
 	defer delete(generated_filename)
 
 	if err_generated != .None {
-		fmt.printfln("Join path error for generated.odin: %v", err_generated);
+		fmt.eprintfln("Join path error for generated.odin: %v", err_generated);
 		os.exit(1);
 	}
 
@@ -40,7 +40,7 @@ main :: proc() {
 	defer xml.destroy(doc)
 
 	if err != .None {
-		fmt.printfln("Load/Parse error: %v", err)
+		fmt.eprintfln("Load/Parse error: %v", err)
 		if err == .File_Error {
 			fmt.eprintfln("%q not found. Did you run \"tests\\download_assets.py\"?", filename)
 		}


### PR DESCRIPTION
Some tools and examples stopped to build after the big "core:os" merge (which affected the "core:path/filepath" package, which defines its `join` procedure as `join :: os.join_path`) and the using-stmt opt-in addition.