### PR TITLE
core/crypto/aes: Fix src size check in encrypt/decrypt_ecb()

### DIFF
--- a/core/crypto/aes/aes_ecb.odin
+++ b/core/crypto/aes/aes_ecb.odin
@@ -21,7 +21,7 @@ init_ecb :: proc(ctx: ^Context_ECB, key: []byte, impl := DEFAULT_IMPLEMENTATION)
 encrypt_ecb :: proc(ctx: ^Context_ECB, dst, src: []byte) {
 	ensure(ctx._is_initialized)
 	ensure(len(dst) == BLOCK_SIZE, "crypto/aes: invalid dst size")
-	ensure(len(dst) == BLOCK_SIZE, "crypto/aes: invalid src size")
+	ensure(len(src) == BLOCK_SIZE, "crypto/aes: invalid src size")
 
 	switch &impl in ctx._impl {
 	case ct64.Context:
@@ -35,7 +35,7 @@ encrypt_ecb :: proc(ctx: ^Context_ECB, dst, src: []byte) {
 decrypt_ecb :: proc(ctx: ^Context_ECB, dst, src: []byte) {
 	ensure(ctx._is_initialized)
 	ensure(len(dst) == BLOCK_SIZE, "crypto/aes: invalid dst size")
-	ensure(len(dst) == BLOCK_SIZE, "crypto/aes: invalid src size")
+	ensure(len(src) == BLOCK_SIZE, "crypto/aes: invalid src size")
 
 	switch &impl in ctx._impl {
 	case ct64.Context:


### PR DESCRIPTION
Fixed a faulty check that would check the `dst` twice instead of checking the `src` and `dst` input parameters in `encrypt_ecb()` & `decrypt_ecb()`.

If the provided `src` is wrong a segfault gets triggered and no feedback is given to the user(i.e. no logs, etc.).

sidenote: I just sat down to learn what API is available to encrypt some bytes for the first time, picked at random AES ECB and hit this bug almost immediately while exploring the API :smile: