### PR TITLE
Make @(rodata) on constants yield 'not supported' message (Fixes #5422)

### DIFF
--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -4229,6 +4229,7 @@ gb_internal DECL_ATTRIBUTE_PROC(const_decl_attribute) {
 	           name == "link_name" ||
 	           name == "link_prefix" ||
 	           name == "link_suffix" ||
+			   name == "rodata" ||
 	           false) {
 		error(elem, "@(%.*s) is not supported for compile time constant value declarations", LIT(name));
 		return true;


### PR DESCRIPTION
`@(rodata) x :: [?]u8{1, 2, 3}` used to produce the following error message:
```
Error: Unknown attribute element name 'rodata' 
	@(rodata) 
	  ^~~~~^ 
	Did you forget to use the build flag '-ignore-unknown-attributes' or '-custom-attribute:rodata'? 
```

Now produces:
```
Error: @(rodata) is not supported for compile time constant value declarations 
	@(rodata) 
	 ^~~~~^ 
 ```