### PR TITLE
Fix deferred_return and segfault in docs writer

### DIFF
--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -2476,7 +2476,9 @@ gb_internal Type *check_get_results(CheckerContext *ctx, Scope *scope, Ast *_res
 			param_value = handle_parameter_value(ctx, nullptr, &type, default_value, false);
 		} else {
 			if (ctx->allow_polymorphic_types && ast_references_poly_params(ctx->scope, field->type)) {
-				type = alloc_type_generic(ctx->scope, 0, string_interner_insert(str_lit("$deferred_return")), nullptr);
+				gbString name = expr_to_string(field->type);
+				type = alloc_type_generic(ctx->scope, 0, string_interner_insert(make_string_c(name)), nullptr);
+				gb_string_free(name);
 			} else {
 				type = check_type(ctx, field->type);
 			}

--- a/src/docs_writer.cpp
+++ b/src/docs_writer.cpp
@@ -670,8 +670,10 @@ gb_internal OdinDocTypeIndex odin_doc_type(OdinDocWriter *w, Type *type, bool ca
 			auto tags = array_make<OdinDocString>(heap_allocator(), type->Struct.fields.count);
 			defer (array_free(&tags));
 
-			for_array(i, type->Struct.fields) {
-				tags[i] = odin_doc_write_string(w, type->Struct.tags[i]);
+			if (type->Struct.tags != nullptr) {
+				for_array(i, type->Struct.fields) {
+					tags[i] = odin_doc_write_string(w, type->Struct.tags[i]);
+				}
 			}
 
 			doc_type.tags = odin_write_slice(w, tags.data, tags.count);


### PR DESCRIPTION
Now parapoly types show properly in return signature.
While at it, I also "fixed" a bug in the docs_writer that ends up segfaulting.

Before:
<img width="846" height="92" alt="image" src="https://github.com/user-attachments/assets/05644d76-2f7d-4897-b3a5-3064a635b420" />
After:
<img width="854" height="76" alt="image" src="https://github.com/user-attachments/assets/edf69302-0fde-4874-aa95-aef1e8c3b01a" />
