### PR TITLE
[core:flags] usage includes enum values

### DIFF
--- a/core/flags/usage.odin
+++ b/core/flags/usage.odin
@@ -162,6 +162,11 @@ write_usage :: proc(out: io.Writer, data_type: typeid, program: string = "", sty
 				flag.type_description = fmt.tprintf("<%v>%s", specific_type_info.elem.id,
 					requirement_spec if len(requirement_spec) > 0 else ", multiple")
 			}
+		case runtime.Type_Info_Enum:
+			enum_names := strings.join(specific_type_info.names, ", ", context.temp_allocator)
+			flag.type_description = fmt.tprintf("{{%s}}%s",
+				enum_names,
+				", required" if flag.is_required else "")
 		case runtime.Type_Info_Named:
 			#partial switch base_type_info in specific_type_info.base.variant {
 			case runtime.Type_Info_Enum:

--- a/core/flags/usage.odin
+++ b/core/flags/usage.odin
@@ -162,7 +162,18 @@ write_usage :: proc(out: io.Writer, data_type: typeid, program: string = "", sty
 				flag.type_description = fmt.tprintf("<%v>%s", specific_type_info.elem.id,
 					requirement_spec if len(requirement_spec) > 0 else ", multiple")
 			}
-
+		case runtime.Type_Info_Named:
+			#partial switch base_type_info in specific_type_info.base.variant {
+			case runtime.Type_Info_Enum:
+				enum_names := strings.join(base_type_info.names, ", ", context.temp_allocator)
+				flag.type_description = fmt.tprintf("{{%s}}%s",
+					enum_names,
+					", required" if flag.is_required else "")
+			case:
+				flag.type_description = fmt.tprintf("<%v>%s",
+					field.type.id,
+					", required" if flag.is_required else "")
+			}
 		case:
 			if flag.is_boolean {
 				/*

--- a/core/flags/usage.odin
+++ b/core/flags/usage.odin
@@ -88,6 +88,19 @@ write_usage :: proc(out: io.Writer, data_type: typeid, program: string = "", sty
 		return
 	}
 
+	describe_enum_type_usage :: proc(flag: Flag, enum_type: runtime.Type_Info_Enum) -> string {
+		enum_names := strings.join(enum_type.names, ", ", context.temp_allocator)
+		return fmt.tprintf("{{%s}}%s",
+			enum_names,
+			", required" if flag.is_required else "")
+	}
+
+	describe_other_type_usage :: proc(flag: Flag, field: reflect.Struct_Field) -> string {
+		return fmt.tprintf("<%v>%s",
+			field.type.id,
+			", required" if flag.is_required else "")
+	}
+
 	builder := strings.builder_make()
 	defer strings.builder_destroy(&builder)
 
@@ -163,21 +176,13 @@ write_usage :: proc(out: io.Writer, data_type: typeid, program: string = "", sty
 					requirement_spec if len(requirement_spec) > 0 else ", multiple")
 			}
 		case runtime.Type_Info_Enum:
-			enum_names := strings.join(specific_type_info.names, ", ", context.temp_allocator)
-			flag.type_description = fmt.tprintf("{{%s}}%s",
-				enum_names,
-				", required" if flag.is_required else "")
+			flag.type_description = describe_enum_type_usage(flag, specific_type_info)
 		case runtime.Type_Info_Named:
 			#partial switch base_type_info in specific_type_info.base.variant {
 			case runtime.Type_Info_Enum:
-				enum_names := strings.join(base_type_info.names, ", ", context.temp_allocator)
-				flag.type_description = fmt.tprintf("{{%s}}%s",
-					enum_names,
-					", required" if flag.is_required else "")
+				flag.type_description = describe_enum_type_usage(flag, base_type_info)
 			case:
-				flag.type_description = fmt.tprintf("<%v>%s",
-					field.type.id,
-					", required" if flag.is_required else "")
+				flag.type_description = describe_other_type_usage(flag, field)
 			}
 		case:
 			if flag.is_boolean {
@@ -187,9 +192,7 @@ write_usage :: proc(out: io.Writer, data_type: typeid, program: string = "", sty
 				}
 				*/
 			} else {
-				flag.type_description = fmt.tprintf("<%v>%s",
-					field.type.id,
-					", required" if flag.is_required else "")
+				flag.type_description = describe_other_type_usage(flag, field)
 			}
 		}
 


### PR DESCRIPTION
Came up in the forum: https://forum.odin-lang.org/t/enum-value-descriptions-with-core-flags/1799

When parsing into a `struct` with enum values, the usage output of `flags` just lists the types of the enums, but not which options are actually available. This PR addresses that.

Example code:
``` Odin
main :: proc() {
	Named_Enum :: enum { option_a, option_b }
	args: struct {
		unnamed: enum { one, two, three },
		named: Named_Enum,
	}
	flags.parse_or_exit(&args, os.args)
}
```
Output of `odin run . -- -h` before the fix:
```
Usage:
        test.exe [-named] [-unnamed]
Flags:
        -named:<Named_Enum>                    | <This flag has not been documented yet.>
        -unnamed:<enum int {one, two, three}>  | <This flag has not been documented yet.>
```
Output of `odin run . -- -h` with the fix:
```
Usage:
        test.exe [-named] [-unnamed]
Flags:
        -named:{option_a, option_b}  | <This flag has not been documented yet.>
        -unnamed:{one, two, three}   | <This flag has not been documented yet.>
```