### PR TITLE
Stack canaries

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1952,18 +1952,9 @@ gb_internal void init_build_context(TargetMetrics *cross_target, Subtarget subta
 		}
 	}
 
-	// note: there are some stack protection toolchain issues on arm
-	// platforms that will clash with PIC/PIE:
-	// `unresolvable R_AARCH64_ADR_PREL_PG_HI21 relocation against symbol`
-	if (metrics->os == TargetOs_linux &&
-			metrics->arch != TargetArch_arm32 &&
-			metrics->arch != TargetArch_arm64
-	) {
-		if (bc->stack_protector == StackProtector_Default) {
-			bc->stack_protector = StackProtector_Ssp;
-		}
-	} else if (metrics->os == TargetOs_windows ||
+	if (metrics->os == TargetOs_windows ||
 			metrics->os == TargetOs_darwin ||
+			metrics->os == TargetOs_linux ||
 			metrics->os == TargetOs_freebsd ||
 			metrics->os == TargetOs_openbsd ||
 			metrics->os == TargetOs_netbsd) {

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1909,16 +1909,6 @@ gb_internal void init_build_context(TargetMetrics *cross_target, Subtarget subta
 				}
 				break;
 		}
-	} else if (metrics->os == TargetOs_linux) {
-		if (bc->reloc_mode == RelocMode_Default) {
-			bc->reloc_mode = RelocMode_PIC;
-		}
-		switch (metrics->arch) {
-		case TargetArch_arm64:
-		case TargetArch_amd64:
-			bc->no_plt = LLVM_VERSION_MAJOR >= 19;
-			break;
-		}
 	} else if (metrics->os == TargetOs_openbsd) {
 		// Always use PIC for OpenBSD: it defaults to PIE
 		if (bc->reloc_mode == RelocMode_Default) {
@@ -1947,9 +1937,36 @@ gb_internal void init_build_context(TargetMetrics *cross_target, Subtarget subta
 			bc->metrics.target_triplet = str_lit("i686-linux-android");
 			bc->reloc_mode = RelocMode_PIC;
 			break;
-		
 		default:
 			GB_PANIC("Unknown architecture for -subtarget:android");
+		}
+	} else if (metrics->os == TargetOs_linux) {
+		if (bc->reloc_mode == RelocMode_Default) {
+			bc->reloc_mode = RelocMode_PIC;
+		}
+		switch (metrics->arch) {
+		case TargetArch_arm64:
+		case TargetArch_amd64:
+			bc->no_plt = LLVM_VERSION_MAJOR >= 19;
+			break;
+		}
+	}
+
+	if (metrics->os == TargetOs_windows ||
+			metrics->os == TargetOs_darwin ||
+			metrics->os == TargetOs_linux ||
+			metrics->os == TargetOs_freebsd ||
+			metrics->os == TargetOs_openbsd ||
+			metrics->os == TargetOs_netbsd) {
+		if (bc->stack_protector == StackProtector_Default) {
+			bc->stack_protector = StackProtector_Ssp;
+		}
+	} else {
+		if (bc->stack_protector == StackProtector_Default) {
+			bc->stack_protector = StackProtector_None;
+		} else {
+			gb_printf_err("-stack-protector is not supported on this target\n");
+			gb_exit(1);
 		}
 	}
 

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1952,9 +1952,18 @@ gb_internal void init_build_context(TargetMetrics *cross_target, Subtarget subta
 		}
 	}
 
