### PR TITLE
core:path/filepath: Remove stale comment about dir()

### DIFF
--- a/core/path/filepath/path.odin
+++ b/core/path/filepath/path.odin
@@ -280,9 +280,8 @@ rel :: proc(base_path, target_path: string, allocator := context.allocator) -> (
 }
 
 /*
-	Returns all but the last path element, usually the path's directory. Once the final element has been removed,
-	`dir` calls `clean` on the path and trailing separators are removed. If the path is empty or consists purely
-	of separators, then `"."` is returned.
+	Returns all but the last path element, usually the path's directory.
+	If the path is empty or consists purely of separators, then `"."` is returned.
 */
 dir :: os.dir
 


### PR DESCRIPTION
> Once the final element has been removed, `dir` calls `clean` on the path and trailing separators are removed.

After https://github.com/odin-lang/Odin/pull/6575, this behavior no longer exists.

Also, the signature of `dir()` changed  
from `dir :: proc(path: string, allocator := context.allocator) -> string`
to `dir :: proc(path: string) -> string`
Old code that pass allocator won't compile now. I think this breaking change should be mentioned in changelog.