### PR TITLE
fix: Get meminfo from `/proc/meminfo` over `sysinfo()`

### DIFF
--- a/core/sys/info/platform_linux.odin
+++ b/core/sys/info/platform_linux.odin
@@ -81,6 +81,8 @@ _os_version :: proc (allocator: runtime.Allocator, loc := #caller_location) -> (
 
 @(private)
 _ram_stats :: proc() -> (total_ram, free_ram, total_swap, free_swap: i64, ok: bool) {
+	// The approach is to read /proc/meminfo for the memory information _over_ sysinfo(),
+	// since sysinfo() just returns MemFree over the value we actually want, MemAvailable.
 	fd, errno := linux.open("/proc/meminfo", {})
 	if errno != .NONE {
 		// This should never happen since something would be wrong with the system

--- a/core/sys/info/platform_linux.odin
+++ b/core/sys/info/platform_linux.odin
@@ -2,6 +2,7 @@ package sysinfo
 
 import "base:intrinsics"
 import "base:runtime"
+import "core:strconv"
 import "core:strings"
 import "core:sys/linux"
 
@@ -79,17 +80,71 @@ _os_version :: proc (allocator: runtime.Allocator, loc := #caller_location) -> (
 }
 
 @(private)
-_ram_stats :: proc "contextless" () -> (total_ram, free_ram, total_swap, free_swap: i64, ok: bool) {
-	// Retrieve RAM info using `sysinfo`
-	sys_info: linux.Sys_Info
-	errno := linux.sysinfo(&sys_info)
-	assert_contextless(errno == .NONE, "Good luck to whoever's debugging this, something's seriously cucked up!")
+_ram_stats :: proc() -> (total_ram, free_ram, total_swap, free_swap: i64, ok: bool) {
+	fd, errno := linux.open("/proc/meminfo", {})
+	if errno != .NONE {
+		// This should never happen since something would be wrong with the system
+		// if /proc/meminfo wasn't able to be opened for any reason
+		return 0, 0, 0, 0, false
+	}
 
-	total_ram  = i64(sys_info.totalram)  * i64(sys_info.mem_unit)
-	free_ram   = i64(sys_info.freeram)   * i64(sys_info.mem_unit)
-	total_swap = i64(sys_info.totalswap) * i64(sys_info.mem_unit)
-	free_swap  = i64(sys_info.freeswap)  * i64(sys_info.mem_unit)
-	ok         = true
+	defer linux.close(fd)
+
+	// We need a relatively large size to store all the info
+	meminfo_buf: [4096]u8
+	n, read_errno := linux.read(fd, meminfo_buf[:])
+	if read_errno != .NONE {
+		return 0, 0, 0, 0, false
+	}
+	meminfo := string(meminfo_buf[:n])
+
+	// Stuff needed as a failsafe for later in the event MemAvailable is being broken
+	mem_free, buffers, cached, shmem, s_reclaimable: i64
+
+	for line in strings.split_lines_iterator(&meminfo) {
+		if len(line) == 0 do continue
+
+		colon_idx := strings.index(line, ":")
+		if colon_idx < 0 do continue
+
+		key := strings.trim_space(line[:colon_idx])
+		value_str := strings.trim_space(strings.trim_suffix(line[colon_idx + 1:], "kB"))
+
+		value, conv_ok := strconv.parse_i64(value_str, 10)
+		if !conv_ok do continue
+
+		switch key {
+		case "MemTotal":
+			total_ram = value
+		case "MemFree":
+			mem_free = value
+		case "MemAvailable":
+			free_ram = value
+		case "SwapTotal":
+			total_swap = value
+		case "SwapFree":
+			free_swap = value
+		case "Buffers":
+			buffers = value
+		case "Cached":
+			cached = value
+		case "Shmem":
+			shmem = value
+		case "SReclaimable":
+			s_reclaimable = value
+		}
+	}
+
+	if free_ram == 0 || free_ram > total_ram {
+		free_ram = mem_free + buffers + cached + s_reclaimable - shmem
+	}
+
+	mem_unit :: 1024
+	total_ram *= mem_unit
+	free_ram *= mem_unit
+	total_swap *= mem_unit
+	free_swap *= mem_unit
+	ok = true
 
 	return
 }

--- a/core/sys/info/platform_linux.odin
+++ b/core/sys/info/platform_linux.odin
@@ -100,8 +100,8 @@ _ram_stats :: proc() -> (total_ram, free_ram, total_swap, free_swap: i64, ok: bo
 	}
 	meminfo := string(meminfo_buf[:n])
 
-	// Stuff needed as a failsafe for later in the event MemAvailable is being broken
-	mem_free, buffers, cached, shmem, s_reclaimable: i64
+	// Fallback in the event MemAvailable is not found or is invalid in its value
+	mem_free: i64
 
 	for line in strings.split_lines_iterator(&meminfo) {
 		if len(line) == 0 {
@@ -132,19 +132,14 @@ _ram_stats :: proc() -> (total_ram, free_ram, total_swap, free_swap: i64, ok: bo
 			total_swap = value
 		case "SwapFree":
 			free_swap = value
-		case "Buffers":
-			buffers = value
-		case "Cached":
-			cached = value
-		case "Shmem":
-			shmem = value
-		case "SReclaimable":
-			s_reclaimable = value
 		}
 	}
 
 	if free_ram == 0 || free_ram > total_ram {
-		free_ram = mem_free + buffers + cached + s_reclaimable - shmem
+		// We opt to return MemFree here if MemAvailable is not found or is broken to come degree.
+		// This will act as a predictable fallback, but shouldn't ever really occur unless the user
+		// is on Linux < 3.14
+		free_ram = mem_free
 	}
 
 	mem_unit :: 1024
@@ -152,6 +147,7 @@ _ram_stats :: proc() -> (total_ram, free_ram, total_swap, free_swap: i64, ok: bo
 	free_ram *= mem_unit
 	total_swap *= mem_unit
 	free_swap *= mem_unit
+
 	ok = true
 
 	return

--- a/core/sys/info/platform_linux.odin
+++ b/core/sys/info/platform_linux.odin
@@ -80,7 +80,10 @@ _os_version :: proc (allocator: runtime.Allocator, loc := #caller_location) -> (
 }
 
 @(private)
-_ram_stats :: proc() -> (total_ram, free_ram, total_swap, free_swap: i64, ok: bool) {
+_ram_stats :: proc "contextless" () -> (total_ram, free_ram, total_swap, free_swap: i64, ok: bool) {
+	// This is here for some of the strings procedures
+	context = runtime.default_context()
+
 	// The approach is to read /proc/meminfo for the memory information. We do this over
 	// reading sysinfo() since sysinfo() only returns MemFree, which is based on the amount
 	// of free pages. The value we actually want is MemAvailable inside meminfo since it is

--- a/core/sys/info/platform_linux.odin
+++ b/core/sys/info/platform_linux.odin
@@ -102,16 +102,22 @@ _ram_stats :: proc() -> (total_ram, free_ram, total_swap, free_swap: i64, ok: bo
 	mem_free, buffers, cached, shmem, s_reclaimable: i64
 
 	for line in strings.split_lines_iterator(&meminfo) {
-		if len(line) == 0 do continue
+		if len(line) == 0 {
+			continue
+		}
 
 		colon_idx := strings.index(line, ":")
-		if colon_idx < 0 do continue
+		if colon_idx < 0 {
+			continue
+		}
 
 		key := strings.trim_space(line[:colon_idx])
 		value_str := strings.trim_space(strings.trim_suffix(line[colon_idx + 1:], "kB"))
 
 		value, conv_ok := strconv.parse_i64(value_str, 10)
-		if !conv_ok do continue
+		if !conv_ok {
+			continue
+		}
 
 		switch key {
 		case "MemTotal":

--- a/core/sys/info/platform_linux.odin
+++ b/core/sys/info/platform_linux.odin
@@ -86,8 +86,21 @@ _ram_stats :: proc() -> (total_ram, free_ram, total_swap, free_swap: i64, ok: bo
 	fd, errno := linux.open("/proc/meminfo", {})
 	if errno != .NONE {
 		// This should never happen since something would be wrong with the system
-		// if /proc/meminfo wasn't able to be opened for any reason
-		return 0, 0, 0, 0, false
+		// if /proc/meminfo wasn't able to be opened for any reason. But, in the
+		// event that this _does_ happen, let's just try to recover through the
+		// syscall
+		sys_info: linux.Sys_Info
+		sysinfo_errno := linux.sysinfo(&sys_info)
+		assert_contextless(sysinfo_errno == .NONE, "If this has failed, there is no recovery from this")
+
+		total_ram = i64(sys_info.totalram) * i64(sys_info.mem_unit)
+		free_ram = i64(sys_info.freeram) * i64(sys_info.mem_unit)
+		total_swap = i64(sys_info.totalswap) * i64(sys_info.mem_unit)
+		free_swap = i64(sys_info.freeswap) * i64(sys_info.mem_unit)
+
+		ok = true
+
+		return
 	}
 
 	defer linux.close(fd)
@@ -96,7 +109,18 @@ _ram_stats :: proc() -> (total_ram, free_ram, total_swap, free_swap: i64, ok: bo
 	meminfo_buf: [4096]u8
 	n, read_errno := linux.read(fd, meminfo_buf[:])
 	if read_errno != .NONE {
-		return 0, 0, 0, 0, false
+		sys_info: linux.Sys_Info
+		sysinfo_errno := linux.sysinfo(&sys_info)
+		assert_contextless(sysinfo_errno == .NONE, "If this has failed, there is no recovery from this")
+
+		total_ram = i64(sys_info.totalram) * i64(sys_info.mem_unit)
+		free_ram = i64(sys_info.freeram) * i64(sys_info.mem_unit)
+		total_swap = i64(sys_info.totalswap) * i64(sys_info.mem_unit)
+		free_swap = i64(sys_info.freeswap) * i64(sys_info.mem_unit)
+
+		ok = true
+
+		return
 	}
 	meminfo := string(meminfo_buf[:n])
 

--- a/core/sys/info/platform_linux.odin
+++ b/core/sys/info/platform_linux.odin
@@ -162,7 +162,7 @@ _ram_stats :: proc() -> (total_ram, free_ram, total_swap, free_swap: i64, ok: bo
 	}
 
 	if free_ram == 0 || free_ram > total_ram {
-		// We opt to return MemFree here if MemAvailable is not found or is broken to come degree.
+		// We opt to return MemFree here if MemAvailable is not found or is broken to some degree.
 		// This will act as a predictable fallback, but shouldn't ever really occur unless the user
 		// is on Linux < 3.14
 		free_ram = mem_free

--- a/core/sys/info/platform_linux.odin
+++ b/core/sys/info/platform_linux.odin
@@ -132,6 +132,7 @@ _ram_stats :: proc "contextless" () -> (total_ram, free_ram, total_swap, free_sw
 	// Fallback in the event MemAvailable is not found or is invalid in its value
 	mem_free: i64
 
+	mem_unit :: 1024
 	for line in strings.split_lines_iterator(&meminfo) {
 		if len(line) == 0 {
 			continue
@@ -152,15 +153,15 @@ _ram_stats :: proc "contextless" () -> (total_ram, free_ram, total_swap, free_sw
 
 		switch key {
 		case "MemTotal":
-			total_ram = value
+			total_ram = value * mem_unit
 		case "MemFree":
-			mem_free = value
+			mem_free = value * mem_unit
 		case "MemAvailable":
-			free_ram = value
+			free_ram = value * mem_unit
 		case "SwapTotal":
-			total_swap = value
+			total_swap = value * mem_unit
 		case "SwapFree":
-			free_swap = value
+			free_swap = value * mem_unit
 		}
 	}
 
@@ -170,12 +171,6 @@ _ram_stats :: proc "contextless" () -> (total_ram, free_ram, total_swap, free_sw
 		// is on Linux < 3.14
 		free_ram = mem_free
 	}
-
-	mem_unit :: 1024
-	total_ram *= mem_unit
-	free_ram *= mem_unit
-	total_swap *= mem_unit
-	free_swap *= mem_unit
 
 	ok = true
 

--- a/core/sys/info/platform_linux.odin
+++ b/core/sys/info/platform_linux.odin
@@ -81,8 +81,10 @@ _os_version :: proc (allocator: runtime.Allocator, loc := #caller_location) -> (
 
 @(private)
 _ram_stats :: proc() -> (total_ram, free_ram, total_swap, free_swap: i64, ok: bool) {
-	// The approach is to read /proc/meminfo for the memory information _over_ sysinfo(),
-	// since sysinfo() just returns MemFree over the value we actually want, MemAvailable.
+	// The approach is to read /proc/meminfo for the memory information. We do this over
+	// reading sysinfo() since sysinfo() only returns MemFree, which is based on the amount
+	// of free pages. The value we actually want is MemAvailable inside meminfo since it is
+	// estimated around being about to evict things out of the page cache.
 	fd, errno := linux.open("/proc/meminfo", {})
 	if errno != .NONE {
 		// This should never happen since something would be wrong with the system

--- a/core/sys/info/sysinfo.odin
+++ b/core/sys/info/sysinfo.odin
@@ -59,7 +59,7 @@ Returns:
 - free_swap:  Free SWAP reported by the operating system, in bytes
 - ok:         `true` when we could retrieve RAM statistics, `false` otherwise
 */
-ram_stats :: proc() -> (total_ram, free_ram, total_swap, free_swap: i64, ok: bool) {
+ram_stats :: proc "contextless" () -> (total_ram, free_ram, total_swap, free_swap: i64, ok: bool) {
 	return _ram_stats()
 }
 

--- a/core/sys/info/sysinfo.odin
+++ b/core/sys/info/sysinfo.odin
@@ -59,7 +59,7 @@ Returns:
 - free_swap:  Free SWAP reported by the operating system, in bytes
 - ok:         `true` when we could retrieve RAM statistics, `false` otherwise
 */
-ram_stats :: proc "contextless" () -> (total_ram, free_ram, total_swap, free_swap: i64, ok: bool) {
+ram_stats :: proc() -> (total_ram, free_ram, total_swap, free_swap: i64, ok: bool) {
 	return _ram_stats()
 }
 


### PR DESCRIPTION
This is a change to `core:sys/info` to fix inaccurate memory reads in Linux. I haven't really touched direct Odin core library code before, so this is my first attempt. If there are _any_ mistakes or improvements to be made, let me know. I'm more than willing to correct any dumb code I may have written.

Also, the reason the size of the buffer here is 4096 is because the actual size of `/proc/meminfo` on my machine is around 1500 bytes, and it felt a little too close to 2048 for me to be comfortable with it. I can adjust this if needed; I just assumed 4096 would work fine here.

Closes #6764 