### PR TITLE
Android: fix aligned_alloc not defined

### DIFF
--- a/src/common_memory.cpp
+++ b/src/common_memory.cpp
@@ -2,6 +2,25 @@
 #include <malloc.h>
 #endif
 
+#ifdef __ANDROID__
+
+// Bionic may not provide aligned_alloc.
+// Provide a fallback using posix_memalign and ensure the alignment
+// satisfies its requirement (multiple of pointer size).
+static void* android_aligned_alloc(size_t align, size_t size) {
+	void* allocated;
+
+	const size_t ptr_size = sizeof(void*);
+	align = (align + (ptr_size - 1)) / ptr_size * ptr_size;
+
+	if (posix_memalign(&allocated, align, size) != 0)
+		return NULL;
+	return allocated;
+}
+#define aligned_alloc android_aligned_alloc
+
+#endif
+
 template <typename U, typename V>
 gb_internal gb_inline U bit_cast(V &v) { return reinterpret_cast<U &>(v); }
 


### PR DESCRIPTION
While testing Odin on Android (Termux), the build fails because
aligned_alloc is not available in the Bionic libc used in this
environment.

This patch provides a small Android-only fallback that redirects
aligned_alloc to a wrapper using posix_memalign.

The wrapper also adjusts the alignment to satisfy posix_memalign
requirements (multiple of pointer size).

With this change I was able to successfully build Odin and generate
LLVM IR on Android, then compile it with Clang to produce a working
executable.

<img width="1080" height="2400" alt="Screenshot_20260404-170208 Termux" src="https://github.com/user-attachments/assets/95de1ad2-9d43-47d3-aa54-69e8101f3b9f" />

Partially fixes #6513 