### PR TITLE
Add bindings for Darwin's Dispatch framework

### DIFF
--- a/core/sys/darwin/Foundation/dispatch.odin
+++ b/core/sys/darwin/Foundation/dispatch.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 import "core:c"

--- a/core/sys/darwin/Foundation/os.odin
+++ b/core/sys/darwin/Foundation/os.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Foundation
 
 os_workgroup_t  :: ^OS_os_workgroup

--- a/core/sys/darwin/copyfile.odin
+++ b/core/sys/darwin/copyfile.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package darwin
 
 import "core:sys/posix"

--- a/core/sys/darwin/kernel_data_types.odin
+++ b/core/sys/darwin/kernel_data_types.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package darwin
 
 import "core:c"

--- a/core/sys/darwin/mach_darwin.odin
+++ b/core/sys/darwin/mach_darwin.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package darwin
 
 foreign import mach "system:System"

--- a/core/sys/darwin/proc.odin
+++ b/core/sys/darwin/proc.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package darwin
 
 import "base:intrinsics"

--- a/core/sys/darwin/qos.odin
+++ b/core/sys/darwin/qos.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package darwin
 
 import "core:c"

--- a/core/sys/darwin/sync.odin
+++ b/core/sys/darwin/sync.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package darwin
 
 // #define OS_WAIT_ON_ADDR_AVAILABILITY \

--- a/core/sys/darwin/xnu_system_call_helpers.odin
+++ b/core/sys/darwin/xnu_system_call_helpers.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package darwin
 
 import "core:c"

--- a/core/sys/darwin/xnu_system_call_numbers.odin
+++ b/core/sys/darwin/xnu_system_call_numbers.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package darwin
 
 // IMPORTANT NOTE: direct syscall usage is not allowed by Apple's review process of apps and should

--- a/core/sys/darwin/xnu_system_call_wrappers.odin
+++ b/core/sys/darwin/xnu_system_call_wrappers.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package darwin
 
 import "core:c"

--- a/vendor/darwin/CoreVideo/CVDisplayLink.odin
+++ b/vendor/darwin/CoreVideo/CVDisplayLink.odin
@@ -1,3 +1,4 @@
+#+build darwin
 // Bindings for [[ CoreVideo ; https://developer.apple.com/documentation/corevideo ]].
 package CoreVideo
 

--- a/vendor/darwin/Metal/MetalClasses.odin
+++ b/vendor/darwin/Metal/MetalClasses.odin
@@ -1,3 +1,4 @@
+#+build darwin
 // Bindings for [[ Metal ; https://developer.apple.com/documentation/metal ]].
 package objc_Metal
 

--- a/vendor/darwin/Metal/MetalEnums.odin
+++ b/vendor/darwin/Metal/MetalEnums.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Metal
 
 import NS "core:sys/darwin/Foundation"

--- a/vendor/darwin/Metal/MetalErrors.odin
+++ b/vendor/darwin/Metal/MetalErrors.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Metal
 
 import NS "core:sys/darwin/Foundation"

--- a/vendor/darwin/Metal/MetalProcedures.odin
+++ b/vendor/darwin/Metal/MetalProcedures.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Metal
 
 import NS "core:sys/darwin/Foundation"

--- a/vendor/darwin/Metal/MetalTypes.odin
+++ b/vendor/darwin/Metal/MetalTypes.odin
@@ -1,3 +1,4 @@
+#+build darwin
 package objc_Metal
 
 import NS "core:sys/darwin/Foundation"

--- a/vendor/darwin/MetalKit/MetalKit.odin
+++ b/vendor/darwin/MetalKit/MetalKit.odin
@@ -1,3 +1,4 @@
+#+build darwin
 // Bindings for [[ MetalKit ; https://developer.apple.com/documentation/metalkit ]].
 package objc_MetalKit
 

--- a/vendor/darwin/QuartzCore/QuartzCore.odin
+++ b/vendor/darwin/QuartzCore/QuartzCore.odin
@@ -1,3 +1,4 @@
+#+build darwin
 // Bindings for [[ QuartzCore ; https://developer.apple.com/documentation/quartzcore ]].
 package objc_QuartzCore
 


### PR DESCRIPTION
This PR adds bindings for Darwin's [Dispatch framework](https://developer.apple.com/documentation/dispatch?language=objc). It is a core Darwin concurrency API that other Darwin APIs depend on (e.g. Metal). These bindings were created by reading the online API documentation linked above from top to bottom and hand-typing their Odin equivalents. I referred to the C header files of the Dispatch framework installed on my machine when needed (e.g. to see the definition of macros). My Dispatch header files version is `#define DISPATCH_API_VERSION 20181008` (copy-pasted from dispatch.h).

