### PR TITLE
Fix u16 multi-pointer to cstring16 transmute condition in lb_emit_conv

### DIFF
--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -2150,7 +2150,7 @@ gb_internal lbValue lb_emit_conv(lbProcedure *p, lbValue value, Type *t) {
 	if (is_type_cstring16(src) && is_type_u16_multi_ptr(dst)) {
 		return lb_emit_transmute(p, value, dst);
 	}
-	if (is_type_u8_multi_ptr(src) && is_type_cstring16(dst)) {
+	if (is_type_u16_multi_ptr(src) && is_type_cstring16(dst)) {
 		return lb_emit_transmute(p, value, dst);
 	}
 	if (is_type_cstring16(src) && is_type_rawptr(dst)) {


### PR DESCRIPTION
The `lb_emit_conv` path that transmutes a multi-pointer to `cstring16` incorrectly checked for `u8` multi-pointers. `cstring16` is UTF-16, so the source should be a `u16` multi-pointer, matching the reverse conversion (`cstring16` → `[^]u16`) already handled above.