### PR TITLE
sys/linux, sys/unix: fully emulate dup2 on arm64 and riscv64

### DIFF
--- a/core/sys/linux/sys.odin
+++ b/core/sys/linux/sys.odin
@@ -418,16 +418,21 @@ dup :: proc "contextless" (fd: Fd) -> (Fd, Errno) {
 */
 dup2 :: proc "contextless" (old: Fd, new: Fd) -> (Fd, Errno) {
 	when ODIN_ARCH == .arm64 || ODIN_ARCH == .riscv64 {
-		ret := syscall(SYS_dup3, old, new, 0)
-
 		// Differences between dup2 and dup3 are:
 		//   - dup3 takes a flags argument
 		//   - dup2 does not return EINVAL
-		fd, errno := errno_unwrap(ret, Fd)
-		if errno == .EINVAL {
-			errno = .NONE
+		//   - if old == new dup3 returns EINVAL, dup2 returns new if it is a valid file descriptor
+		if old == new {
+			_, err := fcntl(new, F_GETFD)
+			if err == nil {
+				return new, .NONE
+			} else {
+				default_fd: Fd
+				return default_fd, .EBADF
+			}
 		}
-		return fd, errno
+		ret := syscall(SYS_dup3, old, new, 0)
+		return errno_unwrap(ret, Fd)
 	} else {
 		ret := syscall(SYS_dup2, old, new)
 		return errno_unwrap(ret, Fd)

--- a/core/sys/unix/syscalls_linux.odin
+++ b/core/sys/unix/syscalls_linux.odin
@@ -1916,6 +1916,12 @@ POLLRDHUP      :: 0x2000
 POLLFREE       :: 0x4000
 POLL_BUSY_LOOP :: 0x8000
 
+// fcntl commands
+F_GETFD :: 1
+
+// errno values
+EBADF :: 9
+
 // perf event data
 Perf_Sample :: struct #raw_union {
 	period:    u64,
@@ -2327,6 +2333,18 @@ sys_dup2 :: proc "contextless" (oldfd: int, newfd: int) -> int {
 	when ODIN_ARCH != .arm64 && ODIN_ARCH != .riscv64 {
 		return int(intrinsics.syscall(SYS_dup2, uintptr(oldfd), uintptr(newfd)))
 	} else {
+		// Differences between dup2 and dup3 are:
+		//   - dup3 takes a flags argument
+		//   - dup2 does not return EINVAL
+		//   - if old == new dup3 returns EINVAL, dup2 returns new if it is a valid file descriptor
+		if oldfd == newfd {
+			ret := sys_fcntl(newfd, F_GETFD, 0)
+			if ret >= 0 {
+				return newfd
+			} else {
+				return -EBADF
+			}
+		}
 		return int(intrinsics.syscall(SYS_dup3, uintptr(oldfd), uintptr(newfd), 0))
 	}
 }


### PR DESCRIPTION
#6632 does not fully fix #6620: we need to actually return the old file descriptor on EINVAL, but only if it is valid.
Additionally, if oldfd == newfd `dup3` does not check if it got a valid file descriptor, it immediatly returns EINVAL. I do that check manually with `fcntl(F_GETFD)`.

I also implemented the same fix for sys/unix.

relevant man page snippets:
```
dup2() makes newfd be the copy of oldfd, closing newfd first if necessary, but note the following:
* If oldfd is not a valid file descriptor, then the call fails, and newfd is not closed.
* If oldfd is a valid file descriptor, and newfd has the same value as oldfd,
  then dup2() does nothing, and returns newfd.
```
```
dup3() is the same as dup2(), except that:
* The caller can force the close-on-exec flag to be set for the new file descriptor
  by specifying O_CLOEXEC in flags. [...]
* If oldfd equals newfd, then dup3() fails with the error EINVAL.
```