### PR TITLE
[net] Unix sockets

### DIFF
--- a/core/nbio/errors.odin
+++ b/core/nbio/errors.odin
@@ -61,17 +61,19 @@ error_string :: proc(err: Error) -> string {
 
 error_string_recv :: proc(recv_err: Recv_Error) -> string {
 	switch err in recv_err {
-	case TCP_Recv_Error: return error_string(err)
-	case UDP_Recv_Error: return error_string(err)
-	case:                return "Unknown"
+	case TCP_Recv_Error:  return error_string(err)
+	case UDP_Recv_Error:  return error_string(err)
+	case Unix_Recv_Error: return error_string(err)
+	case:                 return "Unknown"
 	}
 }
 
 error_string_send :: proc(send_err: Send_Error) -> string {
 	switch err in send_err {
-	case TCP_Send_Error: return error_string(err)
-	case UDP_Send_Error: return error_string(err)
-	case:                return "Unknown"
+	case TCP_Send_Error:  return error_string(err)
+	case UDP_Send_Error:  return error_string(err)
+	case Unix_Send_Error: return error_string(err)
+	case:                 return "Unknown"
 	}
 }
 

--- a/core/nbio/impl_linux.odin
+++ b/core/nbio/impl_linux.odin
@@ -801,6 +801,8 @@ recv_exec :: proc(op: ^Operation) {
 	switch socket in op.recv.socket {
 	case TCP_Socket:
 		sock = linux.Fd(socket)
+	case Unix_Socket:
+		sock = linux.Fd(socket)
 	case UDP_Socket:
 		sock = linux.Fd(socket)
 		op.recv._impl.msghdr.name    = &op.recv._impl.addr_out
@@ -831,6 +833,13 @@ recv_callback :: proc(op: ^Operation, res: i32) -> bool {
 			case:
 				op.recv.err = net._tcp_recv_error(errno)
 			}
+		case Unix_Socket:
+			#partial switch errno {
+			case .ECANCELED:
+				op.recv.err = Unix_Recv_Error.Timeout
+			case:
+				op.recv.err = net._unix_recv_error(errno)
+			}
 		case UDP_Socket:
 			#partial switch errno {
 			case .ECANCELED:
@@ -847,6 +856,23 @@ recv_callback :: proc(op: ^Operation, res: i32) -> bool {
 
 	switch sock in op.recv.socket {
 	case TCP_Socket:
+		if res == 0 {
+			// Connection closed.
+			return true
+		}
+
+		if op.recv.all {
+			total: int
+			for buf in op.recv.bufs {
+				total += len(buf)
+			}
+
+			if op.recv.received < total {
+				recv_exec(op)
+				return false
+			}
+		}
+	case Unix_Socket:
 		if res == 0 {
 			// Connection closed.
 			return true
@@ -886,6 +912,8 @@ send_exec :: proc(op: ^Operation) {
 	switch socket in op.send.socket {
 	case TCP_Socket:
 		sock = linux.Fd(socket)
+	case Unix_Socket:
+		sock = linux.Fd(socket)
 	case UDP_Socket:
 		sock = linux.Fd(socket)
 		op.send._impl.endpoint       = endpoint_to_sockaddr_ip(op.send.endpoint)
@@ -915,6 +943,13 @@ send_callback :: proc(op: ^Operation, res: i32) -> bool {
 				op.send.err = TCP_Send_Error.Timeout
 			case:
 				op.send.err = net._tcp_send_error(errno)
+			}
+		case Unix_Socket:
+			#partial switch errno {
+			case .ECANCELED:
+				op.send.err = Unix_Send_Error.Timeout
+			case:
+				op.send.err = net._unix_send_error(errno)
 			}
 		case UDP_Socket:
 			#partial switch errno {
@@ -1031,8 +1066,9 @@ poll_exec :: proc(op: ^Operation) {
 
 	fd: linux.Fd
 	switch sock in op.poll.socket {
-	case TCP_Socket: fd = linux.Fd(sock)
-	case UDP_Socket: fd = linux.Fd(sock)
+	case TCP_Socket:  fd = linux.Fd(sock)
+	case Unix_Socket: fd = linux.Fd(sock)
+	case UDP_Socket:  fd = linux.Fd(sock)
 	}
 
 	enqueue(op, uring.poll_add(

--- a/core/nbio/impl_posix.odin
+++ b/core/nbio/impl_posix.odin
@@ -802,8 +802,9 @@ send_exec :: proc(op: ^Operation) -> Op_Result {
 		}
 
 		switch _ in op.send.socket {
-		case TCP_Socket: op.send.err = posix_tcp_send_error()
-		case UDP_Socket: op.send.err = posix_udp_send_error()
+		case TCP_Socket:  op.send.err = posix_tcp_send_error()
+		case Unix_Socket: op.send.err = posix_unix_send_error()
+		case UDP_Socket:  op.send.err = posix_udp_send_error()
 		}
 		return .Done
 	}
@@ -827,6 +828,8 @@ send_exec :: proc(op: ^Operation) -> Op_Result {
 		fd: posix.FD
 		switch sock in socket {
 		case TCP_Socket:
+			fd = posix.FD(sock)
+		case Unix_Socket:
 			fd = posix.FD(sock)
 		case UDP_Socket:
 			fd = posix.FD(sock)
@@ -891,6 +894,8 @@ recv_exec :: proc(op: ^Operation) -> Op_Result {
 		fromaddr: posix.sockaddr_storage
 		switch sock in socket {
 		case TCP_Socket:
+			fd = posix.FD(sock)
+		case Unix_Socket:
 			fd = posix.FD(sock)
 		case UDP_Socket:
 			fd = posix.FD(sock)
@@ -1257,6 +1262,9 @@ timeout_and_delete :: proc(target: ^Operation) {
 		case TCP_Socket:
 			target.recv.err = TCP_Recv_Error.Timeout
 			ident = uintptr(sock)
+		case Unix_Socket:
+			target.recv.err = Unix_Recv_Error.Timeout
+			ident = uintptr(sock)
 		case UDP_Socket:
 			target.recv.err = UDP_Recv_Error.Timeout
 			ident = uintptr(sock)
@@ -1266,6 +1274,9 @@ timeout_and_delete :: proc(target: ^Operation) {
 		switch sock in target.send.socket {
 		case TCP_Socket:
 			target.send.err = TCP_Send_Error.Timeout
+			ident = uintptr(sock)
+		case Unix_Socket:
+			target.send.err = Unix_Send_Error.Timeout
 			ident = uintptr(sock)
 		case UDP_Socket:
 			target.send.err = UDP_Send_Error.Timeout

--- a/core/nbio/impl_posix_darwin.odin
+++ b/core/nbio/impl_posix_darwin.odin
@@ -20,10 +20,12 @@ posix_sendfile :: proc(fd: Handle, s: TCP_Socket, offset, nbytes: int) -> (sent:
 	return
 }
 
-posix_listen_error   :: net._listen_error
-posix_accept_error   :: net._accept_error
-posix_dial_error     :: net._dial_error
-posix_tcp_send_error :: net._tcp_send_error
-posix_udp_send_error :: net._udp_send_error
-posix_tcp_recv_error :: net._tcp_recv_error
-posix_udp_recv_error :: net._udp_recv_error
+posix_listen_error    :: net._listen_error
+posix_accept_error    :: net._accept_error
+posix_dial_error      :: net._dial_error
+posix_tcp_send_error  :: net._tcp_send_error
+posix_unix_send_error :: net._unix_send_error
+posix_udp_send_error  :: net._udp_send_error
+posix_tcp_recv_error  :: net._tcp_recv_error
+posix_unix_recv_error :: net._unix_recv_error
+posix_udp_recv_error  :: net._udp_recv_error

--- a/core/nbio/impl_posix_freebsd.odin
+++ b/core/nbio/impl_posix_freebsd.odin
@@ -39,12 +39,20 @@ posix_tcp_send_error :: proc() -> TCP_Send_Error {
 	return net._tcp_send_error(freebsd.Errno(posix.errno()))
 }
 
+posix_unix_send_error :: proc() -> Unix_Send_Error {
+	return net._unix_send_error(freebsd.Errno(posix.errno()))
+}
+
 posix_udp_send_error :: proc() -> UDP_Send_Error {
 	return net._udp_send_error(freebsd.Errno(posix.errno()))
 }
 
 posix_tcp_recv_error :: proc() -> TCP_Recv_Error {
 	return net._tcp_recv_error(freebsd.Errno(posix.errno()))
+}
+
+posix_unix_recv_error :: proc() -> Unix_Recv_Error {
+	return net._unix_recv_error(freebsd.Errno(posix.errno()))
 }
 
 posix_udp_recv_error :: proc() -> UDP_Recv_Error {

--- a/core/nbio/impl_posix_netbsd.odin
+++ b/core/nbio/impl_posix_netbsd.odin
@@ -3,10 +3,12 @@ package nbio
 
 import "core:net"
 
-posix_listen_error   :: net._listen_error
-posix_accept_error   :: net._accept_error
-posix_dial_error     :: net._dial_error
-posix_tcp_send_error :: net._tcp_send_error
-posix_udp_send_error :: net._udp_send_error
-posix_tcp_recv_error :: net._tcp_recv_error
-posix_udp_recv_error :: net._udp_recv_error
+posix_listen_error    :: net._listen_error
+posix_accept_error    :: net._accept_error
+posix_dial_error      :: net._dial_error
+posix_tcp_send_error  :: net._tcp_send_error
+posix_unix_send_error :: net._unix_send_error
+posix_unix_recv_error :: net._unix_recv_error
+posix_udp_send_error  :: net._udp_send_error
+posix_tcp_recv_error  :: net._tcp_recv_error
+posix_udp_recv_error  :: net._udp_recv_error

--- a/core/nbio/impl_posix_netbsd.odin
+++ b/core/nbio/impl_posix_netbsd.odin
@@ -8,7 +8,7 @@ posix_accept_error    :: net._accept_error
 posix_dial_error      :: net._dial_error
 posix_tcp_send_error  :: net._tcp_send_error
 posix_unix_send_error :: net._unix_send_error
-posix_unix_recv_error :: net._unix_recv_error
 posix_udp_send_error  :: net._udp_send_error
 posix_tcp_recv_error  :: net._tcp_recv_error
+posix_unix_recv_error :: net._unix_recv_error
 posix_udp_recv_error  :: net._udp_recv_error

--- a/core/nbio/impl_posix_openbsd.odin
+++ b/core/nbio/impl_posix_openbsd.odin
@@ -3,10 +3,12 @@ package nbio
 
 import "core:net"
 
-posix_listen_error   :: net._listen_error
-posix_accept_error   :: net._accept_error
-posix_dial_error     :: net._dial_error
-posix_tcp_send_error :: net._tcp_send_error
-posix_udp_send_error :: net._udp_send_error
-posix_tcp_recv_error :: net._tcp_recv_error
-posix_udp_recv_error :: net._udp_recv_error
+posix_listen_error    :: net._listen_error
+posix_accept_error    :: net._accept_error
+posix_dial_error      :: net._dial_error
+posix_tcp_send_error  :: net._tcp_send_error
+posix_unix_send_error :: net._unix_send_error
+posix_udp_send_error  :: net._udp_send_error
+posix_tcp_recv_error  :: net._tcp_recv_error
+posix_unix_recv_error :: net._unix_recv_error
+posix_udp_recv_error  :: net._udp_recv_error

--- a/core/nbio/impl_windows.odin
+++ b/core/nbio/impl_windows.odin
@@ -1241,6 +1241,16 @@ recv_exec :: proc(op: ^Operation) -> Op_Result {
 			win.LPWSAOVERLAPPED(&op._impl.over),
 			nil,
 		)
+	case Unix_Socket:
+		status = win.WSARecv(
+			win.SOCKET(sock),
+			win_bufs,
+			u32(len(bufs)),
+			nil,
+			&op.recv._impl.flags,
+			win.LPWSAOVERLAPPED(&op._impl.over),
+			nil,
+		)
 	}
 
 	if status == win.SOCKET_ERROR {
@@ -1249,8 +1259,9 @@ recv_exec :: proc(op: ^Operation) -> Op_Result {
 			return .Pending
 		} else if op._impl.over.Internal == nil {
 			switch _ in op.recv.socket {
-			case TCP_Socket: op.recv.err = net._tcp_recv_error()
-			case UDP_Socket: op.recv.err = net._udp_recv_error()
+			case TCP_Socket:  op.recv.err = net._tcp_recv_error()
+			case UDP_Socket:  op.recv.err = net._udp_recv_error()
+			case Unix_Socket: op.recv.err = net._unix_recv_error()
 			}
 		}
 	}
@@ -1273,16 +1284,18 @@ recv_callback :: proc(op: ^Operation) -> Op_Result {
 		// This error could also happen when the user calls close on the socket.
 		if check_timed_out(op, op.recv.expires) {
 			switch _ in op.recv.socket {
-			case TCP_Socket: op.recv.err = net.TCP_Recv_Error.Timeout
-			case UDP_Socket: op.recv.err = net.UDP_Recv_Error.Timeout
+			case TCP_Socket:  op.recv.err = net.TCP_Recv_Error.Timeout
+			case UDP_Socket:  op.recv.err = net.UDP_Recv_Error.Timeout
+			case Unix_Socket: op.recv.err = net.Unix_Recv_Error.Timeout
 			}
 			return .Done
 		}
 		fallthrough
 	case:
 		switch _ in op.recv.socket {
-		case TCP_Socket: op.recv.err = net._tcp_recv_error()
-		case UDP_Socket: op.recv.err = net._udp_recv_error()
+		case TCP_Socket:  op.recv.err = net._tcp_recv_error()
+		case UDP_Socket:  op.recv.err = net._udp_recv_error()
+		case Unix_Socket: op.recv.err = net._unix_recv_error()
 		}
 		return .Done
 	}
@@ -1313,6 +1326,26 @@ recv_callback :: proc(op: ^Operation) -> Op_Result {
 	case UDP_Socket:
 		assert(op.recv._impl.source_len > 0)
 		op.recv.source = sockaddr_to_endpoint(&op.recv._impl.source)
+
+	case Unix_Socket:
+		if n == 0 {
+			// Connection closed.
+			return .Done
+		}
+
+		if op.recv.all {
+			total: int
+			for buf in op.recv.bufs {
+				total += len(buf)
+			}
+
+			if op.recv.received < total {
+				switch recv_exec(op) {
+				case .Done:    return recv_callback(op)
+				case .Pending: return .Pending
+				}
+			}
+		}
 	}
 
 	return .Done
@@ -1359,6 +1392,16 @@ send_exec :: proc(op: ^Operation) -> Op_Result {
 			win.LPWSAOVERLAPPED(&op._impl.over),
 			nil,
 		)
+	case Unix_Socket:
+		status = win.WSASend(
+			win.SOCKET(sock),
+			win_bufs,
+			u32(len(bufs)),
+			nil,
+			0,
+			win.LPWSAOVERLAPPED(&op._impl.over),
+			nil,
+		)
 	}
 
 	if status == win.SOCKET_ERROR {
@@ -1367,8 +1410,9 @@ send_exec :: proc(op: ^Operation) -> Op_Result {
 			return .Pending
 		} else if op._impl.over.Internal == nil {
 			switch _ in op.send.socket {
-			case TCP_Socket: op.send.err = net._tcp_send_error()
-			case UDP_Socket: op.send.err = net._udp_send_error()
+			case TCP_Socket:  op.send.err = net._tcp_send_error()
+			case UDP_Socket:  op.send.err = net._udp_send_error()
+			case Unix_Socket: op.send.err = net._unix_send_error()
 			}
 		}
 	}
@@ -1391,16 +1435,18 @@ send_callback :: proc(op: ^Operation) -> Op_Result {
 		// This error could also happen when the user calls close on the socket.
 		if check_timed_out(op, op.send.expires) {
 			switch _ in op.send.socket {
-			case TCP_Socket: op.send.err = net.TCP_Send_Error.Timeout
-			case UDP_Socket: op.send.err = net.UDP_Send_Error.Timeout
+			case TCP_Socket:  op.send.err = net.TCP_Send_Error.Timeout
+			case UDP_Socket:  op.send.err = net.UDP_Send_Error.Timeout
+			case Unix_Socket: op.send.err = net.Unix_Send_Error.Timeout
 			}
 			return .Done
 		}
 		fallthrough
 	case:
 		switch _ in op.send.socket {
-		case TCP_Socket: op.send.err = net._tcp_send_error()
-		case UDP_Socket: op.send.err = net._udp_send_error()
+		case TCP_Socket:  op.send.err = net._tcp_send_error()
+		case UDP_Socket:  op.send.err = net._udp_send_error()
+		case Unix_Socket: op.send.err = net._unix_send_error()
 		}
 		return .Done
 	}

--- a/core/nbio/net.odin
+++ b/core/nbio/net.odin
@@ -8,9 +8,11 @@ Dial_Error     :: net.Dial_Error
 Send_Error     :: net.Send_Error
 TCP_Send_Error :: net.TCP_Send_Error
 UDP_Send_Error :: net.UDP_Send_Error
+Unix_Send_Error :: net.Unix_Send_Error
 Recv_Error     :: net.Recv_Error
 TCP_Recv_Error :: net.TCP_Recv_Error
 UDP_Recv_Error :: net.UDP_Recv_Error
+Unix_Recv_Error :: net.Unix_Recv_Error
 Listen_Error   :: net.Listen_Error
 Create_Socket_Error :: net.Create_Socket_Error
 
@@ -25,6 +27,7 @@ Endpoint :: net.Endpoint
 
 TCP_Socket :: net.TCP_Socket
 UDP_Socket :: net.UDP_Socket
+Unix_Socket :: net.Unix_Socket
 Any_Socket :: net.Any_Socket
 
 IP4_Any      :: net.IP4_Any

--- a/core/nbio/ops.odin
+++ b/core/nbio/ops.odin
@@ -547,8 +547,9 @@ prep_recv :: #force_inline proc(
 
 	if err := bufs_init(&op.recv._impl.bufs, &op.recv.bufs, op.l.allocator); err != nil {
 		switch _ in op.recv.socket {
-		case TCP_Socket: op.recv.err = TCP_Recv_Error.Insufficient_Resources
-		case UDP_Socket: op.recv.err = UDP_Recv_Error.Insufficient_Resources
+		case TCP_Socket:  op.recv.err = TCP_Recv_Error.Insufficient_Resources
+		case UDP_Socket:  op.recv.err = UDP_Recv_Error.Insufficient_Resources
+		case Unix_Socket: op.recv.err = Unix_Recv_Error.Insufficient_Resources
 		case:            unreachable()
 		}
 	}
@@ -769,8 +770,9 @@ prep_send :: proc(
 
 	if err := bufs_init(&op.send._impl.bufs, &op.send.bufs, op.l.allocator); err != nil {
 		switch _ in op.send.socket {
-		case TCP_Socket: op.send.err = TCP_Send_Error.Insufficient_Resources
-		case UDP_Socket: op.send.err = UDP_Send_Error.Insufficient_Resources
+		case TCP_Socket:  op.send.err = TCP_Send_Error.Insufficient_Resources
+		case UDP_Socket:  op.send.err = UDP_Send_Error.Insufficient_Resources
+		case Unix_Socket: op.send.err = Unix_Send_Error.Insufficient_Resources
 		case:            unreachable()
 		}
 	}

--- a/core/net/addr.odin
+++ b/core/net/addr.odin
@@ -128,6 +128,9 @@ aton :: proc(address_and_maybe_port: string, family: Address_Family, allow_decim
 	case .IP6:
 		return parse_ip6_address(address_and_maybe_port)
 
+	case .UNIX:
+		panic("net.aton(): no such thing as a UNIX domain address; they use filesystem paths instead.")
+
 	case:
 		return nil, false
 	}

--- a/core/net/common.odin
+++ b/core/net/common.odin
@@ -59,8 +59,10 @@ Network_Error :: union #shared_nil {
 	Bind_Error,
 	TCP_Send_Error,
 	UDP_Send_Error,
+	Unix_Send_Error,
 	TCP_Recv_Error,
 	UDP_Recv_Error,
+	Unix_Recv_Error,
 	Shutdown_Error,
 	Interfaces_Error,
 	Socket_Info_Error,
@@ -120,17 +122,20 @@ DEFAULT_TCP_OPTIONS :: TCP_Options {
 */
 Socket     :: distinct i64
 
-TCP_Socket :: distinct Socket
-UDP_Socket :: distinct Socket
+TCP_Socket  :: distinct Socket
+UDP_Socket  :: distinct Socket
+Unix_Socket :: distinct Socket
 
 Socket_Protocol :: enum {
 	TCP,
 	UDP,
+	UNIX,
 }
 
 Any_Socket :: union {
 	TCP_Socket,
 	UDP_Socket,
+	Unix_Socket,
 }
 
 /*
@@ -158,6 +163,7 @@ Endpoint :: struct {
 Address_Family :: enum {
 	IP4,
 	IP6,
+	UNIX,
 }
 
 Netmask :: distinct Address

--- a/core/net/errors.odin
+++ b/core/net/errors.odin
@@ -142,6 +142,7 @@ Accept_Error :: enum i32 {
 Recv_Error :: union #shared_nil {
 	TCP_Recv_Error,
 	UDP_Recv_Error,
+	Unix_Recv_Error,
 }
 
 TCP_Recv_Error :: enum i32 {

--- a/core/net/errors.odin
+++ b/core/net/errors.odin
@@ -192,9 +192,33 @@ UDP_Recv_Error :: enum i32 {
 	Unknown,
 }
 
+Unix_Recv_Error :: enum i32 {
+	None,
+	// No network connection, or the network stack is not initialized.
+	Network_Unreachable,
+	// Not enough space in internal tables/buffers to create a new socket, or an unsupported protocol is given.
+	Insufficient_Resources,
+	// Invalid socket or buffer given.
+	Invalid_Argument,
+	// The socket is not connected.
+	Not_Connected,
+	// Connection was closed/broken/shutdown while receiving data.
+	Connection_Closed,
+	// Timed out before being able to receive any data.
+	Timeout,
+	// Non-blocking socket that would need to block waiting on data.
+	Would_Block,
+	// Interrupted by a signal or other method of cancellation like WSACancelBlockingCall on Windows.
+	Interrupted,
+
+	// An error unable to be categorized in above categories, `last_platform_error` may have more info.
+	Unknown,
+}
+
 Send_Error :: union #shared_nil {
 	TCP_Send_Error,
 	UDP_Send_Error,
+	Unix_Send_Error,
 }
 
 TCP_Send_Error :: enum i32 {
@@ -206,6 +230,31 @@ TCP_Send_Error :: enum i32 {
 	// Invalid socket or buffer given.
 	Invalid_Argument,
 	// Connection was closed/broken/shutdown while sending data.
+	Connection_Closed,
+	// The socket is not connected.
+	Not_Connected,
+	// Could not reach the remote host.
+	Host_Unreachable,
+	// Timed out before being able to send any data.
+	Timeout,
+	// Non-blocking socket that would need to block waiting on the remote to be able to receive the data.
+	Would_Block,
+	// Interrupted by a signal or other method of cancellation like WSACancelBlockingCall on Windows.
+	Interrupted,
+
+	// An error unable to be categorized in above categories, `last_platform_error` may have more info.
+	Unknown,
+}
+
+Unix_Send_Error :: enum i32 {
+	None,
+	// No network connection, or the network stack is not initialized.
+	Network_Unreachable,
+	// Not enough space in internal tables/buffers to create a new socket, or an unsupported protocol is given.
+	Insufficient_Resources,
+	// Invalid socket or buffer given.
+	Invalid_Argument,
+	// Connection was closed/broken/shutdown while receiving data.
 	Connection_Closed,
 	// The socket is not connected.
 	Not_Connected,

--- a/core/net/errors_freebsd.odin
+++ b/core/net/errors_freebsd.odin
@@ -169,6 +169,28 @@ _tcp_recv_error :: proc(errno: freebsd.Errno) -> TCP_Recv_Error {
 	}
 }
 
+_unix_recv_error :: proc(errno: freebsd.Errno) -> Unix_Recv_Error {
+	assert(errno != nil)
+	_last_error = errno
+
+	#partial switch errno {
+	case .EBADF, .ENOTSOCK, .EFAULT:
+		return .Invalid_Argument
+	case .ENOTCONN:
+		return .Not_Connected
+	case .ECONNRESET:
+		return .Connection_Closed
+	case .ETIMEDOUT:
+		return .Timeout
+	case .EAGAIN:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
+}
+
 _udp_recv_error :: proc(errno: freebsd.Errno) -> UDP_Recv_Error {
 	assert(errno != nil)
 	_last_error = errno
@@ -190,6 +212,34 @@ _udp_recv_error :: proc(errno: freebsd.Errno) -> UDP_Recv_Error {
 }
 
 _tcp_send_error :: proc(errno: freebsd.Errno) -> TCP_Send_Error {
+	assert(errno != nil)
+	_last_error = errno
+
+	#partial switch errno {
+	case .EBADF, .EACCES, .ENOTSOCK, .EFAULT, .EMSGSIZE:
+		return .Invalid_Argument
+	case .ENOBUFS:
+		return .Insufficient_Resources
+	case .ECONNRESET, .EPIPE:
+		return .Connection_Closed
+	case .ENOTCONN:
+		return .Not_Connected
+	case .EHOSTUNREACH:
+		return .Host_Unreachable
+	case .EHOSTDOWN:
+		return .Host_Unreachable
+	case .ENETDOWN:
+		return .Network_Unreachable
+	case .EAGAIN:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
+}
+
+_unix_send_error :: proc(errno: freebsd.Errno) -> Unix_Send_Error {
 	assert(errno != nil)
 	_last_error = errno
 

--- a/core/net/errors_linux.odin
+++ b/core/net/errors_linux.odin
@@ -192,6 +192,28 @@ _udp_recv_error :: proc(errno: linux.Errno) -> UDP_Recv_Error {
 	}
 }
 
+_unix_recv_error :: proc(errno: linux.Errno) -> Unix_Recv_Error {
+	assert(errno != nil)
+	_last_error = errno
+
+	#partial switch errno {
+	case .EBADF, .ENOTSOCK, .EFAULT:
+		return .Invalid_Argument
+	case .ENOTCONN:
+		return .Not_Connected
+	case .ECONNREFUSED, .ECONNRESET:
+		return .Connection_Closed
+	case .ETIMEDOUT:
+		return .Timeout
+	case .EAGAIN:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
+}
+
 _tcp_send_error :: proc(errno: linux.Errno) -> TCP_Send_Error {
 	assert(errno != nil)
 	_last_error = errno
@@ -231,6 +253,34 @@ _udp_send_error :: proc(errno: linux.Errno) -> UDP_Send_Error {
 		return .Insufficient_Resources
 	case .ECONNRESET, .EPIPE:
 		return .Connection_Refused
+	case .EHOSTUNREACH:
+		return .Host_Unreachable
+	case .EHOSTDOWN:
+		return .Host_Unreachable
+	case .ENETDOWN:
+		return .Network_Unreachable
+	case .EAGAIN:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
+}
+
+_unix_send_error :: proc(errno: linux.Errno) -> Unix_Send_Error {
+	assert(errno != nil)
+	_last_error = errno
+
+	#partial switch errno {
+	case .EBADF, .EACCES, .ENOTSOCK, .EFAULT, .EMSGSIZE, .EDESTADDRREQ, .EINVAL, .EISCONN, .EOPNOTSUPP:
+		return .Invalid_Argument
+	case .ENOBUFS, .ENOMEM:
+		return .Insufficient_Resources
+	case .ECONNRESET, .EPIPE:
+		return .Connection_Closed
+	case .ENOTCONN:
+		return .Not_Connected
 	case .EHOSTUNREACH:
 		return .Host_Unreachable
 	case .EHOSTDOWN:

--- a/core/net/errors_posix.odin
+++ b/core/net/errors_posix.odin
@@ -150,6 +150,27 @@ _tcp_recv_error :: proc() -> TCP_Recv_Error {
 	}
 }
 
+_unix_recv_error :: proc() -> Unix_Recv_Error {
+	#partial switch posix.errno() {
+	case .EBADF, .EFAULT, .EINVAL, .ENOTSOCK, .EOPNOTSUPP:
+		return .Invalid_Argument
+	case .ENOBUFS:
+		return .Insufficient_Resources
+	case .ENOTCONN:
+		return .Not_Connected
+	case .ECONNRESET:
+		return .Connection_Closed
+	case .ETIMEDOUT:
+		return .Timeout
+	case .EAGAIN:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
+}
+
 _udp_recv_error :: proc() -> UDP_Recv_Error {
 	#partial switch posix.errno() {
 	case .EBADF, .EFAULT, .EINVAL, .ENOTSOCK, .EOPNOTSUPP, .EMSGSIZE:
@@ -170,6 +191,31 @@ _udp_recv_error :: proc() -> UDP_Recv_Error {
 }
 
 _tcp_send_error :: proc() -> TCP_Send_Error {
+	#partial switch posix.errno() {
+	case .EACCES, .EBADF, .EFAULT, .EMSGSIZE, .ENOTSOCK, .EOPNOTSUPP:
+		return .Invalid_Argument
+	case .ENOBUFS:
+		return .Insufficient_Resources
+	case .ECONNRESET, .EPIPE:
+		return .Connection_Closed
+	case .ENOTCONN:
+		return .Not_Connected
+	case .EHOSTUNREACH:
+		return .Host_Unreachable
+	case .ENETDOWN, .ENETUNREACH:
+		return .Network_Unreachable
+	case .ETIMEDOUT:
+		return .Timeout
+	case .EAGAIN:
+		return .Would_Block
+	case .EINTR:
+		return .Interrupted
+	case:
+		return .Unknown
+	}
+}
+
+_unix_send_error :: proc() -> Unix_Send_Error {
 	#partial switch posix.errno() {
 	case .EACCES, .EBADF, .EFAULT, .EMSGSIZE, .ENOTSOCK, .EOPNOTSUPP:
 		return .Invalid_Argument

--- a/core/net/errors_windows.odin
+++ b/core/net/errors_windows.odin
@@ -105,7 +105,7 @@ _listen_error :: proc() -> Listen_Error {
 		return .Invalid_Argument
 	case .WSAEISCONN:
 		return .Already_Connected
-	case .WSAEOPNOTSUPP, .WSAEINVAL:
+	case .WSAEOPNOTSUPP, .WSAEPFNOSUPPORT, .WSAESOCKTNOSUPPORT, .WSAEPROTONOSUPPORT, .WSAEINVAL:
 		return .Unsupported_Socket
 	case:
 		return .Unknown
@@ -175,6 +175,27 @@ _udp_recv_error :: proc() -> UDP_Recv_Error {
 	}
 }
 
+_unix_recv_error :: proc() -> Unix_Recv_Error {
+	#partial switch win.System_Error(win.WSAGetLastError()) {
+	case .WSANOTINITIALISED, .WSAENETDOWN:
+		return .Network_Unreachable
+	case .WSAEFAULT, .WSAEINPROGRESS, .WSAENOTSOCK, .WSAEMSGSIZE, .WSAEINVAL, .WSAEOPNOTSUPP:
+		return .Invalid_Argument
+	case .WSAENOTCONN:
+		return .Not_Connected
+	case .WSAEINTR:
+		return .Interrupted
+	case .WSAENETRESET, .WSAESHUTDOWN, .WSAECONNABORTED, .WSAECONNRESET:
+		return .Connection_Closed
+	case .WSAEWOULDBLOCK:
+		return .Would_Block
+	case .WSAETIMEDOUT:
+		return .Timeout
+	case:
+		return .Unknown
+	}
+}
+
 _tcp_send_error :: proc() -> TCP_Send_Error {
 	#partial switch win.System_Error(win.WSAGetLastError()) {
 	case .WSANOTINITIALISED, .WSAENETDOWN:
@@ -216,6 +237,31 @@ _udp_send_error :: proc() -> UDP_Send_Error {
 		return .Would_Block
 	case .WSAETIMEDOUT:
 		return .Timeout
+	case:
+		return .Unknown
+	}
+}
+
+_unix_send_error :: proc() -> Unix_Send_Error {
+	#partial switch win.System_Error(win.WSAGetLastError()) {
+	case .WSANOTINITIALISED, .WSAENETDOWN:
+		return .Network_Unreachable
+	case .WSAENOBUFS:
+		return .Insufficient_Resources
+	case .WSAEACCES, .WSAEINPROGRESS, .WSAEFAULT, .WSAENOTSOCK, .WSAEOPNOTSUPP, .WSAEMSGSIZE, .WSAEINVAL:
+		return .Invalid_Argument
+	case .WSAEINTR:
+		return .Interrupted
+	case .WSAENETRESET, .WSAESHUTDOWN, .WSAECONNABORTED, .WSAECONNRESET:
+		return .Connection_Closed
+	case .WSAENOTCONN:
+		return .Not_Connected
+	case .WSAEWOULDBLOCK:
+		return .Would_Block
+	case .WSAETIMEDOUT:
+		return .Timeout
+	case .WSAEHOSTUNREACH:
+		return .Host_Unreachable
 	case:
 		return .Unknown
 	}

--- a/core/net/socket.odin
+++ b/core/net/socket.odin
@@ -52,6 +52,7 @@ any_socket_to_socket :: proc "contextless" (socket: Any_Socket) -> Socket {
 	switch s in socket {
 	case TCP_Socket:  return Socket(s)
 	case UDP_Socket:  return Socket(s)
+	case Unix_Socket: return Socket(s)
 	case:
 		// TODO(tetra): Bluetooth, Raw
 		return Socket({})
@@ -150,6 +151,10 @@ dial_tcp :: proc{
 	dial_tcp_from_host_or_endpoint,
 }
 
+dial_unix :: proc(path: string, loc := #caller_location) -> (socket: Unix_Socket, err: Network_Error) {
+	return _dial_unix(path, loc)
+}
+
 create_socket :: proc(family: Address_Family, protocol: Socket_Protocol) -> (socket: Any_Socket, err: Create_Socket_Error) {
 	return _create_socket(family, protocol)
 }
@@ -193,10 +198,15 @@ make_bound_udp_socket :: proc(bound_address: Address, port: int) -> (socket: UDP
 
 	Errors that can be returned: `Create_Socket_Error`, `Bind_Error`, or `Listen_Error`
 */
-listen_tcp :: proc(interface_endpoint: Endpoint, backlog := 1000) -> (socket: TCP_Socket, err: Network_Error) {
+listen_tcp :: proc(interface_endpoint: Endpoint, backlog := DEFAULT_LISTEN_BACKLOG) -> (socket: TCP_Socket, err: Network_Error) {
 	assert(backlog > 0 && backlog < int(max(i32)))
 
 	return _listen_tcp(interface_endpoint, backlog)
+}
+
+listen_unix :: proc(path: string, backlog := DEFAULT_LISTEN_BACKLOG, loc := #caller_location) -> (socket: Unix_Socket, err: Network_Error) {
+	assert(backlog > 0 && backlog < int(max(i32)))
+	return _listen_unix(path, backlog, loc)
 }
 
 /*
@@ -215,6 +225,10 @@ peer_endpoint :: proc(socket: Any_Socket) -> (endpoint: Endpoint, err: Socket_In
 
 accept_tcp :: proc(socket: TCP_Socket, options := DEFAULT_TCP_OPTIONS) -> (client: TCP_Socket, source: Endpoint, err: Accept_Error) {
 	return _accept_tcp(socket, options)
+}
+
+accept_unix :: proc(socket: Unix_Socket) -> (client: Unix_Socket, err: Network_Error) {
+	return _accept_unix(socket)
 }
 
 close :: proc(socket: Any_Socket) {
@@ -241,6 +255,10 @@ recv_udp :: proc(socket: UDP_Socket, buf: []byte) -> (bytes_read: int, remote_en
 	return _recv_udp(socket, buf)
 }
 
+recv_unix :: proc(socket: Unix_Socket, buf: []byte) -> (bytes_read: int, err: Network_Error) {
+	return _recv_unix(socket, buf)
+}
+
 /*
 	Receive data into a buffer from any socket.
 
@@ -263,11 +281,14 @@ recv_any :: proc(socket: Any_Socket, buf: []byte) -> (
 		return
 	case UDP_Socket:
 		return recv_udp(socktype, buf)
+	case Unix_Socket:
+		bytes_read, err = recv_unix(socktype, buf)
+		return
 	case: panic("Not supported")
 	}
 }
 
-recv :: proc{recv_tcp, recv_udp, recv_any}
+recv :: proc{recv_tcp, recv_udp, recv_unix, recv_any}
 
 /*
 	Repeatedly sends data until the entire buffer is sent.
@@ -287,6 +308,10 @@ send_udp :: proc(socket: UDP_Socket, buf: []byte, to: Endpoint) -> (bytes_writte
 	return _send_udp(socket, buf, to)
 }
 
+send_unix :: proc(socket: Unix_Socket, buf: []byte) -> (bytes_written: int, err: Network_Error) {
+	return _send_unix(socket, buf)
+}
+
 /*
 	Sends data over the socket.
 
@@ -301,11 +326,13 @@ send_any :: proc(socket: Any_Socket, buf: []byte, to: Maybe(Endpoint) = nil) -> 
 		return send_tcp(socktype, buf)
 	case UDP_Socket:
 		return send_udp(socktype, buf, to.(Endpoint))
+	case Unix_Socket:
+		return send_unix(socktype, buf)
 	case: panic("Not supported")
 	}
 }
 
-send :: proc{send_tcp, send_udp, send_any}
+send :: proc{send_tcp, send_udp, send_unix, send_any}
 
 shutdown :: proc(socket: Any_Socket, manner: Shutdown_Manner) -> (err: Shutdown_Error) {
 	return _shutdown(socket, manner)

--- a/core/net/socket_freebsd.odin
+++ b/core/net/socket_freebsd.odin
@@ -57,13 +57,15 @@ _create_socket :: proc(family: Address_Family, protocol: Socket_Protocol) -> (so
 	sys_socket_type: freebsd.Socket_Type     = ---
 
 	switch family {
-	case .IP4: sys_family = .INET
-	case .IP6: sys_family = .INET6
+	case .IP4:  sys_family = .INET
+	case .IP6:  sys_family = .INET6
+	case .UNIX: sys_family = .UNIX
 	}
 
 	switch protocol {
-	case .TCP: sys_protocol = .TCP; sys_socket_type = .STREAM
-	case .UDP: sys_protocol = .UDP; sys_socket_type = .DGRAM
+	case .TCP:  sys_protocol = .TCP; sys_socket_type = .STREAM
+	case .UDP:  sys_protocol = .UDP; sys_socket_type = .DGRAM
+	case .UNIX: sys_protocol = .IP;  sys_socket_type = .STREAM
 	}
 
 	new_socket, errno := freebsd.socket(sys_family, sys_socket_type, sys_protocol)
@@ -73,8 +75,9 @@ _create_socket :: proc(family: Address_Family, protocol: Socket_Protocol) -> (so
 	}
 
 	switch protocol {
-	case .TCP: return cast(TCP_Socket)new_socket, nil
-	case .UDP: return cast(UDP_Socket)new_socket, nil
+	case .TCP:  return cast(TCP_Socket)new_socket,  nil
+	case .UDP:  return cast(UDP_Socket)new_socket,  nil
+	case .UNIX: return cast(Unix_Socket)new_socket, nil
 	}
 
 	return
@@ -101,6 +104,28 @@ _dial_tcp_from_endpoint :: proc(endpoint: Endpoint, options := DEFAULT_TCP_OPTIO
 }
 
 @(private)
+_dial_unix :: proc(path: string, loc := #caller_location) -> (socket: Unix_Socket, err: Network_Error) {
+	assert(len(path) < freebsd.UNIX_PATH_MAX, "net.dial_unix_from_path(): path too long", loc = loc)
+
+	sock := _create_socket(.UNIX, .UNIX) or_return
+	socket = sock.(Unix_Socket)
+
+	sockaddr := freebsd.Socket_Address_Unix {
+		family = .UNIX,
+	}
+	n := copy(sockaddr.path[:], path)
+	sockaddr.path[n] = 0
+
+	res := freebsd.connect(freebsd.Fd(socket), &sockaddr, size_of(sockaddr))
+	if res != nil {
+		err = _dial_error(res)
+		return
+	}
+
+	return
+}
+
+@(private)
 _bind :: proc(socket: Any_Socket, ep: Endpoint) -> (err: Bind_Error) {
 	sockaddr := _endpoint_to_sockaddr(ep)
 	real_socket := any_socket_to_socket(socket)
@@ -111,8 +136,10 @@ _bind :: proc(socket: Any_Socket, ep: Endpoint) -> (err: Bind_Error) {
 	return
 }
 
+DEFAULT_LISTEN_BACKLOG :: 1000
+
 @(private)
-_listen_tcp :: proc(interface_endpoint: Endpoint, backlog := 1000) -> (socket: TCP_Socket, err: Network_Error) {
+_listen_tcp :: proc(interface_endpoint: Endpoint, backlog := DEFAULT_LISTEN_BACKLOG) -> (socket: TCP_Socket, err: Network_Error) {
 	family := family_from_endpoint(interface_endpoint)
 	new_socket := create_socket(family, .TCP) or_return
 	socket = new_socket.(TCP_Socket)
@@ -123,6 +150,34 @@ _listen_tcp :: proc(interface_endpoint: Endpoint, backlog := 1000) -> (socket: T
 	errno := freebsd.listen(cast(Fd)socket, backlog)
 	if errno != nil {
 		err = _listen_error(errno)
+		return
+	}
+
+	return
+}
+
+@(private)
+_listen_unix :: proc(path: string, backlog := DEFAULT_LISTEN_BACKLOG, loc := #caller_location) -> (socket: Unix_Socket, err: Network_Error) {
+	assert(len(path) < freebsd.UNIX_PATH_MAX, "net.listen_unix(): path too long", loc = loc)
+
+	sock := _create_socket(.UNIX, .UNIX) or_return
+	socket = sock.(Unix_Socket)
+
+	sockaddr := freebsd.Socket_Address_Unix {
+		family = .UNIX,
+	}
+	n := copy(sockaddr.path[:], path)
+	sockaddr.path[n] = 0
+
+	res := freebsd.bind(freebsd.Fd(socket), &sockaddr, size_of(sockaddr))
+	if res != nil {
+		err = _bind_error(res)
+		return
+	}
+
+	res = freebsd.listen(freebsd.Fd(socket), int(backlog))
+	if res != nil {
+		err = _listen_error(res)
 		return
 	}
 
@@ -173,6 +228,15 @@ _accept_tcp :: proc(sock: TCP_Socket, options := DEFAULT_TCP_OPTIONS) -> (client
 }
 
 @(private)
+_accept_unix :: proc(listening_socket: Unix_Socket) -> (client: Unix_Socket, err: Accept_Error) {
+	client_sock, errno := freebsd.accept(freebsd.Fd(listening_socket), (^freebsd.Socket_Address_Unix)(nil))
+	if errno != .NONE {
+		return {}, _accept_error(errno)
+	}
+	return Unix_Socket(client_sock), nil
+}
+
+@(private)
 _close :: proc(socket: Any_Socket) {
 	real_socket := cast(Fd)any_socket_to_socket(socket)
 	// TODO: This returns an error number, but the `core:net` interface does not handle it.
@@ -190,6 +254,18 @@ _recv_tcp :: proc(socket: TCP_Socket, buf: []byte) -> (bytes_read: int, err: TCP
 		return
 	}
 	return result, nil
+}
+
+@(private)
+_recv_unix :: proc(socket: Unix_Socket, buf: []byte) -> (bytes_read: int, err: Unix_Recv_Error) {
+	if len(buf) <= 0 {
+		return 0, nil
+	}
+	num_read, errno := freebsd.recv(freebsd.Fd(socket), buf, {})
+	if errno != .NONE {
+		return 0, _unix_recv_error(errno)
+	}
+	return int(num_read), nil
 }
 
 @(private)
@@ -221,6 +297,21 @@ _send_tcp :: proc(socket: TCP_Socket, buf: []byte) -> (bytes_written: int, err: 
 		bytes_written += result
 	}
 	return
+}
+
+@(private)
+_send_unix :: proc(socket: Unix_Socket, buf: []byte) -> (bytes_written: int, err: Unix_Send_Error) {
+	total_written := 0
+	for total_written < len(buf) {
+		limit := min(int(max(i32)), len(buf) - total_written)
+		remaining := buf[total_written:][:limit]
+		res, errno := freebsd.send(freebsd.Fd(socket), remaining, .NOSIGNAL)
+		if errno != nil {
+			return total_written, _unix_send_error(errno)
+		}
+		total_written += int(res)
+	}
+	return total_written, nil
 }
 
 @(private)

--- a/core/net/socket_freebsd.odin
+++ b/core/net/socket_freebsd.odin
@@ -105,7 +105,7 @@ _dial_tcp_from_endpoint :: proc(endpoint: Endpoint, options := DEFAULT_TCP_OPTIO
 
 @(private)
 _dial_unix :: proc(path: string, loc := #caller_location) -> (socket: Unix_Socket, err: Network_Error) {
-	assert(len(path) < freebsd.UNIX_PATH_MAX, "net.dial_unix_from_path(): path too long", loc = loc)
+	assert(len(path) < freebsd.SUNPATHLEN, "net.dial_unix_from_path(): path too long", loc = loc)
 
 	sock := _create_socket(.UNIX, .UNIX) or_return
 	socket = sock.(Unix_Socket)
@@ -158,7 +158,7 @@ _listen_tcp :: proc(interface_endpoint: Endpoint, backlog := DEFAULT_LISTEN_BACK
 
 @(private)
 _listen_unix :: proc(path: string, backlog := DEFAULT_LISTEN_BACKLOG, loc := #caller_location) -> (socket: Unix_Socket, err: Network_Error) {
-	assert(len(path) < freebsd.UNIX_PATH_MAX, "net.listen_unix(): path too long", loc = loc)
+	assert(len(path) < freebsd.SUNPATHLEN, "net.listen_unix(): path too long", loc = loc)
 
 	sock := _create_socket(.UNIX, .UNIX) or_return
 	socket = sock.(Unix_Socket)

--- a/core/net/socket_linux.odin
+++ b/core/net/socket_linux.odin
@@ -72,7 +72,7 @@ _unwrap_os_family :: proc "contextless" (family: Address_Family) -> linux.Addres
 	switch family {
 	case .IP4:  return .INET
 	case .IP6:  return .INET6
-	case .UNIX: return .UNSPEC
+	case .UNIX: return .UNIX
 	case:
 		unreachable()
 	}

--- a/core/net/socket_linux.odin
+++ b/core/net/socket_linux.odin
@@ -61,6 +61,7 @@ _wrap_os_socket :: proc "contextless" (sock: linux.Fd, protocol: Socket_Protocol
 	switch protocol {
 	case .TCP:  return TCP_Socket(Socket(sock))
 	case .UDP:  return UDP_Socket(Socket(sock))
+	case .UNIX: return Unix_Socket(Socket(sock))
 	case:
 		unreachable()
 	}
@@ -71,6 +72,7 @@ _unwrap_os_family :: proc "contextless" (family: Address_Family) -> linux.Addres
 	switch family {
 	case .IP4:  return .INET
 	case .IP6:  return .INET6
+	case .UNIX: return .UNSPEC
 	case:
 		unreachable()
 	}
@@ -81,6 +83,7 @@ _unwrap_os_proto_socktype :: proc "contextless" (protocol: Socket_Protocol) -> (
 	switch protocol {
 	case .TCP:  return .TCP, .STREAM
 	case .UDP:  return .UDP, .DGRAM
+	case .UNIX: return nil,  .STREAM // NOTE(tetra): Passing zero to socket() for the protocol on Windows works.
 	case:
 		unreachable()
 	}
@@ -169,6 +172,28 @@ _dial_tcp_from_endpoint :: proc(endpoint: Endpoint, options := DEFAULT_TCP_OPTIO
 }
 
 @(private)
+_dial_unix :: proc(path: string, loc := #caller_location) -> (socket: Unix_Socket, err: Network_Error) {
+	assert(len(path) < linux.UNIX_PATH_MAX, "net.dial_unix_from_path(): path too long", loc = loc)
+
+	sock := _create_socket(.UNIX, .UNIX) or_return
+	socket = sock.(Unix_Socket)
+
+	sockaddr := linux.Sock_Addr_Un {
+		sun_family = .UNIX,
+	}
+	n := copy(sockaddr.sun_path[:], path)
+	sockaddr.sun_path[n] = 0
+
+	res := linux.connect(linux.Fd(socket), &sockaddr)
+	if res != nil {
+		err = _dial_error(res)
+		return
+	}
+
+	return
+}
+
+@(private)
 _bind :: proc(sock: Any_Socket, endpoint: Endpoint) -> (Bind_Error) {
 	addr := _unwrap_os_addr(endpoint)
 	errno := linux.bind(_unwrap_os_socket(sock), &addr)
@@ -178,8 +203,10 @@ _bind :: proc(sock: Any_Socket, endpoint: Endpoint) -> (Bind_Error) {
 	return nil
 }
 
+DEFAULT_LISTEN_BACKLOG :: 128 // NOTE(tetra): magic number here to avoid importing "sys/posix"
+
 @(private)
-_listen_tcp :: proc(endpoint: Endpoint, backlog := 1000) -> (socket: TCP_Socket, err: Network_Error) {
+_listen_tcp :: proc(endpoint: Endpoint, backlog := DEFAULT_LISTEN_BACKLOG) -> (socket: TCP_Socket, err: Network_Error) {
 	errno: linux.Errno
 	assert(backlog > 0 && i32(backlog) < max(i32))
 
@@ -217,6 +244,34 @@ _listen_tcp :: proc(endpoint: Endpoint, backlog := 1000) -> (socket: TCP_Socket,
 	// Listen on bound socket
 	if errno = linux.listen(os_sock, cast(i32) backlog); errno != .NONE {
 		err = _listen_error(errno)
+	}
+
+	return
+}
+
+@(private)
+_listen_unix :: proc(path: string, backlog := DEFAULT_LISTEN_BACKLOG, loc := #caller_location) -> (socket: Unix_Socket, err: Network_Error) {
+	assert(len(path) < linux.UNIX_PATH_MAX, "net.listen_unix(): path too long", loc = loc)
+
+	sock := _create_socket(.UNIX, .UNIX) or_return
+	socket = sock.(Unix_Socket)
+
+	sockaddr := linux.Sock_Addr_Un {
+		sun_family = .UNIX,
+	}
+	n := copy(sockaddr.sun_path[:], path)
+	sockaddr.sun_path[n] = 0
+
+	res := linux.bind(linux.Fd(socket), &sockaddr)
+	if res != nil {
+		err = _bind_error(res)
+		return
+	}
+
+	res = linux.listen(linux.Fd(socket), i32(backlog))
+	if res != nil {
+		err = _listen_error(res)
+		return
 	}
 
 	return
@@ -262,6 +317,15 @@ _accept_tcp :: proc(sock: TCP_Socket, options := DEFAULT_TCP_OPTIONS) -> (tcp_cl
 }
 
 @(private)
+_accept_unix :: proc(listening_socket: Unix_Socket) -> (client: Unix_Socket, err: Accept_Error) {
+	client_sock, errno := linux.accept(linux.Fd(listening_socket), (^linux.Sock_Addr_Un)(nil))
+	if errno != .NONE {
+		return {}, _accept_error(errno)
+	}
+	return Unix_Socket(client_sock), nil
+}
+
+@(private)
 _close :: proc(sock: Any_Socket) {
 	linux.close(_unwrap_os_socket(sock))
 }
@@ -301,6 +365,19 @@ _recv_udp :: proc(udp_sock: UDP_Socket, buf: []byte) -> (int, Endpoint, UDP_Recv
 }
 
 @(private)
+_recv_unix :: proc(socket: Unix_Socket, buf: []byte) -> (bytes_read: int, err: Unix_Recv_Error) {
+	if len(buf) <= 0 {
+		return 0, nil
+	}
+	num_read, errno := linux.recv(linux.Fd(socket), buf, {})
+	if errno != .NONE {
+		return 0, _unix_recv_error(errno)
+	}
+	return int(num_read), nil
+}
+
+
+@(private)
 _send_tcp :: proc(tcp_sock: TCP_Socket, buf: []byte) -> (int, TCP_Send_Error) {
 	total_written := 0
 	for total_written < len(buf) {
@@ -323,6 +400,21 @@ _send_udp :: proc(udp_sock: UDP_Socket, buf: []byte, to: Endpoint) -> (int, UDP_
 		return bytes_written, _udp_send_error(errno)
 	}
 	return int(bytes_written), nil
+}
+
+@(private)
+_send_unix :: proc(socket: Unix_Socket, buf: []byte) -> (bytes_written: int, err: Unix_Send_Error) {
+	total_written := 0
+	for total_written < len(buf) {
+		limit := min(int(max(i32)), len(buf) - total_written)
+		remaining := buf[total_written:][:limit]
+		res, errno := linux.send(linux.Fd(socket), remaining, {.NOSIGNAL})
+		if errno != nil {
+			return total_written, _unix_send_error(errno)
+		}
+		total_written += int(res)
+	}
+	return total_written, nil
 }
 
 @(private)

--- a/core/net/socket_others.odin
+++ b/core/net/socket_others.odin
@@ -32,7 +32,14 @@ _SHUTDOWN_MANNER_RECEIVE :: -1
 _SHUTDOWN_MANNER_SEND    :: -1
 _SHUTDOWN_MANNER_BOTH    :: -1
 
+DEFAULT_LISTEN_BACKLOG :: 128
+
 _dial_tcp_from_endpoint :: proc(endpoint: Endpoint, options := DEFAULT_TCP_OPTIONS) -> (sock: TCP_Socket, err: Network_Error) {
+	err = Create_Socket_Error.Network_Unreachable
+	return
+}
+
+_dial_unix :: proc(path: string, loc := #caller_location) -> (sock: Unix_Socket, err: Network_Error) {
 	err = Create_Socket_Error.Network_Unreachable
 	return
 }
@@ -47,7 +54,12 @@ _bind :: proc(skt: Any_Socket, ep: Endpoint) -> (err: Bind_Error) {
 	return
 }
 
-_listen_tcp :: proc(interface_endpoint: Endpoint, backlog := 1000) -> (skt: TCP_Socket, err: Network_Error) {
+_listen_tcp :: proc(interface_endpoint: Endpoint, backlog := DEFAULT_LISTEN_BACKLOG) -> (skt: TCP_Socket, err: Network_Error) {
+	err = Create_Socket_Error.Network_Unreachable
+	return
+}
+
+_listen_unix :: proc(path: string, backlog := DEFAULT_LISTEN_BACKLOG, loc := #caller_location) -> (skt: Unix_Socket, err: Network_Error) {
 	err = Create_Socket_Error.Network_Unreachable
 	return
 }
@@ -67,10 +79,20 @@ _accept_tcp :: proc(sock: TCP_Socket, options := DEFAULT_TCP_OPTIONS) -> (client
 	return
 }
 
+_accept_unix :: proc(sock: Unix_Socket) -> (client: Unix_Socket, err: Accept_Error) {
+	err = .Network_Unreachable
+	return
+}
+
 _close :: proc(skt: Any_Socket) {
 }
 
 _recv_tcp :: proc(skt: TCP_Socket, buf: []byte) -> (bytes_read: int, err: TCP_Recv_Error) {
+	err = .Network_Unreachable
+	return
+}
+
+_recv_unix :: proc(skt: Unix_Socket, buf: []byte) -> (bytes_read: int, err: Unix_Recv_Error) {
 	err = .Network_Unreachable
 	return
 }
@@ -81,6 +103,11 @@ _recv_udp :: proc(skt: UDP_Socket, buf: []byte) -> (bytes_read: int, remote_endp
 }
 
 _send_tcp :: proc(skt: TCP_Socket, buf: []byte) -> (bytes_written: int, err: TCP_Send_Error) {
+	err = .Network_Unreachable
+	return
+}
+
+_send_unix :: proc(skt: Unix_Socket, buf: []byte) -> (bytes_written: int, err: Unix_Send_Error) {
 	err = .Network_Unreachable
 	return
 }

--- a/core/net/socket_posix.odin
+++ b/core/net/socket_posix.odin
@@ -57,6 +57,7 @@ _create_socket :: proc(family: Address_Family, protocol: Socket_Protocol) -> (so
 	switch family {
 	case .IP4:  c_family = .INET
 	case .IP6:  c_family = .INET6
+	case .UNIX: c_family = .UNIX
 	case:
 		unreachable()
 	}
@@ -64,6 +65,7 @@ _create_socket :: proc(family: Address_Family, protocol: Socket_Protocol) -> (so
 	switch protocol {
 	case .TCP:  c_type = .STREAM; c_protocol = .TCP
 	case .UDP:  c_type = .DGRAM;  c_protocol = .UDP
+	case .UNIX: c_type = .STREAM; c_protocol = .UNSPEC
 	case:
 		unreachable()
 	}
@@ -75,8 +77,9 @@ _create_socket :: proc(family: Address_Family, protocol: Socket_Protocol) -> (so
 	}
 
 	switch protocol {
-	case .TCP:  return TCP_Socket(sock), nil
-	case .UDP:  return UDP_Socket(sock), nil
+	case .TCP:  return TCP_Socket(sock),  nil
+	case .UDP:  return UDP_Socket(sock),  nil
+	case .UNIX: return Unix_Socket(sock), nil
 	case:
 		unreachable()
 	}
@@ -107,6 +110,29 @@ _dial_tcp_from_endpoint :: proc(endpoint: Endpoint, options := DEFAULT_TCP_OPTIO
 }
 
 @(private)
+_dial_unix :: proc(path: string, loc := #caller_location) -> (socket: Unix_Socket, err: Network_Error) {
+	assert(len(path) < posix.UNIX_PATH_MAX, "net.dial_unix_from_path(): path too long", loc = loc)
+
+	sock := _create_socket(.UNIX, .UNIX) or_return
+	socket = sock.(Unix_Socket)
+
+	sockaddr := posix.sockaddr_un {
+		sun_family = .UNIX,
+	}
+	n := copy(sockaddr.sun_path[:], path)
+	sockaddr.sun_path[n] = 0
+
+	res := posix.connect(posix.FD(socket), cast(^posix.sockaddr)&sockaddr, size_of(sockaddr))
+	if res != nil {
+		err = _dial_error()
+		return
+	}
+
+	return
+}
+
+
+@(private)
 _bind :: proc(skt: Any_Socket, ep: Endpoint) -> (err: Bind_Error) {
 	sockaddr := _endpoint_to_sockaddr(ep)
 	s := any_socket_to_socket(skt)
@@ -117,8 +143,10 @@ _bind :: proc(skt: Any_Socket, ep: Endpoint) -> (err: Bind_Error) {
 	return
 }
 
+DEFAULT_LISTEN_BACKLOG :: posix.SOMAXCONN
+
 @(private)
-_listen_tcp :: proc(interface_endpoint: Endpoint, backlog := 1000) -> (skt: TCP_Socket, err: Network_Error) {
+_listen_tcp :: proc(interface_endpoint: Endpoint, backlog := DEFAULT_LISTEN_BACKLOG) -> (skt: TCP_Socket, err: Network_Error) {
 	assert(backlog > 0 && i32(backlog) < max(i32))
 
 	family := family_from_endpoint(interface_endpoint)
@@ -136,6 +164,27 @@ _listen_tcp :: proc(interface_endpoint: Endpoint, backlog := 1000) -> (skt: TCP_
 
 	if posix.listen(posix.FD(skt), i32(backlog)) != .OK {
 		err = _listen_error()
+	}
+
+	return
+}
+
+@(private)
+_listen_unix :: proc(path: string, backlog := DEFAULT_LISTEN_BACKLOG, loc := #caller_location) -> (socket: Unix_Socket, err: Network_Error) {
+	assert(len(path) < posix.UNIX_PATH_MAX, "net.listen_unix(): path too long", loc = loc)
+
+	sock := _create_socket(.UNIX, .UNIX) or_return
+	socket = sock.(Unix_Socket)
+
+	sockaddr := posix.sockaddr_un {
+		sun_family = .UNIX,
+	}
+	n := copy(sockaddr.sun_path[:], path)
+	sockaddr.sun_path[n] = 0
+
+	if res := posix.bind(posix.FD(socket), (^posix.sockaddr)(&sockaddr), size_of(sockaddr)); res != .OK {
+		err = _listen_error()
+		return
 	}
 
 	return
@@ -183,6 +232,15 @@ _accept_tcp :: proc(sock: TCP_Socket, options := DEFAULT_TCP_OPTIONS) -> (client
 }
 
 @(private)
+_accept_unix :: proc(listening_socket: Unix_Socket) -> (client: Unix_Socket, err: Accept_Error) {
+	client_sock := posix.accept(posix.FD(listening_socket), nil, nil)
+	if client_sock == -1 {
+		return {}, _accept_error()
+	}
+	return Unix_Socket(client_sock), nil
+}
+
+@(private)
 _close :: proc(skt: Any_Socket) {
 	s := any_socket_to_socket(skt)
 	posix.close(posix.FD(s))
@@ -223,6 +281,18 @@ _recv_udp :: proc(skt: UDP_Socket, buf: []byte) -> (bytes_read: int, remote_endp
 }
 
 @(private)
+_recv_unix :: proc(socket: Unix_Socket, buf: []byte) -> (bytes_read: int, err: Unix_Recv_Error) {
+	if len(buf) <= 0 {
+		return 0, nil
+	}
+	num_read := posix.recv(posix.FD(socket), raw_data(buf), len(buf), {})
+	if num_read < 0 {
+		return 0, _unix_recv_error()
+	}
+	return int(num_read), nil
+}
+
+@(private)
 _send_tcp :: proc(skt: TCP_Socket, buf: []byte) -> (bytes_written: int, err: TCP_Send_Error) {
 	for bytes_written < len(buf) {
 		limit := min(int(max(i32)), len(buf) - bytes_written)
@@ -236,6 +306,21 @@ _send_tcp :: proc(skt: TCP_Socket, buf: []byte) -> (bytes_written: int, err: TCP
 		bytes_written += int(res)
 	}
 	return
+}
+
+@(private)
+_send_unix :: proc(socket: Unix_Socket, buf: []byte) -> (bytes_written: int, err: Unix_Send_Error) {
+	total_written := 0
+	for total_written < len(buf) {
+		limit := min(int(max(i32)), len(buf) - total_written)
+		remaining := buf[total_written:][:limit]
+		res := posix.send(posix.FD(socket), raw_data(remaining), len(remaining), {.NOSIGNAL})
+		if res < 0 {
+			return total_written, _unix_send_error()
+		}
+		total_written += int(res)
+	}
+	return total_written, nil
 }
 
 @(private)

--- a/core/net/socket_windows.odin
+++ b/core/net/socket_windows.odin
@@ -61,6 +61,7 @@ _create_socket :: proc(family: Address_Family, protocol: Socket_Protocol) -> (so
 	switch family {
 	case .IP4:  c_family = win.AF_INET
 	case .IP6:  c_family = win.AF_INET6
+	case .UNIX: c_family = win.AF_UNIX
 	case:
 		unreachable()
 	}
@@ -68,6 +69,7 @@ _create_socket :: proc(family: Address_Family, protocol: Socket_Protocol) -> (so
 	switch protocol {
 	case .TCP:  c_type = win.SOCK_STREAM; c_protocol = win.IPPROTO_TCP
 	case .UDP:  c_type = win.SOCK_DGRAM;  c_protocol = win.IPPROTO_UDP
+	case .UNIX: c_type = win.SOCK_STREAM; assert(family == .UNIX)
 	case:
 		unreachable()
 	}
@@ -79,8 +81,9 @@ _create_socket :: proc(family: Address_Family, protocol: Socket_Protocol) -> (so
 	}
 
 	switch protocol {
-	case .TCP:  return TCP_Socket(sock), nil
-	case .UDP:  return UDP_Socket(sock), nil
+	case .TCP:  return TCP_Socket(sock),  nil
+	case .UDP:  return UDP_Socket(sock),  nil
+	case .UNIX: return Unix_Socket(sock), nil
 	case:
 		unreachable()
 	}
@@ -117,6 +120,27 @@ _dial_tcp_from_endpoint :: proc(endpoint: Endpoint, options := DEFAULT_TCP_OPTIO
 	return
 }
 
+_dial_unix :: proc(path: string, loc := #caller_location) -> (socket: Unix_Socket, err: Network_Error) {
+	assert(len(path) < win.UNIX_PATH_MAX, "net.dial_unix_from_path(): path too long", loc = loc)
+
+	sock := _create_socket(.UNIX, .UNIX) or_return
+	socket = sock.(Unix_Socket)
+
+	sockaddr := win.sockaddr_un {
+		sun_family = u16(win.AF_UNIX),
+	}
+	n := copy(sockaddr.sun_path[:], path)
+	sockaddr.sun_path[n] = 0
+
+	res := win.connect(win.SOCKET(socket), cast(^win.SOCKADDR_STORAGE_LH) &sockaddr, size_of(sockaddr))
+	if res < 0 {
+		err = _dial_error()
+		return
+	}
+
+	return
+}
+
 @(private)
 _bind :: proc(socket: Any_Socket, ep: Endpoint) -> (err: Bind_Error) {
 	sockaddr := _endpoint_to_sockaddr(ep)
@@ -128,8 +152,10 @@ _bind :: proc(socket: Any_Socket, ep: Endpoint) -> (err: Bind_Error) {
 	return
 }
 
+DEFAULT_LISTEN_BACKLOG :: 1000
+
 @(private)
-_listen_tcp :: proc(interface_endpoint: Endpoint, backlog := 1000) -> (socket: TCP_Socket, err: Network_Error) {
+_listen_tcp :: proc(interface_endpoint: Endpoint, backlog := DEFAULT_LISTEN_BACKLOG) -> (socket: TCP_Socket, err: Network_Error) {
 	family := family_from_endpoint(interface_endpoint)
 	sock := create_socket(family, .TCP) or_return
 	socket = sock.(TCP_Socket)
@@ -144,6 +170,34 @@ _listen_tcp :: proc(interface_endpoint: Endpoint, backlog := 1000) -> (socket: T
 	if res := win.listen(win.SOCKET(socket), i32(backlog)); res == win.SOCKET_ERROR {
 		err = _listen_error()
 	}
+	return
+}
+
+@(private)
+_listen_unix :: proc(path: string, backlog := DEFAULT_LISTEN_BACKLOG, loc := #caller_location) -> (socket: Unix_Socket, err: Network_Error) {
+	assert(len(path) < win.UNIX_PATH_MAX, "net.listen_unix(): path too long", loc = loc)
+
+	sock := _create_socket(.UNIX, .UNIX) or_return
+	socket = sock.(Unix_Socket)
+
+	sockaddr := win.sockaddr_un {
+		sun_family = u16(win.AF_UNIX),
+	}
+	n := copy(sockaddr.sun_path[:], path)
+	sockaddr.sun_path[n] = 0
+
+	res := win.bind(win.SOCKET(socket), cast(^win.SOCKADDR_STORAGE_LH) &sockaddr, size_of(sockaddr))
+	if res < 0 {
+		err = _bind_error()
+		return
+	}
+
+	res = win.listen(win.SOCKET(socket), c.int(backlog))
+	if res < 0 {
+		err = _listen_error()
+		return
+	}
+
 	return
 }
 
@@ -202,6 +256,16 @@ _accept_tcp :: proc(sock: TCP_Socket, options := DEFAULT_TCP_OPTIONS) -> (client
 }
 
 @(private)
+_accept_unix :: proc(socket: Unix_Socket) -> (client: Unix_Socket, err: Accept_Error) {
+	socket := win.accept(win.SOCKET(socket), nil, nil)
+	if socket < 0 {
+		err = _accept_error()
+		return
+	}
+	return Unix_Socket(socket), nil
+}
+
+@(private)
 _close :: proc(socket: Any_Socket) {
 	if s := any_socket_to_socket(socket); s != {} {
 		win.closesocket(win.SOCKET(s))
@@ -241,6 +305,19 @@ _recv_udp :: proc(socket: UDP_Socket, buf: []byte) -> (bytes_read: int, remote_e
 }
 
 @(private)
+_recv_unix :: proc(socket: Unix_Socket, buf: []byte) -> (bytes_read: int, err: Unix_Recv_Error) {
+	if len(buf) <= 0 {
+		return
+	}
+	res := win.recv(win.SOCKET(socket), raw_data(buf), c.int(len(buf)), 0)
+	if res < 0 {
+		err = _unix_recv_error()
+		return
+	}
+	return int(res), nil
+}
+
+@(private)
 _send_tcp :: proc(socket: TCP_Socket, buf: []byte) -> (bytes_written: int, err: TCP_Send_Error) {
 	for bytes_written < len(buf) {
 		limit := min(int(max(i32)), len(buf) - bytes_written)
@@ -267,6 +344,21 @@ _send_udp :: proc(socket: UDP_Socket, buf: []byte, to: Endpoint) -> (bytes_writt
 			return
 		}
 
+		bytes_written += int(res)
+	}
+	return
+}
+
+@(private)
+_send_unix :: proc(socket: Unix_Socket, buf: []byte) -> (bytes_written: int, err: Unix_Send_Error) {
+	for bytes_written < len(buf) {
+		limit := min(int(max(i32)), len(buf) - bytes_written)
+		remaining := buf[bytes_written:]
+		res := win.send(win.SOCKET(socket), raw_data(remaining), c.int(limit), 0)
+		if res < 0 {
+			err = _unix_send_error()
+			return
+		}
 		bytes_written += int(res)
 	}
 	return

--- a/core/sys/freebsd/syscalls.odin
+++ b/core/sys/freebsd/syscalls.odin
@@ -165,7 +165,7 @@ recv :: proc "contextless" (s: Fd, buf: []u8, flags: Recv_Flags) -> (int, Errno)
 // The accept() system call appeared in 4.2BSD.
 accept_T :: proc "contextless" (s: Fd, sockaddr: ^$T) -> (Fd, Errno)
 where
-	intrinsics.type_is_subtype_of(T, Socket_Address_Header)
+	intrinsics.type_is_subtype_of(T, Socket_Address_Header) || T == Socket_Address_Unix
 {
 	// sockaddr must contain a valid pointer, or this will segfault because
 	// we're telling the syscall that there's memory available to write to.
@@ -408,7 +408,7 @@ socket :: proc "contextless" (domain: Protocol_Family, type: Socket_Type, protoc
 // The connect() system call appeared in 4.2BSD.
 connect :: proc "contextless" (fd: Fd, sockaddr: ^$T, addrlen: socklen_t) -> Errno
 where
-	intrinsics.type_is_subtype_of(T, Socket_Address_Header)
+	intrinsics.type_is_subtype_of(T, Socket_Address_Header) || T == Socket_Address_Unix
 {
 	result, _ := intrinsics.syscall_bsd(SYS_connect,
 		cast(uintptr)fd,
@@ -424,7 +424,7 @@ where
 // The bind() system call appeared in 4.2BSD.
 bind :: proc "contextless" (s: Fd, sockaddr: ^$T, addrlen: socklen_t) -> Errno
 where
-	intrinsics.type_is_subtype_of(T, Socket_Address_Header)
+	intrinsics.type_is_subtype_of(T, Socket_Address_Header) || T == Socket_Address_Unix
 {
 	result, _ := intrinsics.syscall_bsd(SYS_bind,
 		cast(uintptr)s,

--- a/core/sys/freebsd/types.odin
+++ b/core/sys/freebsd/types.odin
@@ -330,10 +330,21 @@ Socket_Address_Basic :: struct #packed {
 	data: [14]c.char,
 }
 
-UNIX_PATH_MAX :: 104
+SUNPATHLEN :: 104
 Socket_Address_Unix :: struct #packed {
-	using _: Socket_Address_Basic,
-	path: [UNIX_PATH_MAX]byte,
+	len: c.uchar,           /* address length */
+	family: Address_Family, /* address family */
+	path: [SUNPATHLEN]byte,
+}
+
+SOCK_MAXADDRLEN :: 255
+_SS_MAXSIZE     :: 128
+Socket_Address_Storage :: struct {
+	ss_len: u8,
+	ss_family: sa_family_t,
+	__ss_pad1: [_SS_PAD1SIZE]byte,
+	__ss_align: i64,
+	__ss_pad2: [_SS_PAD2SIZE]byte,
 }
 
 /*

--- a/core/sys/freebsd/types.odin
+++ b/core/sys/freebsd/types.odin
@@ -330,6 +330,12 @@ Socket_Address_Basic :: struct #packed {
 	data: [14]c.char,
 }
 
+UNIX_PATH_MAX :: 104
+Socket_Address_Unix :: struct #packed {
+	using _: Socket_Address_Basic,
+	path: [UNIX_PATH_MAX]byte,
+}
+
 /*
  * howto arguments for shutdown(2), specified by Posix.1g.
  */

--- a/core/sys/freebsd/types.odin
+++ b/core/sys/freebsd/types.odin
@@ -331,6 +331,9 @@ Socket_Address_Basic :: struct #packed {
 }
 
 SUNPATHLEN :: 104
+
+// NOTE(tetra, 2026-06-08): We can't really use the header here since
+// the data field in the header takes up some of `path` in this.
 Socket_Address_Unix :: struct #packed {
 	len: c.uchar,           /* address length */
 	family: Address_Family, /* address family */
@@ -338,14 +341,6 @@ Socket_Address_Unix :: struct #packed {
 }
 
 SOCK_MAXADDRLEN :: 255
-_SS_MAXSIZE     :: 128
-Socket_Address_Storage :: struct {
-	ss_len: u8,
-	ss_family: sa_family_t,
-	__ss_pad1: [_SS_PAD1SIZE]byte,
-	__ss_align: i64,
-	__ss_pad2: [_SS_PAD2SIZE]byte,
-}
 
 /*
  * howto arguments for shutdown(2), specified by Posix.1g.

--- a/core/sys/linux/types.odin
+++ b/core/sys/linux/types.odin
@@ -805,12 +805,14 @@ Sock_Addr_In6 :: struct #packed {
 	sin6_scope_id: u32,
 }
 
+UNIX_PATH_MAX :: 108
+
 /*
 	Struct representing Unix Domain Socket address
 */
 Sock_Addr_Un :: struct #packed {
 	sun_family: Address_Family,
-	sun_path:   [108]u8,
+	sun_path:   [UNIX_PATH_MAX]u8,
 }
 
 /*

--- a/core/sys/posix/netinet_in.odin
+++ b/core/sys/posix/netinet_in.odin
@@ -23,12 +23,13 @@ INET_ADDRSTRLEN  :: 16
 INET6_ADDRSTRLEN :: 46
 
 Protocol :: enum c.int {
-	IP   = IPPROTO_IP,
-	ICMP = IPPROTO_ICMP,
-	IPV6 = IPPROTO_IPV6,
-	RAW  = IPPROTO_RAW,
-	TCP  = IPPROTO_TCP,
-	UDP  = IPPROTO_UDP,
+	UNSPEC = 0,
+	IP     = IPPROTO_IP,
+	ICMP   = IPPROTO_ICMP,
+	IPV6   = IPPROTO_IPV6,
+	RAW    = IPPROTO_RAW,
+	TCP    = IPPROTO_TCP,
+	UDP    = IPPROTO_UDP,
 }
 
 when ODIN_OS == .Darwin || ODIN_OS == .FreeBSD || ODIN_OS == .NetBSD || ODIN_OS == .OpenBSD || ODIN_OS == .Linux {

--- a/core/sys/posix/sys_un.odin
+++ b/core/sys/posix/sys_un.odin
@@ -21,3 +21,5 @@ when ODIN_OS == .Darwin || ODIN_OS == .FreeBSD || ODIN_OS == .NetBSD || ODIN_OS 
 	}
 
 }
+
+UNIX_PATH_MAX :: 108

--- a/core/sys/windows/types.odin
+++ b/core/sys/windows/types.odin
@@ -5075,6 +5075,7 @@ WSAEPROVIDERFAILEDINIT :: 10106 // Service provider failed to initialize
 
 // Address families
 AF_UNSPEC : c_int : 0  // Unspecified
+AF_UNIX   : c_int : 1  // Unix Domain Sockets; supported on Windows 10 Build 17026 and greater.
 AF_INET   : c_int : 2  // IPv4
 AF_INET6  : c_int : 23 // IPv6
 AF_IRDA   : c_int : 26 // Infrared
@@ -5194,6 +5195,12 @@ sockaddr_in6 :: struct {
 	sin6_flowinfo: c_ulong,
 	sin6_addr:     in6_addr,
 	sin6_scope_id: c_ulong,
+}
+
+UNIX_PATH_MAX :: 108
+sockaddr_un :: struct {
+	sun_family: u16,
+	sun_path: [UNIX_PATH_MAX]byte,
 }
 
 in_addr :: struct {

--- a/tests/core/net/test_core_net.odin
+++ b/tests/core/net/test_core_net.odin
@@ -621,7 +621,7 @@ machine to machine communication (such as defined by the network protocol.)
 		tmp: [64]byte
 		left := MSG
 		for len(left) > 0 {
-			sync.park(worker_data.mu)
+			sync.unpark(worker_data.mu)
 
 			word := next_word(&left)
 			testing.expect_value(worker_data.t, send_full(client, word), nil)
@@ -648,7 +648,7 @@ machine to machine communication (such as defined by the network protocol.)
 	tmp: [64]byte
 	left := MSG
 	for len(left) > 0 {
-		sync.unpark(&mu)
+		sync.park(&mu)
 		word := next_word(&left)
 
 		num_recv, recv_err := net.recv_unix(client, tmp[:])

--- a/tests/core/net/test_core_net.odin
+++ b/tests/core/net/test_core_net.odin
@@ -21,6 +21,7 @@ import "core:time"
 import "core:thread"
 import "core:fmt"
 import "core:log"
+import "core:os"
 
 @test
 address_parsing_test :: proc(t: ^testing.T) {
@@ -565,6 +566,119 @@ test_udp_echo :: proc(t: ^testing.T) {
 	}
 
 	testing.expect_value(t, msg, transmute(string)buf[:bytes_read])
+}
+
+@test
+test_unix_echo :: proc(t: ^testing.T) {
+	MSG :: `
+A socket is defined to be the unique identification to or from which
+information is transmitted in the network. The socket is specified as a 32
+bit number with even sockets identifying receiving sockets and odd sockets
+identifying sending sockets. A socket is also identified by the host in
+which the sending or receiving processer is located.
+
+Previous network papers postulated that a process running under control of
+the host's operating system would have access to a number of ports. A port
+might be a physical input or output device, or a logical I/O device
+supported by system calls to the host's operating system.  The latter
+category includes a) I/O directed to a physical device which is being
+spooled by the operating system, b) a physical device whose basic
+characteristics have not been altered but whose access has been limited and
+possibly transformed by a mapping algorithm (e.g. device address mapping or
+cylinder relocation as in virtual mini disks), c) access to a file system
+through a directory and access method maintained by the operating system,
+d) a procedure for process to process communications, e) a procedure for
+machine to machine communication (such as defined by the network protocol.)
+`
+	SOCKET_PATH :: "test_unix_socket.sock"
+
+	os.remove(SOCKET_PATH) // NOTE(tetra): remove old socket in case of previous crash
+	defer os.remove(SOCKET_PATH)
+
+	mu: sync.Sema
+
+	Worker_Data :: struct {
+		t:  ^testing.T,
+		mu: ^sync.Sema,
+	}
+	worker_data: Worker_Data
+	worker_data.mu = &mu
+	worker_data.t  = t
+
+	worker := thread.create_and_start_with_data(&worker_data, proc(data: rawptr) {
+		worker_data := cast(^Worker_Data)data
+
+		time.sleep(1 * time.Second)
+		client, dial_err := net.dial_unix(SOCKET_PATH)
+		if !testing.expect_value(worker_data.t, dial_err, nil) {
+			return
+		}
+		defer net.close(client)
+
+		tmp: [64]byte
+		left := MSG
+		for len(left) > 0 {
+			word := next_word(&left)
+			sync.wait(worker_data.mu)
+			testing.expect_value(worker_data.t, send_full(client, word), nil)
+
+			num_recv, recv_err := net.recv_unix(client, tmp[:])
+			testing.expect_value(worker_data.t, recv_err, nil)
+			testing.expect_value(worker_data.t, num_recv, len(word))
+			got := string(tmp[:num_recv])
+			testing.expect_value(worker_data.t, got, word)
+		}
+	})
+	defer thread.destroy(worker)
+
+	server, listen_err := net.listen_unix(SOCKET_PATH)
+	if !testing.expect_value(t, listen_err, nil) {
+		return
+	}
+	defer net.close(server)
+
+	client, accept_err := net.accept_unix(server)
+	testing.expect_value(t, accept_err, nil)
+
+	tmp: [64]byte
+	left := MSG
+	for len(left) > 0 {
+		word := next_word(&left)
+
+		sync.post(&mu)
+		num_recv, recv_err := net.recv_unix(client, tmp[:])
+		if num_recv == 0 { break }
+		testing.expect_value(t, recv_err, nil)
+
+		got := string(tmp[:num_recv])
+		testing.expect_value(t, got, word)
+		testing.expect_value(t, send_full(client, got), nil)
+	}
+	testing.expect_value(t, left, "")
+
+
+	send_full :: proc(s: net.Unix_Socket, str: string) -> net.Network_Error {
+		// NOTE: send_*() already loops
+		n := net.send_unix(s, transmute([]byte)str) or_return
+		assert(n == len(str))
+		return nil
+	}
+
+	next_word :: proc(left: ^string) -> string {
+		l := left^
+		index := 0
+		loop: for r in l {
+			switch r {
+			case ' ', '\t', '\n': break loop
+			}
+			index += 1
+		}
+		index = max(index, 1)
+		index = min(index, 64)
+		part := l[:index]
+		left^ = l[index:]
+		return part
+	}
 }
 
 @test

--- a/tests/core/net/test_core_net.odin
+++ b/tests/core/net/test_core_net.odin
@@ -595,11 +595,14 @@ machine to machine communication (such as defined by the network protocol.)
 	os.remove(SOCKET_PATH) // NOTE(tetra): remove old socket in case of previous crash
 	defer os.remove(SOCKET_PATH)
 
-	mu: sync.Sema
+	// NOTE(tetra, 2026-06-08): We want the threads to effectively to exchange a word,
+	// verify it's correct, then proceed together.
+	// The main thread uses this to block the worker until the round trip has been completed.
+	mu: sync.Parker
 
 	Worker_Data :: struct {
 		t:  ^testing.T,
-		mu: ^sync.Sema,
+		mu: ^sync.Parker,
 	}
 	worker_data: Worker_Data
 	worker_data.mu = &mu
@@ -618,8 +621,9 @@ machine to machine communication (such as defined by the network protocol.)
 		tmp: [64]byte
 		left := MSG
 		for len(left) > 0 {
+			sync.park(worker_data.mu)
+
 			word := next_word(&left)
-			sync.wait(worker_data.mu)
 			testing.expect_value(worker_data.t, send_full(client, word), nil)
 
 			num_recv, recv_err := net.recv_unix(client, tmp[:])
@@ -627,6 +631,7 @@ machine to machine communication (such as defined by the network protocol.)
 			testing.expect_value(worker_data.t, num_recv, len(word))
 			got := string(tmp[:num_recv])
 			testing.expect_value(worker_data.t, got, word)
+
 		}
 	})
 	defer thread.destroy(worker)
@@ -643,9 +648,9 @@ machine to machine communication (such as defined by the network protocol.)
 	tmp: [64]byte
 	left := MSG
 	for len(left) > 0 {
+		sync.unpark(&mu)
 		word := next_word(&left)
 
-		sync.post(&mu)
 		num_recv, recv_err := net.recv_unix(client, tmp[:])
 		if num_recv == 0 { break }
 		testing.expect_value(t, recv_err, nil)


### PR DESCRIPTION
Adds `dial_unix()`, `listen_unix()`, `accept_unix()`, `recv_unix()`, `send_unix()`, and a test.

Also, since I was touching the relevant code and noticed this while doing so, this also alters the default listen() backlog for each operating system from a magic 1000, to a more suitable number, according to the maximum number that must be supported by the implementation. e.g. on POSIX, this is `posix.SOMAXCONN`.

NOTE: As of writing this, I have not tested the FreeBSD/NetBSD implementations myself, though the CI can help with that.

NOTE: Unix sockets behave a lot like TCP sockets from what I gather, and as such I have transferred all the errors from that across to Unix socket operations. I have not personally tested all of those are correct, or that there aren't missing ones.

NOTE: The backlog values currently don't really have much validation to check if the selected number is valid.
The Windows impl merely checks it's < max(i32), and the others don't really check at all.
This may be fine however, since if it's not valid the syscall will probably either return an error(?) or simply pick a more suitable number. It is, after all, merely a hint on at least some of the supported systems.