### PR TITLE
core/math/linalg: Fix negated quaternions in angle_from_quaternion

### DIFF
--- a/core/math/linalg/specific.odin
+++ b/core/math/linalg/specific.odin
@@ -512,7 +512,8 @@ quaternion_angle_axis :: proc{
 @(require_results)
 angle_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> f16 {
 	if abs(q.w) > math.SQRT_THREE*0.5 {
-		return math.asin(math.sqrt(q.x*q.x + q.y*q.y + q.z*q.z)) * 2
+		angle := math.asin(math.sqrt(q.x*q.x + q.y*q.y + q.z*q.z)) * 2
+		return q.w < 0 ? math.TAU - angle : angle
 	}
 
 	return math.acos(q.w) * 2
@@ -520,7 +521,8 @@ angle_from_quaternion_f16 :: proc "contextless" (q: Quaternionf16) -> f16 {
 @(require_results)
 angle_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> f32 {
 	if abs(q.w) > math.SQRT_THREE*0.5 {
-		return math.asin(math.sqrt(q.x*q.x + q.y*q.y + q.z*q.z)) * 2
+		angle := math.asin(math.sqrt(q.x*q.x + q.y*q.y + q.z*q.z)) * 2
+		return q.w < 0 ? math.TAU - angle : angle
 	}
 
 	return math.acos(q.w) * 2
@@ -528,7 +530,8 @@ angle_from_quaternion_f32 :: proc "contextless" (q: Quaternionf32) -> f32 {
 @(require_results)
 angle_from_quaternion_f64 :: proc "contextless" (q: Quaternionf64) -> f64 {
 	if abs(q.w) > math.SQRT_THREE*0.5 {
-		return math.asin(math.sqrt(q.x*q.x + q.y*q.y + q.z*q.z)) * 2
+		angle := math.asin(math.sqrt(q.x*q.x + q.y*q.y + q.z*q.z)) * 2
+		return q.w < 0 ? math.TAU - angle : angle
 	}
 
 	return math.acos(q.w) * 2


### PR DESCRIPTION
`angle_from_quaternion` is not handling negated quaternions correctly, and as a result neither does `angle_axis_from_quaternion`:

```odin
q := linalg.quaternion_angle_axis_f32(1.0, {0, 1, 0})
assert(math.abs(linalg.dot(q, -q)) == 1) // q and -q represent the same rotation
angle, axis := linalg.angle_axis_from_quaternion_f32(-q) // axis is correct, angle is wrong
result := linalg.quaternion_angle_axis_f32(angle, axis)
// `result` is returning the inverse rotation instead
assert(math.abs(linalg.dot(q, result)) == 1) // fail
```