### PR TITLE
core/container/pool: fix ABA race in the free list

### DIFF
--- a/core/container/pool/pool.odin
+++ b/core/container/pool/pool.odin
@@ -29,6 +29,13 @@ Pool :: struct($T: typeid) {
 	num_outstanding: int,
 	num_ready:       int,
 	link_off:        uintptr,
+	// Guards free_list.  An untagged Treiber stack is vulnerable to ABA:
+	// between get's head load and its CAS, another thread can pop the head,
+	// reuse it, and push it back — the CAS then succeeds and installs a
+	// stale next pointer, handing an in-flight element to two owners.
+	// A tagged head would keep this lock-free but requires a double-width
+	// CAS, which is not portably available.
+	mu:              sync.Mutex,
 	free_list:       ^T,
 }
 
@@ -61,20 +68,20 @@ destroy :: proc(p: ^Pool($T)) {
 get :: proc(p: ^Pool($T)) -> (elem: ^T, err: runtime.Allocator_Error) #optional_allocator_error {
 	defer sync.atomic_add_explicit(&p.num_outstanding, 1, .Relaxed)
 
-	for {
-		elem = sync.atomic_load_explicit(&p.free_list, .Acquire)
-		if elem == nil {
-			// NOTE: pool arena has an internal lock.
-			return new(T, _pool_arena_allocator(&p.arena))
-		}
-
-		if _, ok := sync.atomic_compare_exchange_weak_explicit(&p.free_list, elem, _get_next(p, elem), .Acquire, .Relaxed); ok {
-			_set_next(p, elem, nil)
-			_unpoison_elem(p, elem)
-			sync.atomic_sub_explicit(&p.num_ready, 1, .Relaxed)
-			return
-		}
+	sync.mutex_lock(&p.mu)
+	elem = p.free_list
+	if elem == nil {
+		sync.mutex_unlock(&p.mu)
+		// NOTE: pool arena has an internal lock.
+		return new(T, _pool_arena_allocator(&p.arena))
 	}
+	p.free_list = _get_next(p, elem)
+	sync.mutex_unlock(&p.mu)
+
+	_set_next(p, elem, nil)
+	_unpoison_elem(p, elem)
+	sync.atomic_sub_explicit(&p.num_ready, 1, .Relaxed)
+	return
 }
 
 put :: proc(p: ^Pool($T), elem: ^T) {
@@ -84,13 +91,10 @@ put :: proc(p: ^Pool($T), elem: ^T) {
 	defer sync.atomic_sub_explicit(&p.num_outstanding, 1, .Relaxed)
 	defer sync.atomic_add_explicit(&p.num_ready, 1, .Relaxed)
 
-	for {
-		head := sync.atomic_load_explicit(&p.free_list, .Relaxed)
-		_set_next(p, elem, head)
-		if _, ok := sync.atomic_compare_exchange_weak_explicit(&p.free_list, head, elem, .Release, .Relaxed); ok {
-			return
-		}
-	}
+	sync.mutex_lock(&p.mu)
+	_set_next(p, elem, p.free_list)
+	p.free_list = elem
+	sync.mutex_unlock(&p.mu)
 }
 
 num_outstanding :: proc(p: ^Pool($T)) -> int {


### PR DESCRIPTION
`Pool`'s free list is an untagged Treiber stack, so `get` has the classic ABA problem:

1. thread A loads `head = X` and computes `next = X.link` (== `Y`)
2. thread B pops `X`, pops `Y` (now in use), and later puts `X` back
3. A's CAS sees `free_list == X`, succeeds, and installs `Y` as the new head

`Y` is in-flight at that point, so the pool ends up handing the same element to two owners. TSan also flags the `_get_next`/`_set_next` accesses.

Repro: a few threads doing get/put with an ownership stamp inside the element catch it within seconds —

```odin
e := pool.get(&p)
if intrinsics.atomic_exchange(&e.owner, my_id) != 0 {
	// two threads got the same element
}
```

With 16 threads on 8 cores this trips after ~70M cycles on my machine (`OWNER CORRUPTED while held: elem 0x1004BC0C8 expected owner 12, found 5`).

A tagged head pointer would keep it lock-free but needs a double-width CAS, which isn't portably available, so this serializes free-list access with a mutex instead. The empty-list slow path already takes the arena's internal lock, so this isn't a new cost class — the same torture test does ~5M get/put per second with the mutex and no double-ownership over 30s.