### PR TITLE
Honour -no-thread-local for variables declared at procedure scope

### DIFF
--- a/src/check_stmt.cpp
+++ b/src/check_stmt.cpp
@@ -2260,7 +2260,9 @@ gb_internal void check_value_decl_stmt(CheckerContext *ctx, Ast *node, u32 mod_f
 					error(e->token, "'thread_local' variables cannot be declared within a defer statement");
 				}
 			}
-			e->Variable.thread_local_model = ac.thread_local_model;
+			if (!build_context.no_thread_local) {
+				e->Variable.thread_local_model = ac.thread_local_model;
+			}
 		}
 
 		if (ac.is_static && ac.thread_local_model != "") {


### PR DESCRIPTION
Fix for #6096. Don't update a variable's thread local model if `build_context.no_thread_local` is set to `true`.