### PR TITLE
address hint to linux virtual mem reserve & made `make_aligned` a builtin

### DIFF
--- a/base/runtime/core_builtin.odin
+++ b/base/runtime/core_builtin.odin
@@ -530,7 +530,7 @@ new_clone :: proc(data: $T, allocator := context.allocator, loc := #caller_locat
 
 DEFAULT_DYNAMIC_ARRAY_CAPACITY :: 8
 
-@(require_results)
+@(builtin, require_results)
 make_aligned :: proc($T: typeid/[]$E, #any_int len: int, alignment: int, allocator := context.allocator, loc := #caller_location) -> (res: T, err: Allocator_Error) #optional_allocator_error {
 	err = _make_aligned_type_erased(&res, size_of(E), len, alignment, allocator, loc)
 	return

--- a/core/mem/virtual/virtual.odin
+++ b/core/mem/virtual/virtual.odin
@@ -16,8 +16,8 @@ platform_memory_init :: proc "contextless" () {
 Allocator_Error :: mem.Allocator_Error
 
 @(require_results, no_sanitize_address)
-reserve :: proc "contextless" (size: uint) -> (data: []byte, err: Allocator_Error) {
-	return _reserve(size)
+reserve :: proc "contextless" (size: uint, address_hint := uintptr(0)) -> (data: []byte, err: Allocator_Error) {
+	return _reserve(size, address_hint)
 }
 
 @(no_sanitize_address)
@@ -27,8 +27,8 @@ commit :: proc "contextless" (data: rawptr, size: uint) -> Allocator_Error {
 }
 
 @(require_results, no_sanitize_address)
-reserve_and_commit :: proc "contextless" (size: uint) -> (data: []byte, err: Allocator_Error) {
-	data = reserve(size) or_return
+reserve_and_commit :: proc "contextless" (size: uint, address_hint := uintptr(0)) -> (data: []byte, err: Allocator_Error) {
+	data = reserve(size, address_hint) or_return
 	commit(raw_data(data), size) or_return
 	return
 }

--- a/core/mem/virtual/virtual_linux.odin
+++ b/core/mem/virtual/virtual_linux.odin
@@ -4,8 +4,8 @@ package mem_virtual
 
 import "core:sys/linux"
 
-_reserve :: proc "contextless" (size: uint) -> (data: []byte, err: Allocator_Error) {
-	addr, errno := linux.mmap(0, size, {}, {.PRIVATE, .ANONYMOUS})
+_reserve :: proc "contextless" (size: uint, address_hint := uintptr(0)) -> (data: []byte, err: Allocator_Error) {
+	addr, errno := linux.mmap(address_hint, size, {}, {.PRIVATE, .ANONYMOUS})
 	if errno == .ENOMEM {
 		return nil, .Out_Of_Memory
 	} else if errno == .EINVAL {


### PR DESCRIPTION
- added a `address_hint` parameter to be passed down to mmap on linux as a hint to around where the user would like .to reserve the memory.  defaults to 0, which it was hardcoded to before.
- made `make_aligned` a builtin