### PR TITLE
[core:io/utils]: fix undeclared name in read_slice (typo)

### DIFF
--- a/core/io/util.odin
+++ b/core/io/util.odin
@@ -10,7 +10,7 @@ read_ptr :: proc(r: Reader, p: rawptr, byte_size: int, n_read: ^int = nil) -> (n
 
 read_slice :: proc(r: Reader, slice: $S/[]$T, n_read: ^int = nil) -> (n: int, err: Error) {
 	size := len(slice)*size_of(T)
-	return read_ptr(w, raw_data(slice), size, n_read)
+	return read_ptr(r, raw_data(slice), size, n_read)
 }
 
 write_ptr :: proc(w: Writer, p: rawptr, byte_size: int, n_written: ^int = nil) -> (n: int, err: Error) {


### PR DESCRIPTION
Fixes a typo where `read_slice` tries to pass a `w` argument to `read_ptr` instead of `r`.