### PR TITLE
Fix naming for wgpuTextureGetDepthOrArrayLayers in wgpu.js

### DIFF
--- a/vendor/wgpu/wgpu.js
+++ b/vendor/wgpu/wgpu.js
@@ -3308,7 +3308,7 @@ class WebGPUInterface {
 			 * @param {number} textureIdx
 			 * @returns {number}
 			 */
-			wgpuTextureDepthOrArrayLayers: (textureIdx) => {
+			wgpuTextureGetDepthOrArrayLayers: (textureIdx) => {
 				const texture = this.textures.get(textureIdx);
 				return texture.depthOrArrayLayers;
 			},


### PR DESCRIPTION
Fix wgpuTextureDepthOrArrayLayers -> wgpuTextureGetDepthOrArrayLayers to match definition in wgpu.odin