### PR TITLE
`vendor:curl`: Fix `what` argument for url_set

### DIFF
--- a/vendor/curl/curl_urlapi.odin
+++ b/vendor/curl/curl_urlapi.odin
@@ -130,7 +130,7 @@ foreign lib {
 	 * error code. The passed in string will be copied. Passing a NULL instead of
 	 * a part string, clears that part.
 	 */
-	url_set :: proc(handle: ^CURLU, what: ^UPart, part: cstring, flags: UFlags) -> Ucode ---
+	url_set :: proc(handle: ^CURLU, what: UPart, part: cstring, flags: UFlags) -> Ucode ---
 
 	/*
 	 * curl_url_strerror() turns a CURLUcode value into the equivalent human


### PR DESCRIPTION
Removes the need for passing pointer for the `what` argument, as per the signature in [`urlapi.h`](https://github.com/fnky/Odin/blob/93d4e56e0be5757ed48a6127e427e93e8d528210/vendor/curl/c/urlapi.h#L141) and `curl_url_set` from https://curl.se/libcurl/c/curl_url_set.html