### PR TITLE
fix: resolve import names based on declared relpath and not filesystem paths

### DIFF
--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -5314,6 +5314,37 @@ gb_internal bool is_string_an_identifier(String s) {
 	return offset == s.len;
 }
 
+gb_internal String resolve_import_name(String name, String relpath) {
+	if (name.len != 0) {
+		return name;
+	}
+
+	isize slash = -1;
+	isize colon = -1;
+
+	for (isize i = relpath.len-1; i >= 0; i--) {
+		u8 c = relpath[i];
+		if (c == '/') {
+			slash = i;
+			break;
+		}
+		if (c == ':') {
+			colon = i;
+			break;
+		}
+	}
+	String entity_name;
+	if (slash > -1) {
+		entity_name = substring(relpath, slash + 1, relpath.len);
+	} else if (colon > -1) {
+		entity_name = substring(relpath, colon + 1, relpath.len);
+	} else {
+		entity_name = relpath;
+	}
+
+	return entity_name;
+}
+
 gb_internal String path_to_entity_name(String name, String fullpath, bool strip_extension=true) {
 	if (name.len != 0) {
 		return name;
@@ -5586,7 +5617,7 @@ gb_internal void check_add_import_decl(CheckerContext *ctx, Ast *decl) {
 	// 	// error(token, "Multiple import of the same file within this scope");
 	// }
 
-	String import_name = path_to_entity_name(id->import_name.string, id->fullpath, false);
+	String import_name = resolve_import_name(id->import_name.string, string_value_from_token(ctx->file, id->relpath));
 	if (is_blank_ident(import_name)) {
 		force_use = true;
 	}


### PR DESCRIPTION
Closes #6754 

When depending on the filesystem to resolve import names for Ast_ImportDecl we are exposed to filesystem implementation details (in this case symlinks). By resolving the import name based on the user-declared relpath we closely match user intent and expectations, avoiding filesystem "traps".

The debug and `examples/demo.odin` test executes as expected and the test case also succeeds.

Test case file tree:
```
.
├── main.odin
├── src -> src2
└── src2
    └── lib.odin
```
`main.odin`
```
package main

import "src"

main :: proc() {
	_ = src.C
}
```
`lib.odin`
```
package src

C :: 3.1415
```
Previously the compiler would assume that the line `import "src"` would declare a `src2` entity because of resolving the name based on the result of a `realpath()` call that follows symlinks.

I'm not sure if foreign imports should use the same mechanic since file names have more meaning in that case.