### PR TITLE
Fix support for array expression in struct literals

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2039,9 +2039,6 @@ gb_internal Ast *parse_literal_value(AstFile *f, Ast *type) {
 }
 
 gb_internal Ast *parse_value(AstFile *f) {
-	if (f->curr_token.kind == Token_OpenBrace) {
-		return parse_literal_value(f, nullptr);
-	}
 	Ast *value;
 	bool prev_allow_range = f->allow_range;
 	f->allow_range = true;


### PR DESCRIPTION
In `src/parser.cpp` the `parse_value()` function has a conditional `parse_literal_value()` call that removes the possibility of having arbitrary expression with array literals in struct literals. 

Removing this condition fixes the behaviour reported at #6721 
This logic surely has a point to exist but I fail to understand it, so I thought I would open this PR to discuss. The `examples/demo.odin` program runs without apparent problem and a minimal example works as intended. 
This was the code used to test this behaviour:

```odin
package main

import "core:fmt"

S :: struct {
	vec: [2]f32,
	x: i32,
	y: i32
}

main :: proc() {
	v: S = {{1, 2} * 10, 100 + 20, 200}
	w: S = {vec = {1, 2} * 5, x = 100, y = 314 }

	fmt.println(v.vec, v.x, v.y) // {10,20}, 120, 200
	fmt.println(w.vec, w.x, w.y) // {5,10}, 100, 314
}
``` 
This yields the expected output.

I'm happy to do any changes or just scrap it if it doesn't make any sense and/or inserts a regression.
Cheers.