### PR TITLE
Fix arena overcommit bug (revisited)

### DIFF
--- a/core/mem/virtual/arena.odin
+++ b/core/mem/virtual/arena.odin
@@ -141,9 +141,9 @@ arena_alloc_unguarded :: proc(arena: ^Arena, size: uint, alignment: uint, loc :=
 
 			needed := mem.align_forward_uint(size, alignment)
 			needed = max(needed, arena.default_commit_size)
-			block_size := max(needed, arena.minimum_block_size) + alignment
+			block_size := max(needed, arena.minimum_block_size)
 
-			new_block := memory_block_alloc(needed, block_size) or_return
+			new_block := memory_block_alloc(needed, block_size, alignment) or_return
 			new_block.prev = arena.curr_block
 			arena.curr_block = new_block
 			arena.total_reserved += new_block.reserved

--- a/core/mem/virtual/virtual.odin
+++ b/core/mem/virtual/virtual.odin
@@ -115,7 +115,7 @@ memory_block_alloc :: proc(committed, reserved: uint, alignment: uint = 0, flags
 	}
 	
 	pmblock.block.committed = committed
-	pmblock.block.reserved  = reserved
+	pmblock.block.reserved  = total_size - uint(base_offset)
 
 	
 	return &pmblock.block, nil


### PR DESCRIPTION
### Version
dev-2026-04:98d6b3bc8

### Context

In #6398 and #5821 a bug with the virtual arena allocator was encountered and attempted to fix.
This PR reverts the change in #6398 as it does not correctly fix the bug and can cause other issues down the line, and fixes the actual root cause.

### Bug
As the other PR/issue correctly identified, passing an aligment other than 0 to `memory_block_alloc` can cause an assert to later be triggered in `do_commit_if_necessary`.
The assert seems to trigger due to overcommitting the reserved memory when in reality the size of the reserved memory is just not calculated correctly and the commit was actually safe.

### Fix
Not passing in the alignment (as implemented by #6398, even with the changes to `block_size`) can cause other issues as the `base_offset`, and by extension the base pointer, will not be calculated correctly, should the alignment requirement be bigger than that of `Platform_Memory_Block`.

The real issue comes from the fact that the `Platform_Memory_Block` and `Memory_Block` disagree on the size of actual reserved memory. `Platform_Memory_Block` correctly assumes `total_size` to be reserved, which includes the alignment and the header size.
`Memory_Block` however only assumes the initially requested `reserved`. This does not include the header size, which is intended, BUT it does also not include the alignment which would be correct, if `alignment` would actually contribute to `base_offset`. But it does not do that if the alignment requirement is already met by `align_of(Platform_Memory_Block)`.

Removing `alignment` from the calculation of `total_size` (as suggested in #5821) is however the wrong approach since it would break the cases where `alignment` actually contributes to `base_offset`.

The correct change is therefore to adjust the calculation of the `Memory_Block`'s `reserved` size to use `total_size - base_offset` instead.




