### PR TITLE
core/sys/linux: fix Time_Val docstring (millisecond -> microsecond)

### DIFF
--- a/core/sys/linux/types.odin
+++ b/core/sys/linux/types.odin
@@ -65,7 +65,7 @@ Time_Spec :: struct {
 }
 
 /*
-	Represents time with millisecond precision.
+	Represents time with microsecond precision.
 */
 Time_Val :: struct {
 	seconds:      int,


### PR DESCRIPTION
## 概要

`core/sys/linux/types.odin` の `Time_Val` の docstring が「millisecond precision」となっているが、struct 自体は `microseconds: int` フィールドを持っており、Linux の `struct timeval { time_t tv_sec; suseconds_t tv_usec; }` の意味とも一致しないため、`millisecond` → `microsecond` に修正しました。

直前にある `Time_Spec` (`time_nsec` / nanosecond precision) は正しく対応しており、本 PR は Time_Val 側 1 行のみの修正です。

## 動作確認

ドキュメンテーション文字列のみの変更で、生成コードへの影響なし:

```
diff --git a/core/sys/linux/types.odin b/core/sys/linux/types.odin
@@ -65,7 +65,7 @@ Time_Spec :: struct {
 }

 /*
-	Represents time with millisecond precision.
+	Represents time with microsecond precision.
 */
 Time_Val :: struct {
 	seconds:      int,
```

`Time_Val` の宣言は無変更なので、コンパイル挙動 / API への影響は無く、追加テストは不要と判断しました。

Closes #6679