### PR TITLE
Add `#optional_allocator_error` to `filepath.join` and `filepath.clean`

### DIFF
--- a/core/path/filepath/path.odin
+++ b/core/path/filepath/path.odin
@@ -39,7 +39,7 @@ join :: proc(
 ) -> (
 	joined: string,
 	err: runtime.Allocator_Error,
-) {
+) #optional_allocator_error {
 	return os.join_path(elems, allocator)
 }
 
@@ -151,7 +151,7 @@ clean :: proc(
 ) -> (
 	cleaned: string,
 	err: runtime.Allocator_Error,
-) {
+) #optional_allocator_error {
 	return os.clean_path(path, allocator)
 }
 


### PR DESCRIPTION
Add `#optional_allocator_error` to `filepath.join` and `filepath.clean`.

This tripped me up porting older code using dev-2026-02 where the directive was present:
https://github.com/odin-lang/Odin/blob/dev-2026-02/core/path/filepath/path_windows.odin?plain=1#L90
https://github.com/odin-lang/Odin/blob/dev-2026-02/core/path/filepath/path.odin?plain=1#L279