### PR TITLE
Add formatting flag for space between time.Duration and unit of measurement

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -2592,7 +2592,7 @@ fmt_named_buitlin_custom_formatters :: proc(fi: ^Info, v: any, verb: rune, info:
 				prec = 6
 				buf[w] = 'm'
 			}
-			if fi.hash {
+			if fi.space {
 				w -= 1
 				buf[w] = ' '
 			}
@@ -2601,7 +2601,7 @@ fmt_named_buitlin_custom_formatters :: proc(fi: ^Info, v: any, verb: rune, info:
 		} else {
 			w -= 1
 			buf[w] = 's'
-			if fi.hash {
+			if fi.space {
 				w -= 1
 				buf[w] = ' '
 			}


### PR DESCRIPTION
Just mirror `%#m` for `time.Duration`.

```odin
package pkg

import "core:fmt"
import "core:time"

main :: proc() {
	subsecond := time.Nanosecond
	supersecond := 2 * time.Second

	fmt.printfln("%v", subsecond)
	fmt.printfln("%#v", subsecond)

	fmt.printfln("%v", supersecond)
	fmt.printfln("%#v", supersecond)
}
/*
Before:
1ns
1ns
2s
2s

After:
1ns
1 ns
2s
2 s
*/
```