### PR TITLE
added missing LDFLAGS for OpenBSD

### DIFF
--- a/build_odin.sh
+++ b/build_odin.sh
@@ -114,7 +114,7 @@ Linux)
 	;;
 OpenBSD)
 	CXXFLAGS="$CXXFLAGS -I/usr/local/include $($LLVM_CONFIG --cxxflags --ldflags)"
-	LDFLAGS="$LDFLAGS -lstdc++ -L/usr/local/lib -liconv"
+	LDFLAGS="$LDFLAGS -lstdc++ -L/usr/local/lib -Wl,-rpath,$($LLVM_CONFIG --libdir) -liconv"
 	LDFLAGS="$LDFLAGS $($LLVM_CONFIG --libs core native --system-libs)"
 	;;
 *)


### PR DESCRIPTION
Tested on OpenBSD 7.9 (latest), must be compiled with `./build.odin release(-native)` or else it will panic with `ENOMEM` followed by `illegal instruction (core dumped)`