### PR TITLE
`-o:minimal` SROA and simplification passes

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -578,7 +578,7 @@ struct BuildContext {
 	bool internal_by_value;
 	bool internal_weak_monomorphization;
 	bool internal_ignore_llvm_verification;
-	bool internal_llvm_mem2reg;
+	bool internal_llvm_no_sroa;
 
 	bool   enable_rvo;
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -9,7 +9,9 @@
 
 #if defined(GB_SYSTEM_WINDOWS)
 
-#define NOMINMAX            1
+#define NOMINMAX
+#define WINDOWS_LEAN_AND_MEAN 1
+#define VC_EXTRALEAN 1
 #include <windows.h>
 #undef NOMINMAX
 #endif

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -9,7 +9,7 @@
 
 #if defined(GB_SYSTEM_WINDOWS)
 
-#define NOMINMAX
+#define NOMINMAX 1
 #define WINDOWS_LEAN_AND_MEAN 1
 #define VC_EXTRALEAN 1
 #include <windows.h>

--- a/src/llvm_backend_passes.cpp
+++ b/src/llvm_backend_passes.cpp
@@ -12,7 +12,7 @@
 			array_add(&passes, "forceattrs");
 			array_add(&passes, "function<eager-inv>(sroa<modify-cfg>,early-cse<>)");
 			array_add(&passes, "always-inline");
-			array_add(&passes, "function<eager-inv>(sroa<modify-cfg>,instsimplify)");
+			array_add(&passes, "function<eager-inv>(sroa<modify-cfg>,instsimplify,simplifycfg<bonus-inst-threshold=1;no-forward-switch-cond;switch-range-to-icmp;no-switch-to-lookup;keep-loops;no-hoist-common-insts;no-sink-common-insts;speculate-blocks;simplify-cond-branch>)");
 			// array_add(&passes, "verify");
 		}
 		array_add(&passes, "function(annotation-remarks)");

--- a/src/llvm_backend_passes.cpp
+++ b/src/llvm_backend_passes.cpp
@@ -3,9 +3,13 @@
 		array_add(&passes, "function(annotation-remarks)");
 		break;
 	case 0:
-		array_add(&passes, "always-inline");
-		if (build_context.internal_llvm_mem2reg) {
-			array_add(&passes, "function<eager-inv>(mem2reg)");
+		if (build_context.internal_llvm_no_sroa) {
+			// Old -o:minimal behavior
+			array_add(&passes, "always-inline");
+		} else {
+			array_add(&passes, "function<eager-inv>(sroa,early-cse)");
+			array_add(&passes, "always-inline");
+			array_add(&passes, "function<eager-inv>(sroa,instcombine<max-iterations=1;no-verify-fixpoint>,simplifycfg)");
 		}
 		array_add(&passes, "function(annotation-remarks)");
 		break;

--- a/src/llvm_backend_passes.cpp
+++ b/src/llvm_backend_passes.cpp
@@ -7,9 +7,9 @@
 			// Old -o:minimal behavior
 			array_add(&passes, "always-inline");
 		} else {
-			array_add(&passes, "function<eager-inv>(sroa,early-cse)");
+			array_add(&passes, "function<eager-inv>(sroa<modify-cfg>,early-cse)");
 			array_add(&passes, "always-inline");
-			array_add(&passes, "function<eager-inv>(sroa,instcombine<max-iterations=1;no-verify-fixpoint>,simplifycfg)");
+			array_add(&passes, "function<eager-inv>(sroa<modify-cfg>,instcombine<max-iterations=1;no-verify-fixpoint>,simplifycfg)");
 		}
 		array_add(&passes, "function(annotation-remarks)");
 		break;

