### PR TITLE
Fix #6495 - Handle starting separator during name comparison

### DIFF
--- a/core/os/path_windows.odin
+++ b/core/os/path_windows.odin
@@ -349,7 +349,7 @@ _get_common_path_len :: proc(base, target: string) -> int {
 	end := min(len(base), len(target))
 	for j in 0..=end {
 		if j == end || _is_path_separator(base[j]) {
-			if _is_path_separator(base[i]) && _is_path_separator(target[i]) {
+			if i < end && _is_path_separator(base[i]) && _is_path_separator(target[i]) {
 				i += 1
 			}
 			if strings.equal_fold(base[i:j], target[i:j]) {


### PR DESCRIPTION
During the loop comparing file/directory names, the starting character in both will be a path separator in most cases.
Since a naive string equality will regard forward slashes and backslashes as different, we must specially handle the first character and exclude it from the equality comparison if necessary.

Fixes #6495