### PR TITLE
Fix nil typing when procedure call argument

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -6674,6 +6674,8 @@ gb_internal CallArgumentError check_call_arguments_internal(CheckerContext *c, A
 					if (!context_allocator_error) {
 						ordered_operands[i].mode = Addressing_Value;
 						ordered_operands[i].type = e->type;
+						if (e->Variable.param_value.kind == ParameterValue_Nil)
+							ordered_operands[i].type = t_untyped_nil;
 						ordered_operands[i].expr = e->Variable.param_value.original_ast_expr;
 
 						dummy_argument_count += 1;


### PR DESCRIPTION
#6453 mentions this code:
```odin
package main

import "core:fmt"

main :: proc() {
        v: int = 5
        foo(v)
}

foo :: proc(v: $T, bar: proc(T) = nil) {
        fmt.println(bar)
}
```
That throws an error during type checking, due to nil having the computed type `proc($T)`, which is not **assignable** to `proc(int)`.

This PR substitutes the computed type with `t_untyped_nil` whenever a nil value is encounted in call arguments.