### PR TITLE
[vendor/sdl3] move satellite libraries to relative import

### DIFF
--- a/vendor/sdl3/image/sdl_image.odin
+++ b/vendor/sdl3/image/sdl_image.odin
@@ -2,7 +2,7 @@
 package sdl3_image
 
 import "core:c"
-import SDL "vendor:sdl3"
+import SDL ".."
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL3_image.lib"

--- a/vendor/sdl3/mixer/sdl3_mixer.odin
+++ b/vendor/sdl3/mixer/sdl3_mixer.odin
@@ -2,7 +2,7 @@ package sdl3_mixer
 
 import "core:c"
 
-import SDL "vendor:sdl3"
+import SDL ".."
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL3_mixer.lib"

--- a/vendor/sdl3/ttf/sdl3_textengine.odin
+++ b/vendor/sdl3/ttf/sdl3_textengine.odin
@@ -1,7 +1,7 @@
 package sdl3_ttf
 
 import "core:c"
-import SDL "vendor:sdl3"
+import SDL ".."
 
 DrawCommand :: enum c.int {
 	NOOP,

--- a/vendor/sdl3/ttf/sdl3_ttf.odin
+++ b/vendor/sdl3/ttf/sdl3_ttf.odin
@@ -2,7 +2,7 @@
 package sdl3_ttf
 
 import "core:c"
-import SDL "vendor:sdl3"
+import SDL ".."
 
 when ODIN_OS == .Windows {
 	foreign import lib "SDL3_ttf.lib"


### PR DESCRIPTION
this should make the sdl3 bindings easier to vendor by making their imports relative. before, vendored bindings would still reference the copy of `sdl3` in `vendor`, resulting in duplicate symbol errors