### PR TITLE
Fixing declaration order bugs

### DIFF
--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -127,6 +127,8 @@ gb_internal void check_struct_fields(CheckerContext *ctx, Ast *node, Slice<Entit
 	i32 field_src_index = 0;
 	i32 field_group_index = -1;
 	for_array(i, params) {
+		*fields = slice_from_array(fields_array);
+		*tags = tags_array.data;
 		Ast *param = params[i];
 		if (param->kind != Ast_Field) {
 			continue;


### PR DESCRIPTION
Fixing false where-clause failures in recursive polymorphic subtype cases (for example, subtype discovery through an earlier using/subtype field while a later field triggers recursion).

Fix #6506 

Fixing incorrectly rejecting valid in-progress/forward union references during checking while still preserving diagnostics for truly invalid union variant types.

Fix #5572 and #5961 
