### PR TITLE
chore: better `for` loop syntax error message

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -4891,13 +4891,15 @@ gb_internal Ast *parse_for_stmt(AstFile *f) {
 		}
 
 		if (f->curr_token.kind != Token_Semicolon) {
+			Token before = f->curr_token;
+
 			cond = parse_simple_stmt(f, StmtAllowFlag_In);
 			if (cond->kind == Ast_AssignStmt && cond->AssignStmt.op.kind == Token_in) {
 				is_range = true;
 			}
 
 			if (cond->kind == Ast_ExprStmt && is_ast_type(cond->ExprStmt.expr)) {
-				syntax_error(cond->ExprStmt.expr->EnumType.token, "Expected an expression, got %.*s", LIT(ast_strings[cond->ExprStmt.expr->kind]));
+				syntax_error(before, "Expected an expression, got %.*s", LIT(ast_strings[cond->ExprStmt.expr->kind]));
 			}
 		}
 


### PR DESCRIPTION
Aims to address the `for` loop enum issue in https://github.com/odin-lang/Odin/issues/6333 - PR is marked as draft because I'm just looking for some feedback on whether this is the correct direction, and what the next steps to get it across the line look like?

Also wondering if there's some way to clear the previous errors? Right now when executing I am still getting the "bad" error messages below the new one that was added in this PR:

```
/Odin/local/test.odin(6:6) Syntax Error: Expected an expression, got enum type 
        for enum, prefix in x { 
            ^ 
 
/Odin/local/test.odin(6:10) Syntax Error: Expected a type, got ',' 
        for enum, prefix in x { 
                ^ 
 
/Odin/local/test.odin(6:12) Syntax Error: Expected '{', got 'identifier' 
        for enum, prefix in x { 
                  ^ 
 
/Odin/local/test.odin(6:19) Syntax Error: Expected an operand 
        for enum, prefix in x { 
                         ^ 
 
/Odin/local/test.odin(8:2) Syntax Error: Expected ';', got newline 
        } 
        ^ 
 
/Odin/local/test.odin(9:1) Syntax Error: Expected an operand 
        } 
        ^ 
 
/Odin/local/test.odin(9:1) Syntax Error: Expected ';', got newline 
        } 
        ^ 
```