### PR TITLE
Link against libstdc++exp for backtrace support

### DIFF
--- a/core/debug/trace/trace_cpp.odin
+++ b/core/debug/trace/trace_cpp.odin
@@ -8,7 +8,7 @@ import "core:strings"
 import "core:c"
 
 // NOTE: Relies on C++23 which adds <stacktrace> and becomes ABI and that can be used
-foreign import stdcpplibbacktrace "system:stdc++_libbacktrace"
+foreign import stdcpplibbacktrace "system:stdc++exp"
 
 foreign import libdl "system:dl"
 


### PR DESCRIPTION
Importing "core:debug/trace" results in a linkage error:
```
mold: fatal: library not found: stdc++_libbacktrace
clang: error: linker command failed with exit code 1 (use -v to see invocation)

```
This is because the link library for backtrace support has changed with release of [GCC14](https://gcc.gnu.org/gcc-14/changes.html). 