### PR TITLE
Explicit quick sort

### DIFF
--- a/core/slice/slice.odin
+++ b/core/slice/slice.odin
@@ -95,7 +95,7 @@ reinterpret :: proc "contextless" ($T: typeid/[]$U, s: []$V) -> []U {
 }
 
 
-swap :: proc(array: $T/[]$E, a, b: int) {
+swap :: #force_inline proc(array: $T/[]$E, a, b: int) {
 	when size_of(E) > 8 {
 		ptr_swap_non_overlapping(&array[a], &array[b], size_of(E))
 	} else {

--- a/core/slice/sort.odin
+++ b/core/slice/sort.odin
@@ -37,7 +37,12 @@ cmp_proc :: proc($E: typeid) -> (proc(E, E) -> Ordering) where ORD(E) {
 // sort sorts a slice
 // This sort is not guaranteed to be stable
 sort :: proc(data: $T/[]$E) where ORD(E) {
-	when size_of(E) != 0 {
+	Core :: intrinsics.type_core_type(E)
+	when intrinsics.type_is_integer(Core) || intrinsics.type_is_float(Core) {
+		// Only use quick sort on basic types not to bloat the executable code size.
+		// Devs who need the performance can call quick_sort explicitly.
+		quick_sort(data)
+	} else when size_of(E) != 0 {
 		if n := len(data); n > 1 {
 			raw := ([^]byte)(raw_data(data))
 			_smoothsort(raw, uint(len(data)), size_of(E), proc(lhs, rhs: rawptr, user_data: rawptr) -> Ordering {

--- a/core/slice/sort.odin
+++ b/core/slice/sort.odin
@@ -1,5 +1,7 @@
 package slice
 
+import "base:intrinsics"
+
 Ordering :: enum {
 	Less    = -1,
 	Equal   =  0,
@@ -81,7 +83,7 @@ sort_by_indices_overwrite :: proc(data: $T/[]$E, indices: []int) {
 	swap_with_slice(data, temp)
 }
 
-sort_from_permutation_indices :: proc(data: $T/[]$E, indices: []int) {
+sort_from_permutation_indices :: proc(data: $T/[]$E, indices: []int) #no_bounds_check {
 	assert(len(data) == len(indices))
 	if len(indices) <= 1 {
 		return
@@ -277,6 +279,37 @@ sort_by_generic_cmp :: proc(data: $T/[]$E, cmp: Generic_Cmp, user_data: rawptr) 
 		if n := len(data); n > 1 {
 			raw := ([^]byte)(raw_data(data))
 			_smoothsort(raw, uint(len(data)), size_of(E), cmp, user_data)
+		}
+	}
+}
+
+
+/*
+Sort for performance sensitive tasks. The default sorting algorithm prioritizes broad compatibility and small (generated) code size.
+Keep in mind calling this polymorphic procedure instantiates an entire quicksort implementation for each type!
+*/
+quick_sort :: proc(data: $T/[]$E) where ORD(E) {
+	when size_of(E) != 0 {
+		if n := len(data); n > 1 {
+			// NOTE(jakub): using the base type allows for one implementation to be shared by multiple
+			// distinct types. That's especially useful for built-in float and integer types.
+			_quick_sort_general(transmute([]intrinsics.type_base_type(E))data, 0, n, _quick_sort_max_depth(n), struct{}{}, .Ordered)
+		}
+	}
+}
+
+quick_sort_by :: proc(data: $T/[]$E, less: proc(i, j: E) -> bool) where ORD(E) {
+	when size_of(E) != 0 {
+		if n := len(data); n > 1 {
+			_quick_sort_general(data, 0, n, _quick_sort_max_depth(n), less, .Less)
+		}
+	}
+}
+
+quick_sort_by_cmp :: proc(data: $T/[]$E, cmp: proc(i, j: E) -> Ordering) where ORD(E) {
+	when size_of(E) != 0 {
+		if n := len(data); n > 1 {
+			_quick_sort_general(data, 0, n, _quick_sort_max_depth(n), cmp, .Cmp)
 		}
 	}
 }

--- a/core/slice/sort.odin
+++ b/core/slice/sort.odin
@@ -291,9 +291,9 @@ Keep in mind calling this polymorphic procedure instantiates an entire quicksort
 quick_sort :: proc(data: $T/[]$E) where ORD(E) {
 	when size_of(E) != 0 {
 		if n := len(data); n > 1 {
-			// NOTE(jakub): using the base type allows for one implementation to be shared by multiple
+			// NOTE(jakub): using the backing type allows for one implementation to be shared by multiple
 			// distinct types. That's especially useful for built-in float and integer types.
-			_quick_sort_general(transmute([]intrinsics.type_base_type(E))data, 0, n, _quick_sort_max_depth(n), struct{}{}, .Ordered)
+			_quick_sort_general(transmute([]intrinsics.type_core_type(E))data, 0, n, _quick_sort_max_depth(n), struct{}{}, .Ordered)
 		}
 	}
 }

--- a/core/slice/sort_private.odin
+++ b/core/slice/sort_private.odin
@@ -3,7 +3,6 @@ package slice
 
 import "base:builtin"
 import "base:intrinsics"
-_ :: intrinsics
 
 ORD :: intrinsics.type_is_ordered
 
@@ -212,5 +211,184 @@ _smoothsort :: proc(base: [^]byte, nel: uint, width: uint, cmp: Generic_Cmp, arg
 			trinkle(head[-width:], width, cmp, arg, p[:], pshift, true, lp[:])
 		}
 		head = head[-width:]
+	}
+}
+
+@(require_results)
+_quick_sort_max_depth :: proc(n: int) -> (depth: int) { // 2*ceil(log2(n+1))
+	for i := n; i > 0; i >>= 1 {
+		depth += 1
+	}
+	return depth * 2
+}
+
+_quick_sort_general :: proc(data: $T/[]$E, a, b, max_depth: int, call: $P, $KIND: Sort_Kind) where (intrinsics.type_is_ordered(E) && KIND == .Ordered) || (KIND != .Ordered) #no_bounds_check {
+	a, b, max_depth := a, b, max_depth
+	
+	// Manual tail call loop
+	for b-a > 64 {
+		if max_depth == 0 {
+			heap_sort(data, a, b, call)
+			return
+		}
+		max_depth -= 1
+		mlo, mhi := do_pivot(data, a, b, call)
+		if mlo-a < b-mhi {
+			_quick_sort_general(data, a, mlo, max_depth, call, KIND)
+			a = mhi
+		} else {
+			_quick_sort_general(data, mhi, b, max_depth, call, KIND)
+			b = mlo
+		}
+	}
+	
+	if b-a > 1 {
+		// Shell short
+		for i in a+16..<b {
+			if less(data[i], data[i-16], call) {
+				swap(data, i, i-16)
+			}
+		}
+		insertion_sort(data, a, b, call)
+	}
+	
+	return
+	
+	less :: #force_inline proc(a, b: E, call: P) -> bool {
+		when KIND == .Ordered {
+			return a < b
+		} else when KIND == .Less {
+			return call(a, b)
+		} else when KIND == .Cmp {
+			return call(a, b) == .Less
+		} else {
+			#panic("unhandled Sort_Kind")
+		}
+	}
+
+	insertion_sort :: #force_inline proc(data: $T/[]$E, a, b: int, call: P) #no_bounds_check {
+		for i in a+1..<b {
+			val := data[i]
+			j := i
+			for ; j > a && less(val, data[j-1], call); j -= 1 {
+				data[j] = data[j-1]
+			}
+			data[j] = val
+		}
+	}
+
+	heap_sort :: proc(data: $T/[]$E, a, b: int, call: P) #no_bounds_check {
+		sift_down :: proc(data: T, lo, hi, first: int, call: P) #no_bounds_check {
+			root := lo
+			for {
+				child := 2*root + 1
+				if child >= hi {
+					break
+				}
+				if child+1 < hi && less(data[first+child], data[first+child+1], call) {
+					child += 1
+				}
+				if !less(data[first+root], data[first+child], call) {
+					return
+				}
+				swap(data, first+root, first+child)
+				root = child
+			}
+		}
+
+
+		first, lo, hi := a, 0, b-a
+
+		for i := (hi-1)/2; i >= 0; i -= 1 {
+			sift_down(data, i, hi, first, call)
+		}
+
+		for i := hi-1; i >= 0; i -= 1 {
+			swap(data, first, first+i)
+			sift_down(data, lo, i, first, call)
+		}
+	}
+
+	median3 :: proc(data: T, m1, m0, m2: int, call: P) #no_bounds_check {
+		if less(data[m1], data[m0], call) {
+			swap(data, m1, m0)
+		}
+		if less(data[m2], data[m1], call) {
+			swap(data, m2, m1)
+			if less(data[m1], data[m0], call) {
+				swap(data, m1, m0)
+			}
+		}
+	}
+
+	do_pivot :: proc(data: T, lo, hi: int, call: P) -> (midlo, midhi: int) #no_bounds_check {
+		m := int(uint(lo+hi)>>1)
+		// Tukey's ninther
+		if hi-lo > 40 {
+			s := (hi-lo)/8
+			median3(data, lo, lo+s, lo+s*2, call)
+			median3(data, m, m-s, m+s, call)
+			median3(data, hi-1, hi-1-s, hi-1-s*2, call)
+		}
+		median3(data, lo, m, hi-1, call)
+
+		pivot := lo
+		a, c := lo+1, hi-1
+
+
+		for ; a < c && less(data[a], data[pivot], call); a += 1 {
+		}
+		b := a
+
+		for {
+			for ; b < c && !less(data[pivot], data[b], call); b += 1 { // data[b] <= pivot
+			}
+			for ; b < c && less(data[pivot], data[c-1], call); c -=1 { // data[c-1] > pivot
+			}
+			if b >= c {
+				break
+			}
+
+			swap(data, b, c-1)
+			b += 1
+			c -= 1
+		}
+
+		protect := hi-c < 5
+		if !protect && hi-c < (hi-lo)/4 {
+			dups := 0
+			if !less(data[pivot], data[hi-1], call) {
+				swap(data, c, hi-1)
+				c += 1
+				dups += 1
+			}
+			if !less(data[b-1], data[pivot], call) {
+				b -= 1
+				dups += 1
+			}
+
+			if !less(data[m], data[pivot], call) {
+				swap(data, m, b-1)
+				b -= 1
+				dups += 1
+			}
+			protect = dups > 1
+		}
+		if protect {
+			for {
+				for ; a < b && !less(data[b-1], data[pivot], call); b -= 1 {
+				}
+				for ; a < b && less(data[a], data[pivot], call); a += 1 {
+				}
+				if a >= b {
+					break
+				}
+				swap(data, a, b-1)
+				a += 1
+				b -= 1
+			}
+		}
+		swap(data, pivot, b-1)
+		return b-1, c
 	}
 }


### PR DESCRIPTION
The original quick sort implementation was replaced by smooth sort because of generated code size. Instantiating the polymorphic procedure implementation hundreds of times across a large codebase is a problem.

## Info

This PR brings back the old implementation with a number of performance improvements, and adds an ***explicit public API*** for people who actually need the performance. So no code bloat.
This actually makes a big difference in practice, I personally ran into issues with slow sorting in my rendering engine in multiple places (depth sorting and batch reordering).

The default is still smoothsort. Only exception is sorting basic integer/float types with `slice.sort` (not sure about this, maybe this behavior is too "magical"? My reason for this is that I often use something like `slice.sort(transmute([]u64)my_slice_of_u64_sized_structs)`)

## API

There are now `quick_sort`, `quick_sort_by` and `quick_sort_by_cmp` procedures with exact same signatures as the default `sort_*` equivalents.

## Performance
This results in a quicksort that's generally ***5x*** faster than the smooth sort implementation, and usually ***1.2x - 2.0x*** faster than the old quick sort implementation depending on the data.

Tweaks to the old quicksort:
- Much larger insertion sort threshold, this alone is a big speedup
- Slightly better insertion sort implementation
- Adapted shell sort
- Force inline in a few places where it matters

All of these parameters were independently benchmarked on various datasets to find the optimum.

Here is my [benchmarking code](https://gist.github.com/jakubtomsu/0d7c80769fdead33f2b2bbec356ca75c).

Just for reference, here is the commit that removed the quicksort: f40fc2792f01b1fa265f62fb2aa4ef39e7529903