### PR TITLE
Faster linalg `dot`, `cross3`, `floor`, `ceil` and add `trunc`

### DIFF
--- a/core/math/linalg/extended.odin
+++ b/core/math/linalg/extended.odin
@@ -1,6 +1,7 @@
 package linalg
 
 import "base:builtin"
+import "base:intrinsics"
 import "core:math"
 
 @(require_results)
@@ -413,26 +414,12 @@ pow :: proc "contextless" (x, e: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 
 @(require_results)
 ceil :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
-	when IS_ARRAY(T) {
-		for i in 0..<len(T) {
-			out[i] = #force_inline math.ceil(x[i])
-		}
-	} else {
-		out = #force_inline math.ceil(x)
-	}
-	return
+	return _from_simd4(T, intrinsics.simd_ceil(_to_simd4(x)))
 }
 
 @(require_results)
 floor :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
-	when IS_ARRAY(T) {
-		for i in 0..<len(T) {
-			out[i] = #force_inline math.floor(x[i])
-		}
-	} else {
-		out = #force_inline math.floor(x)
-	}
-	return
+	return _from_simd4(T, intrinsics.simd_floor(_to_simd4(x)))
 }
 
 @(require_results)
@@ -445,6 +432,11 @@ round :: proc "contextless" (x: $T) -> (out: T) where IS_FLOAT(ELEM_TYPE(T)) {
 		out = #force_inline math.round(x)
 	}
 	return
+}
+
+@(require_results)
+trunc :: proc "contextless" (x: $T) -> (out: T) where IS_NUMERIC(ELEM_TYPE(T)) {
+	return _from_simd4(T, intrinsics.simd_trunc(_to_simd4(x)))
 }
 
 @(require_results)
@@ -612,4 +604,47 @@ not :: proc "contextless" (x: $A/[$N]bool) -> (out: A) {
 		out[i] = !e
 	}
 	return
