### PR TITLE
`intrinsics.c_va_*` 

### DIFF
--- a/base/intrinsics/intrinsics.odin
+++ b/base/intrinsics/intrinsics.odin
@@ -404,6 +404,14 @@ x86_cpuid  :: proc(ax, cx: u32) -> (eax, ebx, ecx, edx: u32) ---
 x86_xgetbv :: proc(cx: u32) -> (eax, edx: u32) ---
 
 
+// C specific things
+c_va_list     :: struct{/*platform specific implementation*/}
+
+c_va_start :: proc(list: ^c_va_list, /*#c_vararg parameter*/ args: ..$T) ---
+c_va_end   :: proc(list: ^c_va_list)                                     ---
+c_va_copy  :: proc(dst, src: ^c_va_list)                                 ---
+c_va_arg   :: proc(list: ^c_va_list, $T: typeid) -> T                    ---
+
 
 // Darwin targets only
 objc_object   :: struct{}

--- a/base/intrinsics/intrinsics.odin
+++ b/base/intrinsics/intrinsics.odin
@@ -405,7 +405,7 @@ x86_xgetbv :: proc(cx: u32) -> (eax, edx: u32) ---
 
 
 // C specific things
-c_va_list     :: struct{/*platform specific implementation*/}
+c_va_list  :: struct{/*platform specific implementation*/}
 
 c_va_start :: proc(list: ^c_va_list, /*#c_vararg parameter*/ args: ..$T) ---
 c_va_end   :: proc(list: ^c_va_list)                                     ---

--- a/core/c/c.odin
+++ b/core/c/c.odin
@@ -1,7 +1,8 @@
 // Defines the basic types used by `C` programs for foreign function and data structure interop.
 package c
 
-import builtin "base:builtin"
+import builtin    "base:builtin"
+import intrinsics "base:intrinsics"
 
 char           :: builtin.u8  // assuming -funsigned-char
 
@@ -115,14 +116,6 @@ NDEBUG         :: !ODIN_DEBUG
 
 CHAR_BIT :: 8
 
-// Since there are no types in C with an alignment larger than that of
-// max_align_t, which cannot be larger than sizeof(long double) as any other
-// exposed type wouldn't be valid C, the maximum alignment possible in a
-// strictly conformant C implementation is 16 on the platforms we care about.
-// The choice of 4096 bytes for storage of this type is more than enough on all
-// relevant platforms.
-va_list :: struct #align(16) {
-	_: [4096]u8,
-}
+va_list :: intrinsics.c_va_list
 
 FILE :: struct {}

--- a/core/c/libc/stdarg.odin
+++ b/core/c/libc/stdarg.odin
@@ -4,11 +4,11 @@ package libc
 
 import "base:intrinsics"
 
-va_list :: intrinsics.va_list
+va_list  :: intrinsics.c_va_list
 
-va_start :: intrinsics.va_start
-va_end   :: intrinsics.va_end
-va_copy  :: intrinsics.va_copy
+va_start :: intrinsics.c_va_start
+va_end   :: intrinsics.c_va_end
+va_copy  :: intrinsics.c_va_copy
 
 
 // We cannot provide va_arg as there is no way to create "C" style procedures

--- a/core/c/libc/stdarg.odin
+++ b/core/c/libc/stdarg.odin
@@ -4,29 +4,12 @@ package libc
 
 import "base:intrinsics"
 
-import "core:c"
+va_list :: intrinsics.va_list
 
-@(private="file")
-@(default_calling_convention="none")
-foreign _ {
-	@(link_name="llvm.va_start") _va_start :: proc(arglist: ^i8) ---
-	@(link_name="llvm.va_end")   _va_end   :: proc(arglist: ^i8) ---
-	@(link_name="llvm.va_copy")  _va_copy  :: proc(dst, src: ^i8) ---
-}
+va_start :: intrinsics.va_start
+va_end   :: intrinsics.va_end
+va_copy  :: intrinsics.va_copy
 
-va_list :: c.va_list
-
-va_start :: #force_inline proc(ap: ^va_list, _: any) {
-	_va_start(cast(^i8)ap)
-}
-
-va_end :: #force_inline proc(ap: ^va_list) {
-	_va_end(cast(^i8)ap)
-}
-
-va_copy :: #force_inline proc(dst, src: ^va_list) {
-	_va_copy(cast(^i8)dst, cast(^i8)src)
-}
 
 // We cannot provide va_arg as there is no way to create "C" style procedures
 // in Odin which take variable arguments the C way. The #c_vararg attribute only

