### PR TITLE
docs: fix Time_Val precision comment

### DIFF
--- a/core/sys/linux/types.odin
+++ b/core/sys/linux/types.odin
@@ -65,7 +65,7 @@ Time_Spec :: struct {
 }
 
 /*
-	Represents time with millisecond precision.
+	Represents time with microsecond precision.
 */
 Time_Val :: struct {
 	seconds:      int,


### PR DESCRIPTION
Fixes #6679

Changes:
- `Represents time with millisecond precision.` -> `Represents time with microsecond precision.` in `core/sys/linux/types.odin` (1 occurrence(s))

Verification:
- Applied exact text replacements against the current upstream base branch.
- Verified no duplicate open PR was found for the referenced issue number(s) before opening this PR.
