### PR TITLE
Native simd width

### DIFF
--- a/base/runtime/internal.odin
+++ b/base/runtime/internal.odin
@@ -17,20 +17,18 @@ RUNTIME_REQUIRE :: false // !ODIN_TILDE
 @(private)
 __float16 :: f16 when __ODIN_LLVM_F16_SUPPORTED else u16
 
-HAS_HARDWARE_SIMD :: NATIVE_SIMD_BIT_WIDTH != 0
+HAS_HARDWARE_SIMD :: false when (ODIN_ARCH == .amd64 || ODIN_ARCH == .i386) && !intrinsics.has_target_feature("sse2") else
+	false when (ODIN_ARCH == .arm64 || ODIN_ARCH == .arm32) && !intrinsics.has_target_feature("neon") else
+	false when (ODIN_ARCH == .wasm64p32 || ODIN_ARCH == .wasm32) && !intrinsics.has_target_feature("simd128") else
+	false when (ODIN_ARCH == .riscv64) && !intrinsics.has_target_feature("v") else
+	true
 
-// Number of bits in the largest native SIMD register.
-// 0 when target doesn't support hardware SIMD.
+// Size of a native SIMD register for the current compilation target
 NATIVE_SIMD_BIT_WIDTH :: 
 	512 when (ODIN_ARCH == .amd64) && intrinsics.has_target_feature("avx512f") else
 	256 when (ODIN_ARCH == .amd64) && (intrinsics.has_target_feature("avx2") || intrinsics.has_target_feature("avx")) else
-	128 when (ODIN_ARCH == .amd64 || ODIN_ARCH == .i386) && intrinsics.has_target_feature("sse") else
-	// ARM: SVE can be larger, but NEON is always 128
-	128 when (ODIN_ARCH == .arm64 || ODIN_ARCH == .arm32) && intrinsics.has_target_feature("neon") else
-	// VLEN can be between 32 and thousands of bits. 128 is a safe bet.
-	128 when (ODIN_ARCH == .riscv64) && intrinsics.has_target_feature("v") else
-	128 when (ODIN_ARCH == .wasm64p32 || ODIN_ARCH == .wasm32) && intrinsics.has_target_feature("simd128") else
-	0
+	// Fallback for no hardware SIMD, but also SSE, NEON, SVE, RVV and WASM SIMD128.
+	128
 
 @(private)
 byte_slice :: #force_inline proc "contextless" (data: rawptr, len: int) -> []byte #no_bounds_check {

--- a/base/runtime/internal.odin
+++ b/base/runtime/internal.odin
@@ -17,12 +17,20 @@ RUNTIME_REQUIRE :: false // !ODIN_TILDE
 @(private)
 __float16 :: f16 when __ODIN_LLVM_F16_SUPPORTED else u16
 
-HAS_HARDWARE_SIMD :: false when (ODIN_ARCH == .amd64 || ODIN_ARCH == .i386) && !intrinsics.has_target_feature("sse2") else
-	false when (ODIN_ARCH == .arm64 || ODIN_ARCH == .arm32) && !intrinsics.has_target_feature("neon") else
-	false when (ODIN_ARCH == .wasm64p32 || ODIN_ARCH == .wasm32) && !intrinsics.has_target_feature("simd128") else
-	false when (ODIN_ARCH == .riscv64) && !intrinsics.has_target_feature("v") else
-	true
+HAS_HARDWARE_SIMD :: NATIVE_SIMD_BIT_WIDTH != 0
 
+// Number of bits in the largest native SIMD register.
+// 0 when target doesn't support hardware SIMD.
+NATIVE_SIMD_BIT_WIDTH :: 
+	512 when (ODIN_ARCH == .amd64) && intrinsics.has_target_feature("avx512f") else
+	256 when (ODIN_ARCH == .amd64) && (intrinsics.has_target_feature("avx2") || intrinsics.has_target_feature("avx")) else
+	128 when (ODIN_ARCH == .amd64 || ODIN_ARCH == .i386) && intrinsics.has_target_feature("sse") else
+	// ARM: SVE can be larger, but NEON is always 128
+	128 when (ODIN_ARCH == .arm64 || ODIN_ARCH == .arm32) && intrinsics.has_target_feature("neon") else
+	// VLEN can be between 32 and thousands of bits. 128 is a safe bet.
+	128 when (ODIN_ARCH == .riscv64) && intrinsics.has_target_feature("v") else
+	128 when (ODIN_ARCH == .wasm64p32 || ODIN_ARCH == .wasm32) && intrinsics.has_target_feature("simd128") else
+	0
 
 @(private)
 byte_slice :: #force_inline proc "contextless" (data: rawptr, len: int) -> []byte #no_bounds_check {


### PR DESCRIPTION
This PR implements `NATIVE_SIMD_BIT_WIDTH` which should help selecting the appropriate SIMD width for a particular target at compile time. The value is in **bits** and defines the size of a native vector register. While it's often reasonable to work only with 4 or 8 lane wide vectors and not care about the underlying hardware, it's useful to have this in some particular cases.

This feature is inspired by ISPC's [`TARGET_WIDTH`](https://ispc.github.io/ispc.html#:~:text=Mathematics-,TARGET_WIDTH,-Vector%20width%20of) compile time constant. However the ISPC constant specifies the number of lanes, because their targets are more constrained and assume the vector element bit width.

On platforms with a non-fixed vector register size (ARM SVE, RISC-V V extension) a reasonable alternative which should always work is used. There is also some additional nuance to the specific supported instructions for this hardware SIMD register width. For example, original SSE doesn't implement any integer operations. SSE2 added those later and then became the lowest spec on 64-bit. But this is fine assuming most common kind of SIMD operations are with 32-bit floats.

The constant is zero when a platform doesn't support hardware SIMD. So now `runtime.HAS_HARDWARE_SIMD`  is equivalent to `runtime.NATIVE_SIMD_BIT_WIDTH != 0`.

There is also currently a bug related to the `has_target_feature` procedure. I submitted a fix here: https://github.com/odin-lang/Odin/pull/6544

Example usage:

```odin
import "base:runtime"

NUM_LANES_32 :: runtime.NATIVE_SIMD_BIT_WIDTH / 32
LanesF32 :: #simd[NUM_LANES_32]f32
```