### PR TITLE
Omit value when formatting map[T]struct{}

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -3132,12 +3132,14 @@ fmt_map :: proc(fi: ^Info, v: any, info: runtime.Type_Info_Map, verb: rune) {
 				value := runtime.map_cell_index_dynamic(vs, info.map_info.vs, bucket_index)
 
 				fmt_arg(&Info{writer = fi.writer}, any{rawptr(key), info.key.id}, verb)
-				if hash {
-					io.write_string(fi.writer, " = ", &fi.n)
-				} else {
-					io.write_string(fi.writer, "=", &fi.n)
+				if info.value.size > 0 {
+					if hash {
+						io.write_string(fi.writer, " = ", &fi.n)
+					} else {
+						io.write_string(fi.writer, "=", &fi.n)
+					}
+					fmt_arg(fi, any{rawptr(value), info.value.id}, verb)
 				}
-				fmt_arg(fi, any{rawptr(value), info.value.id}, verb)
 
 				if do_trailing_comma { io.write_string(fi.writer, ",\n", &fi.n) }
 			}


### PR DESCRIPTION
Consider the following code example where I use a map as a set and print it:
```odin
m: map[int]struct{}
// ...
fmt.println(m)
```
The output looks something like this:
```
map[1={}, 3={}, 0={}, 2={}]
```
The `={}` is clearly redundant, the map is a *set*.

This change just skips the value output in the case map value has size 0, so the result would look more like this:
```
map[1, 3, 0, 2]
```