For quality control, I manually ran every single one of the bindings.

## About how these bindings were designed
Most of the bindings are straightforward translations from C to Odin. The only interesting or opinionated parts of the bindings are:

- Obj-C has protocols (e.g. [OS_dispatch_queue](https://developer.apple.com/documentation/dispatch/os_dispatch_queue?language=objc)). Protocols function similarly to inheritance in object-oriented languages and allow for type-safe polymorphism. The Dispatch API is designed to use such polymorphism:
  ```m
  // The protocol `OS_dispatch_queue_main` inherits from `OS_dispatch_queue`
  dispatch_async( // accepts NSObject<OS_dispatch_queue>*
      dispatch_get_main_queue(), // returns NSObject<OS_dispatch_queue_main>*
      ...
  )
  // Through polymorphism, this compiles successfully
  ```
  But Odin does not have protocols. So instead, I used Odin's subtype polymorphism to do the same thing:
  ```odin
  OS_dispatch_object     :: struct{using _: Object}
  OS_dispatch_queue      :: struct{using _: OS_dispatch_object}
  OS_dispatch_queue_main :: struct{using _: OS_dispatch_queue}

  dispatch_async          :: proc(^OS_dispatch_queue, ...)     { ... }
  disaptch_get_main_queue :: proc() -> ^OS_dispatch_queue_main { ... }

  dispatch_async(dispatch_get_main_queue(), ...)
  // This compiles successfully
  ```
  This technique works with multiple inheritance as well, though the Dispatch framework does not use multiple inheritance.

- [`dispatch_get_global_queue`](https://developer.apple.com/documentation/dispatch/dispatch_get_global_queue?language=objc)'s `identifier` parameter is an `intptr_t`, but according to documentation, you are meant to pass in a QoS macro or `dispatch_queue_priority_t` macro. For clarity, I made Odin's `dispatch_get_global_queue` binding a type-safe proc group:
  ```odin
  dispatch_get_global_queue :: proc{
      dispatch_get_global_queue_by_intptr,
      dispatch_get_global_queue_by_priority,
      dispatch_get_global_queue_by_qos,
  }
  ```

- Every macro has an identically named Odin binding so that users can reliably Ctrl+F for them. Even if a macro was converted into an enum or bit set, I added extra Odin constant variables named identically to the macro. An example is the macros of [dispatch_io_type_t](https://developer.apple.com/documentation/dispatch/dispatch_io_type_t?language=objc):
  ```odin
  dispatch_io_type_t :: enum c.ulong {
      STREAM = 0,
      RANDOM = 1,
  }
  DISPATCH_IO_STREAM :: dispatch_io_type_t.STREAM
  DISPATCH_IO_RANDOM :: dispatch_io_type_t.RANDOM
  ```

## About where I put these bindings
I placed these bindings in `core:sys/darwin/Foundation`. You may feel that it is more appropriate to put it in `core:sys/darwin` because it foreign imports `system:System`, not `system:Foundation.framework`, and I would 100% agree. The reason why I did not put these Dispatch bindings in `core:sys/darwin` is because Dispatch depends on `NSObject`, and the Odin binding for `NSObject` lives in `core:sys/darwin/Foundation`. Making `core:sys/darwin` depend on `core:sys/darwin/Foundation` would be rather unintuitive.

The solution would be to move the Odin binding for `NSObject` to `core:sys/darwin` and make `core:sys/darwin/Foundation` alias it. This would actually match how Darwin's library dependencies are structured. [NSObject](https://developer.apple.com/documentation/objectivec/nsobject-swift.class?language=objc) is defined in the Obj-C runtime, not Foundation. I have experimented with this change locally and confirmed that it can be done without breaking user space. But that would be a follow-up PR. Let's do one thing at a time, assuming I have the maintainers' blessing.

## Other changes
A couple other new files got added:
- `core/sys/darwin/kernel_data_types.odin`
- `core/sys/darwin/qos.odin`
- `core/sys/darwin/os.odin`

These are just dependencies of Dispatch.

And several existing Darwin-releated files got changed too. I needed to add `#+build darwin` to them in order to make compilation of `examples/all` succeed for non-Darwin platforms in CI.