### PR TITLE
[vendor:stb/vorbis] don't use core:c/libc

### DIFF
--- a/vendor/stb/vorbis/stb_vorbis.odin
+++ b/vendor/stb/vorbis/stb_vorbis.odin
@@ -1,7 +1,7 @@
 // Bindings for [[ stb_vorbis.c ; https://github.com/nothings/stb/blob/master/stb_vorbis.c ]].
 package stb_vorbis
 
-import c "core:c/libc"
+import c "core:c"
 
 @(private)
 LIB :: (


### PR DESCRIPTION
The package wasn't working on WASM, since this is plain libc and not the shim. Turns out neither is needed. Tested on Windows and Web.