### PR TITLE
core:sys/darwin/Foundation: Fix NSTimer binding

### DIFF
--- a/core/sys/darwin/Foundation/NSTimer.odin
+++ b/core/sys/darwin/Foundation/NSTimer.odin
@@ -5,11 +5,10 @@ Timer :: struct { using _: Object }
 
 @(objc_type=Timer, objc_name="scheduledTimerWithTimeIntervalRepeatsBlock", objc_is_class_method=true)
 Timer_scheduledTimerWithTimeIntervalRepeatsBlock :: proc(interval: TimeInterval, repeats: BOOL, block: ^Block) -> ^Timer {
-	return msgSend(^Timer, Timer, "scheduledTimerWithTimeInterval:repeats:block:")
+	return msgSend(^Timer, Timer, "scheduledTimerWithTimeInterval:repeats:block:", repeats, block)
 }
 
 @(objc_type=Timer, objc_name="scheduledTimerWithTimeIntervalTargetSelectorUserInfoRepeat", objc_is_class_method=true)
 Timer_scheduledTimerWithTimeIntervalTargetSelectorUserInfoRepeat :: proc(interval: TimeInterval, aTarget: id, aSelector: SEL, userInfo: id, repeats: BOOL) -> ^Timer {
 	return msgSend(^Timer, Timer, "scheduledTimerWithTimeInterval:target:selector:userInfo:repeats:", interval, aTarget, aSelector, userInfo, repeats)
 }
-


### PR DESCRIPTION
This PR fixes the NSTimer scheduledTimerWithTimeInterval:repeats:block: binding.