### PR TITLE
Fix auto reset event signal deadlock

### DIFF
--- a/core/sync/extended.odin
+++ b/core/sync/extended.odin
@@ -222,9 +222,10 @@ thread.
 */
 auto_reset_event_signal :: proc "contextless" (e: ^Auto_Reset_Event) {
 	old_status := atomic_load_explicit(&e.status, .Relaxed)
-	new_status := old_status + 1 if old_status < 1 else 1
 	for {
-		if _, ok := atomic_compare_exchange_weak_explicit(&e.status, old_status, new_status, .Release, .Relaxed); ok {
+		new_status := old_status + 1 if old_status < 1 else 1
+		ok: bool
+		if old_status, ok = atomic_compare_exchange_weak_explicit(&e.status, old_status, new_status, .Release, .Relaxed); ok {
 			break
 		}
 		cpu_relax()


### PR DESCRIPTION
The status variables need to be updated every iteration, otherwise the thread will spin forever, if another thread waits on the event between the load and the compare exchange, because the old value is never updated.