### PR TITLE
core/time: Correct 12-hour clock string

### DIFF
--- a/core/time/time.odin
+++ b/core/time/time.odin
@@ -526,6 +526,9 @@ to_string_hms_12 :: proc(t: Time, buf: []u8, ampm: [2]string = {" am", " pm"}) -
 	h, m, s := clock(t)
 
 	_h := h % 12
+	if _h == 0 {
+		_h = 12
+	}
 	buf[7] = '0' + u8(s % 10); s /= 10
 	buf[6] = '0' + u8(s)
 	buf[5] = ':'
@@ -535,7 +538,7 @@ to_string_hms_12 :: proc(t: Time, buf: []u8, ampm: [2]string = {" am", " pm"}) -
 	buf[1] = '0' + u8(_h% 10); _h /= 10
 	buf[0] = '0' + u8(_h)
 
-	if h < 13 {
+	if h < 12 {
 		copy(buf[8:], ampm[0])
 		return string(buf[:MIN_HMS_LEN+len(ampm[0])])
 	} else {

--- a/tests/core/time/test_core_time.odin
+++ b/tests/core/time/test_core_time.odin
@@ -16,8 +16,8 @@ test_time_and_date_formatting :: proc(t: ^testing.T) {
 		d := time.Duration(now._nsec)
 
 		testing.expect_value(t, time.to_string_hms       (now, buf[:]),               "00:12:44")
-		testing.expect_value(t, time.to_string_hms_12    (now, buf[:]),               "00:12:44 am")
-		testing.expect_value(t, time.to_string_hms_12    (now, buf[:],  {"㏂", "㏘"}), "00:12:44㏂")
+		testing.expect_value(t, time.to_string_hms_12    (now, buf[:]),               "12:12:44 am")
+		testing.expect_value(t, time.to_string_hms_12    (now, buf[:],  {"㏂", "㏘"}), "12:12:44㏂")
 		testing.expect_value(t, time.to_string_hms       (d,   buf[:]),               "00:12:44")
 
 		testing.expect_value(t, time.to_string_yyyy_mm_dd(now, buf[:]),               "1677-09-21")


### PR DESCRIPTION
This function was slightly off, printing 12 am and 12 pm as "00 am".