### PR TITLE
[checker] disallow `*` and `/` for bit sets

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -2131,6 +2131,10 @@ gb_internal bool check_binary_op(CheckerContext *c, Operand *o, Token op) {
 		/*fallthrough*/
 	case Token_Mul:
 	case Token_MulEq:
+		if (is_type_bit_set(type)) {
+			error(op, "Operator '%.*s' is not allowed with bit sets", LIT(op.string));
+			return false;
+		}
 	case Token_AddEq:
 		if (is_type_bit_set(type)) {
 			return true;


### PR DESCRIPTION
before, the following code would compile:
```odin
Foo :: bit_set[enum {A,B,C}]

a := Foo{.A}
b := Foo{.B}
c := a * b
d := b / a
```