### PR TITLE
Add /src as safe directory for nightly linux arm workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,6 +101,7 @@ jobs:
               musl-dev llvm20-dev clang20 git mold lz4 \
               libxml2-static llvm20-static zlib-static zstd-static \
               make &&
+            git config --global --add safe.directory /src &&
             ./ci/build_linux_static.sh
           '
       - name: Odin run


### PR DESCRIPTION
The linux-arm64 binary doesn't have the version information set correctly, because git "detected dubious ownership". This should hopefully be fixed by adding the `git config` line already used in the Linux workflow.