### PR TITLE
Fix xlib binding signatures

### DIFF
--- a/vendor/x11/xlib/xlib_procs.odin
+++ b/vendor/x11/xlib/xlib_procs.odin
@@ -1302,7 +1302,7 @@ foreign xlib {
 		dipslay:   ^Display,
 		window:    Window,
 		screen_no: i32,
-		) -> Status ---
+		) -> b32 ---
 	WithdrawWindow :: proc(
 		dipslay:   ^Display,
 		window:    Window,

--- a/vendor/x11/xlib/xlib_procs.odin
+++ b/vendor/x11/xlib/xlib_procs.odin
@@ -295,6 +295,7 @@ foreign xlib {
 		src_y:      i32,
 		dst_x:      ^i32,
 		dst_y:      ^i32,
+		dst_child:  ^Window,
 		) -> b32 ---
 	QueryPointer :: proc(
 		display: ^Display,


### PR DESCRIPTION
These are two small changes to Xlib to fix some problems I encountered with the X11 bindings in Odin. One is an actual bug, the other is a change of return type due to X11 treating the return type (Status) differently.

The first change was to `XTranslateCoordinates()`, which was missing the *child_return* parameter. This was causing random segfaults for me about ~60% of the time, and my unit tests kept catching it. I reviewed the X11 man pages and noticed the missing parameter.

Comparing the debug assembly output for the Odin code with the C++ equivalent, I noticed that a register is absent from the Odin output. The register `r10` is never set.

Odin output (`-o:none -debug`):

```asm
	movq	416(%rsp), %rax
	movq	(%rax), %rdi
	movq	416(%rsp), %rax
	movq	8(%rax), %rsi
	movq	120(%rsp), %rdx
	xorl	%r8d, %r8d
	leaq	108(%rsp), %r9
	leaq	104(%rsp), %rax
	movl	%r8d, %ecx
	movq	%rax, (%rsp)
	callq	XTranslateCoordinates@PLT
```

C++ output (debug):

```asm
	movq	%rax, %rdi
	movq	-416(%rbp), %rax
	movq	16(%rax), %rsi
	movq	-408(%rbp), %rdx
	xorl	%r8d, %r8d
	leaq	-308(%rbp), %r9
	leaq	-312(%rbp), %r10 ; This register is set
	leaq	-304(%rbp), %rax
	movl	%r8d, %ecx
	movq	%r10, (%rsp)
	movq	%rax, 8(%rsp)
	callq	XTranslateCoordinates@PLT
```

I'm pretty sure what's happening is that since Odin excludes the parameter, and the asm never sets the register properly, X11 attempts to access the pointer and segfaults. When I updated the signature, the errors stopped happening, and everything works properly.

With the fixes applied, they now set the `r10` register for the Odin output:

```diff
8c8,9
< 	leaq	104(%rsp), %rax
---
> 	leaq	104(%rsp), %r10
> 	leaq	112(%rsp), %rax
10c11,12
< 	movq	%rax, (%rsp)
---
> 	movq	%r10, (%rsp)
> 	movq	%rax, 8(%rsp)
```

Now, for the second issue, it's mainly just due to X11 not treating `Status` the way you would expect. For the function `XIconifyWindow()`, even though it does return Status, it doesn't return the Status values that are described in the library. It actually treats its return type similarly to a `b32`, returning false for failure and true for success. The way to actually check the status return is `!(cast(b32)status)`. Changing the return type to b32 makes it far simpler, `!status`.

I can revert this if there is a reason for the type being `Status`, but it appears to me that the function isn't treating its return like a `Status` type.

Here is the snippet from the man pages:

> The `XIconifyWindow` function sends a `WM_CHANGE_STATE` ClientMessage event with a format of 32 and a first data element of IconicState (as described in section 4.1.4 of the Inter-Client Communication Conventions Manual) and a window of w to the root window of the specified screen with an event mask set to `SubstructureNotifyMask|  SubstructureRedirectMask`. Window managers may elect to receive this message and if the window is in its normal state, may treat it as a request to change the window's state from normal to iconic.  If the `WM_CHANGE_STATE` property cannot be interned, `XIconifyWindow` does not send a message and returns a zero status.  It returns a nonzero status if the client message is sent successfully; otherwise, it returns a zero status.

I did a simple local test suite running the changes in my library, and now everything works as expected. Hopefully, I provided enough here. If anything more needs to be done, let me know! I just wanted to make these changes so the library can be a little more stable while I work on my personal project using it.