### PR TITLE
Fix #6811: collect @(test) procs from #+private file by iterating c->…

### DIFF
--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -2875,9 +2875,11 @@ gb_internal void collect_testing_procedures_of_package(Checker *c, AstPackage *p
 	InternedString interned = string_interner_insert(str_lit("Test_Signature"), 0, &hash);
 	Entity *test_signature = scope_lookup_current(testing_scope, interned, hash);
 
-	Scope *s = pkg->scope;
-	for (auto const &entry : s->elements) {
-		Entity *e = entry.value;
+	for_array(i, c->info.entities) {
+		Entity *e = c->info.entities[i];
+		if (e->pkg != pkg) {
+			continue;
+		}
 		if (e->kind != Entity_Procedure) {
 			continue;
 		}


### PR DESCRIPTION
collect @(test) procs from #+private file by iterating c->info.entities instead of pkg->scope->elements.

Test procs in #+private file files were silently dropped by the test runner because collect_testing_procedures_of_package iterated pkg->scope->elements, which only contains entities exported to the package scope. File-private entities are placed in the file scope instead and never reach pkg->scope. Fix by iterating c->info.entities filtered by package, matching how @(init) collection works in generate_minimum_dependency_set_internal. Test procs are already exempted from laziness, so they are guaranteed to appear in c->info.entities by the time collection runs.

Fixes #6811