### PR TITLE
Remove unreachable branch in filename_from_path

### DIFF
--- a/src/string.cpp
+++ b/src/string.cpp
@@ -495,15 +495,6 @@ gb_internal String filename_from_path(String s) {
 		s = substring(s, 0, i);
 		return s;
 	}
-	if (i > 0) {
-		isize j = 0;
-		for (j = s.len-1; j >= 0; j--) {
-			if (is_separator(s[j])) {
-				break;
-			}
-		}
-		return substring(s, j+1, s.len);
-	}
 	return make_string(nullptr, 0);
 }
 


### PR DESCRIPTION
In `filename_from_path`, the `if (i > 0)` block after the `i >= 0` early return can never run: when control reaches it, `string_extension_position` returned a negative value, so `i > 0` is always false. Remove the dead code; behavior is unchanged.