### PR TITLE
Update the boolean values constants.odin in vendor/glfw

### DIFF
--- a/vendor/glfw/constants.odin
+++ b/vendor/glfw/constants.odin
@@ -10,8 +10,8 @@ VERSION_MINOR    :: 4
 VERSION_REVISION :: 0
 
 /* Booleans */
-TRUE  :: true
-FALSE :: false
+TRUE  :: 1
+FALSE :: 0
 
 /* Button/Key states */
 RELEASE :: 0


### PR DESCRIPTION
changed
- `TRUE :: true` to `TRUE :: 1`  
- `FALSE :: false` to `FALSE :: 0`. 
in vendor/glfw

GFLW defines TRUE and FALSE as 1 and 0. you have to convert to i32 or c.int with behavior as is
[see in the Macros section of the docs](https://www.glfw.org/docs/latest/group__init.html#Macros)