### PR TITLE
Fix two bugs in `core:math/big` modular exponentiation

### DIFF
--- a/core/math/big/prime.odin
+++ b/core/math/big/prime.odin
@@ -101,7 +101,7 @@ internal_int_power_modulo :: proc(res, G, X, P: ^Int, allocator := context.alloc
 		If the modulus is odd or dr != 0 use the montgomery method.
 	*/
 	if internal_int_is_odd(P) || dr != 0 {
-		return _private_int_exponent_mod(res, G, X, P, dr)
+		return _private_int_exponent_mod_fast(res, G, X, P, dr)
 	}
 
 	/*

--- a/core/math/big/private.odin
+++ b/core/math/big/private.odin
@@ -439,8 +439,14 @@ _private_int_mul_high :: proc(dest, a, b: ^Int, digits: int, allocator := contex
 		return _private_int_mul_high_comba(dest, a, b, digits)
 	}
 
-	internal_grow(dest, a.used + b.used + 1) or_return
-	dest.used = a.used + b.used + 1
+	/*
+		Set up temporary output `Int`, which we'll swap for `dest` when done.
+	*/
+
+	t := &Int{}
+
+	internal_grow(t, a.used + b.used + 1) or_return
+	t.used = a.used + b.used + 1
 
 	pa := a.used
 	pb := b.used
@@ -451,20 +457,23 @@ _private_int_mul_high :: proc(dest, a, b: ^Int, digits: int, allocator := contex
 			/*
 				Calculate the double precision result.
 			*/
-			r := _WORD(dest.digit[ix + iy]) + _WORD(a.digit[ix]) * _WORD(b.digit[iy]) + _WORD(carry)
+			r := _WORD(t.digit[ix + iy]) + _WORD(a.digit[ix]) * _WORD(b.digit[iy]) + _WORD(carry)
 
 			/*
 				Get the lower part.
 			*/
-			dest.digit[ix + iy] = DIGIT(r & _WORD(_MASK))
+			t.digit[ix + iy] = DIGIT(r & _WORD(_MASK))
 
 			/*
 				Carry the carry.
 			*/
 			carry = DIGIT(r >> _WORD(_DIGIT_BITS))
 		}
-		dest.digit[ix + pb] = carry
+		t.digit[ix + pb] = carry
 	}
+
+    internal_swap(dest, t)
+	internal_destroy(t)
 	return internal_clamp(dest)
 }
 

--- a/core/math/big/private.odin
+++ b/core/math/big/private.odin
@@ -472,7 +472,7 @@ _private_int_mul_high :: proc(dest, a, b: ^Int, digits: int, allocator := contex
 		t.digit[ix + pb] = carry
 	}
 
-    internal_swap(dest, t)
+	internal_swap(dest, t)
 	internal_destroy(t)
 	return internal_clamp(dest)
 }


### PR DESCRIPTION
A bug was exposed by 5c95a48 reducing `_DIGIT_NAILS` from 4 to 1. It predates that commit but was effectively unreachable, and I stumbled upon another bug by chance while digging around.

1. `core/math/big/private.odin`: `_private_int_mul_high` crashes when `dest` and `a` are the same `Int`

**Reproduction** (crashes on dev-2026-03): [bug_repro.odin](https://gist.github.com/mlgudi/10d67ff75b22e8ea9196e3194a65e404)

Barrett reduction calls `_private_int_mul_high(q, q, mu, um)`, so `dest` and `a` are the same `Int`. The non-comba path sets `dest.used = a.used + b.used + 1` and later reads `a.used` to determine the loop bounds. When `dest == a`, the bounds get inflated causing an OOB read.

The same overlap also means the inner loop's writes to `dest.digit` corrupt input reads of `a.digit` for subsequent iterations.

Before 5c95a48, `_DIGIT_NAILS` being 4 meant `_MAX_COMBA = 256`. The comba path handled all realistic operands so the non-comba path in `_private_int_mul_high` was effectively unreachable. After the nail reduction `_MAX_COMBA = 4`, making the non-comba path the primary path for practically all non-trivial inputs.

**Fix**: use a temporary `Int` for accumulation in `_private_int_mul_high`, matching the approach seen in `_private_int_mul`.

2. `core/math/big/prime.odin`: Montgomery/DR branch calls Barrett implementation

`internal_int_power_modulo` is meant to call `_private_int_exponent_mod_fast` (Montgomery/DR) when the modulus is odd or a DR modulus, and otherwise fall back to` _private_int_exponent_mod` (Barrett).

Currently, both branches call the Barrett implementation and the Montgomery/DR proc isn't used anywhere.

**Fix**: call `_private_int_exponent_mod_fast` in the odd/DR case.