### PR TITLE
Fix cg_emit_transmute inner switch for int sources with raw mismatch

### DIFF
--- a/src/tilde_expr.cpp
+++ b/src/tilde_expr.cpp
@@ -224,7 +224,7 @@ gb_internal cgValue cg_emit_transmute(cgProcedure *p, cgValue value, Type *type)
 		if (value.node->dt.raw != dt.raw) {
 			switch (value.node->dt.type) {
 			case TB_INT:
-				switch (value.node->dt.type) {
+				switch (dt.type) {
 				case TB_INT:
 					break;
 				case TB_FLOAT:


### PR DESCRIPTION
In `cg_emit_transmute`, when the value is TB_INT and the raw encoding differs from the destination, the inner `switch` repeated `value.node->dt.type` (still `TB_INT`), so only the inner `TB_INT` arm could run. The `TB_FLOAT` and `TB_PTR` arms were dead. Switch on `dt.type` so int→float and int→pointer transmutes emit the intended TB ops.