### PR TITLE
Fix map reserve calculation

### DIFF
--- a/base/runtime/dynamic_map_internal.odin
+++ b/base/runtime/dynamic_map_internal.odin
@@ -608,15 +608,17 @@ map_reserve_dynamic :: #force_no_inline proc "odin" (#no_alias m: ^Raw_Map, #no_
 		m.allocator = context.allocator
 	}
 
-	new_capacity := new_capacity
+	// Take into account the fact that the map will resize itself at
+	// MAP_LOAD_FACTOR capacity.
+	new_capacity_with_resize := new_capacity * 100 / MAP_LOAD_FACTOR
 	old_capacity := uintptr(map_cap(m^))
 
-	if old_capacity >= new_capacity {
+	if old_capacity >= new_capacity_with_resize {
 		return nil
 	}
 
 	// ceiling nearest power of two
-	log2_new_capacity := ceil_log2(new_capacity)
+	log2_new_capacity := ceil_log2(new_capacity_with_resize)
 
 	log2_min_cap := max(MAP_MIN_LOG2_CAPACITY, log2_new_capacity)
 

--- a/base/runtime/dynamic_map_internal.odin
+++ b/base/runtime/dynamic_map_internal.odin
@@ -594,7 +594,7 @@ map_grow_dynamic :: proc "odin" (#no_alias m: ^Raw_Map, #no_alias info: ^Map_Inf
 
 
 @(require_results)
-map_reserve_dynamic :: #force_no_inline proc "odin" (#no_alias m: ^Raw_Map, #no_alias info: ^Map_Info, new_capacity: uintptr, loc := #caller_location) -> Allocator_Error {
+map_reserve_dynamic :: #force_no_inline proc "odin" (#no_alias m: ^Raw_Map, #no_alias info: ^Map_Info, new_capacity: uintptr, loc := #caller_location) -> (err: Allocator_Error) {
 	@(require_results)
 	ceil_log2 :: #force_inline proc "contextless" (x: uintptr) -> uintptr {
 		z := intrinsics.count_leading_zeros(x)
@@ -610,6 +610,9 @@ map_reserve_dynamic :: #force_no_inline proc "odin" (#no_alias m: ^Raw_Map, #no_
 
 	// Take into account the fact that the map will resize itself at
 	// MAP_LOAD_FACTOR capacity.
+	if new_capacity > (max(uintptr) / 100) {
+		return Allocator_Error.Out_Of_Memory
+	}
 	new_capacity_with_resize := new_capacity * 100 / MAP_LOAD_FACTOR
 	old_capacity := uintptr(map_cap(m^))
 

--- a/base/runtime/dynamic_map_internal.odin
+++ b/base/runtime/dynamic_map_internal.odin
@@ -608,11 +608,16 @@ map_reserve_dynamic :: #force_no_inline proc "odin" (#no_alias m: ^Raw_Map, #no_
 		m.allocator = context.allocator
 	}
 
-	// Take into account the fact that the map will resize itself at
-	// MAP_LOAD_FACTOR capacity.
-	if new_capacity > (max(uintptr) / 100) {
-		return Allocator_Error.Out_Of_Memory
+	// The map will resize itself at MAP_LOAD_FACTOR capacity.
+	// <64 bit systems can have maps close to uintptr size.
+	when size_of(uintptr) < 8 {
+		MAX_CEIL_SYSTEM  :: uintptr(1) << (size_of(uintptr) * 8 - 1)
+		MAX_NEW_CAPACITY :: uintptr(u64(MAX_CEIL_SYSTEM) * 75 / 100)
+		if new_capacity > MAX_NEW_CAPACITY {
+			return Allocator_Error.Out_Of_Memory
+		}
 	}
+	// NOTE(Barney): This will silently return if max(uintptr) / 100 or more is requested.
 	new_capacity_with_resize := new_capacity * 100 / MAP_LOAD_FACTOR
 	old_capacity := uintptr(map_cap(m^))
 

--- a/base/runtime/dynamic_map_internal.odin
+++ b/base/runtime/dynamic_map_internal.odin
@@ -613,11 +613,13 @@ map_reserve_dynamic :: #force_no_inline proc "odin" (#no_alias m: ^Raw_Map, #no_
 	when size_of(uintptr) < 8 {
 		MAX_CEIL_SYSTEM  :: uintptr(1) << (size_of(uintptr) * 8 - 1)
 		MAX_NEW_CAPACITY :: uintptr(u64(MAX_CEIL_SYSTEM) * 75 / 100)
-		if new_capacity > MAX_NEW_CAPACITY {
-			return Allocator_Error.Out_Of_Memory
-		}
+	} else {
+		MAX_NEW_CAPACITY :: max(uintptr) / 100
 	}
-	// NOTE(Barney): This will silently return if max(uintptr) / 100 or more is requested.
+
+	if new_capacity > MAX_NEW_CAPACITY {
+		return Allocator_Error.Out_Of_Memory
+	}
 	new_capacity_with_resize := new_capacity * 100 / MAP_LOAD_FACTOR
 	old_capacity := uintptr(map_cap(m^))
 

--- a/tests/internal/test_map.odin
+++ b/tests/internal/test_map.odin
@@ -1,5 +1,6 @@
 package test_internal
 
+import "base:runtime"
 import "core:log"
 import "base:intrinsics"
 import "core:math/rand"
@@ -211,6 +212,15 @@ map_reserve_correct_capacity :: proc(t: ^testing.T) {
 
 	reserve(&m, 13)
 	testing.expect_value(t, cap(m), 32)
+}
+
+@test
+map_reserve_error_on_overflow :: proc(t: ^testing.T) {
+	m: map[int]struct{}
+	defer delete(m)
+
+	err := reserve(&m, (max(uintptr) / 100) + 1)
+	testing.expect_value(t, err, runtime.Allocator_Error.Out_Of_Memory)
 }
 
 @test

--- a/tests/internal/test_map.odin
+++ b/tests/internal/test_map.odin
@@ -219,7 +219,7 @@ map_reserve_error_on_overflow :: proc(t: ^testing.T) {
 	m: map[int]struct{}
 	defer delete(m)
 
-	err := reserve(&m, (max(uintptr) / 100) + 1)
+	err := reserve(&m, (max(uintptr) / 2))
 	testing.expect_value(t, err, runtime.Allocator_Error.Out_Of_Memory)
 }
 

--- a/tests/internal/test_map.odin
+++ b/tests/internal/test_map.odin
@@ -202,6 +202,18 @@ map_delete_random_key_value :: proc(t: ^testing.T) {
 }
 
 @test
+map_reserve_correct_capacity :: proc(t: ^testing.T) {
+	m: map[int]struct{}
+	defer delete(m)
+
+	reserve(&m, 12)
+	testing.expect_value(t, cap(m), 16)
+
+	reserve(&m, 13)
+	testing.expect_value(t, cap(m), 32)
+}
+
+@test
 set_insert_random_key_value :: proc(t: ^testing.T) {
 	seed_incr := u64(0)
 	for entries in ENTRY_COUNTS {


### PR DESCRIPTION
Fixed #6854 

Copying parts of that issue here for convenience:
Currently, when a user `reserve`s or `make_map_caps` a map, the map's capacity does not account for the fact that the map will resize itself when it's 75% full, which is not the case for other types `reserve` and `make` act upon.

When I reserve X in a map, I expect to be able to insert X elements without the map resizing itself. That is the entire point of `reserve`.

This PR calculates the new capacity ceiling by taking the load factor into account.

-----


Aparte: There is no new "surprise allocation size" effect introduced by this change, since `reserve` and `make` already allocated more than what the user explicitly asked for, always rounding up to the next power of 2.

I.e.: `reserve(&map, 20)` already allocated 32.