### PR TITLE
sys/linux: emulate dup2 better on arm64 and riscv

### DIFF
--- a/core/sys/linux/sys.odin
+++ b/core/sys/linux/sys.odin
@@ -419,7 +419,15 @@ dup :: proc "contextless" (fd: Fd) -> (Fd, Errno) {
 dup2 :: proc "contextless" (old: Fd, new: Fd) -> (Fd, Errno) {
 	when ODIN_ARCH == .arm64 || ODIN_ARCH == .riscv64 {
 		ret := syscall(SYS_dup3, old, new, 0)
-		return errno_unwrap(ret, Fd)
+
+		// Differences between dup2 and dup3 are:
+		//   - dup3 takes a flags argument
+		//   - dup2 does not return EINVAL
+		fd, errno := errno_unwrap(ret, Fd)
+		if errno == .EINVAL {
+			errno = .NONE
+		}
+		return fd, errno
 	} else {
 		ret := syscall(SYS_dup2, old, new)
 		return errno_unwrap(ret, Fd)


### PR DESCRIPTION
Fixes #6620. `linux.dup2` actually calls dup3 on arm64 and riscv64.  dup2 can return EINVAL from dup3, where dup2 cannot.  Relevant man page snippets:

```none
   dup3()
     dup3() is the same as dup2(), except that:

     •  The caller can force the close-on-exec flag to be set for the new file descriptor by specifying O_CLOEXEC in flags.  See the description of the same flag in  open(2)
        for reasons why this may be useful.

     •  If oldfd equals newfd, then dup3() fails with the error EINVAL.
```

```none
ERRORS
     ...
     EINVAL
            (dup3()) flags contain an invalid value.

     EINVAL
            (dup3()) oldfd was equal to newfd.

```