### PR TITLE
Win32: ensure `make_*` style bounds traps are handled in test runner `expect_signal`

### DIFF
--- a/core/testing/signal_handler_windows.odin
+++ b/core/testing/signal_handler_windows.odin
@@ -134,7 +134,7 @@ This is a dire bug and should be reported to the Odin developers.
 			}
 			signal := local_test_expected_failures.signal
 			switch signal {
-			case libc.SIGILL:  passed = code == win32.EXCEPTION_ILLEGAL_INSTRUCTION
+			case libc.SIGILL:  passed = code == win32.EXCEPTION_ILLEGAL_INSTRUCTION || code == win32.EXCEPTION_ARRAY_BOUNDS_EXCEEDED
 			case libc.SIGSEGV: passed = code == win32.EXCEPTION_ACCESS_VIOLATION
 			case libc.SIGFPE:
 				switch code {

--- a/tests/core/testing/test_core_testing.odin
+++ b/tests/core/testing/test_core_testing.odin
@@ -50,3 +50,9 @@ test_expected_signal :: proc(t: ^testing.T) {
 	testing.expect_signal(t, libc.SIGILL)
 	libc.raise(libc.SIGILL)
 }
+
+@test
+test_array_bounds_trap_signal :: proc(t: ^testing.T) {
+	testing.expect_signal(t, libc.SIGILL)
+	_ = make([]u8, -1)
+}


### PR DESCRIPTION
Upon writing unit testing code, I discovered that `testing.expect_signal` has platform differences on win32 when bounds trapping code is involved.
This refers to `runtime.bounds_trap` invocations when called in either an out of bounds situation, or a `make_*` call with incorrect params, e.g. `make([]u8, /*len*/ -1)` invokes this.

On win32, a bounds_trap executes a `RaiseException(EXCEPTION_ARRAY_BOUNDS_EXCEEDED)` as opposed to posix systems where an intrinsics.trap is executed (ud2 which results in SIGILL signal). 

```go
@(no_instrumentation)
bounds_trap :: proc "contextless" () -> ! {
	when ODIN_OS == .Windows {
		windows_trap_array_bounds()
	} else when ODIN_OS == .Orca {
		abort_ext("", "", 0, "bounds trap")
	} else {
		trap()
	}
}
```

The former case is not handled by the win32 testing signal handler, therefore these kinds of signals cannot currently be detected on windows, and the following message is generated by the test runner:

`Caught signal to stop test #3 tests.bounds_violation for: Unknown`

I changed this so `testing.expect_signal(t, libc.SIGILL)` can successfully detect those bounds traps and is therefor consistent with other platforms. This new code now explicitly handles intrinsics.trap and internal runtime.windows_trap_* calls (for bounds related matters and type assertions; see error_checks.odin).

Therefor the cross platform way of expects traps in tests is:
```go
TRAP_SIG :: posix.SIGTRAP when ODIN_OS == .Darwin else libc.SIGILL
testing.expect_signal(t, TRAP_SIG)
something_that_causes_trap()
```
(as it always was)