### PR TITLE
webgl: Add bindings, fix `Tex*Image*D`

### DIFF
--- a/vendor/wasm/WebGL/webgl.odin
+++ b/vendor/wasm/WebGL/webgl.odin
@@ -52,6 +52,7 @@ foreign webgl {
 	GetError :: proc() -> Enum ---
 	
 	IsExtensionSupported :: proc(name: string) -> bool ---
+	GetExtension :: proc(name: string) ---
 
 	ActiveTexture         :: proc(x: Enum) ---
 	AttachShader          :: proc(program: Program, shader: Shader) ---
@@ -118,6 +119,7 @@ foreign webgl {
 	
 	GenerateMipmap :: proc(target: Enum) ---
 	
+	GetBufferParameter    :: proc(target, name: Enum) -> int ---
 	GetAttribLocation     :: proc(program: Program, name: string) -> i32 ---
 	GetUniformLocation    :: proc(program: Program, name: string) -> i32 ---
 	GetVertexAttribOffset :: proc(index: i32, pname: Enum) -> uintptr ---
@@ -373,7 +375,21 @@ GetShaderInfoLog :: proc "contextless" (shader: Shader, buf: []byte) -> string {
 	return string(buf[:length])
 }
 
+IterateSupportedExtensions :: proc(index: ^int, buf: []byte) -> (string, bool) {
+	foreign webgl {
+		@(link_name="GetSupportedExtensionFromIndex")
+		_GetSupportedExtensionFromIndex :: proc "contextless" (index: int, buf: []byte, length: ^int) -> bool ---
+	}
 
+	length: int
+	if !_GetSupportedExtensionFromIndex(index^, buf[:], &length) {
+		return "", false
+	}
+
+	index^ += 1
+
+	return string(buf[:length]), true
+}
 
 BufferDataSlice :: proc "contextless" (target: Enum, slice: $S/[]$E, usage: Enum) {
 	BufferData(target, len(slice)*size_of(E), raw_data(slice), usage)

--- a/vendor/wasm/WebGL/webgl2.odin
+++ b/vendor/wasm/WebGL/webgl2.odin
@@ -35,6 +35,7 @@ foreign webgl2 {
 	RenderbufferStorageMultisample :: proc(target: Enum, samples: i32, internalformat: Enum, width, height: i32) ---
 	
 	/* Texture objects */
+	TexStorage2D			:: proc(target: Enum, levels: i32, internalformat: Enum, width, height: i32) ---
 	TexStorage3D            :: proc(target: Enum, levels: i32, internalformat: Enum, width, height, depth: i32) ---
 	TexImage3D              :: proc(target: Enum, level: i32, internalformat: Enum, width, height, depth: i32, border: i32, format, type: Enum, size: int, data: rawptr) ---
 	TexSubImage3D           :: proc(target: Enum, level: i32, xoffset, yoffset, zoffset, width, height, depth: i32, format, type: Enum, size: int, data: rawptr) ---


### PR DESCRIPTION
Added `TexStorage2D` which is the preferred way to initialize texture objects and `GetExtension` for basic extension activation.

The `Tex*Image*D` set of functions require texel data to be passed as a specific typed array depending on the `type` argument, such as `Float32Array` for `GL_FLOAT` and `Uint16Array` for `GL_UNSIGNED_SHORT` and `GL_HALF_FLOAT`, so I've updated the bindings to account for that.

I've also added `IterateSupportedExtensions`, this doesn't exist in the API but it provides the functionality of `GetSupportedExtensions` in a way that doesn't involve allocators.