### PR TITLE
Support Multiple Return Values within Compound Literal Elements

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -10385,9 +10385,12 @@ gb_internal ExprKind check_compound_literal(CheckerContext *c, Operand *o, Ast *
 			} else {
 				bool seen_field_value = false;
 
-				for_array(index, cl->elems) {
+				isize handled_elem_count = 0;
+				isize index = 0;
+				for (Ast *elem : cl->elems) {
+					defer (index += 1);
+
 					Entity *field = nullptr;
-					Ast *elem = cl->elems[index];
 					if (elem->kind == Ast_FieldValue) {
 						seen_field_value = true;
 						error(elem, "Mixture of 'field = value' and value elements in a literal is not allowed");
@@ -10406,23 +10409,46 @@ gb_internal ExprKind check_compound_literal(CheckerContext *c, Operand *o, Ast *
 					}
 
 					Operand o = {};
-					check_expr_or_type(c, &o, elem, field->type);
-
-					if (elem_cannot_be_constant(field->type)) {
+					check_multi_expr_with_type_hint(c, &o, elem, field->type);
+					if (is_type_tuple(o.type)) {
 						is_constant = false;
-					}
-					if (is_constant) {
-						is_constant = check_is_operand_compound_lit_constant(c, &o, field->type);
+
+						TypeTuple *tt = &o.type->Tuple;
+						isize jj = 0;
+						for (Entity *src_field : tt->variables) {
+							Operand src_o = o;
+							src_o.type = src_field->type;
+
+							field = t->Struct.fields[index + (jj++)];
+
+							check_assignment(c, &src_o, field->type, str_lit("structure literal"));
+						}
+
+						index += tt->variables.count-1;
+
+						handled_elem_count += tt->variables.count;
+					} else {
+						check_not_tuple(c, &o);
+
+						if (elem_cannot_be_constant(field->type)) {
+							is_constant = false;
+						}
+						if (is_constant) {
+							is_constant = check_is_operand_compound_lit_constant(c, &o, field->type);
+						}
+
+						check_assignment(c, &o, field->type, str_lit("structure literal"));
+
+						handled_elem_count += 1;
 					}
 
-					check_assignment(c, &o, field->type, str_lit("structure literal"));
 				}
 				if (cl->elems.count < field_count) {
 					if (min_field_count < field_count) {
-					    if (cl->elems.count < min_field_count) {
+						if (cl->elems.count < min_field_count) {
 							error(cl->close, "Too few values in structure literal, expected at least %td, got %td", min_field_count, cl->elems.count);
-					    }
-					} else {
+						}
+					} else if (handled_elem_count != field_count) {
 						error(cl->close, "Too few values in structure literal, expected %td, got %td", field_count, cl->elems.count);
 					}
 				}

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -10630,8 +10630,9 @@ gb_internal ExprKind check_compound_literal(CheckerContext *c, Operand *o, Ast *
 
 			cl->max_count = max;
 		} else {
-			isize index = 0;
-			for (; index < cl->elems.count; index++) {
+			for (isize index = 0; index < cl->elems.count; index++) {
+				defer (max += 1);
+
 				Ast *e = cl->elems[index];
 				if (e == nullptr) {
 					error(node, "Invalid literal element");
@@ -10648,16 +10649,24 @@ gb_internal ExprKind check_compound_literal(CheckerContext *c, Operand *o, Ast *
 				}
 
 				Operand operand = {};
-				check_expr_with_type_hint(c, &operand, e, elem_type);
-				check_assignment(c, &operand, elem_type, context_name);
+				check_multi_expr_with_type_hint(c, &operand, e, elem_type);
+				if (is_type_tuple(operand.type)) {
+					is_constant = false;
+					TypeTuple *tt = &operand.type->Tuple;
+					for_array(jj, tt->variables) {
+						Operand oo = operand;
+						oo.type = tt->variables[jj]->type;
+						check_assignment(c, &oo, elem_type, context_name);
+					}
 
-				if (is_constant) {
-					is_constant = check_is_operand_compound_lit_constant(c, &operand, elem_type);
+					max += tt->variables.count-1;
+				} else {
+					check_assignment(c, &operand, elem_type, context_name);
+
+					if (is_constant) {
+						is_constant = check_is_operand_compound_lit_constant(c, &operand, elem_type);
+					}
 				}
-			}
-
-			if (max < index) {
-				max = index;
 			}
 		}
 
@@ -10678,6 +10687,12 @@ gb_internal ExprKind check_compound_literal(CheckerContext *c, Operand *o, Ast *
 				if (0 < max && max < t->Struct.soa_count) {
 					error(node, "Expected %lld values for this #soa array literal, got %lld", cast(long long)t->Struct.soa_count, cast(long long)max);
 				}
+			}
+		} else if (t->kind == Type_FixedCapacityDynamicArray) {
+			if (max > t->FixedCapacityDynamicArray.capacity) {
+				error(node, "Expected a maximum of %lld values for this fixed capacity dynamic array, got %lld",
+				      cast(long long)t->FixedCapacityDynamicArray.capacity,
+				      cast(long long)max);
 			}
 		}
 
@@ -10703,6 +10718,8 @@ gb_internal ExprKind check_compound_literal(CheckerContext *c, Operand *o, Ast *
 				}
 			}
 		}
+
+		cl->max_count = max;
 
 		break;
 	}

--- a/src/llvm_backend_const.cpp
+++ b/src/llvm_backend_const.cpp
@@ -1476,17 +1476,24 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, lb
 				return res;
 			} else {
 				// Assume that compound value is an array literal
-				GB_ASSERT_MSG(elem_count == type->Array.count, "%td != %td", elem_count, type->Array.count);
+				GB_ASSERT_MSG(elem_count <= type->Array.count, "%td <= %td", elem_count, type->Array.count);
 
 				LLVMValueRef *values = gb_alloc_array(temporary_allocator(), LLVMValueRef, cast(isize)type->Array.count);
 
+				isize elem_index = 0;
 				for (isize i = 0; i < elem_count; i++) {
 					TypeAndValue tav = cl->elems[i]->tav;
 					GB_ASSERT(tav.mode != Addressing_Invalid);
-					values[i] = lb_const_value(m, elem_type, tav.value, cc, tav.type).value;
+					if (is_type_tuple(tav.type)) {
+						elem_index += tav.type->Tuple.variables.count;
+					} else {
+						values[elem_index++] = lb_const_value(m, elem_type, tav.value, cc, tav.type).value;
+					}
 				}
-				for (isize i = elem_count; i < type->Array.count; i++) {
-					values[i] = LLVMConstNull(lb_type(m, elem_type));
+				for (isize i = 0; i < type->Array.count; i++) {
+					if (values[i] == nullptr) {
+						values[i] = LLVMConstNull(lb_type(m, elem_type));
+					}
 				}
 
 				res.value = lb_build_constant_array_values(m, type, elem_type, cast(isize)type->Array.count, values, cc);
@@ -1560,20 +1567,28 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, lb
 				res.value = lb_build_constant_array_values(m, type, elem_type, cast(isize)type->EnumeratedArray.count, values, cc);
 				return res;
 			} else {
-				GB_ASSERT_MSG(elem_count == type->EnumeratedArray.count, "%td != %td", elem_count, type->EnumeratedArray.count);
+				// Assume that compound value is an array literal
+				GB_ASSERT_MSG(elem_count <= type->EnumeratedArray.count, "%td <= %td", elem_count, type->EnumeratedArray.count);
 
 				LLVMValueRef *values = gb_alloc_array(temporary_allocator(), LLVMValueRef, cast(isize)type->EnumeratedArray.count);
 
+				isize elem_index = 0;
 				for (isize i = 0; i < elem_count; i++) {
 					TypeAndValue tav = cl->elems[i]->tav;
 					GB_ASSERT(tav.mode != Addressing_Invalid);
-					values[i] = lb_const_value(m, elem_type, tav.value, cc, tav.type).value;
+					if (is_type_tuple(tav.type)) {
+						elem_index += tav.type->Tuple.variables.count;
+					} else {
+						values[elem_index++] = lb_const_value(m, elem_type, tav.value, cc, tav.type).value;
+					}
 				}
-				for (isize i = elem_count; i < type->EnumeratedArray.count; i++) {
-					values[i] = LLVMConstNull(lb_type(m, elem_type));
+				for (isize i = 0; i < type->EnumeratedArray.count; i++) {
+					if (values[i] == nullptr) {
+						values[i] = LLVMConstNull(lb_type(m, elem_type));
+					}
 				}
 
-				res.value = lb_build_constant_array_values(m, type, elem_type, cast(isize)type->EnumeratedArray.count, values, cc);
+				res.value = lb_build_constant_array_values(m, type, elem_type, cast(isize)type->Array.count, values, cc);
 				return res;
 			}
 		} else if (is_type_fixed_capacity_dynamic_array(type)) {
@@ -1666,16 +1681,23 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, lb
 
 				LLVMValueRef *values = gb_alloc_array(temporary_allocator(), LLVMValueRef, cast(isize)capacity);
 
+				isize elem_index = 0;
 				for (isize i = 0; i < elem_count; i++) {
 					TypeAndValue tav = cl->elems[i]->tav;
 					GB_ASSERT(tav.mode != Addressing_Invalid);
-					values[i] = lb_const_value(m, elem_type, tav.value, cc, tav.type).value;
+					if (is_type_tuple(tav.type)) {
+						elem_index += tav.type->Tuple.variables.count;
+					} else {
+						values[elem_index++] = lb_const_value(m, elem_type, tav.value, cc, tav.type).value;
+					}
 				}
-				for (isize i = elem_count; i < capacity; i++) {
-					values[i] = LLVMConstNull(lb_type(m, elem_type));
+				for (isize i = 0; i < capacity; i++) {
+					if (values[i] == nullptr) {
+						values[i] = LLVMConstNull(lb_type(m, elem_type));
+					}
 				}
 
-				res.value = lb_fill_fixed_capacity_dynamic_array(m, elem_count, original_type, values, cc);
+				res.value = lb_fill_fixed_capacity_dynamic_array(m, elem_index, original_type, values, cc);
 				return res;
 			}
 		} else if (is_type_simd_vector(type)) {

--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -5319,6 +5319,157 @@ gb_internal lbAddr lb_build_addr_slice_expr(lbProcedure *p, Ast *expr) {
 	return {};
 }
 
+gb_internal void lb_build_struct_compound_lit_field_assignment(lbProcedure *p, lbValue comp_lit_ptr, Entity *field_entity, isize index, lbValue field_expr, bool is_raw_union) {
+	Type *ft = field_entity->type;
+
+	lbValue gep = {};
+	if (is_raw_union) {
+		gep = lb_emit_conv(p, comp_lit_ptr, alloc_type_pointer(ft));
+	} else {
+		gep = lb_emit_struct_ep(p, comp_lit_ptr, cast(i32)index);
+	}
+
+	Type *fet = field_expr.type;
+	GB_ASSERT(fet->kind != Type_Tuple);
+
+	if (is_type_union(ft) && !are_types_identical(fet, ft) && !is_type_untyped(fet)) {
+		if (union_is_variant_of(ft, fet)) {
+			// NOTE(bill, 2026-03-15): If it's a direct assignment for a variant to the
+			// direct union we can just assign it directly to minimize wasted code generation
+			//
+			// TODO(bill): Allow this for deeply nested unions too e.g. union{union{T}}
+			GB_ASSERT_MSG(union_variant_index_checked(ft, fet) >= 0, "%s", type_to_string(fet));
+			GB_ASSERT(are_types_identical(type_deref(gep.type), ft));
+
+			lb_emit_store_union_variant(p, gep, field_expr, fet);
+		} else {
+			lbValue fv = lb_emit_conv(p, field_expr, ft);
+			lb_emit_store(p, gep, fv);
+		}
+	} else {
+		lbValue fv = lb_emit_conv(p, field_expr, ft);
+		lb_emit_store(p, gep, fv);
+	}
+}
+
+gb_internal void lb_build_addr_struct_compound_lit_populate(lbProcedure *p, Ast *expr, Type *type, lbAddr v) {
+	ast_node(cl, CompoundLit, expr);
+
+	// TODO(bill): "constant" '#raw_union's are not initialized constantly at the moment.
+	// NOTE(bill): This is due to the layout of the unions when printed to LLVM-IR
+	Type *bt = base_type(type);
+	GB_ASSERT(bt->kind == Type_Struct);
+	GB_ASSERT(bt->Struct.soa_kind == StructSoa_None);
+	TypeStruct *st = &bt->Struct;
+
+	if (cl->elems.count == 0) {
+		return;
+	}
+
+	bool is_raw_union = st->is_raw_union;
+
+	lb_addr_store(p, v, lb_const_value(p->module, type, exact_value_compound(expr)));
+	lbValue comp_lit_ptr = lb_addr_get_ptr(p, v);
+
+	if (cl->elems[0]->kind == Ast_FieldValue) {
+		for (Ast *elem : cl->elems) {
+			lbValue field_expr = {};
+			Entity *field = nullptr;
+
+			ast_node(fv, FieldValue, elem);
+			InternedString interned = fv->field->Ident.interned;
+			Selection sel = lookup_field(bt, interned, false);
+			GB_ASSERT(!sel.indirect);
+
+			elem = fv->value;
+			if (sel.index.count > 1) {
+				if (lb_is_nested_possibly_constant(type, sel, elem)) {
+					continue;
+				}
+				field_expr = lb_build_expr(p, elem);
+				field_expr = lb_emit_conv(p, field_expr, sel.entity->type);
+				if (sel.is_bit_field) {
+					Selection sub_sel = trim_selection(sel);
+					lbValue trimmed_dst = lb_emit_deep_field_gep(p, comp_lit_ptr, sub_sel);
+					Type *bf = base_type(type_deref(trimmed_dst.type));
+					if (is_type_pointer(bf)) {
+						trimmed_dst = lb_emit_load(p, trimmed_dst);
+						bf = base_type(type_deref(trimmed_dst.type));
+					}
+					GB_ASSERT(bf->kind == Type_BitField);
+
+					isize idx = sel.index[sel.index.count-1];
+					lbAddr dst = lb_addr_bit_field(trimmed_dst, bf->BitField.fields[idx]->type, bf->BitField.bit_offsets[idx], bf->BitField.bit_sizes[idx]);
+					lb_addr_store(p, dst, field_expr);
+
+				} else {
+					lbValue dst = lb_emit_deep_field_gep(p, comp_lit_ptr, sel);
+					lb_emit_store(p, dst, field_expr);
+				}
+				continue;
+			}
+
+			isize index = sel.index[0];
+
+			field = st->fields[index];
+			Type *ft = field->type;
+			if (!is_raw_union && !is_type_typeid(ft) && lb_is_elem_const(elem, ft)) {
+				continue;
+			}
+
+			field_expr = lb_build_expr(p, elem);
+
+			lb_build_struct_compound_lit_field_assignment(p, comp_lit_ptr, field, index, field_expr, is_raw_union);
+		}
+
+		return;
+	}
+
+	GB_ASSERT(!is_raw_union);
+
+	isize field_index = 0;
+
+	for (Ast *elem : cl->elems) {
+		if (is_type_tuple(elem->tav.type)) {
+			lbValue tuple_field_expr = lb_build_expr(p, elem);
+			GB_ASSERT(is_type_tuple(tuple_field_expr.type));
+
+			TypeTuple *tt = &tuple_field_expr.type->Tuple;
+			for_array(jj, tt->variables) {
+				isize index = field_index++;
+				GB_ASSERT(st->fields[index]->Variable.field_index == index);
+				Selection sel = lookup_field_from_index(bt, index);
+				GB_ASSERT(sel.index.count == 1);
+				GB_ASSERT(!sel.indirect);
+				index = sel.index[0];
+
+				Entity *field = st->fields[index];
+				lbValue field_expr = lb_emit_struct_ev(p, tuple_field_expr, cast(i32)jj);
+
+				lb_build_struct_compound_lit_field_assignment(p, comp_lit_ptr, field, index, field_expr, is_raw_union);
+			}
+			continue;
+		}
+
+		isize index = field_index++;
+		GB_ASSERT(st->fields[index]->Variable.field_index == index);
+		Selection sel = lookup_field_from_index(bt, index);
+		GB_ASSERT(sel.index.count == 1);
+		GB_ASSERT(!sel.indirect);
+		index = sel.index[0];
+
+		Entity *field = st->fields[index];
+		Type *ft = field->type;
+		if (!is_type_typeid(ft) && lb_is_elem_const(elem, ft)) {
+			continue;
+		}
+
+		lbValue field_expr = lb_build_expr(p, elem);
+
+		lb_build_struct_compound_lit_field_assignment(p, comp_lit_ptr, field, index, field_expr, is_raw_union);
+	}
+}
+
 gb_internal lbAddr lb_build_addr_compound_lit(lbProcedure *p, Ast *expr) {
 	ast_node(cl, CompoundLit, expr);
 
@@ -5539,105 +5690,9 @@ gb_internal lbAddr lb_build_addr_compound_lit(lbProcedure *p, Ast *expr) {
 		return v;
 	}
 
-	case Type_Struct: {
-		// TODO(bill): "constant" '#raw_union's are not initialized constantly at the moment.
-		// NOTE(bill): This is due to the layout of the unions when printed to LLVM-IR
-		bool is_raw_union = is_type_raw_union(bt);
-		GB_ASSERT(is_type_struct(bt) || is_raw_union);
-		TypeStruct *st = &bt->Struct;
-		if (cl->elems.count > 0) {
-			lb_addr_store(p, v, lb_const_value(p->module, type, exact_value_compound(expr)));
-			lbValue comp_lit_ptr = lb_addr_get_ptr(p, v);
-
-			for_array(field_index, cl->elems) {
-				Ast *elem = cl->elems[field_index];
-
-				lbValue field_expr = {};
-				Entity *field = nullptr;
-				isize index = field_index;
-
-				if (elem->kind == Ast_FieldValue) {
-					ast_node(fv, FieldValue, elem);
-					InternedString interned = fv->field->Ident.interned;
-					Selection sel = lookup_field(bt, interned, false);
-					GB_ASSERT(!sel.indirect);
-
-					elem = fv->value;
-					if (sel.index.count > 1) {
-						if (lb_is_nested_possibly_constant(type, sel, elem)) {
-							continue;
-						}
-						field_expr = lb_build_expr(p, elem);
-						field_expr = lb_emit_conv(p, field_expr, sel.entity->type);
-						if (sel.is_bit_field) {
-							Selection sub_sel = trim_selection(sel);
-							lbValue trimmed_dst = lb_emit_deep_field_gep(p, comp_lit_ptr, sub_sel);
-							Type *bf = base_type(type_deref(trimmed_dst.type));
-							if (is_type_pointer(bf)) {
-								trimmed_dst = lb_emit_load(p, trimmed_dst);
-								bf = base_type(type_deref(trimmed_dst.type));
-							}
-							GB_ASSERT(bf->kind == Type_BitField);
-
-							isize idx = sel.index[sel.index.count-1];
-							lbAddr dst = lb_addr_bit_field(trimmed_dst, bf->BitField.fields[idx]->type, bf->BitField.bit_offsets[idx], bf->BitField.bit_sizes[idx]);
-							lb_addr_store(p, dst, field_expr);
-
-						} else {
-							lbValue dst = lb_emit_deep_field_gep(p, comp_lit_ptr, sel);
-							lb_emit_store(p, dst, field_expr);
-						}
-						continue;
-					}
-
-					index = sel.index[0];
-				} else {
-					Selection sel = lookup_field_from_index(bt, st->fields[field_index]->Variable.field_index);
-					GB_ASSERT(sel.index.count == 1);
-					GB_ASSERT(!sel.indirect);
-					index = sel.index[0];
-				}
-
-				field = st->fields[index];
-				Type *ft = field->type;
-				if (!is_raw_union && !is_type_typeid(ft) && lb_is_elem_const(elem, ft)) {
-					continue;
-				}
-
-				field_expr = lb_build_expr(p, elem);
-
-				lbValue gep = {};
-				if (is_raw_union) {
-					gep = lb_emit_conv(p, comp_lit_ptr, alloc_type_pointer(ft));
-				} else {
-					gep = lb_emit_struct_ep(p, comp_lit_ptr, cast(i32)index);
-				}
-
-				Type *fet = field_expr.type;
-				GB_ASSERT(fet->kind != Type_Tuple);
-
-				if (is_type_union(ft) && !are_types_identical(fet, ft) && !is_type_untyped(fet)) {
-					if (union_is_variant_of(ft, fet)) {
-						// NOTE(bill, 2026-03-15): If it's a direct assignment for a variant to the
-						// direct union we can just assign it directly to minimize wasted code generation
-						//
-						// TODO(bill): Allow this for deeply nested unions too e.g. union{union{T}}
-						GB_ASSERT_MSG(union_variant_index_checked(ft, fet) >= 0, "%s", type_to_string(fet));
-						GB_ASSERT(are_types_identical(type_deref(gep.type), ft));
-
-						lb_emit_store_union_variant(p, gep, field_expr, fet);
-					} else {
-						lbValue fv = lb_emit_conv(p, field_expr, ft);
-						lb_emit_store(p, gep, fv);
-					}
-				} else {
-					lbValue fv = lb_emit_conv(p, field_expr, ft);
-					lb_emit_store(p, gep, fv);
-				}
-			}
-		}
+	case Type_Struct:
+		lb_build_addr_struct_compound_lit_populate(p, expr, type, v);
 		break;
-	}
 
 	case Type_Map: {
 		if (cl->elems.count == 0) {
@@ -5931,6 +5986,7 @@ gb_internal lbAddr lb_build_addr_compound_lit(lbProcedure *p, Ast *expr) {
 
 	return v;
 }
+
 
 
 gb_internal lbAddr lb_build_addr_internal(lbProcedure *p, Ast *expr) {

--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -4516,9 +4516,9 @@ gb_internal void lb_build_addr_compound_lit_populate(lbProcedure *p, Slice<Ast *
 	GB_ASSERT(et != nullptr);
 
 
+	isize elem_index = 0;
 	// NOTE(bill): Separate value, gep, store into their own chunks
-	for_array(i, elems) {
-		Ast *elem = elems[i];
+	for (Ast *elem : elems) {
 		if (elem->kind == Ast_FieldValue) {
 			ast_node(fv, FieldValue, elem);
 			if (bt->kind != Type_DynamicArray && lb_is_elem_const(fv->value, et)) {
@@ -4588,22 +4588,39 @@ gb_internal void lb_build_addr_compound_lit_populate(lbProcedure *p, Slice<Ast *
 
 		} else {
 			if (bt->kind != Type_DynamicArray && lb_is_elem_const(elem, et)) {
+				elem_index++;
 				continue;
 			}
 
 			lbValue field_expr = lb_build_expr(p, elem);
-			GB_ASSERT(!is_type_tuple(field_expr.type));
 
-			lbValue ev = lb_emit_conv(p, field_expr, et);
+			if (is_type_tuple(field_expr.type)) {
+				TypeTuple *tt = &field_expr.type->Tuple;
+				for_array(jj, tt->variables) {
+					lbValue sub_field_expr = lb_emit_struct_ev(p, field_expr, cast(i32)jj);
+					lbValue ev = lb_emit_conv(p, sub_field_expr, et);
 
-			lbCompoundLitElemTempData data = {};
-			data.value = ev;
-			if (bt->kind == Type_Matrix) {
-				data.elem_index = matrix_row_major_index_to_offset(bt, i);
+					lbCompoundLitElemTempData data = {};
+					data.value = ev;
+					if (bt->kind == Type_Matrix) {
+						data.elem_index = matrix_row_major_index_to_offset(bt, elem_index++);
+					} else {
+						data.elem_index = elem_index++;
+					}
+					array_add(temp_data, data);
+				}
 			} else {
-				data.elem_index = i;
+				lbValue ev = lb_emit_conv(p, field_expr, et);
+
+				lbCompoundLitElemTempData data = {};
+				data.value = ev;
+				if (bt->kind == Type_Matrix) {
+					data.elem_index = matrix_row_major_index_to_offset(bt, elem_index++);
+				} else {
+					data.elem_index = elem_index++;
+				}
+				array_add(temp_data, data);
 			}
-			array_add(temp_data, data);
 		}
 	}
 }


### PR DESCRIPTION
```odin
Foo{123, multiple_return_values(), true}

v2: [2]f32 = ...
[4]f32{x, expand_values(v2), 1}
```