### PR TITLE
Fix target feature lookup, canonicalize target_features_set

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -2218,21 +2218,14 @@ gb_internal bool check_target_feature_is_enabled(String const &feature, String *
 		String plus_str  = concatenate_strings(temporary_allocator(), make_string_c("+"), feature_str);
 		String minus_str = concatenate_strings(temporary_allocator(), make_string_c("-"), feature_str);
 		
-		bool has_raw   = string_set_exists(&build_context.target_features_set, str);
+		bool has_raw   = string_set_exists(&build_context.target_features_set, feature_str);
 		bool has_plus  = string_set_exists(&build_context.target_features_set, plus_str);
 		bool has_minus = string_set_exists(&build_context.target_features_set, minus_str);
 		
+		// NOTE(jakubtomsu): this way "feature" and "+feature" is ALWAYS equivalent,
+		// and also allows the minus sign to do a final override.
 		bool is_enabled = (has_plus || has_raw) && !has_minus;
 		
-		if ((has_plus || has_raw) && has_minus) {
-			printf("ENTRIES for '%.*s' / '%.*s':\n", LIT(plus_str), LIT(minus_str));
-			for (StringSetEntry& str : build_context.target_features_set) {
-				printf("\thash: %i, next: %i, val: %.*s\n", str.hash, str.next, LIT(str.value));
-			}
-		}
-		
-		GB_ASSERT(!((has_plus || has_raw) && has_minus));
-
 		if (want_enabled != is_enabled) {
 			if (not_enabled) *not_enabled = str;
 			return false;

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -2215,18 +2215,25 @@ gb_internal bool check_target_feature_is_enabled(String const &feature, String *
 		}
 		if (feature_str == "") break;
 
-		if (!string_set_exists(&build_context.target_features_set, str)) {
-			String plus_str = concatenate_strings(temporary_allocator(), make_string_c("+"), feature_str);
-
-			if (want_enabled && !string_set_exists(&build_context.target_features_set, plus_str)) {
-				if (not_enabled) *not_enabled = str;
-				return false;
+		String plus_str  = concatenate_strings(temporary_allocator(), make_string_c("+"), feature_str);
+		String minus_str = concatenate_strings(temporary_allocator(), make_string_c("-"), feature_str);
+		
+		bool has_raw   = string_set_exists(&build_context.target_features_set, str);
+		bool has_plus  = string_set_exists(&build_context.target_features_set, plus_str);
+		bool has_minus = string_set_exists(&build_context.target_features_set, minus_str);
+		
+		bool is_enabled = (has_plus || has_raw) && !has_minus;
+		
+		if ((has_plus || has_raw) && has_minus) {
+			printf("ENTRIES for '%.*s' / '%.*s':\n", LIT(plus_str), LIT(minus_str));
+			for (StringSetEntry& str : build_context.target_features_set) {
+				printf("\thash: %i, next: %i, val: %.*s\n", str.hash, str.next, LIT(str.value));
 			}
 		}
+		
+		GB_ASSERT(!((has_plus || has_raw) && has_minus));
 
-		String minus_str = concatenate_strings(temporary_allocator(), make_string_c("-"), feature_str);
-
-		if (!want_enabled && !string_set_exists(&build_context.target_features_set, minus_str)) {
+		if (want_enabled != is_enabled) {
 			if (not_enabled) *not_enabled = str;
 			return false;
 		}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3973,15 +3973,16 @@ int main(int arg_count, char const **arg_ptr) {
 		for (;;) {
 			String item = string_split_iterator(&target_it, ',');
 			if (item == "") break;
-
-			if (*item.text == '+' || *item.text == '-') {
-				item.text++;
-				item.len--;
+			
+			String stripped_item = item;
+			if (*stripped_item.text == '+' || *stripped_item.text == '-') {
+				stripped_item.text++;
+				stripped_item.len--;
 			}
 
 			String invalid;
-			if (!check_target_feature_is_valid_for_target_arch(item, &invalid) && item != str_lit("help")) {
-				if (item != str_lit("?")) {
+			if (!check_target_feature_is_valid_for_target_arch(stripped_item, &invalid) && stripped_item != str_lit("help")) {
+				if (stripped_item != str_lit("?")) {
 					gb_printf_err("Unkown target feature '%.*s'.\n", LIT(invalid));
 				}
 				gb_printf("Possible -target-features for target %.*s are:\n", LIT(target_arch_names[build_context.metrics.arch]));
@@ -4005,8 +4006,25 @@ int main(int arg_count, char const **arg_ptr) {
 
 				return 1;
 			}
-
-			string_set_add(&build_context.target_features_set, item);
+			
+			// Ensure the feature name always has +/- prefix. If there isn't, default to '+'
+			String feature_str = item;
+			if (*feature_str.text != '+' && *feature_str.text != '-') {
+				feature_str = concatenate_strings(temporary_allocator(), make_string_c("+"), feature_str);
+			}
+			
+			// Ensure there is only a single entry for each feature in the target set.
+			// If the negative exists, override the existing value with the current one.
+			String neg_feature_str = clone_string(temporary_allocator(), feature_str);
+			switch (*neg_feature_str.text) {
+				case '+': *neg_feature_str.text = '-'; break;
+				case '-': *neg_feature_str.text = '+'; break;
+				default: GB_ASSERT(false); break;
+			}
+			
+			string_set_remove(&build_context.target_features_set, neg_feature_str);
+			
+			string_set_add(&build_context.target_features_set, feature_str);
 		}
 	}
 

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -508,6 +508,13 @@ gb_internal String filename_without_directory(String s) {
 	return substring(s, gb_max(j+1, 0), s.len);
 }
 
+gb_internal String clone_string(gbAllocator a, String const &x) {
+	u8 *data = gb_alloc_array(a, u8, x.len+1);
+	gb_memmove(data, x.text, x.len);
+	data[x.len] = 0;
+	return make_string(data, x.len);
+}
+
 gb_internal String concatenate_strings(gbAllocator a, String const &x, String const &y) {
 	isize len = x.len+y.len;
 	u8 *data = gb_alloc_array(a, u8, len+1);


### PR DESCRIPTION
The addition of +/- target feature checks introduced subtle bugs in feature lookup code. This caused real issues especially in `-microarch:native` mode. For example, I got results like this:

```
ODIN_ARCH = amd64
ODIN_MICROARCH_STRING = skylake
ODIN_NO_BOUNDS_CHECK = false

 avx512f = true // WRONG
+avx512f = false
-avx512f = true

 avx2 = true
+avx2 = true
-avx2 = false

 sse2 = true
+sse2 = true
-sse2 = false

 neon = false
+neon = false
-neon = false // WRONG
```

Clearly this is completely wrong. No sign and `+` should be equivalent in all cases. My computer doesn't have AVX512 and NEON ofc, yet `avx512f` and `-neon` report otherwise.

<details>
<summary>Code</summary>

```odin
    fmt.println("ODIN_ARCH =", ODIN_ARCH)
    fmt.println("ODIN_MICROARCH_STRING =", ODIN_MICROARCH_STRING)
    fmt.println("ODIN_NO_BOUNDS_CHECK =", ODIN_NO_BOUNDS_CHECK)
    fmt.println()
    fmt.println(" avx512f =", intrinsics.has_target_feature("avx512f"))
    fmt.println("+avx512f =", intrinsics.has_target_feature("+avx512f"))
    fmt.println("-avx512f =", intrinsics.has_target_feature("-avx512f"))
    fmt.println()
    fmt.println(" avx2 =", intrinsics.has_target_feature("avx2"))
    fmt.println("+avx2 =", intrinsics.has_target_feature("+avx2"))
    fmt.println("-avx2 =", intrinsics.has_target_feature("-avx2"))
    fmt.println()
    fmt.println(" sse2 =", intrinsics.has_target_feature("sse2"))
    fmt.println("+sse2 =", intrinsics.has_target_feature("+sse2"))
    fmt.println("-sse2 =", intrinsics.has_target_feature("-sse2"))
    fmt.println()
    fmt.println(" neon =", intrinsics.has_target_feature("neon"))
    fmt.println("+neon =", intrinsics.has_target_feature("+neon"))
    fmt.println("-neon =", intrinsics.has_target_feature("-neon"))
```

</details>


After this change, the result looks like this:

```
ODIN_ARCH = amd64
ODIN_MICROARCH_STRING = skylake
ODIN_NO_BOUNDS_CHECK = false

 avx512f = false
+avx512f = false
-avx512f = true

 avx2 = true
+avx2 = true
-avx2 = false

 sse2 = true
+sse2 = true
-sse2 = false

 neon = false
+neon = false
-neon = true
```

I initially just "hardened" the `check_target_feature_is_enabled` function properly check all variants. But then I looked into the real reason the target_features_set was wrong in the first place. Turns out "extra" flags always got the prefix stripped (even minus!) and there were absolutely no checks of the existing flags.

So I implemented a simple feature name canonicalization (so now features always have +/- prefix) and a de-duplication check. I kept the extra checks in `check_target_feature_is_enabled` even though they shouldn't be necessary, just to be safe. The code is quite a lot more straightforward and I doubt the performance penalty has any impact whatsoever.

Additionally, I implemented a `clone_string` function because I couldn't find anything. I guess the entire codebase uses `gb_array_alloc` + `gb_memmove` + `make_string` when working with mutable strings?

I'm open to feedback on this! Please let me know if there are better ways to do things or if I misunderstood how some of this stuff works! :)