### PR TITLE
Fixed the upper bound of Decimal in round_shortest

### DIFF
--- a/core/strconv/generic_float.odin
+++ b/core/strconv/generic_float.odin
@@ -281,7 +281,7 @@ round_shortest :: proc(d: ^decimal.Decimal, mant: u64, exp: int, flt: ^Float_Inf
 	}
 
 	upper_: decimal.Decimal; upper := &upper_
-	decimal.assign(upper, 2*mant - 1)
+	decimal.assign(upper, 2*mant + 1)
 	decimal.shift(upper, exp - int(flt.mantbits) - 1)
 
 	mantlo: u64


### PR DESCRIPTION
The current version does not give correct results for the round_shortest code path:
```
package main

import "core:fmt"

main :: proc() {
    value := 0.0009;
    fmt.printf("%v %e %g\n", value, value, value);

    value = 0.3;
    fmt.printf("%v %e %g\n", value, value, value);
}
```

The output is:
```
0.00089999999999999998 9.000000e-04 0.00089999999999999998
0.29999999999999999 3.000000e-01 0.29999999999999999
```

After the fix it becomes:
```
0.0009 9.000000e-04 0.0009
0.3 3.000000e-01 0.3
```