### PR TITLE
fix buffer overflow when running a test which shrinks a dynamic array…

### DIFF
--- a/core/mem/rollback_stack_allocator.odin
+++ b/core/mem/rollback_stack_allocator.odin
@@ -344,7 +344,7 @@ rb_resize_bytes_non_zeroed :: proc(
 		}
 	}
 	result = rb_alloc_bytes_non_zeroed(stack, size, alignment) or_return
-	runtime.mem_copy_non_overlapping(raw_data(result), ptr, old_size)
+	runtime.mem_copy_non_overlapping(raw_data(result), ptr, min(old_size, size))
 	err = rb_free(stack, ptr)
 	return
 }


### PR DESCRIPTION
fix buffer overflow when running a test which shrinks a dynamic array that was not the last allocation

to see this behaviour
`
package test

import "core:testing"
import "core:log"

@(test)
buffer_overflow :: proc(t: ^testing.T) {
  a := make([dynamic]int, 128)
  defer delete(a)
  b := make([dynamic]int, 64)
  defer delete(b)
  shrink(&a, 64)
  log.infof("%v\n",a)
}
`
and step though shrink call in debugger, where it allocates 64 bytes and then copies in 128
this causes a problem when the old size is larger then the remaining size of the block


