### PR TITLE
[ci] fixed git + docker mount permissions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,6 +58,7 @@ jobs:
               musl-dev llvm20-dev clang20 git mold lz4 \
               libxml2-static llvm20-static zlib-static zstd-static \
               make &&
+            git config --global --add safe.directory /src &&
             ./ci/build_linux_static.sh
           '
       - name: Odin run


### PR DESCRIPTION
adds git config that fixes permissions issues caused by the repo being in a docker container