### PR TITLE
Add control sequences for Alternate Screen Buffer

### DIFF
--- a/core/terminal/ansi/ansi.odin
+++ b/core/terminal/ansi/ansi.odin
@@ -32,12 +32,14 @@ DSR     :: "6n" // Device Status Report
 
 // CSI: private sequences
 
-SCP          :: "s"    // Save Current Cursor Position
-RCP          :: "u"    // Restore Saved Cursor Position
-DECAWM_ON    :: "?7h"  // Auto Wrap Mode (Enabled)
-DECAWM_OFF   :: "?7l"  // Auto Wrap Mode (Disabled)
-DECTCEM_SHOW :: "?25h" // Text Cursor Enable Mode (Visible)
-DECTCEM_HIDE :: "?25l" // Text Cursor Enable Mode (Invisible)
+SCP          :: "s"      // Save Current Cursor Position
+RCP          :: "u"      // Restore Saved Cursor Position
+DECAWM_ON    :: "?7h"    // Auto Wrap Mode (Enabled)
+DECAWM_OFF   :: "?7l"    // Auto Wrap Mode (Disabled)
+DECTCEM_SHOW :: "?25h"   // Text Cursor Enable Mode (Visible)
+DECTCEM_HIDE :: "?25l"   // Text Cursor Enable Mode (Invisible)
+DECASB_ENTER :: "?1049h" // Alternate Screen Buffer (Enter)
+DECASB_EXIT  :: "?1049l" // Alternate Screen Buffer (Exit)
 
 // SGR sequences
 


### PR DESCRIPTION
Adds constants DECASB_ENTER and DECASB_EXIT to ansi.odin. ASB stands for Alternate Screen Buffer. DECASB_ENTER ( ?1049h ) saves the cursor position, clears the alternate buffer, and switches the view to said buffer. DECASB_EXIT ( ?1049l ) restores the main buffer's contents and the cursor position. Commonly used by editors, games, and TUIs in general to avoid polluting the main buffer.