### PR TITLE
Fix cg_emit_comp_against_nil TODO path to use GB_PANIC

### DIFF
--- a/src/tilde_expr.cpp
+++ b/src/tilde_expr.cpp
@@ -813,7 +813,7 @@ gb_internal cgValue cg_emit_comp_against_nil(cgProcedure *p, TokenKind op_kind, 
 				cgValue tag = cg_emit_transmute(p, x, t_rawptr);
 				return cg_emit_comp_against_nil(p, op_kind, tag);
 			} else {
-				GB_ASSERT("TODO(bill): cg_emit_union_tag_value");
+				GB_PANIC("TODO(bill): cg_emit_union_tag_value");
 				// cgValue tag = cg_emit_union_tag_value(p, x);
 				// return cg_emit_comp(p, op_kind, tag, cg_zero(p->module, tag.type));
 			}


### PR DESCRIPTION
The `cg_emit_union_tag_value` TODO used `GB_ASSERT` with a string literal. `GB_ASSERT` checks a boolean expression; a non-null string pointer is always true, so the assertion never fired. Use `GB_PANIC` for this unreachable/TODO path instead.