### PR TITLE
Bug/stringprecision

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -1487,7 +1487,10 @@ fmt_string :: proc(fi: ^Info, s: string, verb: rune) {
 	s, verb := s, verb
 	if ol, ok := fi.optional_len.?; ok {
 		s = s[:clamp(ol, 0, len(s))]
-	}
+	} else if fi.prec_set {
+        s = s[:clamp(fi.prec, 0, len(s))]
+    }
+        
 	if !fi.in_bad && fi.record_level > 0 && verb == 'v' {
 		verb = 'q'
 	}

--- a/tests/core/fmt/test_core_fmt.odin
+++ b/tests/core/fmt/test_core_fmt.odin
@@ -8,6 +8,15 @@ import "core:mem"
 import "core:testing"
 
 @(test)
+test_fmt_string::proc(t: ^testing.T) {
+    check(t, "12345", "%s", "12345")
+    check(t, "1234", "%.4s", "12345")
+    check(t, " 1234", "%5.4s", "12345")
+    check(t, "1234 ", "%+5.4s", "12345")
+   
+}
+
+@(test)
 test_fmt_memory :: proc(t: ^testing.T) {
 	check(t, "5b",        "%m",    5)
 	check(t, "5B",        "%M",    5)


### PR DESCRIPTION
This is to fix a difference in fmt between how C handles precision and how Odin handles Precision.

I noticed that when using the following with wprintf(stream, "%5.4s", "12345") I would get the result of "12345" instead of what I expected was " 1234" which is the C result.

I altered fmt.fmt_string and noticed there was already code that did this with structure tags.  The code to do this from the wprintf was not present. I added the code ensuring that the precision is taken into effect only if there was no structure tag.