### PR TITLE
vendor/vulkan: improve Vulkan ergonomics slightly

### DIFF
--- a/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
+++ b/vendor/vulkan/_gen/create_vulkan_odin_wrapper.py
@@ -943,7 +943,7 @@ API_VERSION_VARIANT :: proc "contextless" (version: u32) -> u32 {
 // Base types
 Flags         :: distinct u32
 Flags64       :: distinct u64
-DeviceSize    :: distinct u64
+DeviceSize    :: u64
 DeviceAddress :: distinct u64
 SampleMask    :: distinct u32
 

--- a/vendor/vulkan/core.odin
+++ b/vendor/vulkan/core.odin
@@ -42,7 +42,7 @@ API_VERSION_VARIANT :: proc "contextless" (version: u32) -> u32 {
 // Base types
 Flags         :: distinct u32
 Flags64       :: distinct u64
-DeviceSize    :: distinct u64
+DeviceSize    :: u64
 DeviceAddress :: distinct u64
 SampleMask    :: distinct u32
 


### PR DESCRIPTION
This change removes `distinct` from `vk.DeviceSize`.

`vk.WHOLE_SIZE` constant is `u64`. You have to cast it, and of course you need to cast arbitrary offsets and sizes:
```c
vk.CmdFillBuffer(cmdbuf, buf, 0, vk.DeviceSize(vk.WHOLE_SIZE), 0x0)
vk.CmdFillBuffer(cmdbuf, buf, vk.DeviceSize(offset), vk.DeviceSize(size), 0x0)
write_ubo(&{buf, 0, vk.DeviceSize(vk.WHOLE_SIZE)})
```

Some functions take `[^]DeviceSize`, so you may need to make an array for this distinct type.

With Odin's strict type system you cannot confuse `u64` with `int` or `u32`. So, one can store API-agnostic `u64` for buffer sizes and offsets in the engine, and have slightly less Vulkan-specific code.