### PR TITLE
Fix `bit_set`s inside of `bit_field`s in vulkan.

### DIFF
--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -1134,6 +1134,15 @@ gb_internal void check_bit_field_type(CheckerContext *ctx, Type *bit_field_type,
 				error(f->bit_size, "A bit_field's specified bit size cannot exceed its type, got %lld, expect <=%lld", cast(long long)bit_size_i64, cast(long long)sz);
 				bit_size_i64 = sz;
 			}
+			if (is_type_bit_set(type)) {
+				Type *bit_set = base_type(type);
+				GB_ASSERT(bit_set->kind == Type_BitSet);
+				i64 required_bits = 1 + bit_set->BitSet.upper - bit_set->BitSet.lower;
+				if (bit_size_i64 < required_bits) {
+					error(f->bit_size, "A bit_set in a bit_field must have a large enough bit size, got %lld, expected >=%lld", cast(long long)bit_size_i64, cast(long long)required_bits);
+					bit_size_i64 = required_bits;
+				}
+			}
 
 			bit_size_u8 = cast(u8)bit_size_i64;
 

--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -1079,11 +1079,11 @@ gb_internal void check_bit_field_type(CheckerContext *ctx, Type *bit_field_type,
 
 		if (is_type_untyped(type)) {
 			gbString s = type_to_string(type);
-			error(f->type, "The type of a bit_field's field must be a typed integer, enum, or boolean, got %s", s);
+			error(f->type, "The type of a bit_field's field must be a typed integer, enum, boolean or bit_set, got %s", s);
 			gb_string_free(s);
-		} else if (!(is_type_integer(type) || is_type_enum(type) || is_type_boolean(type))) {
+		} else if (!(is_type_integer(type) || is_type_enum(type) || is_type_boolean(type) || is_type_bit_set(type))) {
 			gbString s = type_to_string(type);
-			error(f->type, "The type of a bit_field's field must be an integer, enum, or boolean, got %s", s);
+			error(f->type, "The type of a bit_field's field must be an integer, enum, boolean or bit_set, got %s", s);
 			gb_string_free(s);
 		}
 

--- a/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
+++ b/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
@@ -616,11 +616,10 @@ class Bitfield:
         else:
             f.write("{}{} bit_field {} {{\n".format('\t' * indent, name + ' ::' if name else 'using _:', self.type))
             for field in self.fields:
-                type_ = field.type.replace("Flags", "Flag")
                 f.write("{}{} {} | {},\n".format(
                     '\t' * (indent + 1),
                     (field.name + ":").ljust(max_name + 1),
-                    type_.ljust(max_type),
+                    field.type.ljust(max_type),
                     field.bitsize))
             f.write(('\t' * indent) + "}" + ("," if name is None else "") + "\n")
 

--- a/vendor/vulkan/structs.odin
+++ b/vendor/vulkan/structs.odin
@@ -5685,7 +5685,7 @@ AccelerationStructureInstanceKHR :: struct {
 	},
 	using _: bit_field u32 {
 		instanceShaderBindingTableRecordOffset: u32                      | 24,
-		flags:                                  GeometryInstanceFlagKHR  | 8,
+		flags:                                  GeometryInstanceFlagsKHR | 8,
 	},
 	accelerationStructureReference: u64,
 }
@@ -6757,7 +6757,7 @@ AccelerationStructureMatrixMotionInstanceNV :: struct {
 	},
 	using _: bit_field u32 {
 		instanceShaderBindingTableRecordOffset: u32                      | 24,
-		flags:                                  GeometryInstanceFlagKHR  | 8,
+		flags:                                  GeometryInstanceFlagsKHR | 8,
 	},
 	accelerationStructureReference: u64,
 }
@@ -6790,7 +6790,7 @@ AccelerationStructureSRTMotionInstanceNV :: struct {
 	},
 	using _: bit_field u32 {
 		instanceShaderBindingTableRecordOffset: u32                      | 24,
-		flags:                                  GeometryInstanceFlagKHR  | 8,
+		flags:                                  GeometryInstanceFlagsKHR | 8,
 	},
 	accelerationStructureReference: u64,
 }


### PR DESCRIPTION
This fixes eg. `vk.AccelerationStructureInstanceKHR`:
```C
typedef struct VkAccelerationStructureInstanceKHR {
    VkTransformMatrixKHR          transform;
    uint32_t                      instanceCustomIndex:24;
    uint32_t                      mask:8;
    uint32_t                      instanceShaderBindingTableRecordOffset:24;
    VkGeometryInstanceFlagsKHR    flags:8; // This was translated to GeometryInstanceFlagKHR (singular) previously
    uint64_t                      accelerationStructureReference;
} VkAccelerationStructureInstanceKHR;
```