### PR TITLE
Fix GB_PANIC format string in lb_emit_conv invalid subtype cast

### DIFF
--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -2579,7 +2579,7 @@ gb_internal lbValue lb_emit_conv(lbProcedure *p, lbValue value, Type *t) {
 		sel.index.allocator = temporary_allocator();
 		if (lookup_subtype_polymorphic_selection(t, src_type, &sel)) {
 			if (sel.entity == nullptr) {
-				GB_PANIC("invalid subtype cast  %s -> ", type_to_string(src_type), type_to_string(t));
+				GB_PANIC("invalid subtype cast  %s -> %s", type_to_string(src_type), type_to_string(t));
 			}
 			if (st_is_ptr) {
 				lbValue res = lb_emit_deep_field_gep(p, value, sel);


### PR DESCRIPTION
In `lb_emit_conv`, the invalid polymorphic subtype cast panic used a format string with only one `%s` while passing two type strings. Add the missing specifier so the message prints both source and destination types.