### PR TITLE
Revert "added get_page_size() to `core:mem/virtual`"

### DIFF
--- a/core/mem/virtual/virtual.odin
+++ b/core/mem/virtual/virtual.odin
@@ -45,17 +45,6 @@ release :: proc "contextless" (data: rawptr, size: uint) {
 	_release(data, size)
 }
 
-get_page_size :: proc() -> int {
-	// NOTE(tetra): The page size never changes, so why do anything complicated
-	// if we don't have to.
-	@static page_size := -1
-	if page_size != -1 {
-		return page_size
-	}
-	page_size = _get_page_size()
-	return page_size
-}
-
 Protect_Flag :: enum u32 {
 	Read,
 	Write,

--- a/core/mem/virtual/virtual_linux.odin
+++ b/core/mem/virtual/virtual_linux.odin
@@ -3,7 +3,6 @@
 package mem_virtual
 
 import "core:sys/linux"
-import "core:sys/posix"
 
 _reserve :: proc "contextless" (size: uint) -> (data: []byte, err: Allocator_Error) {
 	addr, errno := linux.mmap(0, size, {}, {.PRIVATE, .ANONYMOUS})
@@ -32,10 +31,6 @@ _decommit :: proc "contextless" (data: rawptr, size: uint) {
 
 _release :: proc "contextless" (data: rawptr, size: uint) {
 	_ = linux.munmap(data, size)
-}
-
-_get_page_size :: proc() -> int {
-	return int(posix.sysconf(._PAGE_SIZE))
 }
 
 _protect :: proc "contextless" (data: rawptr, size: uint, flags: Protect_Flags) -> bool {

--- a/core/mem/virtual/virtual_other.odin
+++ b/core/mem/virtual/virtual_other.odin
@@ -21,10 +21,6 @@ _decommit :: proc "contextless" (data: rawptr, size: uint) {
 _release :: proc "contextless" (data: rawptr, size: uint) {
 }
 
-_get_page_size :: proc() -> int {
-	return 0
-}
-
 _protect :: proc "contextless" (data: rawptr, size: uint, flags: Protect_Flags) -> bool {
 	return false
 }

--- a/core/mem/virtual/virtual_posix.odin
+++ b/core/mem/virtual/virtual_posix.odin
@@ -20,10 +20,6 @@ _release :: proc "contextless" (data: rawptr, size: uint) {
 	posix.munmap(data, size)
 }
 
-_get_page_size :: proc() -> int {
-	return int(posix.sysconf(._PAGE_SIZE))
-}
-
 _protect :: proc "contextless" (data: rawptr, size: uint, flags: Protect_Flags) -> bool {
 	#assert(i32(posix.Prot_Flag_Bits.READ)  == i32(Protect_Flag.Read))
 	#assert(i32(posix.Prot_Flag_Bits.WRITE) == i32(Protect_Flag.Write))

--- a/core/mem/virtual/virtual_windows.odin
+++ b/core/mem/virtual/virtual_windows.odin
@@ -123,13 +123,6 @@ _release :: proc "contextless" (data: rawptr, size: uint) {
 	VirtualFree(data, 0, MEM_RELEASE)
 }
 
-_get_page_size :: proc() -> int {
-	info: SYSTEM_INFO
-	GetSystemInfo(&info)
-
-	return int(info.dwPageSize)
-}
-
 @(no_sanitize_address)
 _protect :: proc "contextless" (data: rawptr, size: uint, flags: Protect_Flags) -> bool {
 	pflags: u32


### PR DESCRIPTION
Reverts odin-lang/Odin#6467

Turns out we already have `DEFAULT_PAGE_SIZE`.