### PR TITLE
Add #optional_allocator_error to os/path

### DIFF
--- a/core/os/path.odin
+++ b/core/os/path.odin
@@ -162,7 +162,7 @@ This will remove duplicate separators and unneeded references to the current or
 parent directory.
 */
 @(require_results)
-clean_path :: proc(path: string, allocator: runtime.Allocator) -> (cleaned: string, err: runtime.Allocator_Error) {
+clean_path :: proc(path: string, allocator: runtime.Allocator) -> (cleaned: string, err: runtime.Allocator_Error) #optional_allocator_error {
 	if path == "" || path == "." {
 		return strings.clone(".", allocator)
 	}
@@ -504,7 +504,7 @@ Join all `elems` with the system's path separator and normalize the result.
 For example, `join_path({"/home", "foo", "bar.txt"})` will result in `"/home/foo/bar.txt"`.
 */
 @(require_results)
-join_path :: proc(elems: []string, allocator: runtime.Allocator) -> (joined: string, err: runtime.Allocator_Error) {
+join_path :: proc(elems: []string, allocator: runtime.Allocator) -> (joined: string, err: runtime.Allocator_Error) #optional_allocator_error {
 	for e, i in elems {
 		if e != "" {
 			temp_allocator := TEMP_ALLOCATOR_GUARD({ allocator })


### PR DESCRIPTION
Not sure how you guys decide when to add `#optional_allocator_error`, but these are a couple of cases I hit that feel like they should have it.