### PR TITLE
[vendor/sdl3] added bindings for tray click properties added in 3.2.0

### DIFF
--- a/vendor/sdl3/sdl3_tray.odin
+++ b/vendor/sdl3/sdl3_tray.odin
@@ -22,31 +22,39 @@ TRAYENTRY_DISABLED  :: TrayEntryFlags{.DISABLED} /**< Make the entry disabled. O
 TRAYENTRY_CHECKED   :: TrayEntryFlags{.CHECKED}  /**< Make the entry checked. This is valid only for checkboxes. Optional. */
 
 TrayCallback :: #type proc "c" (userdata: rawptr, entry: ^TrayEntry)
+TrayClickCallback :: #type proc "c" (userdata: rawptr, tray: ^Tray) -> bool
 
+PROP_TRAY_CREATE_ICON_POINTER                 :: "SDL.tray.create.icon"
+PROP_TRAY_CREATE_TOOLTIP_STRING               :: "SDL.tray.create.tooltip"
+PROP_TRAY_CREATE_USERDATA_POINTER             :: "SDL.tray.create.userdata"
+PROP_TRAY_CREATE_LEFTCLICK_CALLBACK_POINTER   :: "SDL.tray.create.leftclick_callback"
+PROP_TRAY_CREATE_RIGHTCLICK_CALLBACK_POINTER  :: "SDL.tray.create.rightclick_callback"
+PROP_TRAY_CREATE_MIDDLECLICK_CALLBACK_POINTER :: "SDL.tray.create.middleclick_callback"
 
 @(default_calling_convention="c", link_prefix="SDL_", require_results)
 foreign lib {
-	CreateTray             :: proc(icon: ^Surface, tooltip: cstring) -> ^Tray ---
-	SetTrayIcon            :: proc(tray: ^Tray, icon: ^Surface) ---
-	SetTrayTooltip         :: proc(tray: ^Tray, tooltip: cstring) ---
-	CreateTrayMenu         :: proc(tray: ^Tray) -> ^TrayMenu ---
-	CreateTraySubmenu      :: proc(entry: ^TrayEntry) -> ^TrayMenu ---
-	GetTrayMenu            :: proc(tray: ^Tray) -> TrayMenu ---
-	GetTraySubmenu         :: proc(entry: ^TrayEntry) -> ^TrayMenu ---
-	GetTrayEntries         :: proc(menu: ^TrayMenu, size: ^c.int) -> [^]^TrayEntry ---
-	RemoveTrayEntry        :: proc(entry: ^TrayEntry) ---
-	InsertTrayEntryAt      :: proc(menu: ^TrayMenu, pos: c.int, label: cstring, flags: TrayEntryFlags) -> ^TrayEntry ---
-	SetTrayEntryLabel      :: proc(entry: ^TrayEntry, label: cstring) ---
-	GetTrayEntryLabel      :: proc(entry: ^TrayEntry) -> cstring ---
-	SetTrayEntryChecked    :: proc(entry: ^TrayEntry, checked: bool) ---
-	GetTrayEntryChecked    :: proc(entry: ^TrayEntry) -> bool ---
-	SetTrayEntryEnabled    :: proc(entry: ^TrayEntry, enabled: bool) ---
-	GetTrayEntryEnabled    :: proc(entry: ^TrayEntry) -> bool ---
-	SetTrayEntryCallback   :: proc(entry: ^TrayEntry, callback: TrayCallback, userdata: rawptr) ---
-	ClickTrayEntry         :: proc(entry: ^TrayEntry) ---
-	DestroyTray            :: proc(tray: ^Tray) ---
-	GetTrayEntryParent     :: proc(entry: ^TrayEntry) -> ^TrayMenu ---
-	GetTrayMenuParentEntry :: proc(menu: ^TrayMenu) -> ^TrayEntry ---
-	GetTrayMenuParentTray  :: proc(menu: ^TrayMenu) -> ^Tray ---
-	UpdateTrays            :: proc() ---
+	CreateTray               :: proc(icon: ^Surface, tooltip: cstring) -> ^Tray ---
+	CreateTrayWithProperties :: proc(props: PropertiesID) -> ^Tray ---
+	SetTrayIcon              :: proc(tray: ^Tray, icon: ^Surface) ---
+	SetTrayTooltip           :: proc(tray: ^Tray, tooltip: cstring) ---
+	CreateTrayMenu           :: proc(tray: ^Tray) -> ^TrayMenu ---
+	CreateTraySubmenu        :: proc(entry: ^TrayEntry) -> ^TrayMenu ---
+	GetTrayMenu              :: proc(tray: ^Tray) -> TrayMenu ---
+	GetTraySubmenu           :: proc(entry: ^TrayEntry) -> ^TrayMenu ---
+	GetTrayEntries           :: proc(menu: ^TrayMenu, size: ^c.int) -> [^]^TrayEntry ---
+	RemoveTrayEntry          :: proc(entry: ^TrayEntry) ---
+	InsertTrayEntryAt        :: proc(menu: ^TrayMenu, pos: c.int, label: cstring, flags: TrayEntryFlags) -> ^TrayEntry ---
+	SetTrayEntryLabel        :: proc(entry: ^TrayEntry, label: cstring) ---
+	GetTrayEntryLabel        :: proc(entry: ^TrayEntry) -> cstring ---
+	SetTrayEntryChecked      :: proc(entry: ^TrayEntry, checked: bool) ---
+	GetTrayEntryChecked      :: proc(entry: ^TrayEntry) -> bool ---
+	SetTrayEntryEnabled      :: proc(entry: ^TrayEntry, enabled: bool) ---
+	GetTrayEntryEnabled      :: proc(entry: ^TrayEntry) -> bool ---
+	SetTrayEntryCallback     :: proc(entry: ^TrayEntry, callback: TrayCallback, userdata: rawptr) ---
+	ClickTrayEntry           :: proc(entry: ^TrayEntry) ---
+	DestroyTray              :: proc(tray: ^Tray) ---
+	GetTrayEntryParent       :: proc(entry: ^TrayEntry) -> ^TrayMenu ---
+	GetTrayMenuParentEntry   :: proc(menu: ^TrayMenu) -> ^TrayEntry ---
+	GetTrayMenuParentTray    :: proc(menu: ^TrayMenu) -> ^Tray ---
+	UpdateTrays              :: proc() ---
 }


### PR DESCRIPTION
Allows for tray click actions introduced in SDL 3.2.0