### PR TITLE
Fix type info not being generated for types only used in []typeid literals

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -12463,6 +12463,7 @@ gb_internal void check_multi_expr_with_type_hint(CheckerContext *c, Operand *o, 
 		break;
 	case Addressing_Type:
 		if (type_hint != nullptr && is_type_typeid(type_hint)) {
+			add_type_info_type(c, o->type);
 			break;
 		}
 		error_operand_not_expression(o);


### PR DESCRIPTION
previously this was broken (I think because compound literals are now checked as multi expressions) and the type info for `Foo` would not be generated.

```odin
package test

main :: proc() {
	Foo :: enum {}
	types := []typeid{ Foo, }
	info  := type_info_of(types[0])
	assert(info.size == size_of(Foo))
}
```