### PR TITLE
 Fix os._volume_name_len to handle paths of purely path separators

### DIFF
--- a/core/os/stat_windows.odin
+++ b/core/os/stat_windows.odin
@@ -377,17 +377,25 @@ _volume_name_len :: proc(path: string) -> (length: int) {
 
 	// UNC path, minimum version of the volume is `\\h\s` for host, share.
 	// Can also contain an IP address in the host position.
+	// (path might be purely path separators)
 	slash_count := 0
+	found_host: bool
 	for i in prefix..<len(path) {
 		// Host needs to be at least 1 character
-		if _is_path_separator(path[i]) && i > 0 {
+		if _is_path_separator(path[i]) {
 			slash_count += 1
 
-			if slash_count == 2 {
+			if slash_count == 2 && found_host {
 				return i
+			}
+		} else {
+			found_host = true
+			// Found a host but no trailing slash `\\h\s`
+			if slash_count == 1 && i == len(path)-1 {
+				return len(path)
 			}
 		}
 	}
 
-	return len(path)
+	return 0
 }


### PR DESCRIPTION
Looking into why os.clean_path was not properly cleaning a path that consists of only path separators.
Turns out, on windows, clean_path was not given a chance to do its work because _volume_name_len
was misidentifying the all slashes case as a UNC share.
This change addresses that and also fixes the UNC share case where the path does not have a trailing
 slash. `\\hostname\sharename`

Notes:
Returning `len(path)` at the end of _volume_name_len seems incorrect. At that point in the procedure a 
volume name has not been positively identified so returning 0 seems like the right thing to do and is
required for the all slashes case to fall through.
Also, removed ` i > 0` test which was always true and use a bool for this instead.
