### PR TITLE
rotate crashes with 0 length

### DIFF
--- a/core/slice/slice.odin
+++ b/core/slice/slice.odin
@@ -433,6 +433,9 @@ fill :: proc "contextless" (array: $T/[]$E, value: E) #no_bounds_check {
 }
 
 rotate_left :: proc "contextless" (array: $T/[]$E, mid: int) {
+	if len(a) == 0 {
+		return
+	}
 	n := len(array)
 	m := mid %% n
 	k := n - m


### PR DESCRIPTION
added a check for rotate_left

rotating with 0 length array crashes