### PR TITLE
Revert fix for 6425

### DIFF
--- a/core/compress/common.odin
+++ b/core/compress/common.odin
@@ -360,23 +360,26 @@ refill_lsb_from_memory :: #force_inline proc(z: ^Context_Memory_Input, width := 
 	refill := u64(width)
 	b      := u64(0)
 
-	if z.num_bits > refill {
-		return
-	}
-
 	for {
+		if z.num_bits > refill {
+			break
+		}
+		if z.code_buffer == 0 && z.num_bits > 63 {
+			z.num_bits = 0
+		}
+		if z.code_buffer >= 1 << uint(z.num_bits) {
+			// Code buffer is malformed.
+			z.num_bits = max(u64)
+			return
+		}
 		if len(z.input_data) != 0 {
 			b = u64(z.input_data[0])
 			z.input_data = z.input_data[1:]
 		} else {
-			b = 0
+			return
 		}
-
 		z.code_buffer |= b << u8(z.num_bits)
 		z.num_bits += 8
-		if z.num_bits > refill {
-			break
-		}
 	}
 }
 

--- a/core/compress/zlib/zlib.odin
+++ b/core/compress/zlib/zlib.odin
@@ -322,9 +322,6 @@ decode_huffman_slowpath :: proc(z: ^$C, t: ^Huffman_Table) -> (r: u16, err: Erro
 @(optimization_mode="favor_size")
 decode_huffman :: proc(z: ^$C, t: ^Huffman_Table) -> (r: u16, err: Error) #no_bounds_check {
 	if z.num_bits < 16 {
-		if z.num_bits > 63 {
-			return 0, .Code_Buffer_Malformed
-		}
 		compress.refill_lsb(z)
 		if z.num_bits > 63 {
 			return 0, .Stream_Too_Short


### PR DESCRIPTION
Temporarily revert the fix for #6425. It broke some PNG files that were not in the test suite.

#6425 will be fixed after April's release with a more comprehensive approach.