### PR TITLE
encoding/cbor: fix order-dependent partial unmarshals

### DIFF
--- a/core/encoding/cbor/unmarshal.odin
+++ b/core/encoding/cbor/unmarshal.odin
@@ -661,8 +661,7 @@ _unmarshal_map :: proc(d: Decoder, v: any, ti: ^reflect.Type_Info, hdr: Header, 
 		unknown := length == -1
 		fields := reflect.struct_fields_zipped(ti.id)
 
-		idx := 0
-		for ; idx < len(fields) && (unknown || idx < length); idx += 1 {
+		for idx := 0; unknown || idx < length; idx += 1 {
 			// Decode key, keys can only be strings.
 			key: string
 			if keyv, kerr := decode_key(d, v, context.temp_allocator); unknown && kerr == .Break {
@@ -708,16 +707,6 @@ _unmarshal_map :: proc(d: Decoder, v: any, ti: ^reflect.Type_Info, hdr: Header, 
 			ptr   := rawptr(uintptr(v.data) + field.offset)
 			fany  := any{ptr, field.type.id}
 			_unmarshal_value(d, fany, _decode_header(r) or_return) or_return
-		}
-
-		// If there are fields left in the map that did not get decoded into the struct, decode and discard them.
-		if !unknown {
-			for _ in idx..<length {
-				key := err_conv(_decode_from_decoder(d, allocator=context.temp_allocator)) or_return
-				destroy(key, context.temp_allocator)
-				val := err_conv(_decode_from_decoder(d, allocator=context.temp_allocator)) or_return
-				destroy(val, context.temp_allocator)
-			}
 		}
 
 		return

--- a/tests/core/encoding/cbor/test_core_cbor.odin
+++ b/tests/core/encoding/cbor/test_core_cbor.odin
@@ -427,6 +427,7 @@ test_unmarshal_map_into_struct_partially :: proc(t: ^testing.T) {
 	}
 
 	Foo_More :: struct {
+		foo: bool,
 		bar: struct {
 			hello:   string,
 			world:   string,
@@ -436,6 +437,7 @@ test_unmarshal_map_into_struct_partially :: proc(t: ^testing.T) {
 		baz: int,
 	}
 	more := Foo_More{
+		foo = false,
 		bar = {
 			hello   = "hello",
 			world   = "world",


### PR DESCRIPTION
This changes CBOR struct unmarshalling to iterate over all map entries instead of stopping after len(destination_struct_fields) entries.

This fixes partial unmarshals that can break depending on the field ordering. Since the old behaviour only reads n fields, if the desired field is encoded at a later index, the loop would end before reaching the field.

The old code was iterating through all fields anyways just to discard them. I can add a field counter for similar behavour to discard remaining entries once all desired struct fields have been decoded, let me know if you want this.