### PR TITLE
Fix #6455

### DIFF
--- a/core/mem/virtual/file.odin
+++ b/core/mem/virtual/file.odin
@@ -10,7 +10,14 @@ map_file :: proc{
 }
 
 map_file_from_path :: proc(filename: string, flags: Map_File_Flags) -> (data: []byte, error: Map_File_Error) {
-	f, err := os.open(filename, os.O_RDWR)
+	open_flags : os.File_Flags
+	if .Read in flags {
+		open_flags += {.Read}
+	}
+	if .Write in flags {
+		open_flags += {.Write}
+	}
+	f, err := os.open(filename, open_flags)
 	if err != nil {
 		return nil, .Open_Failure
 	}


### PR DESCRIPTION
`virtual.map_file_from_path` now passes the appropriate flags on to `os.open` based on the `flags` parameter instead of always calling it with os.O_RDWR.
It will no longer try to open a file with write permissions if the user didn't request write access to the file mapping (or vice-versa).

Fixes https://github.com/odin-lang/Odin/issues/6455