### PR TITLE
Be more thorough in detecting generic procedure types

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -2199,6 +2199,57 @@ parse_proc_tags :: proc(p: ^Parser) -> (tags: ast.Proc_Tags) {
 	return
 }
 
+is_expr_generic :: proc(expr : ^ast.Expr) -> bool {
+	is_generic := false
+	if expr != nil {
+		#partial switch e in expr.derived_expr {
+		case ^ast.Typeid_Type:
+			is_generic = e.specialization != nil
+		case ^ast.Poly_Type:
+			is_generic = true
+		case ^ast.Proc_Type:
+			is_generic = e.generic
+		case ^ast.Pointer_Type:
+			is_generic = is_expr_generic(e.elem)
+		case ^ast.Multi_Pointer_Type:
+			is_generic = is_expr_generic(e.elem)
+		case ^ast.Array_Type:
+			is_generic = is_expr_generic(e.len) || is_expr_generic(e.elem)
+		case ^ast.Dynamic_Array_Type:
+			is_generic = is_expr_generic(e.elem)
+		case ^ast.Fixed_Capacity_Dynamic_Array_Type:
+			is_generic = is_expr_generic(e.capacity) || is_expr_generic(e.elem)
+		case ^ast.Bit_Set_Type:
+			is_generic = is_expr_generic(e.elem)
+		case ^ast.Map_Type:
+			is_generic = is_expr_generic(e.key) || is_expr_generic(e.value)
+		case ^ast.Matrix_Type:
+			is_generic = is_expr_generic(e.row_count) || is_expr_generic(e.column_count) || is_expr_generic(e.elem)
+		}
+	}
+	return is_generic
+}
+
+is_field_list_generic :: proc(field_list : ^ast.Field_List, check_names : bool) -> bool {
+	is_generic := false
+	loop: for param in field_list.list {
+		if is_expr_generic(param.type) {
+			is_generic = true
+			break loop
+		}
+		if !check_names || param.type == nil {
+			continue
+		}
+		for name in param.names {
+			if _, ok := name.derived.(^ast.Poly_Type); ok {
+				is_generic = true
+				break loop
+			}
+		}
+	}
+	return is_generic
+}
+
 parse_proc_type :: proc(p: ^Parser, tok: tokenizer.Token) -> ^ast.Proc_Type {
 	cc: ast.Proc_Calling_Convention
 	if p.curr_tok.kind == .String {
@@ -2220,21 +2271,9 @@ parse_proc_type :: proc(p: ^Parser, tok: tokenizer.Token) -> ^ast.Proc_Type {
 	expect_closing_parentheses_of_field_list(p)
 	results, diverging := parse_results(p)
 
-	is_generic := false
-
-	loop: for param in params.list {
-		if param.type != nil {
-			if _, ok := param.type.derived.(^ast.Poly_Type); ok {
-				is_generic = true
-				break loop
-			}
-			for name in param.names {
-				if _, ok := name.derived.(^ast.Poly_Type); ok {
-					is_generic = true
-					break loop
-				}
-			}
-		}
+	is_generic := is_field_list_generic(params, true)
+	if !is_generic && results != nil {
+		is_generic = is_field_list_generic(results, false)
 	}
 
 	end := end_pos(p.prev_tok)

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -4106,6 +4106,71 @@ gb_internal ProcCallingConvention string_to_calling_convention(String const &s) 
 	return ProcCC_Invalid;
 }
 
+gb_internal bool is_ast_generic(Ast *a) {
+	bool is_generic = false;
+	if (a != nullptr) {
+		switch (a->kind) {
+		case Ast_TypeidType:
+			is_generic = a->TypeidType.specialization != nullptr;
+			break;
+		case Ast_PolyType:
+			is_generic = true;
+			break;
+		case Ast_ProcType:
+			is_generic = a->ProcType.generic;
+			break;
+		case Ast_PointerType:
+			is_generic = is_ast_generic(a->PointerType.type);
+			break;
+		case Ast_MultiPointerType:
+			is_generic = is_ast_generic(a->MultiPointerType.type);
+			break;
+		case Ast_ArrayType:
+			is_generic = is_ast_generic(a->ArrayType.elem) || is_ast_generic(a->ArrayType.count);
+			break;
+		case Ast_DynamicArrayType:
+			is_generic = is_ast_generic(a->DynamicArrayType.elem);
+			break;
+		case Ast_FixedCapacityDynamicArrayType:
+			is_generic = is_ast_generic(a->FixedCapacityDynamicArrayType.elem) || is_ast_generic(a->FixedCapacityDynamicArrayType.capacity);
+			break;
+		case Ast_BitSetType:
+			is_generic = is_ast_generic(a->BitSetType.elem);
+			break;
+		case Ast_MapType:
+			is_generic = is_ast_generic(a->MapType.key) || is_ast_generic(a->MapType.value);
+			break;
+		case Ast_MatrixType:
+			is_generic = is_ast_generic(a->MatrixType.row_count) || is_ast_generic(a->MatrixType.column_count) || is_ast_generic(a->MatrixType.elem);
+			break;
+		}
+	}
+	return is_generic;
+}
+
+gb_internal bool is_field_list_generic(AstFieldList *field_list, bool check_names) {
+	bool is_generic = false;
+
+	for (Ast *param : field_list->list) {
+		ast_node(field, Field, param);
+		if (is_ast_generic(field->type)) {
+			is_generic = true;
+			goto end;
+		}
+		if (!check_names || field->type == nullptr) {
+			continue;
+		}
+		for (Ast *name : field->names) {
+			if (name->kind == Ast_PolyType) {
+				is_generic = true;
+				goto end;
+			}
+		}
+	}
+end:
+	return is_generic;
+}
+
 gb_internal Ast *parse_proc_type(AstFile *f, Token proc_token) {
 	Ast *params = nullptr;
 	Ast *results = nullptr;
@@ -4141,24 +4206,11 @@ gb_internal Ast *parse_proc_type(AstFile *f, Token proc_token) {
 	results = parse_results(f, &diverging);
 
 	u64 tags = 0;
-	bool is_generic = false;
-
-	for (Ast *param : params->FieldList.list) {
-		ast_node(field, Field, param);
-		if (field->type != nullptr) {
-		    if (field->type->kind == Ast_PolyType) {
-				is_generic = true;
-				goto end;
-			}
-			for (Ast *name : field->names) {
-				if (name->kind == Ast_PolyType) {
-					is_generic = true;
-					goto end;
-				}
-			}
-		}
+	bool is_generic = is_field_list_generic(&params->FieldList, true);
+	if (!is_generic && (results != nullptr)) {
+		is_generic = is_field_list_generic(&results->FieldList, false);
 	}
-end:
+
 	return ast_proc_type(f, proc_token, params, results, tags, cc, is_generic, diverging);
 }
 


### PR DESCRIPTION
It's something I noticed by accident when comparing ast dump and tree sitter grammar output - not all procedures with generic parameters were denoted as generic. I'm not really sure if it fixes anything though. Below is a test program I used to see if parser marks the procedures as generic.

The code does not handle parameters with struct types (like `proc(a : struct($T : typeid) { t : T })`) or union types. I also ignored relative types, not sure if the code should care about this one.

```odin
package main

import "core:fmt"
import "core:odin/ast"
import "core:odin/parser"
import "core:os"

// 1. typeid

typeid_not_generic :: proc(typeid) {}

typeid_specialized_unnamed :: proc(typeid/[]$E) {}

typeid_specialized_named :: proc($T : typeid/[]$E) {}

// 2. helper type - not allowed in procedure parameters

// 3. distinct type - not allowed in procedure parameters

// 4. poly type

poly_type :: proc($T) {}

// 5. proc type

proc_type_not_generic :: proc(p : proc()) {}

proc_type_param :: proc(p : proc($T)) {}

proc_type_result :: proc(p : proc() -> $T) {}

// 6. pointer type

pointer_type_not_generic :: proc(p : ^int) {}

pointer_type :: proc(p : ^$T) {}

// 7 multi pointer type

multi_pointer_type_not_generic :: proc(p : [^]int) {}

multi_pointer_type :: proc(p : [^]$T) {}

// 8. array type

array_type_not_generic :: proc(a : [4]int) {}

array_type_count :: proc(a : [$I]int) {}

array_type_type :: proc(a : [4]$T) {}

// 9. dynamic array type

dynamic_array_type_not_generic :: proc(a : [dynamic]int) {}

dynamic_array_type :: proc(a : [dynamic]$T) {}

// 10. fixed capacity array type

fixed_capacity_array_type_not_generic :: proc(a : [dynamic; 3]int) {}

fixed_capacity_array_type_cap :: proc(a : [dynamic; $I]int) {}

fixed_capacity_array_type_type :: proc(a : [dynamic; 3]$T) {}

// 11. struct type - ohman, don't specify anonymous struct type inside
// proc parameters, just don't.

// 12. union type - same here

// 13. enum type  - not allowed in procedure parameters

enum_type_not_generic :: proc(e : enum {AE1, AE2}) {}

// 14. bit set type

E :: enum {E1, E2}

bit_set_type_not_generic :: proc(s : bit_set[E; u8]) {}

bit_set_type_enum :: proc(s : bit_set[$T; u8]) {}

// generic underlying not allowed
//
// bit_set_type_underlying :: proc(s : bit_set[E; $U]) {}

// 15. map type

map_type_not_generic :: proc(m : map[int]int) {}

map_type_key :: proc(m : map[$K]int) {}

map_type_value :: proc(m : map[int]$V) {}

// 16. relative type - ignore it?

// 17. matrix type

matrix_type_not_generic :: proc(m : matrix[2, 3]int) {}

matrix_type_row :: proc(m : matrix[$R, 3]int) {}

matrix_type_col :: proc(m : matrix[2, $C]int) {}

matrix_type_type :: proc(m : matrix[2, 3]$T) {}

// 18. bit field type

bit_field_type_not_generic :: proc(b : bit_field u8 { a : u8 | 1}) {}

cb :: proc(n : ^ast.Node) -> bool {
    if n == nil {
        return false
    }
    //fmt.printfln("%v", n.derived)
    #partial switch e in n.derived {
    case ^ast.Package, ^ast.File:
        return true
    case ^ast.Value_Decl:
        if !e.is_mutable {
            fmt.println("idents:")
            for name in e.names {
                i, ok := name.derived_expr.(^ast.Ident)
                if ok {
                    fmt.printfln("  %s", i.name)
                }
            }
            for v in e.values {
                ast.inspect(v, cb2)
            }
        }
    }
    return false
}

cb2 :: proc(n : ^ast.Node) -> bool {
    if n != nil {
        p, ok := n.derived.(^ast.Proc_Type)
        if ok {
            fmt.printfln("    proc type generic: %v", p.generic)
            fmt.printfln("    going into params:")
            ast.inspect(p.params, cb2)
            fmt.printfln("    done with params")
            return false
        }
    }
    return true
}

main :: proc() {
    p, ok := parser.parse_package_from_path(".")
    if !ok {
        fmt.eprintln("failed to parse us")
        os.exit(1)
    }
    ast.inspect(p, cb)
}
```