### PR TITLE
fix Error: Missing return statement at the end of the procedure pop_fixed_capacity_dynamic_array

### DIFF
--- a/base/runtime/core_builtin.odin
+++ b/base/runtime/core_builtin.odin
@@ -258,6 +258,7 @@ pop_fixed_capacity_dynamic_array :: proc(array: ^$T/[dynamic; $N]$E, loc := #cal
 	end := rawptr(uintptr(array) + uintptr(elem_size*(len(array)-1)))
 	intrinsics.mem_copy_non_overlapping(&res, end, elem_size)
 	(^Raw_Fixed_Capacity_Dynamic_Array(N, E))(array).len -= 1
+	return res
 }
 
 


### PR DESCRIPTION
Add return to pop_fixed_capacity_dynamic_array to be able to compile
```
package error

main::proc()
{
	array:[dynamic;10]int

	append(&array,1)

	v:=pop(&array)
}
```
without
Odin/base/runtime/core_builtin.odin(261:1) Error: Missing return statement at the end of the procedure 'pop_fixed_capacity_dynamic_array'