### PR TITLE
fix memory leak and inconsistency in os.read_entire_file_from_file

### DIFF
--- a/core/os/file_util.odin
+++ b/core/os/file_util.odin
@@ -216,18 +216,18 @@ read_entire_file_from_file :: proc(f: ^File, allocator: runtime.Allocator, loc :
 		return
 	} else {
 		buffer: [1024]u8
-		out_buffer := make([dynamic]u8, 0, 0, allocator, loc)
-		total := 0
+		out_buffer := make([dynamic]u8, 0, 0, allocator, loc) or_return
 		for {
 			n: int
 			n, err = read(f, buffer[:])
-			total += n
-			append_elems(&out_buffer, ..buffer[:n], loc=loc) or_return
+			if _, aerr := append_elems(&out_buffer, ..buffer[:n], loc=loc); aerr != nil {
+				return out_buffer[:], aerr
+			}
 			if err != nil {
 				if err == .EOF || err == .Broken_Pipe {
 					err = nil
 				}
-				data = out_buffer[:total]
+				data = out_buffer[:]
 				return
 			}
 		}


### PR DESCRIPTION
This PR fixes some issues in `os.read_entire_file_from_file`:

1. Handle `make` errors which were previously discarded
2. Fix leaking `out_buffer` memory in case of `append_elems` error
3. In case of `append_elems` error, return the partially read data to be consistent with the other branch