### PR TITLE
[sys/linux] remove parapoly from `rt_sigaction`

### DIFF
--- a/core/sys/linux/sys.odin
+++ b/core/sys/linux/sys.odin
@@ -213,7 +213,7 @@ rt_sigreturn :: proc "c" () -> ! {
 /*
 	Alter an action taken by a process.
 */
-rt_sigaction :: proc "contextless" (sig: Signal, sigaction: ^Sig_Action($T), old_sigaction: ^Sig_Action($U)) -> Errno {
+rt_sigaction :: proc "contextless" (sig: Signal, sigaction: ^Sig_Action, old_sigaction: ^Sig_Action) -> Errno {
 	// NOTE(jason): It appears that the restorer is required for i386 and amd64
 	when ODIN_ARCH == .i386 || ODIN_ARCH == .amd64 {
 		sigaction.flags += {.RESTORER}

--- a/core/sys/linux/types.odin
+++ b/core/sys/linux/types.odin
@@ -747,10 +747,10 @@ Sig_Action_Special :: enum uint {
 }
 
 Sig_Action_Flags :: bit_set[Sig_Action_Flag; uint]
-Sig_Action :: struct($T: typeid) {
+Sig_Action :: struct {
 	using _u: struct #raw_union {
 		handler: Sig_Handler_Fn,
-		sigaction: #type proc "c" (sig: Signal, si: ^Sig_Info, ctx: ^T),
+		sigaction: #type proc "c" (sig: Signal, si: ^Sig_Info, ctx: rawptr),
 		special: Sig_Action_Special,
 	},
 	flags: Sig_Action_Flags,


### PR DESCRIPTION
the `sigaction` variant of the union can only ever be a pointer. removing parapoly allows passing `nil` again and more closely reflects the actual kernel api