### PR TITLE
Fix #6818: Remove dependency on mbedx509, mbedcrypto for Darwin.

### DIFF
--- a/vendor/curl/curl.odin
+++ b/vendor/curl/curl.odin
@@ -18,8 +18,6 @@ when ODIN_OS == .Windows {
 	@(export)
 	foreign import lib {
 		"system:curl",
-		"system:mbedx509",
-		"system:mbedcrypto",
 		"system:z",
 		"system:SystemConfiguration.framework",
 	}


### PR DESCRIPTION
Fixes #6818.

Apple system libcurl uses SecureTransport/LibreSSL and has no mbedTLS dependency. The unconditional system:mbedx509 and system:mbedcrypto entries in the Darwin foreign link block caused link failures on macOS when mbedTLS was not separately installed. The reporter verified via dyld_info -dependents /usr/lib/libcurl.4.dylib that Apple system libcurl lists no mbedTLS libraries, and I confirmed independently that the build succeeds with these entries removed.

Via the Homebrew formula API we find that curl 8.19.0 depends on openssl@3, not mbedTLS. The brew install curl mbedtls in CI installs mbedTLS as an independent step. That's why CI has been masking this bug. Suggest also removing mbedtls from the CI brew install line.

If removing mbedtls from the brew install curl mbedtls line in the macOS CI job is all that's needed to stop masking this, I'm happy to add that change to this PR.