### PR TITLE
[checker] fix break/continue being allowed in a nested unrolled range loop

### DIFF
--- a/src/check_stmt.cpp
+++ b/src/check_stmt.cpp
@@ -1130,8 +1130,8 @@ gb_internal void check_unroll_range_stmt(CheckerContext *ctx, Ast *node, u32 mod
 		}
 	}
 
-	check_stmt(ctx, irs->body, mod_flags);
-
+	u32 new_flags = mod_flags & ~Stmt_BreakAllowed & ~Stmt_ContinueAllowed;
+	check_stmt(ctx, irs->body, new_flags);
 }
 
 gb_internal void check_switch_stmt(CheckerContext *ctx, Ast *node, u32 mod_flags) {


### PR DESCRIPTION
before, break and continue flags were passed down into the loop body transparently without removing the break and continue flags. this meant that the following code:
```odin
for i in 0 ..< 10 {
  #unroll for j in 0 ..< 10 {
    if i % 2 != 0 do continue
  }
}
```
would compile

fixes: #5991