+}
+
+
+@(require_results)
+_to_simd4 :: #force_inline proc "contextless" (a: $T) -> (out: #simd[4]ELEM_TYPE(T)) where IS_NUMERIC(ELEM_TYPE(T)) #no_bounds_check {
+	when IS_ARRAY(T) {
+		when len(T) == 1 {
+			_a: [4]ELEM_TYPE(T)
+			_a.x = a.x
+			return transmute(#simd[4]ELEM_TYPE(T))_a
+		} else when len(T) == 2 {
+			_a: [4]ELEM_TYPE(T)
+			_a.xy = a
+			return transmute(#simd[4]ELEM_TYPE(T))_a
+		} else when len(T) == 3 {
+			_a: [4]ELEM_TYPE(T)
+			_a.xyz = a
+			return transmute(#simd[4]ELEM_TYPE(T))_a
+		} else {
+			return transmute(#simd[4]ELEM_TYPE(T))a
+		}
+	} else {
+		_a: [4]ELEM_TYPE(T)
+		_a.x = a
+		return transmute(#simd[4]ELEM_TYPE(T))_a
+	}
+}
+
+@(require_results)
+_from_simd4 :: #force_inline proc "contextless" ($T: typeid, a: $V/#simd[4]$E) -> T where IS_NUMERIC(ELEM_TYPE(T)) #no_bounds_check {
+	when IS_ARRAY(T) {
+		when len(T) == 1 {
+			return (transmute([4]ELEM_TYPE(T))a).x
+		} else when len(T) == 2 {
+			return (transmute([4]ELEM_TYPE(T))a).xy
+		} else when len(T) == 3 {
+			return (transmute([4]ELEM_TYPE(T))a).xyz
+		} else {
+			return transmute([4]ELEM_TYPE(T))a
+		}       
+	} else {
+		return (transmute([4]ELEM_TYPE(T))a).x
+	}
 }

--- a/core/math/linalg/general.odin
+++ b/core/math/linalg/general.odin
@@ -45,7 +45,7 @@ scalar_dot :: proc "contextless" (a, b: $T) -> T where IS_FLOAT(T), !IS_ARRAY(T)
 }
 
 @(require_results)
-vector_dot :: #force_inline proc "contextless" (a, b: $T/[$N]$E) -> (c: E) where IS_NUMERIC(E) #no_bounds_check {
+vector_dot :: proc "contextless" (a, b: $T/[$N]$E) -> (c: E) where IS_NUMERIC(E) #no_bounds_check {
 	ab := a * b
 	when N == 1 {
 		return ab.x

--- a/core/math/linalg/general.odin
+++ b/core/math/linalg/general.odin
@@ -45,12 +45,24 @@ scalar_dot :: proc "contextless" (a, b: $T) -> T where IS_FLOAT(T), !IS_ARRAY(T)
 }
 
 @(require_results)
-vector_dot :: proc "contextless" (a, b: $T/[$N]$E) -> (c: E) where IS_NUMERIC(E) #no_bounds_check {
-	for i in 0..<N {
-		c += a[i] * b[i]
+vector_dot :: #force_inline proc "contextless" (a, b: $T/[$N]$E) -> (c: E) where IS_NUMERIC(E) #no_bounds_check {
+	ab := a * b
+	when N == 1 {
+		return ab.x
+	} else when N == 2 {
+		return ab.x + ab.y
+	} else when N == 3 {
+		return ab.x + ab.y + ab.z
+	} else when N == 4 {
+		return ab.x + ab.y + ab.z + ab.w
+	} else {
+		for elem in ab {
+			c += elem
+		}
+		return c
 	}
-	return
 }
+
 @(require_results)
 quaternion64_dot :: proc "contextless" (a, b: $T/quaternion64) -> (c: f16) {
 	return a.w*b.w + a.x*b.x + a.y*b.y + a.z*b.z
@@ -86,11 +98,8 @@ vector_cross2 :: proc "contextless" (a, b: $T/[2]$E) -> E where IS_NUMERIC(E) {
 }
 
 @(require_results)
-vector_cross3 :: proc "contextless" (a, b: $T/[3]$E) -> (c: T) where IS_NUMERIC(E) {
-	c[0] = a[1]*b[2] - b[1]*a[2]
-	c[1] = a[2]*b[0] - b[2]*a[0]
-	c[2] = a[0]*b[1] - b[0]*a[1]
-	return
+vector_cross3 :: proc "contextless" (a, b: $T/[3]$E) -> (c: T) where IS_NUMERIC(E) #no_bounds_check {
+	return a.yzx*b.zxy - b.yzx*a.zxy
 }
 
 @(require_results)
@@ -130,12 +139,12 @@ normalize0 :: proc{vector_normalize0, quaternion_normalize0}
 
 @(require_results)
 vector_length :: proc "contextless" (v: $T/[$N]$E) -> E where IS_FLOAT(E) {
-	return math.sqrt(dot(v, v))
+	return #force_inline math.sqrt(#force_inline dot(v, v))
 }
 
 @(require_results)
 vector_length2 :: proc "contextless" (v: $T/[$N]$E) -> E where IS_NUMERIC(E) {
-	return dot(v, v)
+	return #force_inline dot(v, v)
 }
 
 @(require_results)


### PR DESCRIPTION
I was just goofing around with some math procedures and turns out a lot of them are a lot slower than they could be (especially on Windows), and can be improved without that much effort or code complexity.

This includes 3 major changes:
- faster dot product using array programming
- faster cross3 product using array programming
- faster floor/ceil using SIMD

This generally results in **4x - 6x speedup** on Windows with `-o:speed`.

The dot product codegen was especially bad on *windows*, because we don't have vectorcall calling convention support yet. On Linux the perfomance is pretty much identical. I have no idea about other platforms.

<details>
<summary>Codegen Comparison</summary>

Here is the assembly code for the dot product. The other procedures are not worth showing as the difference is way larger.

Old on Windows. This one is really ugly 🤮. This is what we want to avoid at all costs.
```asm
"linalg_bench::dot_linalg":
	vmovss	(%rcx), %xmm0
	vmulss	(%rdx), %xmm0, %xmm0
	vxorps	%xmm1, %xmm1, %xmm1
	vaddss	%xmm1, %xmm0, %xmm0
	vmovsd	4(%rcx), %xmm1
	vmovsd	4(%rdx), %xmm2
	vmulps	%xmm2, %xmm1, %xmm1
	vaddss	%xmm1, %xmm0, %xmm0
	vmovshdup	%xmm1, %xmm1
	vaddss	%xmm1, %xmm0, %xmm0
	retq
```

Old on Linux. Pretty nice code.
```asm
"linalg_bench::dot_linalg":
        vmulps  %xmm2, %xmm0, %xmm0
        vxorps  %xmm2, %xmm2, %xmm2
        vaddss  %xmm2, %xmm0, %xmm2
        vmovshdup       %xmm0, %xmm0
        vaddss  %xmm0, %xmm2, %xmm0
        vmulss  %xmm3, %xmm1, %xmm1
        vaddss  %xmm1, %xmm0, %xmm0
        retq
```

New on Linux. The [vinsert](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=insert_ps&ig_expand=3840)'s aren't the best but there is one less add. Overall improvement. On Windows it needs two additional `vmovsd`'s because of the awful callconv.
```asm
"linalg_bench::dot_new":
        vinsertps       $32, %xmm1, %xmm0, %xmm0
        vinsertps       $32, %xmm3, %xmm2, %xmm1
        vmulps  %xmm1, %xmm0, %xmm0
        vmovshdup       %xmm0, %xmm1
        vaddss  %xmm1, %xmm0, %xmm1
        vshufpd $1, %xmm0, %xmm0, %xmm0
        vaddss  %xmm1, %xmm0, %xmm0
        retq
```


</details>

There's also now a new trunc procedure.

## Focus

All of the optimizations above **focus on 3xf32 math** with `-o:speed`, but I made sure the non-optimized code isn't significantly slower (in my benchmarks it's like 0.95x the original speed in general). Speed of vector math of width 1, 2 and 4 is generally unaffected or faster.
> The floor/ceil procedures are also *significantly* faster this way for scalar math.

## Results

You can find my final [benchmarking code here](https://gist.github.com/jakubtomsu/08212f9216935db0354b1e08f87b3814). But that's the result of another benchmark I wrote which had a LOT more variants for each of the tested procedures, as well as many more procedures which didn't turn out to be worth optimizing. I have also used the Compiler Explorer a lot.

| NAME |  Cycles/Elem  |       Total Cycles        | Ms | Speedup
| -- | -- | -- | -- | -- 
|     dot_linalg |  21 (20 ..168) | 177936 (170854 ..1376594) |  59 | 1.000x
|        dot_new |   4 ( 4 .. 28) |  37981 ( 37631 .. 234637) |  12 | 4.685x
|   cross_linalg |  24 (22 ..157) | 197057 (182855 ..1290448) |  65 | 1.000x
|      cross_new |   6 ( 6 .. 83) |  56374 ( 53615 .. 685982) |  18 | 3.496x
|  length_linalg |  29 (28 ..133) | 237700 (229828 ..1096887) |  79 | 1.000x
|     length_new |   4 ( 4 .. 32) |  39735 ( 38653 .. 263547) |  13 | 5.982x
| length2_linalg |  21 (20 ..148) | 174202 (167141 ..1217799) |  58 | 1.000x
|    length2_new |   4 ( 4 .. 28) |  37024 ( 36730 .. 233127) |  12 | 4.705x
|   floor_linalg |  56 (54 ..118) | 464851 (446381 .. 974453) | 154 | 1.000x
|      floor_new |  23 (22 .. 50) | 189890 (188086 .. 411024) |  63 | 2.448x
|    ceil_linalg |  55 (53 ..199) | 454396 (437759 ..1632766) | 151 | 1.000x
|       ceil_new |  23 (22 .. 49) | 190358 (188088 .. 406526) |  63 | 2.387x
|      trunc_new |  23 (22 ..192) | 195991 (188087 ..1575865) |  65 | 1.000x

> the values are `average (min .. max)`

Some of the speedups are purely thanks to forced inlining.

```
ODIN_OPTIMIZATION_MODE = Speed
ODIN_ARCH = amd64
ODIN_MICROARCH_STRING = x86-64-v2
ODIN_NO_BOUNDS_CHECK = true
```
```
Odin:    dev-2026-04:e1a376123
OS:      Windows 10 Professional (version: 22H2), build 19045.6466
CPU:     Intel(R) Core(TM) i7-9700 CPU @ 3.00GHz
RAM:     32681 MiB
Backend: LLVM 20.1.0
```

## Closing Thoughs

To be honest I've probably spent more effort on this than is worth, but I really tried to make sure to follow every rabbit hole so I could explain why the perf differences are what they are. I also really tried to make sure the actual benchmark code isn't biased towards one variant or another.

Of course if someone really needs to do fast vector math then they should use SIMD directly. But the changes here seem relatively simple and help when vectorcalls aren't available.