### PR TITLE
core/nbio: fix use-after-free of op.l in cross-thread exec

### DIFF
--- a/core/nbio/nbio.odin
+++ b/core/nbio/nbio.odin
@@ -406,13 +406,18 @@ exec :: proc(op: ^Operation, trigger_wake_up := true) {
 	if op.l == &_tls_event_loop {
 		_exec(op)
 	} else {
-		for !mpsc_enqueue(&op.l.queue, op) {
+		// Capture the loop pointer before the enqueue publishes `op`: the
+		// target loop can complete the operation and return it to the
+		// operation pool before `op.l` is re-read below, and `l` is in a
+		// raw union with the pool's free-list link.
+		l := op.l
+		for !mpsc_enqueue(&l.queue, op) {
 			warn("operation queue on event loop filled up")
-			wake_up(op.l)
+			wake_up(l)
 			_yield()
 		}
 		if trigger_wake_up {
-			wake_up(op.l)
+			wake_up(l)
 		}
 	}
 }


### PR DESCRIPTION
`exec` re-reads `op.l` after `mpsc_enqueue` has already published the op to the target loop:

```odin
for !mpsc_enqueue(&op.l.queue, op) { ... }
if trigger_wake_up {
	wake_up(op.l)   // op may already be completed and recycled here
}
```

Once the op is in the queue, a busy target loop can dequeue it, complete it, and return it to the operation pool before the submitting thread gets to `wake_up(op.l)`. Since `l` sits in a raw union with the pool's intrusive free-list link (`_pool_link`), that re-read can come back as free-list bytes reinterpreted as an `^Event_Loop` — I was seeing sporadic crashes in `_wake_up` (garbage loop pointer, `refs == 0`, bogus `err`) with a couple of worker threads submitting ops to one busy I/O thread. The faster the target loop drains, the easier it triggers.

Fix: capture `l := op.l` before the enqueue and use it for the retry loop and the wake-up.