--- a/core/c/libc/wchar.odin
+++ b/core/c/libc/wchar.odin
@@ -17,12 +17,12 @@ foreign libc {
 	fwscanf   :: proc(stream: ^FILE, format: [^]wchar_t, #c_vararg arg: ..any) -> int ---
 	swprintf  :: proc(stream: ^FILE, n: size_t, format: [^]wchar_t, #c_vararg arg: ..any) -> int ---
 	swscanf   :: proc(s, format: [^]wchar_t, #c_vararg arg: ..any) -> int ---
-	vfwprintf :: proc(stream: ^FILE, format: [^]wchar_t, arg: va_list) -> int ---
-	vfwscanf  :: proc(stream: ^FILE, format: [^]wchar_t, arg: va_list) -> int ---
-	vswprintf :: proc(s: [^]wchar_t, n: size_t, format: [^]wchar_t, arg: va_list) -> int ---
-	vswscanf  :: proc(s, format: [^]wchar_t, arg: va_list) -> int ---
-	vwprintf  :: proc(format: [^]wchar_t, arg: va_list) -> int ---
-	vwscanf   :: proc(format: [^]wchar_t, arg: va_list) -> int ---
+	vfwprintf :: proc(stream: ^FILE, format: [^]wchar_t, arg: ^va_list) -> int ---
+	vfwscanf  :: proc(stream: ^FILE, format: [^]wchar_t, arg: ^va_list) -> int ---
+	vswprintf :: proc(s: [^]wchar_t, n: size_t, format: [^]wchar_t, arg: ^va_list) -> int ---
+	vswscanf  :: proc(s, format: [^]wchar_t, arg: ^va_list) -> int ---
+	vwprintf  :: proc(format: [^]wchar_t, arg: ^va_list) -> int ---
+	vwscanf   :: proc(format: [^]wchar_t, arg: ^va_list) -> int ---
 	wprintf   :: proc(format: [^]wchar_t, #c_vararg arg: ..any) -> int ---
 	wscanf    :: proc(format: [^]wchar_t, #c_vararg arg: ..any) -> int ---
 

--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -739,6 +739,131 @@ gb_internal bool check_builtin_objc_procedure(CheckerContext *c, Operand *operan
 	}
 }
 
+gb_internal bool check_builtin_c_procedure(CheckerContext *c, Operand *operand, Ast *call, i32 id, Type *type_hint) {
+	String const &builtin_name = builtin_procs[id].name;
+
+	ast_node(ce, CallExpr, call);
+	switch (id) {
+	default:
+		GB_PANIC("Implement objective built-in procedure: %.*s", LIT(builtin_name));
+		return false;
+
+	case BuiltinProc_c_va_start: {
+		Operand list = {};
+		check_expr(c, &list, ce->args[0]);
+		if (list.mode == Addressing_Invalid) {
+			return false;
+		}
+		if (!are_types_identical(list.type, t_c_va_list_ptr)) {
+			gbString lpt = type_to_string(t_c_va_list_ptr);
+			gbString t = type_to_string(list.type);
+			error(list.expr, "'%.*s' expected a value of type %s, got type %s", LIT(builtin_name), lpt, t);
+			gb_string_free(t);
+			gb_string_free(lpt);
+			return false;
+		}
+
+		Operand args = {};
+		check_expr(c, &args, ce->args[1]);
+		if (list.mode == Addressing_Invalid) {
+			return false;
+		}
+		Entity *e = entity_of_node(args.expr);
+		if (e == nullptr || (e->flags & EntityFlag_CVarArg) == 0) {
+			error(list.expr, "'%.*s' expected a `#c_vararg` parameter", LIT(builtin_name));
+		}
+
+		operand->mode = Addressing_NoValue;
+		operand->type = nullptr;
+		return true;
+
+	} break;
+
+	case BuiltinProc_c_va_end: {
+		Operand list = {};
+		check_expr(c, &list, ce->args[0]);
+		if (list.mode == Addressing_Invalid) {
+			return false;
+		}
+		if (!are_types_identical(list.type, t_c_va_list_ptr)) {
+			gbString lpt = type_to_string(t_c_va_list_ptr);
+			gbString t = type_to_string(list.type);
+			error(list.expr, "'%.*s' expected a value of type %s, got type %s", LIT(builtin_name), lpt, t);
+			gb_string_free(t);
+			gb_string_free(lpt);
+			return false;
+		}
+
+		operand->mode = Addressing_NoValue;
+		operand->type = nullptr;
+		return true;
+
+	} break;
+
+	case BuiltinProc_c_va_copy: {
+		Operand dst = {};
+		check_expr(c, &dst, ce->args[0]);
+		if (dst.mode == Addressing_Invalid) {
+			return false;
+		}
+		if (!are_types_identical(dst.type, t_c_va_list_ptr)) {
+			gbString lpt = type_to_string(t_c_va_list_ptr);
+			gbString t = type_to_string(dst.type);
+			error(dst.expr, "'%.*s' expected a value of type %s, got type %s", LIT(builtin_name), lpt, t);
+			gb_string_free(t);
+			gb_string_free(lpt);
+			return false;
+		}
+
+		Operand src = {};
+		check_expr(c, &src, ce->args[1]);
+		if (src.mode == Addressing_Invalid) {
+			return false;
+		}
+		if (!are_types_identical(src.type, t_c_va_list_ptr)) {
+			gbString lpt = type_to_string(t_c_va_list_ptr);
+			gbString t = type_to_string(src.type);
+			error(src.expr, "'%.*s' expected a value of type %s, got type %s", LIT(builtin_name), lpt, t);
+			gb_string_free(t);
+			gb_string_free(lpt);
+			return false;
+		}
+
+		operand->mode = Addressing_NoValue;
+		operand->type = nullptr;
+		return true;
+
+	} break;
+
+	case BuiltinProc_c_va_arg: {
+		Operand list = {};
+		check_expr(c, &list, ce->args[0]);
+		if (list.mode == Addressing_Invalid) {
+			return false;
+		}
+		if (!are_types_identical(list.type, t_c_va_list_ptr)) {
+			gbString lpt = type_to_string(t_c_va_list_ptr);
+			gbString t = type_to_string(list.type);
+			error(list.expr, "'%.*s' expected a value of type %s, got type %s", LIT(builtin_name), lpt, t);
+			gb_string_free(t);
+			gb_string_free(lpt);
+			return false;
+		}
+
+
+		Type *type = check_type(c, ce->args[1]);
+		if (type == nullptr || type == t_invalid) {
+			error(ce->args[1], "'%.*s' expected a type as the second parameter to intrinsics.%.*s", LIT(builtin_name));
+			return false;
+		}
+
+		operand->mode = Addressing_Value;
+		operand->type = type;
+		return true;
+	} break;
+	}
+}
+
 gb_internal bool check_atomic_memory_order_argument(CheckerContext *c, Ast *expr, String const &builtin_name, OdinAtomicMemoryOrder *memory_order_, char const *extra_message = nullptr) {
 	Operand x = {};
 	check_expr_with_type_hint(c, &x, expr, t_atomic_memory_order);
@@ -2687,6 +2812,12 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 	case BuiltinProc_objc_block:
 	case BuiltinProc_objc_super:
 		return check_builtin_objc_procedure(c, operand, call, id, type_hint);
+
+	case BuiltinProc_c_va_start:
+	case BuiltinProc_c_va_end:
+	case BuiltinProc_c_va_copy:
+	case BuiltinProc_c_va_arg:
+		return check_builtin_c_procedure(c, operand, call, id, type_hint);
 
 	case BuiltinProc___entry_point:
 		operand->mode = Addressing_NoValue;

--- a/src/check_decl.cpp
+++ b/src/check_decl.cpp
@@ -1556,9 +1556,9 @@ gb_internal void check_proc_decl(CheckerContext *ctx, Entity *e, DeclInfo *d) {
 		if (is_foreign) {
 			error(pl->body, "A foreign procedure cannot have a body");
 		}
-		if (proc_type->Proc.c_vararg) {
-			error(pl->body, "A procedure with a '#c_vararg' field cannot have a body and must be foreign");
-		}
+		// if (proc_type->Proc.c_vararg) {
+		// 	error(pl->body, "A procedure with a '#c_vararg' field cannot have a body and must be foreign");
+		// }
 
 		d->scope = ctx->scope;
 

--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -1449,6 +1449,72 @@ gb_internal void init_universal(void) {
 
 		t_objc_instancetype = add_global_type_name(intrinsics_pkg->scope, str_lit("objc_instancetype"), t_objc_id);
 	}
+
+	// intrinsics types for C stuff
+	{
+		Scope *scope = create_scope(nullptr, nullptr);
+
+		auto dummy_field = [](Scope *scope, Type *type, i32 field_index, char const *name = nullptr) -> Entity * {
+			auto token = blank_token;
+			if (name) {
+				token.string = make_string_c(name);
+			}
+			return alloc_entity_field(scope, token, type, false, 0, EntityState_Resolved);
+		};
+
+		auto fields = array_make<Entity *>(permanent_allocator(), 0, 8);
+
+		switch (build_context.metrics.arch) {
+		case TargetArch_amd64:
+			switch (build_context.metrics.os) {
+			case TargetOs_freestanding:
+				/*check*/
+			case TargetOs_linux:
+			case TargetOs_freebsd:
+			case TargetOs_netbsd:
+			case TargetOs_openbsd:
+				array_add(&fields, dummy_field(scope, t_u32,    0, "gp_offset"));
+				array_add(&fields, dummy_field(scope, t_u32,    1, "fp_offset"));
+				array_add(&fields, dummy_field(scope, t_rawptr, 2, "overflow_arg_area"));
+				array_add(&fields, dummy_field(scope, t_rawptr, 3, "reg_save_area"));
+				break;
+			}
+			break;
+
+		case TargetArch_arm64:
+			switch (build_context.metrics.os) {
+			case TargetOs_darwin:
+				// AARCH64 architecture is different to other arm64 platforms
+				array_add(&fields, dummy_field(scope, t_rawptr, 0));
+				break;
+
+			case TargetOs_freestanding:
+			case TargetOs_linux:
+			case TargetOs_freebsd:
+			case TargetOs_netbsd:
+			case TargetOs_openbsd: // Not sure if this is correct
+				array_add(&fields, dummy_field(scope, t_rawptr, 0, "__stack"));
+				array_add(&fields, dummy_field(scope, t_rawptr, 1, "__gr_top"));
+				array_add(&fields, dummy_field(scope, t_rawptr, 2, "__vr_top"));
+				array_add(&fields, dummy_field(scope, t_i32,    3, "__gr_offs"));
+				array_add(&fields, dummy_field(scope, t_i32,    4, "__vr_offs"));
+				break;
+			}
+			break;
+		}
+
+		if (fields.count == 0) {
+			array_add(&fields, dummy_field(scope, t_rawptr, 0));
+		}
+
+		Type *va_list_struct = alloc_type_struct_complete();
+		va_list_struct->Struct.scope  = scope;
+		va_list_struct->Struct.fields = slice_from_array(fields);
+		GB_ASSERT(type_size_of(va_list_struct) > 0);
+
+		t_c_va_list = add_global_type_name(intrinsics_pkg->scope, str_lit("c_va_list"), va_list_struct);
+		t_c_va_list_ptr = alloc_type_pointer(t_c_va_list);
+	}
 }
 
 

--- a/src/checker_builtin_procs.hpp
+++ b/src/checker_builtin_procs.hpp
@@ -388,6 +388,11 @@ BuiltinProc__type_end,
 	BuiltinProc_objc_block,
 	BuiltinProc_objc_super,
 
+	BuiltinProc_c_va_start,
+	BuiltinProc_c_va_end,
+	BuiltinProc_c_va_copy,
+	BuiltinProc_c_va_arg,
+
 	BuiltinProc_constant_utf16_cstring,
 
 	BuiltinProc_wasm_memory_grow,
@@ -780,6 +785,12 @@ gb_global BuiltinProc builtin_procs[BuiltinProc_COUNT] = {
 	{STR_LIT("objc_ivar_get"),          1, false, Expr_Expr, BuiltinProcPkg_intrinsics, false, true},
 	{STR_LIT("objc_block"),             1, true,  Expr_Expr, BuiltinProcPkg_intrinsics},
 	{STR_LIT("objc_super"),             1, true,  Expr_Expr, BuiltinProcPkg_intrinsics},
+
+	{STR_LIT("c_va_start"),             2, false,  Expr_Stmt, BuiltinProcPkg_intrinsics},
+	{STR_LIT("c_va_end"),               1, false,  Expr_Stmt, BuiltinProcPkg_intrinsics},
+	{STR_LIT("c_va_copy"),              2, false,  Expr_Stmt, BuiltinProcPkg_intrinsics},
+	{STR_LIT("c_va_arg"),               2, false,  Expr_Expr, BuiltinProcPkg_intrinsics},
+
 
 	{STR_LIT("constant_utf16_cstring"), 1, false, Expr_Expr, BuiltinProcPkg_intrinsics},
 

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -625,6 +625,11 @@ gb_internal void lb_begin_procedure_body(lbProcedure *p) {
 					continue;
 				}
 
+				if (e->flags & EntityFlag_CVarArg) {
+					GB_ASSERT(i+1 == params->variables.count);
+					continue;
+				}
+
 				lbArgType *arg_type = &ft->args[param_index];
 				defer (param_index += 1);
 
@@ -4277,6 +4282,53 @@ gb_internal lbValue lb_build_builtin_proc(lbProcedure *p, Ast *expr, TypeAndValu
 	case BuiltinProc_objc_ivar_get:          return lb_handle_objc_ivar_get(p, expr);
 	case BuiltinProc_objc_block:             return lb_handle_objc_block(p, expr);
 	case BuiltinProc_objc_super:             return lb_handle_objc_super(p, expr);
+
+
+	case BuiltinProc_c_va_start:
+		{
+			lbValue ptr  = lb_build_expr(p, ce->args[0]);
+			lbValue args = lb_build_expr(p, ce->args[1]);
+
+			gb_unused(args);
+
+			LLVMValueRef va_start_args[] = {ptr.value};
+			LLVMTypeRef  va_start_types[] = {lb_type(p->module, ptr.type)};
+			LLVMValueRef res = lb_call_intrinsic(p, "llvm.va_start", va_start_args, gb_count_of(va_start_args), va_start_types, gb_count_of(va_start_types));
+			gb_unused(res);
+
+			return {};
+		} break;
+	case BuiltinProc_c_va_end:
+		{
+			lbValue ptr = lb_build_expr(p, ce->args[0]);
+
+			LLVMValueRef va_end_args[] = {ptr.value};
+			LLVMTypeRef  va_end_types[] = {lb_type(p->module, ptr.type)};
+			LLVMValueRef res = lb_call_intrinsic(p, "llvm.va_end", va_end_args, gb_count_of(va_end_args), va_end_types, gb_count_of(va_end_types));
+			gb_unused(res);
+
+			return {};
+		} break;
+	case BuiltinProc_c_va_copy:
+		{
+			lbValue dst = lb_build_expr(p, ce->args[0]);
+			lbValue src = lb_build_expr(p, ce->args[1]);
+
+			LLVMValueRef va_end_args[] = {dst.value, src.value};
+			LLVMTypeRef  va_end_types[] = {lb_type(p->module, dst.type)};
+			LLVMValueRef res = lb_call_intrinsic(p, "llvm.va_copy", va_end_args, gb_count_of(va_end_args), va_end_types, gb_count_of(va_end_types));
+			gb_unused(res);
+
+			return {};
+		} break;
+	case BuiltinProc_c_va_arg:
+		{
+			lbValue ptr = lb_build_expr(p, ce->args[0]);
+			Type *type = type_of_expr(ce->args[1]);
+			LLVMValueRef value = LLVMBuildVAArg(p->builder, ptr.value, lb_type(p->module, type), "");
+
+			return {value, type};
+		} break;
 
 
 	case BuiltinProc_constant_utf16_cstring:

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -776,6 +776,11 @@ gb_global Type *t_objc_Class = nullptr;
 gb_global Type *t_objc_Ivar  = nullptr;
 gb_global Type *t_objc_instancetype = nullptr; // Special distinct variant of t_objc_id used mimic auto-typing of instancetype* in Objective-C
 
+
+gb_global Type *t_c_va_list     = nullptr;
+gb_global Type *t_c_va_list_ptr = nullptr;
+
+
 enum OdinAtomicMemoryOrder : i32 {
 	OdinAtomicMemoryOrder_relaxed = 0, // unordered
 	OdinAtomicMemoryOrder_consume = 1, // monotonic


### PR DESCRIPTION
```odin
// C specific intrinsics (type and procedures)
c_va_list     :: struct{/*platform specific implementation*/}

c_va_start :: proc(list: ^c_va_list, /*#c_vararg parameter*/ args: ..$T) ---
c_va_end   :: proc(list: ^c_va_list)                                     ---
c_va_copy  :: proc(dst, src: ^c_va_list)                                 ---
c_va_arg   :: proc(list: ^c_va_list, $T: typeid) -> T                    ---
```

This allows for user-side implementation of C style variadic arguments/parameters: e.g. `#c_vararg args: ..any`