### PR TITLE
Handle invalid utf8 when parsing json

### DIFF
--- a/core/encoding/json/parser.odin
+++ b/core/encoding/json/parser.odin
@@ -474,7 +474,10 @@ unquote_string :: proc(token: Token, spec: Specification, allocator := context.a
 			i += width
 
 			buf, buf_width := utf8.encode_rune(r)
-			assert(buf_width <= width)
+			// If we have an invalid utf8 character, width can be smaller than the width of RUNE_ERROR
+			if r != utf8.RUNE_ERROR {
+				assert(buf_width <= width)
+			}
 			copy(b[w:], buf[:buf_width])
 			w += buf_width
 		}


### PR DESCRIPTION
Resolves https://github.com/odin-lang/Odin/issues/6644

When encountering an invalid utf8 character, `r, width := utf8.decode_rune_in_string(s[i:])` will return `uft8.RUNE_ERROR` for the rune, but `width` will be the number of bytes in the invalid character, which can be less than the width of `utf8.RUNE_ERROR`, causing the assert to be hit when encountering an invalid utf8 character. This just gates the assert to only be checked on valid utf8 characters. This effectively means that invalid utf8 characters encountered will now be replaced with `\ufffd`, which is what would have happened anyways previously if the invalid character was wide enough.