### PR TITLE
fixes Android build

### DIFF
--- a/src/bundle_command.cpp
+++ b/src/bundle_command.cpp
@@ -186,7 +186,11 @@ i32 bundle_android(String original_init_directory) {
 		gb_string_clear(cmd);
 
 		cmd = gb_string_append_length(cmd, android_sdk_build_tools.text, android_sdk_build_tools.len);
+#if defined(GB_SYSTEM_WINDOWS)
+        cmd = gb_string_appendc(cmd, "apksigner.bat");
+#else
 		cmd = gb_string_appendc(cmd, "apksigner");
+#endif
 		cmd = gb_string_appendc(cmd, " sign");
 
 		String keystore = normalize_path(temporary_allocator(), build_context.android_keystore, NIX_SEPARATOR_STRING);

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -676,7 +676,7 @@ try_cross_linking:;
 				defer (gb_string_free(glue));
 
 				glue = gb_string_append_fmt(glue, "bin/clang");
-				glue = gb_string_append_fmt(glue, " --target=%s%d ", build_context.metrics.target_triplet, ODIN_ANDROID_API_LEVEL);
+				glue = gb_string_append_fmt(glue, " --target=%.*s%d ", LIT(build_context.metrics.target_triplet), ODIN_ANDROID_API_LEVEL);
 				glue = gb_string_appendc(glue, "-c \"");
 				glue = gb_string_append_length(glue, ODIN_ANDROID_NDK.text, ODIN_ANDROID_NDK.len);
 				glue = gb_string_appendc(glue, "sources/android/native_app_glue/android_native_app_glue.c");
@@ -731,12 +731,12 @@ try_cross_linking:;
 					return result;
 				}
 
-				object_files = gb_string_append_fmt(object_files, "\'%.*s\' ", LIT(android_glue_static_lib));
+				object_files = gb_string_append_fmt(object_files, "\"%.*s\" ", LIT(android_glue_static_lib));
 			}
 
 
 			for (String object_path : gen->output_object_paths) {
-				object_files = gb_string_append_fmt(object_files, "\'%.*s\' ", LIT(object_path));
+				object_files = gb_string_append_fmt(object_files, "\"%.*s\" ", LIT(object_path));
 			}
 
 			gbString link_settings = gb_string_make_reserve(heap_allocator(), 32);
@@ -925,7 +925,10 @@ try_cross_linking:;
 				GB_ASSERT(ODIN_ANDROID_NDK_TOOLCHAIN_SYSROOT.len != 0);
 
 				platform_lib_str = gb_string_appendc(platform_lib_str, "\"-L");
-				platform_lib_str = gb_string_append_length(platform_lib_str, ODIN_ANDROID_NDK_TOOLCHAIN_LIB_LEVEL.text, ODIN_ANDROID_NDK_TOOLCHAIN_LIB_LEVEL.len);
+				platform_lib_str = gb_string_append_length(platform_lib_str, ODIN_ANDROID_NDK_TOOLCHAIN_SYSROOT.text, ODIN_ANDROID_NDK_TOOLCHAIN_SYSROOT.len);
+				platform_lib_str = gb_string_appendc(platform_lib_str, "usr/lib/");
+				platform_lib_str = gb_string_append_length(platform_lib_str, ODIN_ANDROID_NDK_TOOLCHAIN_LIB.text, ODIN_ANDROID_NDK_TOOLCHAIN_LIB.len);
+				platform_lib_str = gb_string_append_fmt(platform_lib_str, "/%d", ODIN_ANDROID_API_LEVEL);
 				platform_lib_str = gb_string_appendc(platform_lib_str, "\" ");
 
 				platform_lib_str = gb_string_appendc(platform_lib_str, "-landroid ");
@@ -970,7 +973,7 @@ try_cross_linking:;
 				gbString ndk_bin_directory = gb_string_make_length(temporary_allocator(), ODIN_ANDROID_NDK_TOOLCHAIN.text, ODIN_ANDROID_NDK_TOOLCHAIN.len);
 				link_command_line = gb_string_appendc(link_command_line, ndk_bin_directory);
 				link_command_line = gb_string_appendc(link_command_line, "bin/clang");
-				link_command_line = gb_string_append_fmt(link_command_line, " --target=%s%d ", build_context.metrics.target_triplet,  ODIN_ANDROID_API_LEVEL);
+				link_command_line = gb_string_append_fmt(link_command_line, " --target=%.*s%d ", LIT(build_context.metrics.target_triplet),  ODIN_ANDROID_API_LEVEL);
 			} else {
 				link_command_line = gb_string_appendc(link_command_line, clang_path);
 			}


### PR DESCRIPTION
- Use `apksigner.bat` on Windows instead of `apksigner`
- build_context.metrics.target_triplet -> LIT(build_context.metrics.target_triplet)
- fix ndk library paths, use " instead of ' for "clang: error: no such file or directory: .." error