-	if (metrics->os == TargetOs_windows ||
+	// note: there are some stack protection toolchain issues on non-intel 
+	// platforms that will clash with PIC/PIE:
+	// `unresolvable R_AARCH64_ADR_PREL_PG_HI21 relocation against symbol`
+	if (metrics->os == TargetOs_linux && (
+			metrics->arch == TargetArch_amd64 ||
+			metrics->arch == TargetArch_i386
+	)) {
+		if (bc->stack_protector == StackProtector_Default) {
+			bc->stack_protector = StackProtector_Ssp;
+		}
+	} else if (metrics->os == TargetOs_windows ||
 			metrics->os == TargetOs_darwin ||
-			metrics->os == TargetOs_linux ||
 			metrics->os == TargetOs_freebsd ||
 			metrics->os == TargetOs_openbsd ||
 			metrics->os == TargetOs_netbsd) {

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -278,6 +278,14 @@ enum RelocMode : u8 {
 	RelocMode_DynamicNoPIC,
 };
 
+enum StackProtector : u8 {
+	StackProtector_Default,
+	StackProtector_None,
+	StackProtector_Ssp,
+	StackProtector_SspReq,
+	StackProtector_SspStrong,
+};
+
 enum BuildPath : u8 {
 	BuildPath_Main_Package,     // Input  Path to the package directory (or file) we're building.
 	BuildPath_RC,               // Input  Path for .rc  file, can be set with `-resource:`.
@@ -599,7 +607,9 @@ struct BuildContext {
 
 	bool   print_linker_flags;
 
-	RelocMode reloc_mode;
+	RelocMode      reloc_mode;
+	StackProtector stack_protector;
+
 	bool   disable_red_zone;
 	bool   disable_unwind;
 	bool   no_plt;

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1952,13 +1952,13 @@ gb_internal void init_build_context(TargetMetrics *cross_target, Subtarget subta
 		}
 	}
 
-	// note: there are some stack protection toolchain issues on non-intel 
+	// note: there are some stack protection toolchain issues on arm
 	// platforms that will clash with PIC/PIE:
 	// `unresolvable R_AARCH64_ADR_PREL_PG_HI21 relocation against symbol`
-	if (metrics->os == TargetOs_linux && (
-			metrics->arch == TargetArch_amd64 ||
-			metrics->arch == TargetArch_i386
-	)) {
+	if (metrics->os == TargetOs_linux &&
+			metrics->arch != TargetArch_arm32 &&
+			metrics->arch != TargetArch_arm64
+	) {
 		if (bc->stack_protector == StackProtector_Default) {
 			bc->stack_protector = StackProtector_Ssp;
 		}

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -1959,7 +1959,7 @@ gb_internal void init_build_context(TargetMetrics *cross_target, Subtarget subta
 			metrics->os == TargetOs_openbsd ||
 			metrics->os == TargetOs_netbsd) {
 		if (bc->stack_protector == StackProtector_Default) {
-			bc->stack_protector = StackProtector_Ssp;
+			bc->stack_protector = StackProtector_SspStrong;
 		}
 	} else {
 		if (bc->stack_protector == StackProtector_Default) {

--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -3154,32 +3154,12 @@ gb_internal bool lb_generate_code(lbGenerator *gen) {
 	// NOTE(bill, 2021-05-04): Target machines must be unique to each module because they are not thread safe
 	auto target_machines = array_make<LLVMTargetMachineRef>(permanent_allocator(), 0, gen->modules.count);
 
-	// NOTE(dweiler): Dynamic libraries require position-independent code.
-	LLVMRelocMode reloc_mode = LLVMRelocDefault;
-	if (build_context.build_mode == BuildMode_DynamicLibrary) {
-		reloc_mode = LLVMRelocPIC;
-	}
-
-	switch (build_context.reloc_mode) {
-	case RelocMode_Default:
-		break;
-	case RelocMode_Static:
-		reloc_mode = LLVMRelocStatic;
-		break;
-	case RelocMode_PIC:
-		reloc_mode = LLVMRelocPIC;
-		break;
-	case RelocMode_DynamicNoPIC:
-		reloc_mode = LLVMRelocDynamicNoPic;
-		break;
-	}
-
 	for (auto const &entry : gen->modules) {
 		LLVMTargetMachineRef target_machine = LLVMCreateTargetMachine(
 			target, target_triple, (const char *)llvm_cpu.text,
 			llvm_features,
 			code_gen_level,
-			reloc_mode,
+			get_reloc_mode(),
 			code_mode);
 		lbModule *m = entry.value;
 		m->target_machine = target_machine;

--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -1,5 +1,6 @@
 gb_internal void lb_add_debug_local_variable(lbProcedure *p, LLVMValueRef ptr, Type *type, Token const &token);
 gb_internal LLVMValueRef llvm_const_string_internal(lbModule *m, Type *t, LLVMValueRef data, LLVMValueRef len);
+gb_internal LLVMRelocMode get_reloc_mode();
 
 gb_global Entity *lb_global_type_info_data_entity   = {};
 gb_global lbAddr lb_global_type_info_member_types   = {};
@@ -65,6 +66,12 @@ gb_internal WORKER_TASK_PROC(lb_init_module_worker_proc) {
 			"RtLibUseGOT", 11, 
 			LLVMValueAsMetadata(LLVMConstInt(LLVMInt32TypeInContext(m->ctx), 1, true)));
 	}
+	
+	LLVMAddModuleFlag(m->mod,
+		LLVMModuleFlagBehaviorWarning,
+		"PIC Level", 9, 
+		LLVMValueAsMetadata(LLVMConstInt(LLVMInt32TypeInContext(m->ctx), get_reloc_mode(), true)));
+
 	if (build_context.ODIN_DEBUG) {
 		enum {DEBUG_METADATA_VERSION = 3};
 
@@ -3666,4 +3673,26 @@ gb_internal void lb_set_linkage_from_entity_flags(lbModule *m, LLVMValueRef valu
 	} else if (flags & EntityFlag_CustomLinkage_LinkOnce) {
 		LLVMSetLinkage(value, LLVMLinkOnceAnyLinkage);
 	}
+}
+
+LLVMRelocMode get_reloc_mode() {
+	// NOTE(dweiler): Dynamic libraries require position-independent code.
+	LLVMRelocMode reloc_mode = LLVMRelocDefault;
+	if (build_context.build_mode == BuildMode_DynamicLibrary) {
+		reloc_mode = LLVMRelocPIC;
+	}
+	switch (build_context.reloc_mode) {
+	case RelocMode_Default:
+		break;
+	case RelocMode_Static:
+		reloc_mode = LLVMRelocStatic;
+		break;
+	case RelocMode_PIC:
+		reloc_mode = LLVMRelocPIC;
+		break;
+	case RelocMode_DynamicNoPIC:
+		reloc_mode = LLVMRelocDynamicNoPic;
+		break;
+	}
+	return reloc_mode;
 }

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -161,13 +161,15 @@ gb_internal lbProcedure *lb_create_procedure(lbModule *m, Entity *entity, bool i
 	}
 
 	switch (build_context.stack_protector) {
-		case StackProtector_Default:
 		case StackProtector_Ssp:
 			lb_add_attribute_to_proc(m, p->value, "ssp");
+			break;
 		case StackProtector_SspReq:
 			lb_add_attribute_to_proc(m, p->value, "sspreq");
+			break;
 		case StackProtector_SspStrong:
 			lb_add_attribute_to_proc(m, p->value, "sspstrong");
+			break;
 	}
 
 	if (build_context.disable_unwind) {

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -160,6 +160,16 @@ gb_internal lbProcedure *lb_create_procedure(lbModule *m, Entity *entity, bool i
 		lb_add_attribute_to_proc(m, p->value, "nonlazybind");
 	}
 
+	switch (build_context.stack_protector) {
+		case StackProtector_Default:
+		case StackProtector_Ssp:
+			lb_add_attribute_to_proc(m, p->value, "ssp");
+		case StackProtector_SspReq:
+			lb_add_attribute_to_proc(m, p->value, "sspreq");
+		case StackProtector_SspStrong:
+			lb_add_attribute_to_proc(m, p->value, "sspstrong");
+	}
+
 	if (build_context.disable_unwind) {
 		lb_add_attribute_to_proc(m, p->value, "nounwind");
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -354,6 +354,7 @@ enum BuildFlagKind {
 	BuildFlag_NoThreadLocal,
 
 	BuildFlag_RelocMode,
+	BuildFlag_StackProtector,
 	BuildFlag_DisableRedZone,
 
 	BuildFlag_DisableUnwind,
@@ -587,6 +588,7 @@ gb_internal bool parse_build_flags(Array<String> args) {
 	add_flag(&build_flags, BuildFlag_MinimumOSVersion,        str_lit("minimum-os-version"),        BuildFlagParam_String,  Command__does_build | Command_bundle_android);
 
 	add_flag(&build_flags, BuildFlag_RelocMode,               str_lit("reloc-mode"),                BuildFlagParam_String,  Command__does_build);
+	add_flag(&build_flags, BuildFlag_StackProtector,          str_lit("stack-protector"),           BuildFlagParam_String,  Command__does_build);
 	add_flag(&build_flags, BuildFlag_DisableRedZone,          str_lit("disable-red-zone"),          BuildFlagParam_None,    Command__does_build);
 
 	add_flag(&build_flags, BuildFlag_DisableUnwind,           str_lit("disable-unwind"),          BuildFlagParam_None,    Command__does_build);
@@ -1430,6 +1432,29 @@ gb_internal bool parse_build_flags(Array<String> args) {
 							}
 
 							break;
+						}
+						case BuildFlag_StackProtector: {
+							GB_ASSERT(value.kind == ExactValue_String);
+							String v = value.value_string;
+							if (v == "default") {
+								build_context.stack_protector = StackProtector_Default;
+							} else if (v == "none") {
+								build_context.stack_protector = StackProtector_None;
+							} else if (v == "base") {
+								build_context.stack_protector = StackProtector_Ssp;
+							} else if (v == "all") {
+								build_context.stack_protector = StackProtector_SspReq;
+							} else if (v == "strong") {
+								build_context.stack_protector = StackProtector_SspStrong;
+							} else {
+								gb_printf_err("-stack-protector flag expected one of the following\n");
+								gb_printf_err("\tdefault\n");
+								gb_printf_err("\tnone\n");
+								gb_printf_err("\tbase\n");
+								gb_printf_err("\tall\n");
+								gb_printf_err("\tstrong\n");
+								bad_flags = true;
+							}
 						}
 						case BuildFlag_DisableRedZone:
 							build_context.disable_red_zone = true;
@@ -2984,6 +3009,16 @@ gb_internal int print_show_help(String const arg0, String command, String option
 				print_usage_line(3, "-reloc-mode:static");
 				print_usage_line(3, "-reloc-mode:pic");
 				print_usage_line(3, "-reloc-mode:dynamic-no-pic");
+		}
+
+		if (print_flag("-stack-protector:<string>")) {
+			print_usage_line(2, "Specifies the stack protector.");
+			print_usage_line(2, "Available options:");
+				print_usage_line(3, "-stack-protector:default");
+				print_usage_line(3, "-stack-protector:none");
+				print_usage_line(3, "-stack-protector:base");
+				print_usage_line(3, "-stack-protector:all");
+				print_usage_line(3, "-stack-protector:strong");
 		}
 
 	#if defined(GB_SYSTEM_WINDOWS)


### PR DESCRIPTION
adds support for/enables by default stack canaries on all desktop platforms, barring arm. arm seemingly has some odd behavior where glibc is compiled without `-fPIC`, resulting in some linking errors. i will test this on other platforms to see if this is just github CI but disabled this to be safe - edit: tested on both fresh ubuntu and fedora arm machines, the issue persists. i can make it work in clang though so this is my issue

additionally, i reordered the linux pic/plt logic since as it was (my mistake), it would break the android subtarget