### PR TITLE
Fix missing argument in adjtimex syscall in core:sys/linux

### DIFF
--- a/core/sys/linux/sys.odin
+++ b/core/sys/linux/sys.odin
@@ -2207,7 +2207,7 @@ when ODIN_ARCH == .amd64 || ODIN_ARCH == .i386 {
 	Available since Linux 1.0.
 */
 adjtimex :: proc "contextless" (buf: ^Timex) -> (Clock_State, Errno) {
-	ret := syscall(SYS_adjtimex)
+	ret := syscall(SYS_adjtimex, buf)
 	return errno_unwrap(ret, Clock_State)
 }
 


### PR DESCRIPTION
The adjtimex syscall is missing its buf argument.
Despite this, the syscall still works at least sometimes in non-optimized builds, probably because buf is in the correct register by accident. Doesn't work with -o:speed though.