### PR TITLE
gh 6621

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -3066,6 +3066,14 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 
 		// check_assignment(c, operand, nullptr, str_lit("argument of 'type_of'"));
 		if (o.mode == Addressing_Invalid || o.mode == Addressing_Builtin) {
+			Entity *e = entity_of_node(expr);
+			if (e != nullptr &&
+			    e->state == EntityState_InProgress &&
+			    e->type == nullptr) {
+				gbString s = expr_to_string(expr);
+				error(expr, "Invalid cyclic type usage from 'type_of', got '%s'", s);
+				gb_string_free(s);
+			}
 			return false;
 		}
 		if (o.type == nullptr || o.type == t_invalid || is_type_asm_proc(o.type)) {

--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -59,6 +59,12 @@ else
 	echo "SUCCESSFUL 0/1"
 	exit 1
 fi
+if [[ $($ODIN build ../test_issue_6621.odin $COMMON 2>&1 >/dev/null | grep -c "Error:") -eq 1 ]] ; then
+	echo "SUCCESSFUL 1/1"
+else
+	echo "SUCCESSFUL 0/1"
+	exit 1
+fi
 $ODIN test ../test_pr_6470.odin $COMMON
 if [[ $($ODIN test ../test_pr_6470.odin -define:TEST_EXPECT_FAILURE=true $COMMON 2>&1 >/dev/null | grep -c "Error:") -eq 1 ]] ; then
 	echo "SUCCESSFUL 1/1"

--- a/tests/issues/test_issue_6621.odin
+++ b/tests/issues/test_issue_6621.odin
@@ -1,0 +1,10 @@
+// Tests issue #6621 https://github.com/odin-lang/Odin/issues/6621
+package test_issues
+
+t: struct {
+	next: ^type_of(t),
+}
+
+main :: proc() {
+	_ = t
+}


### PR DESCRIPTION
Fixes #6621

type_of could previously allow an unresolved variable type to escape as t_invalid, which later reached LLVM-type emission and triggered an assertion.
This now reports a normal cyclic type_of diagnostic, and adds a test covering the crash case.
