### PR TITLE
Array Casting

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -3418,9 +3418,9 @@ gb_internal bool check_is_castable_to(CheckerContext *c, Operand *operand, Type 
 
 
 	if (dst->kind == Type_Array && src->kind == Type_Array) {
-		if (are_types_identical(dst->Array.elem, src->Array.elem)) {
-			return dst->Array.count == src->Array.count;
-		}
+		Operand op = *operand;
+		op.type = src->Array.elem;
+		return check_is_castable_to(c, &op, dst->Array.elem);
 	}
 
 	if (dst->kind == Type_Slice && src->kind == Type_Slice) {

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -3418,6 +3418,9 @@ gb_internal bool check_is_castable_to(CheckerContext *c, Operand *operand, Type 
 
 
 	if (dst->kind == Type_Array && src->kind == Type_Array) {
+		if (dst->Array.count > 4) {
+			return false;
+		}
 		Operand op = *operand;
 		op.type = src->Array.elem;
 		return check_is_castable_to(c, &op, dst->Array.elem);

--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -2740,7 +2740,7 @@ gb_internal lbValue lb_emit_conv(lbProcedure *p, lbValue value, Type *t) {
 		Type *elem = base_array_type(dst);
 		isize index_count = cast(isize)gb_min(get_array_type_count(src), get_array_type_count(dst));
 
-		// NOTE: Do fill with zero because the dst may be longer than src
+		// NOTE: Fill with zero because dst may be longer than src
 		lbAddr v = lb_add_local_generated(p, t, true);
 
 		lbValue psrc = lb_address_from_load_or_generate_local(p, value);

--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -2691,7 +2691,7 @@ gb_internal lbValue lb_emit_conv(lbProcedure *p, lbValue value, Type *t) {
 	}
 
 
-	if (is_type_array_like(dst)) {
+	if (is_type_array_like(dst) && !is_type_array_like(src)) {
 		Type *elem = base_array_type(dst);
 		isize index_count = cast(isize)get_array_type_count(dst);
 
@@ -2731,6 +2731,41 @@ gb_internal lbValue lb_emit_conv(lbProcedure *p, lbValue value, Type *t) {
 			for (isize i = 0; i < index_count; i++) {
 				lbValue elem = lb_emit_array_epi(p, v.addr, i);
 				lb_emit_store(p, elem, e);
+			}
+		}
+		return lb_addr_load(p, v);
+	}
+
+	if (is_type_array_like(dst) && is_type_array_like(src)) {
+		Type *elem = base_array_type(dst);
+		isize index_count = cast(isize)gb_min(get_array_type_count(src), get_array_type_count(dst));
+		isize inlineable = type_size_of(dst) <= build_context.max_simd_align;
+
+		// NOTE: Do fill with zero because the dst may be longer than src
+		lbAddr v = lb_add_local_generated(p, t, true);
+
+		lbValue psrc = lb_address_from_load_or_generate_local(p, value);
+		lbValue pdst = v.addr;
+
+		if (!inlineable) {
+			auto loop_data = lb_loop_start(p, index_count, t_int);
+
+			lbValue sp = lb_emit_array_ep(p, psrc, loop_data.idx);
+			lbValue dp = lb_emit_array_ep(p, pdst, loop_data.idx);
+
+			lbValue s = lb_emit_load(p, sp);
+			s = lb_emit_conv(p, s, dst->Matrix.elem);
+			lb_emit_store(p, dp, s);
+
+			lb_loop_end(p, loop_data);
+		} else {
+			for (isize i = 0; i < index_count; i++) {
+				lbValue sp = lb_emit_array_epi(p, psrc, i);
+				lbValue dp = lb_emit_array_epi(p, pdst, i);
+
+				lbValue s = lb_emit_load(p, sp);
+				s = lb_emit_conv(p, s, dst->Matrix.elem);
+				lb_emit_store(p, dp, s);
 			}
 		}
 		return lb_addr_load(p, v);

--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -2739,7 +2739,6 @@ gb_internal lbValue lb_emit_conv(lbProcedure *p, lbValue value, Type *t) {
 	if (is_type_array_like(dst) && is_type_array_like(src)) {
 		Type *elem = base_array_type(dst);
 		isize index_count = cast(isize)gb_min(get_array_type_count(src), get_array_type_count(dst));
-		isize inlineable = type_size_of(dst) <= build_context.max_simd_align;
 
 		// NOTE: Do fill with zero because the dst may be longer than src
 		lbAddr v = lb_add_local_generated(p, t, true);
@@ -2747,27 +2746,16 @@ gb_internal lbValue lb_emit_conv(lbProcedure *p, lbValue value, Type *t) {
 		lbValue psrc = lb_address_from_load_or_generate_local(p, value);
 		lbValue pdst = v.addr;
 
-		if (!inlineable) {
-			auto loop_data = lb_loop_start(p, index_count, t_int);
-
-			lbValue sp = lb_emit_array_ep(p, psrc, loop_data.idx);
-			lbValue dp = lb_emit_array_ep(p, pdst, loop_data.idx);
+		// NOTE: Always inline because dst must have <= 4 elements
+		for (isize i = 0; i < index_count; i++) {
+			lbValue sp = lb_emit_array_epi(p, psrc, i);
+			lbValue dp = lb_emit_array_epi(p, pdst, i);
 
 			lbValue s = lb_emit_load(p, sp);
 			s = lb_emit_conv(p, s, dst->Matrix.elem);
 			lb_emit_store(p, dp, s);
-
-			lb_loop_end(p, loop_data);
-		} else {
-			for (isize i = 0; i < index_count; i++) {
-				lbValue sp = lb_emit_array_epi(p, psrc, i);
-				lbValue dp = lb_emit_array_epi(p, pdst, i);
-
-				lbValue s = lb_emit_load(p, sp);
-				s = lb_emit_conv(p, s, dst->Matrix.elem);
-				lb_emit_store(p, dp, s);
-			}
 		}
+
 		return lb_addr_load(p, v);
 	}
 


### PR DESCRIPTION
Allows arrays to be cast to arrays where the elements can be cast e.g.:
```odin
a := [2]i32{1, 2}
b := ([2]f32)(a)
```
Which is useful when using arrays as vectors because you currently have to do:
```odin
a := [2]i32{1, 2}
b := [2]f32{f32(a.x), f32(a.y)}
```
For casts where the array lengths are different, the array is either truncated or padded with zero.