### PR TITLE
WASM: Conditionally compile os-dependent procs in vendor/OpenGL

### DIFF
--- a/vendor/OpenGL/helpers.odin
+++ b/vendor/OpenGL/helpers.odin
@@ -3,10 +3,8 @@ package vendor_gl
 
 // Helper for loading shaders into a program
 
-import    "core:os"
 import    "core:fmt"
 import    "core:strings"
-@(require) import "core:time"
 import    "base:runtime"
 _ :: fmt
 _ :: runtime
@@ -150,38 +148,10 @@ create_and_link_program :: proc(shader_ids: []u32, binary_retrievable := false) 
 	return
 }
 
-load_compute_file :: proc(filename: string, binary_retrievable := false) -> (program_id: u32, ok: bool) {
-	cs_data, cs_data_err := os.read_entire_file(filename, context.allocator)
-	if cs_data_err != nil {
-		return 0, false
-	}
-	defer delete(cs_data)
-
-	// Create the shaders
-	compute_shader_id := compile_shader_from_source(string(cs_data), Shader_Type(COMPUTE_SHADER)) or_return
-	return create_and_link_program([]u32{compute_shader_id}, binary_retrievable)
-}
-
 load_compute_source :: proc(cs_data: string, binary_retrievable := false) -> (program_id: u32, ok: bool) {
 	// Create the shaders
 	compute_shader_id := compile_shader_from_source(cs_data, Shader_Type(COMPUTE_SHADER)) or_return
 	return create_and_link_program([]u32{compute_shader_id}, binary_retrievable)
-}
-
-load_shaders_file :: proc(vs_filename, fs_filename: string, binary_retrievable := false) -> (program_id: u32, ok: bool) {
-	vs_data, vs_data_err := os.read_entire_file(vs_filename, context.allocator)
-	if vs_data_err != nil {
-		return 0, false
-	}
-	defer delete(vs_data)
-	
-	fs_data, fs_data_err := os.read_entire_file(fs_filename, context.allocator)
-	if fs_data_err != nil {
-		return 0, false
-	}
-	defer delete(fs_data)
-
-	return load_shaders_source(string(vs_data), string(fs_data), binary_retrievable)
 }
 
 load_shaders_source :: proc(vs_source, fs_source: string, binary_retrievable := false) -> (program_id: u32, ok: bool) {
@@ -193,66 +163,6 @@ load_shaders_source :: proc(vs_source, fs_source: string, binary_retrievable := 
 	defer DeleteShader(fragment_shader_id)
 
 	return create_and_link_program([]u32{vertex_shader_id, fragment_shader_id}, binary_retrievable)
-}
-
-load_shaders :: proc{load_shaders_file}
-
-
-when ODIN_OS == .Windows {
-	update_shader_if_changed :: proc(
-		vertex_name, fragment_name: string, 
-		program: u32, 
-		last_vertex_time, last_fragment_time: time.Time,
-	) -> (
-		old_program: u32, 
-		current_vertex_time, current_fragment_time: time.Time,
-		updated: bool,
-	) {
-		current_vertex_time, _   = os.modification_time_by_path(vertex_name)
-		current_fragment_time, _ = os.modification_time_by_path(fragment_name)
-		old_program = program
-
-		if current_vertex_time != last_vertex_time || current_fragment_time != last_fragment_time {
-			new_program, success := load_shaders(vertex_name, fragment_name)
-			if success {
-				DeleteProgram(old_program)
-				old_program = new_program
-				fmt.println("Updated shaders")
-				updated = true
-			} else {
-				fmt.println("Failed to update shaders")
-			}
-		}
-
-		return old_program, current_vertex_time, current_fragment_time, updated
-	}
-
-	update_shader_if_changed_compute :: proc(
-		compute_name: string, 
-		program: u32, 
-		last_compute_time: time.Time,
-	) -> (
-		old_program: u32, 
-		current_compute_time: time.Time,
-		updated: bool,
-	) {
-		current_compute_time, _ = os.modification_time_by_path(compute_name)
-		old_program = program
-
-		if current_compute_time != last_compute_time {
-			new_program, success := load_compute_file(compute_name)
-			if success {
-				DeleteProgram(old_program)
-				old_program = new_program
-				fmt.println("Updated shaders")
-				updated = true
-			} else {
-				fmt.println("Failed to update shaders")
-			}
-		}
-
-		return old_program, current_compute_time, updated
-	}
 }
 
 

--- a/vendor/OpenGL/helpers_file_io.odin
+++ b/vendor/OpenGL/helpers_file_io.odin
@@ -1,0 +1,96 @@
+#+build !js
+#+build !wasi
+#+build !orca
+package vendor_gl
+
+import "core:fmt"
+import "core:os"
+@(require) import "core:time"
+_ :: fmt
+
+load_compute_file :: proc(filename: string, binary_retrievable := false) -> (program_id: u32, ok: bool) {
+    cs_data, cs_data_err := os.read_entire_file(filename, context.allocator)
+    if cs_data_err != nil {
+        return 0, false
+    }
+    defer delete(cs_data)
+
+    // Create the shaders
+    compute_shader_id := compile_shader_from_source(string(cs_data), Shader_Type(COMPUTE_SHADER)) or_return
+    return create_and_link_program([]u32{compute_shader_id}, binary_retrievable)
+}
+
+load_shaders_file :: proc(vs_filename, fs_filename: string, binary_retrievable := false) -> (program_id: u32, ok: bool) {
+	vs_data, vs_data_err := os.read_entire_file(vs_filename, context.allocator)
+	if vs_data_err != nil {
+		return 0, false
+	}
+	defer delete(vs_data)
+	
+	fs_data, fs_data_err := os.read_entire_file(fs_filename, context.allocator)
+	if fs_data_err != nil {
+		return 0, false
+	}
+	defer delete(fs_data)
+
+	return load_shaders_source(string(vs_data), string(fs_data), binary_retrievable)
+}
+
+load_shaders :: proc {load_shaders_file}
+
+when ODIN_OS == .Windows {
+    update_shader_if_changed :: proc(
+        vertex_name, fragment_name: string,
+        program: u32,
+        last_vertex_time, last_fragment_time: time.Time,
+    ) -> (
+        old_program: u32,
+        current_vertex_time, current_fragment_time: time.Time,
+        updated: bool,
+    ) {
+        current_vertex_time, _ = os.modification_time_by_path(vertex_name)
+        current_fragment_time, _ = os.modification_time_by_path(fragment_name)
+        old_program = program
+
+        if current_vertex_time != last_vertex_time || current_fragment_time != last_fragment_time {
+            new_program, success := load_shaders(vertex_name, fragment_name)
+            if success {
+                DeleteProgram(old_program)
+                old_program = new_program
+                fmt.println("Updated shaders")
+                updated = true
+            } else {
+                fmt.println("Failed to update shaders")
+            }
+        }
+
+        return old_program, current_vertex_time, current_fragment_time, updated
+    }
+
+    update_shader_if_changed_compute :: proc(
+        compute_name: string,
+        program: u32,
+        last_compute_time: time.Time,
+    ) -> (
+        old_program: u32,
+        current_compute_time: time.Time,
+        updated: bool,
+    ) {
+        current_compute_time, _ = os.modification_time_by_path(compute_name)
+        old_program = program
+
+        if current_compute_time != last_compute_time {
+            new_program, success := load_compute_file(compute_name)
+            if success {
+                DeleteProgram(old_program)
+                old_program = new_program
+                fmt.println("Updated shaders")
+                updated = true
+            } else {
+                fmt.println("Failed to update shaders")
+            }
+        }
+
+        return old_program, current_compute_time, updated
+    }
+}


### PR DESCRIPTION
Example below fails `odin check gl_wasm_example.odin -target:js_wasm32`:

```odin
package main

@(require) import gl "vendor:OpenGL"

main :: proc() {  }
```

Error:
```
gl_wasm_example.odin(4:1) Error: Compile time panic: core:os is unsupported on js/wasm 
        #panic("core:os is unsupported on js/wasm") 
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
 ```