### PR TITLE
Make typed literal values on left-hand side more consistent

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -1658,7 +1658,7 @@ parse_type_or_ident :: proc(p: ^Parser) -> ^ast.Expr {
 	p.expr_level = -1
 
 	lhs := true
-	return parse_atom_expr(p, parse_operand(p, lhs), lhs)
+	return parse_atom_expr(p, parse_operand(p, lhs))
 }
 parse_type :: proc(p: ^Parser) -> ^ast.Expr {
 	type := parse_type_or_ident(p)
@@ -3275,7 +3275,7 @@ empty_selector_expr :: proc(tok: tokenizer.Token, operand: ^ast.Expr) -> ^ast.Se
 	return sel
 }
 
-parse_atom_expr :: proc(p: ^Parser, value: ^ast.Expr, lhs: bool) -> (operand: ^ast.Expr) {
+parse_atom_expr :: proc(p: ^Parser, value: ^ast.Expr) -> (operand: ^ast.Expr) {
 	operand = value
 	if operand == nil {
 		if p.allow_type {
@@ -3288,7 +3288,6 @@ parse_atom_expr :: proc(p: ^Parser, value: ^ast.Expr, lhs: bool) -> (operand: ^a
 	}
 
 	loop := true
-	is_lhs := lhs
 	for loop {
 		#partial switch p.curr_tok.kind {
 		case:
@@ -3461,22 +3460,16 @@ parse_atom_expr :: proc(p: ^Parser, value: ^ast.Expr, lhs: bool) -> (operand: ^a
 			operand = oe
 
 		case .Open_Brace:
-			if !is_lhs && is_literal_type(operand) && p.expr_level >= 0 {
+			if is_literal_type(operand) && p.expr_level >= 0 {
 				operand = parse_literal_value(p, operand)
 			} else {
 				loop = false
 			}
 
 		case .Increment, .Decrement:
-			if !lhs {
-				tok := advance_token(p)
-				error(p, tok.pos, "postfix '%s' operator is not supported", tok.text)
-			} else {
-				loop = false
-			}
+			tok := advance_token(p)
+			error(p, tok.pos, "postfix '%s' operator is not supported", tok.text)
 		}
-
-		is_lhs = false
 	}
 
 	return operand
@@ -3541,7 +3534,7 @@ parse_unary_expr :: proc(p: ^Parser, lhs: bool) -> ^ast.Expr {
 		return ise
 
 	}
-	return parse_atom_expr(p, parse_operand(p, lhs), lhs)
+	return parse_atom_expr(p, parse_operand(p, lhs))
 }
 parse_binary_expr :: proc(p: ^Parser, lhs: bool, prec_in: int) -> ^ast.Expr {
 	start_pos := p.curr_tok.pos

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -3314,7 +3314,7 @@ gb_internal void parse_check_or_return(Ast *operand, char const *msg) {
 	}
 }
 
-gb_internal Ast *parse_atom_expr(AstFile *f, Ast *operand, bool lhs) {
+gb_internal Ast *parse_atom_expr(AstFile *f, Ast *operand) {
 	if (operand == nullptr) {
 		if (f->allow_type) return nullptr;
 		Token begin = f->curr_token;
@@ -3473,7 +3473,7 @@ gb_internal Ast *parse_atom_expr(AstFile *f, Ast *operand, bool lhs) {
 			break;
 
 		case Token_OpenBrace:
-			if (!lhs && is_literal_type(operand) && f->expr_level >= 0) {
+			if (is_literal_type(operand) && f->expr_level >= 0) {
 				operand = parse_literal_value(f, operand);
 			} else {
 				loop = false;
@@ -3482,11 +3482,9 @@ gb_internal Ast *parse_atom_expr(AstFile *f, Ast *operand, bool lhs) {
 
 		case Token_Increment:
 		case Token_Decrement:
-			if (!lhs) {
+			{
 				Token token = advance_token(f);
 				syntax_error(token, "Postfix '%.*s' operator is not supported", LIT(token.string));
-			} else {
-				loop = false;
 			}
 			break;
 
@@ -3494,8 +3492,6 @@ gb_internal Ast *parse_atom_expr(AstFile *f, Ast *operand, bool lhs) {
 			loop = false;
 			break;
 		}
-
-		lhs = false; // NOTE(bill): 'tis not lhs anymore
 	}
 
 	return operand;
@@ -3551,7 +3547,7 @@ gb_internal Ast *parse_unary_expr(AstFile *f, bool lhs) {
 	}
 	}
 
-	return parse_atom_expr(f, parse_operand(f, lhs), lhs);
+	return parse_atom_expr(f, parse_operand(f, lhs));
 }
 
 gb_internal bool is_ast_range(Ast *expr) {
@@ -4655,7 +4651,7 @@ gb_internal Ast *parse_type_or_ident(AstFile *f) {
 
 	bool lhs = true;
 	Ast *operand = parse_operand(f, lhs);
-	Ast *type = parse_atom_expr(f, operand, lhs);
+	Ast *type = parse_atom_expr(f, operand);
 	return type;
 }
 


### PR DESCRIPTION
There are two forms of literal values:

- naked (`{ … }`)
- typed (`type { … }` or `pkg.type { … }`)

Left-hand side expressions beginning with a naked literal value are not accepted by the parser and this is controlled by parse_operand with its lhs parameter.

Left-hand side expressions beginning with a typed literal value are only accepted by the parser if they come in the form of `pkg.type { … }`. This is because `pkg` is an lhs operand, `.type` is an lhs atom expr and `{` becomes an rhs atom expr. Braces are accepted in rhs atom expressions.

I'd argue that typed literal values of both forms should be accepted in such expressions even if their usefulness is rather limited. This makes language a bit more consistent and the parse_atom_expr a bit simpler.

And in contexts where typed literal values should not be accepted, setting `expr_level` to -1 should be used (like in parse_type_or_ident).

Demo code:

In "pkg" directory:

```odin
package pkg

Some_Type :: struct {
	ptr : ^int
}
```

In parent directory:

```odin
package main
import p "./pkg"

T :: p.Some_Type

main :: proc() {
	i : int
	p.Some_Type{ ptr = &i }.ptr^ = 42
	assert(i == 42)
	// Does not compile.
	// Error is "Syntax Error: Expected ';', got {".
	// This PR fixes it.
	T{ ptr = &i }.ptr^ = 13
	assert(i == 13)
}
```