### PR TITLE
Fix tokenizer init

### DIFF
--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -379,6 +379,7 @@ gb_internal void advance_to_next_rune(Tokenizer *t) {
 
 gb_internal void init_tokenizer_with_data(Tokenizer *t, String const &fullpath, void const *data, isize size) {
 	t->fullpath = fullpath;
+	t->column_minus_one = -1;
 	t->line_count = 1;
 
 	t->start = cast(u8 *)data;


### PR DESCRIPTION
Without setting column_minus_one to -1 at init, the token line position in the first line of the file was offset by 1.