### PR TITLE
Add unicode mapping between 'ẞ' <-> 'ß'

### DIFF
--- a/core/unicode/tables.odin
+++ b/core/unicode/tables.odin
@@ -540,6 +540,7 @@ to_upper_ranges := [?]i32{
 
 @(rodata)
 to_upper_singlets := [?]i32{
+	0x00df, 8115,
 	0x00ff, 621,
 	0x0101, 499,
 	0x0103, 499,
@@ -1204,6 +1205,7 @@ to_lower_singlets := [?]i32{
 	0x1e90, 501,
 	0x1e92, 501,
 	0x1e94, 501,
+	0x1e9e, -7115,
 	0x1ea0, 501,
 	0x1ea2, 501,
 	0x1ea4, 501,


### PR DESCRIPTION
fixes #6660 Adds mapping from 'ẞ' U+1E9E and 'ß' U+00DF in unicode to_lower and to_upper

Test case
```
package main

import "core:fmt"
import "core:unicode"

main :: proc() {
	upper_original := 'ẞ'
	lower_original := 'ß'
	
	lower_actual := unicode.to_lower('ẞ')
        fmt.println("To Lower")
	fmt.printfln("Original: %d %c", upper_original, upper_original)
	fmt.printfln("Expected: %d %c", lower_original, lower_original)
	fmt.printfln("Actual: %d %c", lower_actual, lower_actual)

	upper_actual := unicode.to_upper(lower_original)
	fmt.println("\nTo Upper")
	fmt.printfln("Original: %d %c", lower_original, lower_original)
	fmt.printfln("Expected: %d %c", upper_original, upper_original)
	fmt.printfln("Actual: %d %c", upper_actual, upper_actual)
}
```
