### PR TITLE
FCD array proc group add `append_fixed_capacity_elems`

### DIFF
--- a/base/runtime/core_builtin.odin
+++ b/base/runtime/core_builtin.odin
@@ -928,6 +928,7 @@ non_zero_append :: proc{
 	non_zero_append_elem_string,
 
 	append_fixed_capacity_elem,
+	append_fixed_capacity_elems,
 	non_zero_append_elem_fixed_capacity_string,
 
 	non_zero_append_soa_elem,


### PR DESCRIPTION
The new FCD stack based array is cool, but the proc group wasn't working.
This adds `append_fixed_capacity_elems` to the `non_zero_append` proc group.