### PR TITLE
Fix virtual.map_file usage example

### DIFF
--- a/core/mem/virtual/doc.odin
+++ b/core/mem/virtual/doc.odin
@@ -65,8 +65,8 @@ Example:
 	import vmem "core:mem/virtual"
 
 	main :: proc() {
-		data, err := virtual.map_file_from_path(#file, {.Read})
-		defer virtual.unmap_file(data)
+		data, err := vmem.map_file_from_path(#file, {.Read})
+		defer vmem.unmap_file(data)
 		fmt.printfln("Error: %v", err)
 		fmt.printfln("Data:  %s", data)
 	}


### PR DESCRIPTION
Fix the virtual.map_file example to use the defined vmem import alias.