### PR TITLE
core:os: remove unused File_Flag cases

### DIFF
--- a/core/os/file.odin
+++ b/core/os/file.odin
@@ -65,10 +65,8 @@ File_Flag :: enum {
 	Excl,
 	Sync,
 	Trunc,
-	Sparse,
 	Inheritable,
 	Non_Blocking,
-	Unbuffered_IO,
 }
 
 O_RDONLY  :: File_Flags{.Read}
@@ -79,7 +77,6 @@ O_CREATE  :: File_Flags{.Create}
 O_EXCL    :: File_Flags{.Excl}
 O_SYNC    :: File_Flags{.Sync}
 O_TRUNC   :: File_Flags{.Trunc}
-O_SPARSE  :: File_Flags{.Sparse}
 
 /*
 	If specified, the file handle is inherited upon the creation of a child


### PR DESCRIPTION
## Summary

Removes unused `core:os` file flags:

- `.Sparse`
- `.Unbuffered_IO`
- `O_SPARSE`

These flags were listed as cleanup items in #4710 and were not wired up by any platform implementation.

## Tests

- `./odin check core/os -no-entry-point`
- `./odin check tests/core/os -no-entry-point`
- `./odin test tests/core/os`

Refs #4710