--- a/src/llvm_backend_passes.cpp
+++ b/src/llvm_backend_passes.cpp
@@ -7,9 +7,13 @@
 			// Old -o:minimal behavior
 			array_add(&passes, "always-inline");
 		} else {
-			array_add(&passes, "function<eager-inv>(sroa<modify-cfg>,early-cse)");
+			array_add(&passes, "annotation2metadata");
+			array_add(&passes, "inferattrs");
+			array_add(&passes, "forceattrs");
+			array_add(&passes, "function<eager-inv>(sroa<modify-cfg>,early-cse<>)");
 			array_add(&passes, "always-inline");
-			array_add(&passes, "function<eager-inv>(sroa<modify-cfg>,instcombine<max-iterations=1;no-verify-fixpoint>,simplifycfg)");
+			array_add(&passes, "function<eager-inv>(sroa<modify-cfg>,instsimplify)");
+			// array_add(&passes, "verify");
 		}
 		array_add(&passes, "function(annotation-remarks)");
 		break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -402,7 +402,7 @@ enum BuildFlagKind {
 	BuildFlag_InternalByValue,
 	BuildFlag_InternalWeakMonomorphization,
 	BuildFlag_InternalLLVMVerification,
-	BuildFlag_InternalLLVMMem2Reg,
+	BuildFlag_InternalLLVMNoSROA,
 	BuildFlag_InternalEnableRVO,
 
 	BuildFlag_Sanitize,
@@ -634,7 +634,7 @@ gb_internal bool parse_build_flags(Array<String> args) {
 	add_flag(&build_flags, BuildFlag_InternalByValue,         str_lit("internal-by-value"),         BuildFlagParam_None,    Command_all);
 	add_flag(&build_flags, BuildFlag_InternalWeakMonomorphization, str_lit("internal-weak-monomorphization"), BuildFlagParam_None, Command_all);
 	add_flag(&build_flags, BuildFlag_InternalLLVMVerification, str_lit("internal-ignore-llvm-verification"), BuildFlagParam_None, Command_all);
-	add_flag(&build_flags, BuildFlag_InternalLLVMMem2Reg,     str_lit("internal-llvm-mem2reg"), BuildFlagParam_None, Command_all);
+	add_flag(&build_flags, BuildFlag_InternalLLVMNoSROA,      str_lit("internal-llvm-no-sroa"), BuildFlagParam_None, Command_all);
 	add_flag(&build_flags, BuildFlag_InternalEnableRVO,       str_lit("internal-enable-rvo"), BuildFlagParam_None, Command_all);
 
 
@@ -1628,8 +1628,8 @@ gb_internal bool parse_build_flags(Array<String> args) {
 						case BuildFlag_InternalLLVMVerification:
 							build_context.internal_ignore_llvm_verification = true;
 							break;
-						case BuildFlag_InternalLLVMMem2Reg:
-							build_context.internal_llvm_mem2reg = true;
+						case BuildFlag_InternalLLVMNoSROA:
+							build_context.internal_llvm_no_sroa = true;
 							break;
 						case BuildFlag_InternalEnableRVO:
 							build_context.enable_rvo = true;


### PR DESCRIPTION
This started just as a little experiment because I stumbled upon Bill's `mem2reg` internal flag from few weeks ago. Turns out we can get a lot of benefits in `minimal` builds by running simplification passes at *zero* compile time cost.

So the new `-o:minimal` does passes SROA, early-CSE, inlining, and instruction and CFG simplification by default.
> Previously, it ran only `always-inline` by default.

The idea is to do try to simplify as much as possible rather than running any actual optimization.

All of this can be disabled with `-internal-llvm-no-sroa` flag, which replaces the `-internal-llvm-mem2reg` flag. The results made me confident this could be the default, unless there is something I don't know about that could cause problems to users.

## Results

### Speedup

I tested this on a 3D benchmark scene from my [game engine](https://github.com/jakubtomsu/raven) and the frame time went from **~50 to ~36** milliseconds per frame. That's huge, almost a 40% speedup! Fully optimized builds run at 13-14 but that requires all the super expensive passes.

### Compile time

I expected this to slow down compile times at least a little bit, but they usually stayed the same or actually got a few percent faster. I guess that's because the early simplification passes help reduce the codegen amount in later lowering stages..?

Without the new passes:
```
D:\projects\raven>d:\projects\odin\odin build examples\stress_test_3d -o:minimal -microarch:native -show-timings -internal-llvm-no-sroa
Total Time                         -   587.397 ms - 100.00%
initialization                     -     7.358 ms -   1.25%
parse files                        -    30.164 ms -   5.13%
type check                         -   147.503 ms -  25.11%
LLVM API Code Gen (   81 modules ) -   204.251 ms -  34.77%
msvc-link                          -   198.115 ms -  33.72%
```
With the new passes:
```
D:\projects\raven>d:\projects\odin\odin build examples\stress_test_3d -o:minimal -microarch:native -show-timings
Total Time                         -   519.337 ms - 100.00%
initialization                     -     7.199 ms -   1.38%
parse files                        -    31.459 ms -   6.05%
type check                         -   147.737 ms -  28.44%
LLVM API Code Gen (   81 modules ) -   157.558 ms -  30.33%
msvc-link                          -   175.378 ms -  33.76%
```
And just for reference, the optimized build:
```
D:\projects\raven>d:\projects\odin\odin run examples\stress_test_3d -o:speed -microarch:native -show-timings
Total Time        -  3995.720 ms - 100.00%
initialization    -     7.247 ms -   0.18%
parse files       -    28.805 ms -   0.72%
type check        -   147.293 ms -   3.68%
LLVM API Code Gen -  3693.159 ms -  92.42%
msvc-link         -   119.209 ms -   2.98%
```

### ASM

The codegen is *much* nicer especially because all of the awful and redundant stack movs get eliminated.

The comparison here is using code from my [linalg PR from yesterday](https://github.com/odin-lang/Odin/pull/6549) and the associated benchmark.

#### Old (`-o:minimal -microarch:native`)
Actual garbage code
```
"linalg_bench::dot_new":
.seh_proc "linalg_bench::dot_new"
	subq	$120, %rsp
	.seh_stackalloc 120
	.seh_endprologue
	movq	%rdx, 8(%rsp)
	movq	%rcx, 16(%rsp)
	movq	8(%rsp), %rax
	movq	16(%rsp), %rcx
	movl	8(%rcx), %edx
	movl	%edx, 48(%rsp)
	movq	(%rcx), %rcx
	movq	%rcx, 40(%rsp)
	movl	8(%rax), %ecx
	movl	%ecx, 32(%rsp)
	movq	(%rax), %rax
	movq	%rax, 24(%rsp)
	movl	48(%rsp), %eax
	movl	%eax, 104(%rsp)
	movq	40(%rsp), %rax
	movq	%rax, 96(%rsp)
	movl	32(%rsp), %eax
	movl	%eax, 88(%rsp)
	movq	24(%rsp), %rax
	movq	%rax, 80(%rsp)
	movl	$0, 76(%rsp)
	vmovaps	96(%rsp), %xmm0
	vmovaps	80(%rsp), %xmm1
	vmulps	%xmm1, %xmm0, %xmm0
	vextractps	$2, %xmm0, 72(%rsp)
	vmovq	%xmm0, 64(%rsp)
	vmovss	64(%rsp), %xmm0
	vmovss	68(%rsp), %xmm1
	vmovss	72(%rsp), %xmm2
	vmovss	%xmm2, 60(%rsp)
	vmovss	%xmm1, 56(%rsp)
	vmovss	%xmm0, 52(%rsp)
	vmovss	52(%rsp), %xmm0
	vaddss	56(%rsp), %xmm0, %xmm0
	vaddss	60(%rsp), %xmm0, %xmm0
	vmovss	%xmm0, 76(%rsp)
	addq	$120, %rsp
	retq
```

#### Old (`-o:minimal -microarch:native -internal-enable-rvo -internal-llvm-mem2reg`)
Subtle improvements, but the RVO and mem2reg alone don't really do anything
```
"linalg_bench::dot_new":
.seh_proc "linalg_bench::dot_new"
	subq	$120, %rsp
	.seh_stackalloc 120
	.seh_endprologue
	movq	%rdx, 8(%rsp)
	movq	%rcx, 16(%rsp)
	movq	8(%rsp), %rax
	movq	16(%rsp), %rcx
	movl	8(%rcx), %edx
	movl	%edx, 48(%rsp)
	movq	(%rcx), %rcx
	movq	%rcx, 40(%rsp)
	movl	8(%rax), %ecx
	movl	%ecx, 32(%rsp)
	movq	(%rax), %rax
	movq	%rax, 24(%rsp)
	movl	48(%rsp), %eax
	movl	%eax, 104(%rsp)
	movq	40(%rsp), %rax
	movq	%rax, 96(%rsp)
	movl	32(%rsp), %eax
	movl	%eax, 88(%rsp)
	movq	24(%rsp), %rax
	movq	%rax, 80(%rsp)
	vmovaps	96(%rsp), %xmm0
	vmovaps	80(%rsp), %xmm1
	vmulps	%xmm1, %xmm0, %xmm0
	vextractps	$2, %xmm0, 72(%rsp)
	vmovq	%xmm0, 64(%rsp)
	vmovss	64(%rsp), %xmm0
	vmovss	68(%rsp), %xmm1
	vmovss	72(%rsp), %xmm2
	vmovss	%xmm2, 60(%rsp)
	vmovss	%xmm1, 56(%rsp)
	vmovss	%xmm0, 52(%rsp)
	vmovss	52(%rsp), %xmm0
	vaddss	56(%rsp), %xmm0, %xmm0
	vaddss	60(%rsp), %xmm0, %xmm0
	addq	$120, %rsp
	retq
```    
    
#### Old (`-o:speed -microarch:native`)
This is relatively nice optimized code, but at the cost of very long compile times.
```
"linalg_bench::dot_new":
	vmovsd	(%rcx), %xmm0
	vinsertps	$32, 8(%rcx), %xmm0, %xmm0
	vmovsd	(%rdx), %xmm1
	vinsertps	$32, 8(%rdx), %xmm1, %xmm1
	vmulps	%xmm1, %xmm0, %xmm0
	vmovshdup	%xmm0, %xmm1
	vaddss	%xmm1, %xmm0, %xmm1
	vshufpd	$1, %xmm0, %xmm0, %xmm0
	vaddss	%xmm1, %xmm0, %xmm0
	retq
```

#### NEW (`-o:minimal -microarch:native`)
This is surprisingly close to the optimized version.
```
"linalg_bench::dot_new":
	vmovss	8(%rcx), %xmm1
	vmovq	(%rcx), %xmm0
	vinsertps	$32, %xmm1, %xmm0, %xmm0
	vmovss	8(%rdx), %xmm2
	vmovq	(%rdx), %xmm1
	vinsertps	$32, %xmm2, %xmm1, %xmm1
	vmulps	%xmm1, %xmm0, %xmm1
	vmovaps	%xmm1, %xmm0
	vmovshdup	%xmm1, %xmm2
	vpermilpd	$1, %xmm1, %xmm1
	vaddss	%xmm2, %xmm0, %xmm0
	vaddss	%xmm1, %xmm0, %xmm0
	retq
```