### PR TITLE
Better error reporting for unary decrement/increment operators

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -1390,7 +1390,7 @@ parse_stmt :: proc(p: ^Parser) -> ^ast.Stmt {
 	     .Pointer,
 	     .Asm, // Inline assembly
 	     // Unary Expressions
-	     .Add, .Sub, .Xor, .Not, .And:
+	     .Add, .Sub, .Xor, .Not, .And, .Increment, .Decrement:
 
 		s := parse_simple_stmt(p, {Stmt_Allow_Flag.Label})
 		expect_semicolon(p, s)

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -5393,7 +5393,10 @@ gb_internal Ast *parse_stmt(AstFile *f) {
 	case Token_Xor:
 	case Token_Not:
 	case Token_And:
-	case Token_Mul: // Used for error handling when people do C-like things
+	// Used for error handling when people do C-like things
+	case Token_Mul:
+	case Token_Increment:
+	case Token_Decrement:
 		s = parse_simple_stmt(f, StmtAllowFlag_Label);
 		expect_semicolon(f);
 		return s;


### PR DESCRIPTION
There was a missing routing for those operators in `parse_stmt` function.

For code like:

```odin
package p

main :: proc() {
	i : int
	++i
	assert(i == 1)
}
```

Old error message: `…/main.odin(5:2) Syntax Error: Expected a statement, got '++'`
New error message: `…/main.odin(5:2) Syntax Error: Unary '++' operator is not supported`