### PR TITLE
Fix race condition relating to type specialization

### DIFF
--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -1491,6 +1491,22 @@ gb_internal void check_bit_set_type(CheckerContext *c, Type *type, Type *named_t
 }
 
 
+// If `specialization` is a polymorphic-record specialization that has been published into
+// its originating record's `gen_types` cache, return that cache's `GenTypesData`. Its
+// `RecursiveMutex` guards concurrent `find_polymorphic_record_entity` reads, so the
+// in-place finalization below must hold it. Returns nullptr otherwise.
+gb_internal GenTypesData *gen_types_data_of_specialization(Type *specialization) {
+	if (specialization != nullptr &&
+	    specialization->kind == Type_Named &&
+	    specialization->Named.type_name != nullptr) {
+		Type *orig = specialization->Named.type_name->TypeName.original_type_for_parapoly;
+		if (orig != nullptr && orig->kind == Type_Named) {
+			return orig->Named.gen_types_data;
+		}
+	}
+	return nullptr;
+}
+
 gb_internal bool check_type_specialization_to(CheckerContext *ctx, Type *specialization, Type *type, bool compound, bool modify_type) {
 	if (type == nullptr ||
 	    type == t_invalid) {
@@ -1559,8 +1575,14 @@ gb_internal bool check_type_specialization_to(CheckerContext *ctx, Type *special
 			}
 
 			if (modify_type) {
-				// NOTE(bill): This is needed in order to change the actual type but still have the types defined within it
+				// NOTE(bill): This is needed in order to change the actual type but still have the types defined within it.
+				// `specialization` may already be published in a polymorphic record's gen_types cache;
+				// finalize it under that record's (recursive) gen_types mutex so a concurrent
+				// find_polymorphic_record_entity on another thread cannot observe a torn Type.
+				GenTypesData *gen_types = gen_types_data_of_specialization(specialization);
+				if (gen_types != nullptr) mutex_lock(&gen_types->mutex);
 				gb_memmove(specialization, type, gb_size_of(Type));
+				if (gen_types != nullptr) mutex_unlock(&gen_types->mutex);
 			}
 
 			return true;
@@ -1606,8 +1628,12 @@ gb_internal bool check_type_specialization_to(CheckerContext *ctx, Type *special
 			}
 
 			if (modify_type) {
-				// NOTE(bill): This is needed in order to change the actual type but still have the types defined within it
+				// NOTE(bill): This is needed in order to change the actual type but still have the types defined within it.
+				// See the struct branch above: finalize under the originating record's gen_types mutex.
+				GenTypesData *gen_types = gen_types_data_of_specialization(specialization);
+				if (gen_types != nullptr) mutex_lock(&gen_types->mutex);
 				gb_memmove(specialization, type, gb_size_of(Type));
+				if (gen_types != nullptr) mutex_unlock(&gen_types->mutex);
 			}
 
 			return true;


### PR DESCRIPTION
_Click bait title ;)_ 
15x speedup improvement, resulting from being able to actually use multithreading.

I have been having a hell of a time lately with Odin giving intermittent compiler errors, then passing on rebuild. 

Setting the compiler flag `-thread-count:1` has been working, but feels greasy. I've taken some time to chase this... but Odin has some advanced multithreading, which I fully admit is beyond my area of expertise. So I'm including the diagnostic methodology with my fix

This appears to be distinct from #2463 (fixed by #3326), as I can still repro this bug on master.

The bug in #5051 is similar(and still reproducible for me). This fix does not address(see note at bottom)

Possibly related to  #2949



### Environment

OS: Mac OS Tahoe 26
CPU: M2 Pro

### Diagnosis Methodology

1. Build the compiler with ThreadSanitizer enabled
```sh
CXXFLAGS="-fsanitize=thread" LDFLAGS="-fsanitize=thread" \
    LLVM_CONFIG=/opt/homebrew/opt/llvm/bin/llvm-config \
    ./build_odin.sh debug
```

2. Run the repro 
```
TSAN_OPTIONS="halt_on_error=0 history_size=7" ./odin build /path/to/repro -out:/tmp/x  2> tsan.log
```

3. Ignore everything with my intensely focused wishful thinking

The run reported ~2500 races (Odin does advanced stuff here most analyzers don't understand), then filtered to the functions in play rather than reading all of it:

```
  grep -c "WARNING: ThreadSanitizer: data race" tsan.log      # total
  grep -c "check_type_specialization_to" tsan.log             # the writer
  grep -c "find_polymorphic_record_entity" tsan.log           # the reader
```

Now feel the sigh of relief that you don't have to read through all the garbage, and you've added another 6 months before you need glasses

### Problem

   With the multi-threaded checker, compiling code that instantiates a polymorphic record intermittently aborts during
   type-checking:

   ```
   src/check_type.cpp(598): Assertion Failure: `tuple != nullptr` Pool($T=...) ::
   This is a compiler error. Please report this.
   ```
The assert is in `find_polymorphic_record_entity` (on some runs the sibling `GB_ASSERT(param_count ==
   tuple->variables.count)` on line 599 fires instead). It is non-deterministic — the instantiation named in the message
   varies from run to run and it **never** reproduces with `-thread-count:1`. That combination points to a data race
   rather than a logic error.

   (Not the same as #2463, fixed by #3326: that was a race on the `gen_types` container itself; here the container is
   correctly locked and the unsynchronized write is the in-place type finalization described below.)

### Root cause

`check_type_specialization_to` finalizes a polymorphic record/union specialization in place:

```cpp
if (modify_type) {
    gb_memmove(specialization, type, gb_size_of(Type));   // struct + union branches
}
```

That `specialization` `Type` is the same object that gets published into the record's `gen_types` cache (via `add_polymorphic_record_entity`) before this finalizing memmove runs.

I did attempt to confirm by instrumentation: publish precedes the memmove on the same thread in 2010/2010 observed specializations.

Both `find_polymorphic_record_entity` (its caller in `check_expr.cpp`) and `add_polymorphic_record_entity` hold the record's `gen_types` `RecursiveMutex`, but this memmove does not.

So a concurrent `find` on another worker thread reads the entry via `base_type(e->type)` mid-copy → torn read → `get_record_polymorphic_params` returns null → the assert fires.

ThreadSanitizer records:

```
read           = base_type in find_polymorphic_record_entity
previous write = the gb_memmove in check_type_specialization_to
```

### Fix

There is multiple paths to address this. I'm included the least invasive one. There's probably a "more correct" approach, but I leave that to those who know this massive codebase better to make a suggestion

1. Acquire the originating record's `gen_types` mutex across the memmove, so the finalization is serialized against `find`. 
The `GenTypesData` is looked up from `ctx->info->gen_types` via the specialization's polymorphic parent. 

2. The mutex is recursive, so the lock is taken unconditionally and is safe whether or not the caller (the record-instantiation path) already holds it. 

3. When the specialization is not a published record entity, the helper returns `nullptr` and behavior is unchanged.

###  Validation

I had a polymorphic-dense test package, which aborts at the assert
- **Reproduction (standard build, LLVM)**:  ~**6/80** plain `odin build` runs; 
- **Single threaded**: does not reproduce with `-thread-count:1`.
- **After fix:** **0/300** runs.

My minimal reproducer is a single file: a polymorphic record (`Pool($T)`) used as a procedure parameter (`use :: proc(p: ^Pool($T), v: T)`), plus a handful of trivial procedures that instantiate it 

```odin
package repro
  use_001 :: proc() {
        pi: Pool(int);     pool_add(&pi, 1);    _ = pool_get(&pi, 0)
        ps: Pool(string);  pool_add(&ps, "x");  _ = pool_get(&ps, 0)
        pf: Pool(f32);     pool_add(&pf, 1.0);  _ = pool_get(&pf, 0)
        pb: Pool(bool);    pool_add(&pb, true); _ = pool_get(&pb, 0)
        pp: Pool(^int);    pool_add(&pp, nil);  _ = pool_get(&pp, 0)
  }

// repeated 200 times identically
```

Plain `proc(x: $T)` does **not** trigger it (the memmove is in the struct/union branch only).


### * Note: a bug in #5051 same-class sibling *
flagging it in case it becomes relevant

`is_polymorphic_type_assignable` (`check_expr.cpp`, `case Type_Generic`) has a sibling `gb_memmove(poly, ds, gb_size_of(Type))`. 
It's the same family of specialization related race condition

ThreadSanitizer flags it, but its target is a `Type_Generic` (not a published record entity, so not `gen_types` lockable)
