### PR TITLE
Remove assert crashing parser with for init statements

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -933,9 +933,10 @@ parse_for_stmt :: proc(p: ^Parser) -> ^ast.Stmt {
 						next_token := peek_token(p)
 						if next_token.kind == .In || next_token.kind == .Comma {
 							cond = parse_simple_stmt(p, {.In})
-							as := cond.derived_stmt.(^ast.Assign_Stmt)
-							assert(as.op.kind == .In)
-							is_range = true
+							if as, ok := cond.derived_stmt.(^ast.Assign_Stmt); ok {
+								assert(as.op.kind == .In)
+								is_range = true
+							}
 							break general_conds
 						}
 					}


### PR DESCRIPTION
We've been encountering issues in `ols` after the for init feature was added that looks like 
```sh
[ERROR][2026-03-29 07:55:12] ...p/_transport.lua:36	"rpc"	"ols"	"stderr"	"/Users/bradlewis/repos/Odin/core/odin/parser/parser.odin(936:14) type assertion: Invalid type assertion from Any_Stmt to ^Assign_Stmt, actual type: ^Value_Decl\n"
```

A minimal example to replicate this is
```odin
package main

main :: proc() {
	for a
	a, b := c()
}
``` 

Basically when we're typing the for statement it'll crash the lsp.

We also get a similar issue with the cpp parser:

```sh
❯ odin check main.odin -file
^[[Asrc/parser.cpp(4954): Assertion Failure: `cond->kind == Ast_AssignStmt && cond->AssignStmt.op.kind == Token_in`
This is a compiler error. Please report this.
[1]    17997 trace trap  odin check main.odin -file
```

I'm not sure what error we would want to report here, but on the odin parser within ols side of things there's already a lot of errors reported regarding this so an easy "fix" was to just make it a check rather than asserting the type cast. I'm not sure if we would want to do the same thing on the cpp side though or make something more explicit. Let me know what you think.