### PR TITLE
Kill deprecated file tags and fix assignment of package docs

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -6725,11 +6725,6 @@ gb_internal bool parse_file(Parser *p, AstFile *f) {
 
 	String filepath = f->tokenizer.fullpath;
 	String base_dir = dir_from_path(filepath);
-	if (f->curr_token.kind == Token_Comment) {
-		consume_comment_groups(f, f->prev_token);
-	}
-
-	CommentGroup *docs = f->lead_comment;
 
 	Array<Token> tags = array_make<Token>(temporary_allocator());
 	bool first_invalid_token_set = false;
@@ -6750,6 +6745,8 @@ gb_internal bool parse_file(Parser *p, AstFile *f) {
 			advance_token(f);
 		}
 	}
+
+	CommentGroup *docs = f->lead_comment;
 
 	if (f->curr_token.kind != Token_package) {
 		ERROR_BLOCK();


### PR DESCRIPTION
1. Let's kill the deprecated file tags - I think they were deprecated for long enough for projects to move away from them. Also, there were some issues with it - ignored if they appeared after `#+` file tags, and possibly could end up in package docs (unless some extra preprocessing happened to remove them).

2. So far, the first comment found was marked as package docs, which meant that for the following code, the TODO comment would be assigned to the package declaration instead of the comment directly preceding the
package declaration.

```odin
// TODO: drop after finished with refactoring
#+ feature using-stmt
// Package foo implements this and that.
package foo
```

3. Drop some pointless code, which modifies a local variable after it was stored in an out parameter, so this modification has no effect.
