### PR TITLE
Fix compiler warning on linux.

### DIFF
--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -339,8 +339,8 @@ gb_internal bool is_simd_able_type(Type *t) {
 		TypeEndianKind kind = type_endian_kind_of(t);
 		switch (kind) {
 		case TypeEndian_Platform: return true;
-		case TypeEndian_Little:   return build_context.endian_kind == TypeEndian_Little;
-		case TypeEndian_Big:      return build_context.endian_kind == TypeEndian_Big;
+		case TypeEndian_Little:   return build_context.endian_kind == TargetEndian_Little;
+		case TypeEndian_Big:      return build_context.endian_kind == TargetEndian_Big;
 		}
 	}
 	return false;


### PR DESCRIPTION
The resulting compiler binary would also crash with a core dump when trying to compile odin code with it.

❰ionut❙/opt/odin(git:master)❱✔≻ time ./build_odin.sh release-native
+ clang++ src/main.cpp src/libtommath.cpp -Wno-switch -Wno-macro-redefined -Wno-unused-value '-DGIT_SHA="5dfd110be"' '-DODIN_VERSION_RAW="dev-2026-04"' -std=c++14 -I/usr/include -std=c++17 -D_GNU_SOURCE -D_GLIBCXX_USE_CXX11_ABI=1 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -fno-exceptions -L/usr/lib -O3 -march=native -pthread -lm -lstdc++ -ldl /usr/lib/libLLVM-22.so '-Wl,-rpath=$ORIGIN' -o odin
In file included from src/main.cpp:80:
In file included from src/llvm_backend.cpp:29:
src/llvm_backend_expr.cpp:342:62: warning: comparison of different enumeration types ('TargetEndianKind' and 'TypeEndianKind') [-Wenum-compare]
  342 |                 case TypeEndian_Little:   return build_context.endian_kind == TypeEndian_Little;
      |                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~
src/llvm_backend_expr.cpp:343:62: warning: comparison of different enumeration types ('TargetEndianKind' and 'TypeEndianKind') [-Wenum-compare]
  343 |                 case TypeEndian_Big:      return build_context.endian_kind == TypeEndian_Big;
      |                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~
2 warnings generated.
+ set +x

________________________________________________________
Executed in   32.00 secs    fish           external
   usr time   31.66 secs  245.00 micros   31.66 secs
   sys time    0.20 secs  149.00 micros    0.20 secs
