### PR TITLE
feat(vulkan): add version macros

### DIFF
--- a/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
+++ b/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
@@ -899,6 +899,7 @@ load_proc_addresses :: proc{
 with open("../core.odin", 'w', encoding='utf-8') as f:
     f.write(BASE)
     f.write(PACKAGE_LINE)
+    f.write("\n")
     f.write("""
 // Core API
 API_VERSION_1_0 :: (1<<22) | (0<<12) | (0)
@@ -907,8 +908,36 @@ API_VERSION_1_2 :: (1<<22) | (2<<12) | (0)
 API_VERSION_1_3 :: (1<<22) | (3<<12) | (0)
 API_VERSION_1_4 :: (1<<22) | (4<<12) | (0)
 
+MAKE_API_VERSION :: proc "contextless" (variant, major, minor, patch: u32) -> u32 {
+\treturn (variant<<29) | (major<<22) | (minor<<12) | (patch)
+}
+
 MAKE_VERSION :: proc "contextless" (major, minor, patch: u32) -> u32 {
 \treturn (major<<22) | (minor<<12) | (patch)
+}
+
+API_VERSION_MAJOR :: proc "contextless" (version: u32) -> u32 {
+\treturn (version>>22) & 0x7F
+}
+
+VERSION_MAJOR :: proc "contextless" (version: u32) -> u32 {
+\treturn (version>>22)
+}
+
+API_VERSION_MINOR :: proc "contextless" (version: u32) -> u32 {
+\treturn (version>>12) & 0x3FF
+}
+
+VERSION_MINOR :: API_VERSION_MINOR
+
+API_VERSION_PATCH :: proc "contextless" (version: u32) -> u32 {
+\treturn (version & 0xFFF)
+}
+
+VERSION_PATCH :: API_VERSION_PATCH
+
+API_VERSION_VARIANT :: proc "contextless" (version: u32) -> u32 {
+\treturn (version>>29)
 }
 
 // Base types
@@ -973,12 +1002,13 @@ MAKE_VIDEO_STD_VERSION :: MAKE_VERSION
     parse_flags_def(f)
 with open("../enums.odin", 'w', encoding='utf-8') as f:
     f.write(PACKAGE_LINE)
-    f.write("\n")
+    f.write("\n\n")
     parse_enums(f)
     parse_fake_enums(f)
     f.write("\n\n")
 with open("../structs.odin", 'w', encoding='utf-8') as f:
     f.write(PACKAGE_LINE)
+    f.write("\n")
     f.write("""
 import "core:c"
 
@@ -1040,7 +1070,7 @@ MTLCommandQueue_id :: rawptr
     f.write("\n\n")
 with open("../procedures.odin", 'w', encoding='utf-8') as f:
     f.write(PACKAGE_LINE)
-    f.write("\n")
+    f.write("\n\n")
     parse_procedures(f)
     f.write("\n")
     group_functions(f)

--- a/vendor/vulkan/core.odin
+++ b/vendor/vulkan/core.odin
@@ -7,8 +7,36 @@ API_VERSION_1_2 :: (1<<22) | (2<<12) | (0)
 API_VERSION_1_3 :: (1<<22) | (3<<12) | (0)
 API_VERSION_1_4 :: (1<<22) | (4<<12) | (0)
 
+MAKE_API_VERSION :: proc "contextless" (variant, major, minor, patch: u32) -> u32 {
+	return (variant<<29) | (major<<22) | (minor<<12) | (patch)
+}
+
 MAKE_VERSION :: proc "contextless" (major, minor, patch: u32) -> u32 {
 	return (major<<22) | (minor<<12) | (patch)
+}
+
+API_VERSION_MAJOR :: proc "contextless" (version: u32) -> u32 {
+	return (version>>22) & 0x7F
+}
+
+VERSION_MAJOR :: proc "contextless" (version: u32) -> u32 {
+	return (version>>22)
+}
+
+API_VERSION_MINOR :: proc "contextless" (version: u32) -> u32 {
+	return (version>>12) & 0x3FF
+}
+
+VERSION_MINOR :: API_VERSION_MINOR
+
+API_VERSION_PATCH :: proc "contextless" (version: u32) -> u32 {
+	return (version & 0xFFF)
+}
+
+VERSION_PATCH :: API_VERSION_PATCH
+
+API_VERSION_VARIANT :: proc "contextless" (version: u32) -> u32 {
+	return (version>>29)
 }
 
 // Base types


### PR DESCRIPTION
This just adds some of the missing version macros from the Vulkan bindings.

[MAKE_API_VERSION](https://docs.vulkan.org/refpages/latest/refpages/source/VK_MAKE_API_VERSION.html)
[VK_VERSION_MAJOR](https://docs.vulkan.org/refpages/latest/refpages/source/VK_VERSION_MAJOR.html)
[VK_API_VERSION_MAJOR](https://docs.vulkan.org/refpages/latest/refpages/source/VK_API_VERSION_MAJOR.html)
[VK_VERSION_MINOR](https://docs.vulkan.org/refpages/latest/refpages/source/VK_VERSION_MINOR.html)
[VK_API_VERSION_MINOR](https://docs.vulkan.org/refpages/latest/refpages/source/VK_API_VERSION_MINOR.html)
[VK_VERSION_PATCH](https://docs.vulkan.org/refpages/latest/refpages/source/VK_VERSION_PATCH.html)
[VK_API_VERSION_PATCH](https://docs.vulkan.org/refpages/latest/refpages/source/VK_API_VERSION_PATCH.html)
[VK_API_VERSION_VARIANT](https://docs.vulkan.org/refpages/latest/refpages/source/VK_API_VERSION_VARIANT.html)

This time, I updated the Python script, rather than the files directly.

Also, it seems like Python has changed the way newlines are handled in multi-line strings, and initial newlines are stripped out now. I added a few newlines here & there to keep the generated files from changing.