### PR TITLE
Remove extra 'defer bufio.writer_flush' from fprint procs

### DIFF
--- a/core/fmt/fmt_os.odin
+++ b/core/fmt/fmt_os.odin
@@ -14,7 +14,6 @@ import "core:bufio"
 fprint :: proc(f: ^os.File, args: ..any, sep := " ", flush := true) -> int {
 	buf: [1024]byte
 	b: bufio.Writer
-	defer bufio.writer_flush(&b)
 
 	bufio.writer_init_with_buf(&b, os.to_stream(f), buf[:])
 	w := bufio.writer_to_writer(&b)
@@ -25,7 +24,6 @@ fprint :: proc(f: ^os.File, args: ..any, sep := " ", flush := true) -> int {
 fprintln :: proc(f: ^os.File, args: ..any, sep := " ", flush := true) -> int {
 	buf: [1024]byte
 	b: bufio.Writer
-	defer bufio.writer_flush(&b)
 
 	bufio.writer_init_with_buf(&b, os.to_stream(f), buf[:])
 
@@ -36,7 +34,6 @@ fprintln :: proc(f: ^os.File, args: ..any, sep := " ", flush := true) -> int {
 fprintf :: proc(f: ^os.File, fmt: string, args: ..any, flush := true, newline := false) -> int {
 	buf: [1024]byte
 	b: bufio.Writer
-	defer bufio.writer_flush(&b)
 
 	bufio.writer_init_with_buf(&b, os.to_stream(f), buf[:])
 
@@ -50,7 +47,6 @@ fprintfln :: proc(f: ^os.File, fmt: string, args: ..any, flush := true) -> int {
 fprint_type :: proc(f: ^os.File, info: ^runtime.Type_Info, flush := true) -> (n: int, err: io.Error) {
 	buf: [1024]byte
 	b: bufio.Writer
-	defer bufio.writer_flush(&b)
 
 	bufio.writer_init_with_buf(&b, os.to_stream(f), buf[:])
 
@@ -60,7 +56,6 @@ fprint_type :: proc(f: ^os.File, info: ^runtime.Type_Info, flush := true) -> (n:
 fprint_typeid :: proc(f: ^os.File, id: typeid, flush := true) -> (n: int, err: io.Error) {
 	buf: [1024]byte
 	b: bufio.Writer
-	defer bufio.writer_flush(&b)
 
 	bufio.writer_init_with_buf(&b, os.to_stream(f), buf[:])
 


### PR DESCRIPTION
While looking at something with godbolt I noticed that the printing procedures do two consecutive calls to `bufio::writer_flush`.

Going through the commit history it looks like the deferred calls to `bufio.writer_flush` predate the addition of the flush param to the printing procedures and the deferred flush could have been removed then?
There probably is a need for doing two flushes and I just can't see it.

If the caller specifies flush=false to the fprint* procedures this change could leave bytes unflushed. But the buffer is on the stack here so I don't know what the caller expects to happen when flush=false in this situation. One flush is needed one way or the other.

godbolt fmt.println snippet:
        movq    %r14, %rdi
        movq    %rbx, %rsi
        callq   "bufio::writer_flush"
        movq    %r14, %rdi
        movq    %rbx, %rsi
        callq   "bufio::writer_flush"