### PR TITLE
Fix assertion failure when comparing array-backed `bit_field`s

### DIFF
--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -3450,6 +3450,10 @@ gb_internal lbValue lb_emit_comp(lbProcedure *p, TokenKind op_kind, lbValue left
 	}
 	if (is_type_array_like(a)) {
 		Type *tl = base_type(a);
+		if (is_type_bit_field(left.type)) {
+			left = lb_emit_transmute(p, left, tl);
+			right = lb_emit_transmute(p, right, tl);
+		}
 		lbValue lhs = lb_address_from_load_or_generate_local(p, left);
 		lbValue rhs = lb_address_from_load_or_generate_local(p, right);
 

--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -3450,7 +3450,8 @@ gb_internal lbValue lb_emit_comp(lbProcedure *p, TokenKind op_kind, lbValue left
 	}
 	if (is_type_array_like(a)) {
 		Type *tl = base_type(a);
-		if (is_type_bit_field(left.type)) {
+		bool inline_array_arith = lb_can_try_to_inline_array_arith(tl);
+		if (inline_array_arith && is_type_bit_field(left.type)) {
 			left = lb_emit_transmute(p, left, tl);
 			right = lb_emit_transmute(p, right, tl);
 		}
@@ -3468,7 +3469,6 @@ gb_internal lbValue lb_emit_comp(lbProcedure *p, TokenKind op_kind, lbValue left
 			cmp_op = Token_And;
 		}
 
-		bool inline_array_arith = lb_can_try_to_inline_array_arith(tl);
 		i32 count = 0;
 		switch (tl->kind) {
 		case Type_Array:           count = cast(i32)tl->Array.count;           break;


### PR DESCRIPTION
A fix for #6717.

Minimal repro of the assertion failure:

```odin
package main

Example :: bit_field [1]u8 {}

main :: proc() {
    eg : Example
    fails := eg == eg
}
```

The source of the assertion failure is the inline array arith path within the [array-like block of `lb_emit_comp`](https://github.com/odin-lang/Odin/blob/d9b9acdf47098a66693d9d50a08fe79f8df75c83/src/llvm_backend_expr.cpp#L3451).

The block is guarded by the condition `is_type_array_like(a)`, where `a` is `core_type(left.type)`. For array-backed `bit_field`s, `a` is the backing array so the condition is satisfied.

The `lhs` and `rhs` variables are almost immediately declared within that block using the `left` / `right` variables:

```cpp
lbValue lhs = lb_address_from_load_or_generate_local(p, left);
lbValue rhs = lb_address_from_load_or_generate_local(p, right);
```

For array-backed `bit_field`s, this meant `lhs` and `rhs` were `lbValue`s with a type of `Type_BitField`.

When `type_size_of(base_type(a)) <= build_context.max_simd_align`, the inline array arith path would be taken. That path directly passes `lhs` / `rhs` to `lb_emit_array_epi` calls:

```cpp
		if (inline_array_arith) {
			// inline
			lbAddr val = lb_add_local_generated(p, t_bool, false);
			lb_addr_store(p, val, res);
			for (i32 i = 0; i < count; i++) {
				lbValue x = lb_emit_load(p, lb_emit_array_epi(p, lhs, i));
				lbValue y = lb_emit_load(p, lb_emit_array_epi(p, rhs, i));
				lbValue cmp = lb_emit_comp(p, op_kind, x, y);
				lbValue new_res = lb_emit_arith(p, cmp_op, lb_addr_load(p, val), cmp, t_bool);
				lb_addr_store(p, val, lb_emit_conv(p, new_res, t_bool));
			}

			return lb_addr_load(p, val);
		}
```

`lb_emit_array_epi` expects array-like values, not `Type_BitField`, so the internal assertion would fail:

```cpp
	Type *t = s.type;
	GB_ASSERT(is_type_pointer(t));
	Type *st = base_type(type_deref(t));
	...
	GB_ASSERT_MSG(is_type_array(st) || is_type_enumerated_array(st) || is_type_matrix(st), "%s", type_to_string(st));
```

My fix is to conditionally transmute `left` / `right` to `tl` (i.e. `base_type(a)`) prior to `lhs` / `rhs` being declared. This is only needed when `left` is `Type_BitField` and the inline path would be taken, so the declaration of `inline_array_arith` is moved up to allow both conditions to be checked prior to the `lhs` / `rhs` declarations:

```cpp
	if (is_type_array_like(a)) {
		Type *tl = base_type(a);
		bool inline_array_arith = lb_can_try_to_inline_array_arith(tl);
		if (inline_array_arith && is_type_bit_field(left.type)) {
			left = lb_emit_transmute(p, left, tl);
			right = lb_emit_transmute(p, right, tl);
		}
		lbValue lhs = lb_address_from_load_or_generate_local(p, left);
		lbValue rhs = lb_address_from_load_or_generate_local(p, right);
```

This ensures the inline branch is passing `Type_Array` `lbValue`s to `lb_array_emit_epi`, resolving the issue in my local tests.

I'm unsure if my use of `lb_emit_transmute` is correct or if `lb_emit_conv` would be preferable.

I opted to only transmute for the inline branch to avoid any changes to, or unnecessary transmutes for, the other functional branch. This means the non-inline branch will still receive `lhs` / `rhs` as `Type_BitField`.

From my reading, the non-inline path should always result in a call of the `memory_compare` runtime proc being emitted for array-backed `bit_field`s. `lhs` / `rhs` would be converted to `rawptr` when the args are constructed, so I don't think `lhs` / `rhs` being `Type_BitField` creates any risk there.

This is my first time touching the compiler codebase so please do let me know if the fix has any problems or a better solution exists.

Thanks!