### PR TITLE
Small_Array formatting

### DIFF
--- a/core/container/small_array/small_array.odin
+++ b/core/container/small_array/small_array.odin
@@ -21,7 +21,7 @@ Example:
 	}
 */
 Small_Array :: struct($N: int, $T: typeid) where N >= 0 {
-	data: [N]T,
+	data: [N]T `fmt:",len"`,
 	len:  int,
 }
 


### PR DESCRIPTION
This enables fmt (and other packages that use it, like log) to format Small_Arrays with only the used portion of the array.

As an example, for the following code:
```odin
main :: proc () {
	a: sa.Small_Array(16, int)
	sa.append(&a, 1, 2, 3)
	fmt.println(a)
}
```

Before, this would output:
```
Small_Array($N=16, $T=int){data = [1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len = 3}
```

Now, it will output:
```
Small_Array($N=16, $T=int){data = [1, 2, 3], len = 3}
```

I'm on the fence as to whether `len` should still be shown or not. I've left it in this PR, since I could see it still being handy to identify invalid lengths (e.g. so it would be apparent if `len > N`), but I wouldn't be opposed to removing it from the formatting.