### PR TITLE
core:os (Linux): Convert (f)stat calls to statx

### DIFF
--- a/core/os/dir_linux.odin
+++ b/core/os/dir_linux.odin
@@ -98,7 +98,7 @@ _read_directory_iterator_init :: proc(it: ^Read_Directory_Iterator, f: ^File) {
 	}
 
 	stat: linux.Statx
-	errno := linux.statx(linux.Fd(fd(f)), "", {.EMPTY_PATH}, {.MODE}, &stat)
+	errno := linux.statx(linux.Fd(fd(f)), "", {.EMPTY_PATH}, {.TYPE}, &stat)
 	if errno != .NONE {
 		read_directory_iterator_set_error(it, name(f), _get_platform_error(errno))
 		return

--- a/core/os/dir_linux.odin
+++ b/core/os/dir_linux.odin
@@ -97,8 +97,8 @@ _read_directory_iterator_init :: proc(it: ^Read_Directory_Iterator, f: ^File) {
 		return
 	}
 
-	stat: linux.Stat
-	errno := linux.fstat(linux.Fd(fd(f)), &stat)
+	stat: linux.Statx
+	errno := linux.statx(linux.Fd(fd(f)), "", {.EMPTY_PATH}, {.MODE}, &stat)
 	if errno != .NONE {
 		read_directory_iterator_set_error(it, name(f), _get_platform_error(errno))
 		return

--- a/core/os/file_linux.odin
+++ b/core/os/file_linux.odin
@@ -279,10 +279,8 @@ _write_at :: proc(f: ^File_Impl, p: []byte, offset: i64) -> (nt: i64, err: Error
 
 @(no_sanitize_memory)
 _file_size :: proc(f: ^File_Impl) -> (n: i64, err: Error) {
-	// TODO: Identify 0-sized "pseudo" files and return No_Size. This would
-	//       eliminate the need for the _read_entire_pseudo_file procs.
-	s: linux.Stat = ---
-	errno := linux.fstat(f.fd, &s)
+	s: linux.Statx = ---
+	errno := linux.statx(f.fd, "", {.EMPTY_PATH}, {.SIZE, .MODE}, &s)
 	if errno != .NONE {
 		return 0, _get_platform_error(errno)
 	}

--- a/core/os/file_linux.odin
+++ b/core/os/file_linux.odin
@@ -280,7 +280,7 @@ _write_at :: proc(f: ^File_Impl, p: []byte, offset: i64) -> (nt: i64, err: Error
 @(no_sanitize_memory)
 _file_size :: proc(f: ^File_Impl) -> (n: i64, err: Error) {
 	s: linux.Statx = ---
-	errno := linux.statx(f.fd, "", {.EMPTY_PATH}, {.SIZE, .MODE}, &s)
+	errno := linux.statx(f.fd, "", {.EMPTY_PATH}, {.SIZE, .TYPE}, &s)
 	if errno != .NONE {
 		return 0, _get_platform_error(errno)
 	}

--- a/core/os/process_linux.odin
+++ b/core/os/process_linux.odin
@@ -439,7 +439,7 @@ _process_start :: proc(desc: Process_Desc) -> (process: Process, err: Error) {
 
 			exe_path = strings.to_cstring(&exe_builder) or_return
 			stat: linux.Statx
-			if linux.statx(linux.AT_FDCWD, exe_path, {}, {.MODE}, &stat) == .NONE && .IFREG in stat.mode && .IXUSR in stat.mode {
+			if linux.statx(linux.AT_FDCWD, exe_path, {}, {.TYPE, .MODE}, &stat) == .NONE && .IFREG in stat.mode && .IXUSR in stat.mode {
 				found = true
 				break
 			}

--- a/core/os/process_linux.odin
+++ b/core/os/process_linux.odin
@@ -129,8 +129,8 @@ _process_info_by_pid :: proc(pid: int, selection: Process_Info_Fields, allocator
 	defer linux.close(proc_fd)
 
 	username_if: if .Username in selection {
-		s: linux.Stat
-		if errno = linux.fstat(proc_fd, &s); errno != .NONE {
+		s: linux.Statx
+		if errno = linux.statx(proc_fd, "", {.EMPTY_PATH}, {.UID}, &s); errno != .NONE {
 			err = _get_platform_error(errno)
 			break username_if
 		}
@@ -438,8 +438,8 @@ _process_start :: proc(desc: Process_Desc) -> (process: Process, err: Error) {
 			strings.write_string(&exe_builder, executable_name)
 
 			exe_path = strings.to_cstring(&exe_builder) or_return
-			stat := linux.Stat{}
-			if linux.stat(exe_path, &stat) == .NONE && .IFREG in stat.mode && .IXUSR in stat.mode {
+			stat: linux.Statx
+			if linux.statx(linux.AT_FDCWD, exe_path, {}, {.MODE}, &stat) == .NONE && .IFREG in stat.mode && .IXUSR in stat.mode {
 				found = true
 				break
 			}

--- a/core/os/stat_linux.odin
+++ b/core/os/stat_linux.odin
@@ -11,8 +11,8 @@ _fstat :: proc(f: ^File, allocator: runtime.Allocator) -> (File_Info, Error) {
 }
 
 _fstat_internal :: proc(fd: linux.Fd, allocator: runtime.Allocator) -> (fi: File_Info, err: Error) {
-	s: linux.Stat
-	errno := linux.fstat(fd, &s)
+	s: linux.Statx
+	errno := linux.statx(fd, "", {.EMPTY_PATH}, {.TYPE, .MODE, .ATIME, .MTIME, .CTIME, .INO, .SIZE}, &s)
 	if errno != .NONE {
 		return {}, _get_platform_error(errno)
 	}
@@ -28,7 +28,6 @@ _fstat_internal :: proc(fd: linux.Fd, allocator: runtime.Allocator) -> (fi: File
 	}
 	mode := transmute(Permissions)(0o7777 & transmute(u32)s.mode)
 
-	// TODO: As of Linux 4.11, the new statx syscall can retrieve creation_time
 	fi = File_Info {
 		fullpath          = _get_full_path(fd, allocator) or_return,
 		name              = "",
@@ -36,9 +35,9 @@ _fstat_internal :: proc(fd: linux.Fd, allocator: runtime.Allocator) -> (fi: File
 		size              = i64(s.size),
 		mode              = mode,
 		type              = type,
-		modification_time = time.Time {i64(s.mtime.time_sec) * i64(time.Second) + i64(s.mtime.time_nsec)},
-		access_time       = time.Time {i64(s.atime.time_sec) * i64(time.Second) + i64(s.atime.time_nsec)},
-		creation_time     = time.Time{i64(s.ctime.time_sec) * i64(time.Second) + i64(s.ctime.time_nsec)}, // regular stat does not provide this
+		modification_time = time.Time {i64(s.mtime.sec) * i64(time.Second) + i64(s.mtime.nsec)},
+		access_time       = time.Time {i64(s.atime.sec) * i64(time.Second) + i64(s.atime.nsec)},
+		creation_time     = time.Time {i64(s.btime.sec) * i64(time.Second) + i64(s.btime.nsec)},
 	}
 	fi.creation_time = fi.modification_time
 	_, fi.name = split_path(fi.fullpath)

--- a/src/string_interner.cpp
+++ b/src/string_interner.cpp
@@ -81,7 +81,7 @@ gb_internal String string_interner_load(InternedString interned) {
 	u8 *base = cast(u8 *)interner + interned.value;
 	u32 str_len = *cast(u32 *)base;
 	u8 *text = base + 4;
-	String str = { text, str_len };
+	String str = { text, cast(isize)str_len };
 	return str;
 }
 


### PR DESCRIPTION
This provides access to `os.Stat.creation_time` for Linux.

NOTE: Sneaky edit to string_interner.cpp: Added a cast for 32-bit builds of the compiler.

I converted all uses of `linux.Stat` to `Statx` which wasn't strictly necessary.  Statx is supposed to be a bit faster since you request what you want to be filled out instead of just getting everything.  Also, regular `(f)stat` was giving me file size issues in a 386 container that I used for testing (both Odin and C).

The downside is it cuts off people with kernels older than 4.11 (released April 2017).  This takes out anything Ubuntu 16.04 and below.  I could add a fallback wrapper if we want to support older kernels.