### PR TITLE
Fix D3D12_BARRIER_SUBRESOURCE_RANGE struct

### DIFF
--- a/vendor/directx/d3d12/d3d12.odin
+++ b/vendor/directx/d3d12/d3d12.odin
@@ -5458,12 +5458,12 @@ TEXTURE_BARRIER_FLAGS :: enum i32 {
 }
 
 BARRIER_SUBRESOURCE_RANGE :: struct {
-	IndexOrFirstMipLevel: uint,
-	NumMipLevels:         uint,
-	FirstArraySlice:      uint,
-	NumArraySlices:       uint,
-	FirstPlane:           uint,
-	NumPlanes:            uint,
+	IndexOrFirstMipLevel: u32,
+	NumMipLevels:         u32,
+	FirstArraySlice:      u32,
+	NumArraySlices:       u32,
+	FirstPlane:           u32,
+	NumPlanes:            u32,
 }
 
 GLOBAL_BARRIER :: struct {


### PR DESCRIPTION
Should be all u32 in this struct, not uint

https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ns-d3d12-d3d12_barrier_subresource_range