### PR TITLE
Support Macports in `build_odin.sh`

### DIFF
--- a/build_odin.sh
+++ b/build_odin.sh
@@ -97,7 +97,7 @@ fi
 case "$OS_NAME" in
 Darwin)
 	darwin_sysroot=
-	if [ $(which xcrun) ]; then
+	if [ -n "$(command -v xcrun)" ]; then
 		darwin_sysroot="--sysroot $(xcrun --sdk macosx --show-sdk-path)"
 	elif [[ -e "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" ]]; then
 		darwin_sysroot="--sysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"

--- a/build_odin.sh
+++ b/build_odin.sh
@@ -99,7 +99,7 @@ Darwin)
 	darwin_sysroot=
 	if [ -n "$(command -v xcrun)" ]; then
 		darwin_sysroot="--sysroot $(xcrun --sdk macosx --show-sdk-path)"
-	elif [[ -e "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" ]]; then
+	elif [ -e "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" ]; then
 		darwin_sysroot="--sysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
 	else
 		echo "Warning: MacOSX.sdk not found."

--- a/build_odin.sh
+++ b/build_odin.sh
@@ -38,6 +38,14 @@ if [ -z "$LLVM_CONFIG" ] &&  [ -n "$(command -v brew)" ]; then
 	done
 fi
 
+# Macports supports many concurrent llvm installations.
+# Pin an active one with `sudo port select llvm`.
+if [ -z "$LLVM_CONFIG" ] && [ "$OS_NAME" = "Darwin" ] && [ -n "$(command -v port)" ]; then
+    if command -v llvm-config >/dev/null 2>&1; then
+        LLVM_CONFIG="$(command -v llvm-config)"
+    fi
+fi
+
 if [ -z "$LLVM_CONFIG" ]; then
 	DEFAULT_VERSION=""
 
@@ -57,6 +65,10 @@ if [ -z "$LLVM_CONFIG" ]; then
 		elif [ -n "$(command -v "llvm-config$V")" ]; then
 			LLVM_CONFIG="llvm-config$V"
 			break
+		# macports
+    elif [ -n "$(command -v "llvm-config-mp-$V")" ]; then
+    	LLVM_CONFIG="llvm-config-mp-$V"
+    	break
 		fi
 	done
 
@@ -95,6 +107,11 @@ Darwin)
 
 	CXXFLAGS="$CXXFLAGS $($LLVM_CONFIG --cxxflags --ldflags) ${darwin_sysroot}"
 	LDFLAGS="$LDFLAGS -liconv -ldl -framework System -lLLVM"
+
+	if [ -n "$(command -v port)" ]; then
+		LLVM_LIBDIR="$($LLVM_CONFIG --libdir)"
+		LDFLAGS="$LDFLAGS -Wl,-rpath,$LLVM_LIBDIR"
+	fi
 	;;
 FreeBSD)
 	CXXFLAGS="$CXXFLAGS $($LLVM_CONFIG --cxxflags --ldflags)"


### PR DESCRIPTION
This is more of a "trust me bro, it works on my machine".

Let me know if this is OK, and I'd be happy to polish it: add docs for the official site …

But I don't think it's worth updating the CI for it. I mean from your perspective it should just build on a mac, no? At least until it's really needed …