### PR TITLE
Additional Xlib binding changes

### DIFF
--- a/vendor/x11/xlib/xlib_const.odin
+++ b/vendor/x11/xlib/xlib_const.odin
@@ -713,7 +713,7 @@ AllHints :: WMHints{
 	.WindowGroupHint,
 }
 
-SizeHints :: bit_set[SizeHintsBits; uint]
+SizeHints :: bit_set[SizeHintsBits; int]
 SizeHintsBits :: enum {
 	USPosition  = 0,
 	USSize      = 1,

--- a/vendor/x11/xlib/xlib_const.odin
+++ b/vendor/x11/xlib/xlib_const.odin
@@ -110,6 +110,8 @@ PropModePrepend :: 1
 PropModeAppend  :: 2
 
 XA_ATOM              :: Atom(4)
+XA_CARDINAL          :: Atom(6)
+XA_INTEGER           :: Atom(19)
 XA_WM_CLASS          :: Atom(67)
 XA_WM_CLIENT_MACHINE :: Atom(36)
 XA_WM_COMMAND        :: Atom(34)

--- a/vendor/x11/xlib/xlib_procs.odin
+++ b/vendor/x11/xlib/xlib_procs.odin
@@ -1367,7 +1367,7 @@ foreign xlib {
 		display: ^Display,
 		window:  Window,
 		) -> ^XWMHints ---
-	// Setting and reading MW_NORMAL_HINTS property
+	// Setting and reading WM_NORMAL_HINTS property
 	AllocSizeHints :: proc() -> ^XSizeHints ---
 	SetWMNormalHints :: proc(
 		display: ^Display,

--- a/vendor/x11/xlib/xlib_procs.odin
+++ b/vendor/x11/xlib/xlib_procs.odin
@@ -181,11 +181,11 @@ foreign xlib {
 	DestroyWindow     :: proc(display: ^Display, window: Window) ---
 	DestroySubwindows :: proc(display: ^Display, window: Window) ---
 	// Windows: mapping/unmapping
-	MapWindow         :: proc(display: ^Display, window: Window) ---
-	MapRaised         :: proc(display: ^Display, window: Window) ---
-	MapSubwindows     :: proc(display: ^Display, window: Window) ---
-	UnmapWindow       :: proc(display: ^Display, window: Window) ---
-	UnmapSubwindows   :: proc(display: ^Display, window: Window) ---
+	MapWindow         :: proc(display: ^Display, window: Window) -> b32 ---
+	MapRaised         :: proc(display: ^Display, window: Window) -> b32 ---
+	MapSubwindows     :: proc(display: ^Display, window: Window) -> b32 ---
+	UnmapWindow       :: proc(display: ^Display, window: Window) -> b32 ---
+	UnmapSubwindows   :: proc(display: ^Display, window: Window) -> b32 ---
 	// Windows: configuring
 	ConfigureWindow :: proc(
 		display: ^Display,

--- a/vendor/x11/xlib/xlib_procs.odin
+++ b/vendor/x11/xlib/xlib_procs.odin
@@ -1027,7 +1027,7 @@ foreign xlib {
 	// Events
 	SelectInput   :: proc(display: ^Display, window: Window, mask: EventMask) ---
 	Flush         :: proc(display: ^Display) -> i32 ---
-	Sync          :: proc(display: ^Display, discard: bool) -> i32 ---
+	Sync          :: proc(display: ^Display, discard: b32) -> i32 ---
 	EventsQueued  :: proc(display: ^Display, mode: EventQueueMode) -> i32 ---
 	Pending       :: proc(display: ^Display) -> i32 ---
 	NextEvent     :: proc(display: ^Display, event: ^XEvent) ---

--- a/vendor/x11/xlib/xlib_procs.odin
+++ b/vendor/x11/xlib/xlib_procs.odin
@@ -339,10 +339,10 @@ foreign xlib {
 		long_len:    int,
 		delete:      b32,
 		req_type:    Atom,
-		act_type:    [^]Atom,
-		act_format:  [^]i32,
-		nitems:      [^]uint,
-		bytes_after: [^]uint,
+		act_type:    ^Atom,
+		act_format:  ^i32,
+		nitems:      ^uint,
+		bytes_after: ^uint,
 		props:       ^rawptr,
 	) -> i32 ---
 	ListProperties :: proc(


### PR DESCRIPTION
Here are some more changes and clean-up I have been doing while working on a private project. Some are small, like the typo, but others are correcting a few signatures and adding some constants (`XA_CARDINAL` and `XA_INTEGER`). I did change the internal type of the SizeHints from a `uint` to a regular `int` since the actual flags in C are listed as a regular `long`. The behavior doesn't really change at all, but I figure accuracy for Xlib is best here. All of the mapping/unmapping functions have added return types for `b32` now, since they can fail. I decided that those are useful to have for some error checking. I changed some of `XGetWindowProperty()`'s parameters since they are formed like pointers to arrays, but they are just pointers to regular data. This is more semantic or purely visual since they both compile down to the same thing, from what I saw. Lastly, `XSync()`'s second parameter was changed from a `bool` to `b32` since the parameter type is an `int` in the actual signature. I don't know if it could've broken anything staying as a `bool`, so better safe than sorry.

Also, should I go ahead and add the other Atom constants? There are quite a few missing from what is in the header, but I'm unsure if it's intentional. If you want, I can step through and just add all of them so they're there when they're needed?