### PR TITLE
Fix #6814: reject transitive #subtype-only implicit conversion in checker

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -5030,9 +5030,15 @@ gb_internal isize check_is_assignable_to_using_subtype(Type *src, Type *dst, isi
 				return level+1;
 			}
 		}
-		isize nested_level = check_is_assignable_to_using_subtype(f->type, dst, level+1, src_is_ptr, allow_polymorphic);
-		if (nested_level > 0) {
-			return nested_level;
+		// Only follow the chain transitively when the field also has `using`, which is
+		// what the backend's lookup_subtype_polymorphic_selection requires (it gates
+		// recursion on EntityFlag_Using). A plain `#subtype`-only field enables a
+		// single-hop conversion but not a two-or-more hop transitive one.
+		if (f->flags & EntityFlag_Using) {
+			isize nested_level = check_is_assignable_to_using_subtype(f->type, dst, level+1, src_is_ptr, allow_polymorphic);
+			if (nested_level > 0) {
+				return nested_level;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #6814

When a struct Baz has #subtype bar: Bar and Bar has #subtype foo: Foo, the checker was accepting a Baz value passed to a procedure expecting Foo. This caused a GB_PANIC("Invalid type conversion") in llvm_backend_expr.cpp because the backend's lookup_subtype_polymorphic_selection only follows transitive subtype chains through fields that also have using (EntityFlag_Using), while the checker's check_is_assignable_to_using_subtype was recursing into any field with EntityFlags_IsSubtype (which includes plain #subtype fields that only set EntityFlag_Subtype).

The fix aligns the checker's recursion guard with the backend: transitive descent now only happens when the intermediate field also has EntityFlag_Using (i.e. declared with using or using #subtype). Single-hop #subtype and transitive using #subtype chains are unaffected.

This previously panicked, now gives a proper checker error:

```
package main

Foo :: struct { x: int }
Bar :: struct { #subtype foo: Foo }
Baz :: struct { #subtype bar: Bar }

takes_foo :: proc(f: Foo) {}

main :: proc() {
    baz: Baz
    takes_foo(baz) // Error: Cannot assign value 'baz' of type 'Baz' to 'Foo' in a procedure argument
}
```
