### PR TITLE
Update handle map procedures to accept pointers

### DIFF
--- a/core/container/handle_map/doc.odin
+++ b/core/container/handle_map/doc.odin
@@ -24,11 +24,11 @@ Example:
 		hm.remove(&entities, h1)
 
 		h3 := hm.add(&entities, Entity{pos = {6, 7}})
-		assert(hm.is_valid(entities, h3))
+		assert(hm.is_valid(&entities, h3))
 
 		it := hm.iterator_make(&entities)
 		for e, h in hm.iterate(&it) {
-			assert(hm.is_valid(entities, h))
+			assert(hm.is_valid(&entities, h))
 			e.pos += {1, 2}
 		}
 	}
@@ -48,11 +48,11 @@ Example:
 		hm.remove(&entities, h1)
 
 		h3 := hm.add(&entities, Entity{pos = {6, 7}})
-		assert(hm.is_valid(entities, h3))
+		assert(hm.is_valid(&entities, h3))
 
 		it := hm.iterator_make(&entities)
 		for e, h in hm.iterate(&it) {
-			assert(hm.is_valid(entities, h))
+			assert(hm.is_valid(&entities, h))
 			e.pos += {1, 2}
 		}
 	}

--- a/core/container/handle_map/dynamic_handle_map.odin
+++ b/core/container/handle_map/dynamic_handle_map.odin
@@ -90,13 +90,13 @@ dynamic_is_valid :: proc "contextless" (m: ^$D/Dynamic_Handle_Map($T, $Handle_Ty
 
 // Returns the number of possibly valid items in the handle map.
 @(require_results)
-dynamic_len :: proc "contextless" (m: $D/Dynamic_Handle_Map($T, $Handle_Type)) -> uint {
+dynamic_len :: proc "contextless" (m: ^$D/Dynamic_Handle_Map($T, $Handle_Type)) -> uint {
 	n := xar.len(m.items) - xar.len(m.unused_items)
 	return uint(n-1 if n > 0 else 0)
 }
 
 @(require_results)
-dynamic_cap :: proc "contextless" (m: $D/Dynamic_Handle_Map($T, $Handle_Type)) -> uint {
+dynamic_cap :: proc "contextless" (m: ^$D/Dynamic_Handle_Map($T, $Handle_Type)) -> uint {
 	n := xar.cap(m.items)
 	return uint(n-1 if n > 0 else 0)
 }

--- a/core/container/handle_map/static_handle_map.odin
+++ b/core/container/handle_map/static_handle_map.odin
@@ -115,13 +115,13 @@ static_remove :: proc "contextless" (m: ^$H/Static_Handle_Map($N, $T, $Handle_Ty
 
 // Returns true when the handle `h` is valid relating to the handle map.
 @(require_results)
-static_is_valid :: proc "contextless" (m: $H/Static_Handle_Map($N, $T, $Handle_Type), h: Handle_Type) -> bool {
+static_is_valid :: proc "contextless" (m: ^$H/Static_Handle_Map($N, $T, $Handle_Type), h: Handle_Type) -> bool {
 	return h.idx > 0 && u32(h.idx) < m.used_len && m.items[h.idx].handle == h
 }
 
 // Returns the number of possibly valid items in the handle map.
 @(require_results)
-static_len :: proc "contextless" (m: $H/Static_Handle_Map($N, $T, $Handle_Type)) -> uint {
+static_len :: proc "contextless" (m: ^$H/Static_Handle_Map($N, $T, $Handle_Type)) -> uint {
 	n := uint(m.used_len) - uint(m.unused_len)
 	return n-1 if n > 0 else 0
 }
@@ -129,7 +129,7 @@ static_len :: proc "contextless" (m: $H/Static_Handle_Map($N, $T, $Handle_Type))
 // Returns the capacity of the items in a handle map.
 // This is equivalent to `N-1` as the zero value is reserved for the zero-value sentinel.
 @(require_results)
-static_cap :: proc "contextless" (m: $H/Static_Handle_Map($N, $T, $Handle_Type)) -> uint {
+static_cap :: proc "contextless" (m: ^$H/Static_Handle_Map($N, $T, $Handle_Type)) -> uint {
 	// We could just return `N` but I am doing this for clarity
 	return builtin.len(m.items)-1
 }


### PR DESCRIPTION
Static_Handle_Map has several procedures that accept handle map by copy. 
Other read-only procedures like `get` already accept it by pointer.

Update Static_Handle_Map and Dynamic_Handle_Map procedures to accept the handle map argument by pointer.
Dynamic_Handle_Map was updated for consistency.