### PR TITLE
Fix typo of word 'Successful' in documentation

### DIFF
--- a/core/mem/alloc.odin
+++ b/core/mem/alloc.odin
@@ -218,7 +218,7 @@ buffer is aligned to the boundary specified by `alignment`.
 	keeps track of the sizes of allocations, this parameter is optional.
 
 **Returns**:
-1. The slice of the  memory region after resize operation, if successfull,
+1. The slice of the  memory region after resize operation, if successful,
 	`nil` otherwise.
 2. An error, if the resize failed.
 
@@ -502,7 +502,7 @@ buffer is aligned to the boundary specified by `alignment`.
 - `allocator`: The owner of the memory region to resize.
 
 **Returns**:
-1. The pointer to the resized memory region, if successfull, `nil` otherwise.
+1. The pointer to the resized memory region, if successful, `nil` otherwise.
 2. Error, if resize failed.
 
 **Errors**:
@@ -562,7 +562,7 @@ memory.
 - `allocator`: The owner of the memory region to resize.
 
 **Returns**:
-1. The pointer to the resized memory region, if successfull, `nil` otherwise.
+1. The pointer to the resized memory region, if successful, `nil` otherwise.
 2. Error, if resize failed.
 
 **Errors**:
@@ -618,7 +618,7 @@ buffer is aligned to the boundary specified by `alignment`.
 - `allocator`: The owner of the memory region to resize.
 
 **Returns**:
-1. The resized memory region, if successfull, `nil` otherwise.
+1. The resized memory region, if successful, `nil` otherwise.
 2. Error, if resize failed.
 
 **Errors**:
@@ -675,7 +675,7 @@ any new memory.
 - `allocator`: The owner of the memory region to resize.
 
 **Returns**:
-1. The resized memory region, if successfull, `nil` otherwise.
+1. The resized memory region, if successful, `nil` otherwise.
 2. Error, if resize failed.
 
 **Errors**:

--- a/core/sync/chan/chan.odin
+++ b/core/sync/chan/chan.odin
@@ -1159,7 +1159,7 @@ If the message is nil, corresponding send channel will be skipped.
 
 **Returns**
 - Position of the available channel which was used for receiving or sending
-- `true` if sending/receiving was successfull, `false` if the channel was closed or no channel was available
+- `true` if sending/receiving was successful, `false` if the channel was closed or no channel was available
 
 Example:
 

--- a/core/sys/linux/sys.odin
+++ b/core/sys/linux/sys.odin
@@ -8,7 +8,7 @@ import "base:intrinsics"
 /*
 	Read data from file into the buffer
 	Returns the number of bytes successfully read, which may be less than the size
-	of the buffer even if the termination is successfull.
+	of the buffer even if the termination is successful.
 	Available since Linux 1.0.
 	Before Linux 3.14, this operation is not atomic (i.e. not thread safe).
 */
@@ -20,7 +20,7 @@ read :: proc "contextless" (fd: Fd, buf: []u8) -> (int, Errno) {
 /*
 	Write the data from a buffer into the file
 	Returns the number of bytes successfully written, which may be less than the size
-	of the buffer, even if the termination is successfull
+	of the buffer, even if the termination is successful
 	When using direct I/O, error doesn't mean the write has failed. Partial data may
 	have been written.
 	If .Eintr is returned, the write operation has failed due to interrupt. You'll probably

--- a/core/sys/posix/pthread.odin
+++ b/core/sys/posix/pthread.odin
@@ -197,7 +197,7 @@ foreign lib {
 	pthread_equal :: proc(t1: pthread_t, t2: pthread_t) -> b32 ---
 
 	/*
-	Terminates the calling thread and make the given value available to any successfull join calls.
+	Terminates the calling thread and make the given value available to any successful join calls.
 
 	[[ More; https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_exit.html ]]
 	*/


### PR DESCRIPTION
The word Successful was incorrectly spelled as "successfull" many times in documentation for functions.