### PR TITLE
gh 6584

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -378,7 +378,9 @@ advance_token :: proc(p: ^Parser) -> tokenizer.Token {
 	prev := p.prev_tok
 
 	if next_token0(p) {
-		consume_comment_groups(p, prev)
+		if p.curr_tok.kind == .Comment {
+			consume_comment_groups(p, prev)
+		}
 	}
 	return prev
 }
@@ -2327,10 +2329,11 @@ parse_operand :: proc(p: ^Parser, lhs: bool) -> ^ast.Expr {
 
 	case .Open_Paren:
 		open := expect_token(p, .Open_Paren)
-		p.expr_level += 1
+		prev_level := p.expr_level
+		p.expr_level = max(p.expr_level, 0)+1
 		expr := parse_expr(p, false)
 		skip_possible_newline(p)
-		p.expr_level -= 1
+		p.expr_level = prev_level
 		close := expect_token(p, .Close_Paren)
 
 		pe := ast.new(ast.Paren_Expr, open.pos, end_pos(close))
@@ -3553,6 +3556,13 @@ parse_binary_expr :: proc(p: ^Parser, lhs: bool, prec_in: int) -> ^ast.Expr {
 
 	for prec := token_precedence(p, p.curr_tok.kind); prec >= prec_in; prec -= 1 {
 		loop: for {
+			if tokenizer.is_newline(p.curr_tok) && p.expr_level > 0 {
+				next := peek_token(p)
+				if token_precedence(p, next.kind) > 0 {
+					advance_token(p)
+				}
+			}
+
 			op := p.curr_tok
 			op_prec := token_precedence(p, op.kind)
 			if op_prec != prec {

--- a/tests/core/odin/test_parser.odin
+++ b/tests/core/odin/test_parser.odin
@@ -9,6 +9,19 @@ import "core:odin/parser"
 import "core:odin/tokenizer"
 import "core:testing"
 
+parse_file_source :: proc(t: ^testing.T, src: string) -> (file: ast.File, ok: bool) {
+	file = ast.File{
+		fullpath = "test.odin",
+		src      = src,
+	}
+
+	p := parser.default_parser()
+	ok = parser.parse_file(&p, &file)
+
+	testing.expectf(t, ok, "expected parse_file to succeed, got %v syntax errors", file.syntax_error_count)
+	return
+}
+
 @test
 test_parse_demo :: proc(t: ^testing.T) {
 	context.allocator = context.temp_allocator
@@ -65,6 +78,45 @@ Foo :: bit_field uint {
 
 	ok := parser.parse_file(&p, &file)
 	testing.expect(t, ok, "bad parse")
+}
+
+@test
+test_parse_multiline_if_condition :: proc(t: ^testing.T) {
+	context.allocator = context.temp_allocator
+	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
+
+	multiline_file, multiline_ok := parse_file_source(t, `
+package main
+
+import "core:fmt"
+
+f :: proc() {
+	x := 1
+	if (x == 2
+		|| x == 3) {
+		fmt.println("1")
+	}
+	fmt.println("0")
+}
+`)
+	testing.expect(t, multiline_ok, "multiline if condition should parse")
+	testing.expectf(t, multiline_file.syntax_error_count == 0, "multiline if condition produced %v syntax errors", multiline_file.syntax_error_count)
+
+	single_line_file, single_line_ok := parse_file_source(t, `
+package main
+
+import "core:fmt"
+
+f :: proc() {
+	x := 1
+	if (x == 2 || x == 3) {
+		fmt.println("1")
+	}
+	fmt.println("0")
+}
+`)
+	testing.expect(t, single_line_ok, "single-line if condition should parse")
+	testing.expectf(t, single_line_file.syntax_error_count == 0, "single-line if condition produced %v syntax errors", single_line_file.syntax_error_count)
 }
 
 @test


### PR DESCRIPTION
Fixes #6584 

core:parser stopped parsing if conditions at newline semicolons, leading to false syntax errors
I aligned the core parser to the compiler parser's behaviour