### PR TITLE
Fix: in struct literals, tuples(functions with multiple returns) are treaded as being 1 element

### DIFF
--- a/src/llvm_backend_const.cpp
+++ b/src/llvm_backend_const.cpp
@@ -1967,8 +1967,9 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, Ty
 					}
 				}
 			} else {
+				isize multiple_return_offset = 0;
 				for_array(i, cl->elems) {
-					Entity *f = type->Struct.fields[i];
+					Entity *f = type->Struct.fields[i+multiple_return_offset];
 					TypeAndValue tav = cl->elems[i]->tav;
 
 					// INFO: dead code:
@@ -1978,11 +1979,19 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, Ty
 					// 	val = tav.value;
 					// }
 
+					if (is_type_tuple(tav.type)){
+						multiple_return_offset = tav.type->Tuple.variables.count-1;
+					}
+
 					i32 index = field_remapping[f->Variable.field_index];
+
+
 					if (elem_type_can_be_constant(f->type)) {
 						lbValue value = lb_const_value(m, f->type, tav.value, tav.type, cc);
 						LLVMTypeRef value_type = LLVMTypeOf(value.value);
-						GB_ASSERT_MSG(lb_sizeof(value_type) == type_size_of(f->type), "%s vs %s", LLVMPrintTypeToString(value_type), type_to_string(f->type));
+						isize lb_sizeof_value_type = lb_sizeof(value_type);
+						isize type_size_of_f_type =  type_size_of(f->type);
+						GB_ASSERT_MSG(lb_sizeof_value_type ==type_size_of_f_type, "%s vs %s", LLVMPrintTypeToString(value_type), type_to_string(f->type));
 						values[index]  = value.value;
 						visited[index] = true;
 					}

--- a/src/llvm_backend_const.cpp
+++ b/src/llvm_backend_const.cpp
@@ -1970,10 +1970,13 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, Ty
 				for_array(i, cl->elems) {
 					Entity *f = type->Struct.fields[i];
 					TypeAndValue tav = cl->elems[i]->tav;
-					ExactValue val = {};
-					if (tav.mode != Addressing_Invalid) {
-						val = tav.value;
-					}
+
+					// INFO: dead code:
+	
+					// ExactValue val = {};
+					// if (tav.mode != Addressing_Invalid) {
+					// 	val = tav.value;
+					// }
 
 					i32 index = field_remapping[f->Variable.field_index];
 					if (elem_type_can_be_constant(f->type)) {

--- a/tests/issues/test_issue_6853.odin
+++ b/tests/issues/test_issue_6853.odin
@@ -1,0 +1,25 @@
+package test_issues
+
+import "core:testing"
+
+@(test)
+test_issue_6853 :: proc(t: ^testing.T) {
+
+	test_s :: struct {
+		a, b, c, d, e: u64,
+	}
+
+	expected := test_s{1, 2, 3, 4, 5}
+
+	case0 :: proc() -> (u64, u64) {return 1, 2}
+	test0 := test_s{case0(), 3, 4, 5}
+	testing.expect_value(t, test0, expected)
+
+	case1 :: proc() -> (u64, u64, u64) {return 1, 2, 3}
+	test1 := test_s{case1(), 4, 5}
+	testing.expect_value(t, test1, expected)
+
+	case2 :: proc() -> (u64, u64) {return 2, 3}
+	test2 := test_s{1, case2(), 4, 5}
+	testing.expect_value(t, test2, expected)
+}


### PR DESCRIPTION
The rest of the elements fallowing such a tuple are incorrectly assigned to the wrong fields.

This is based on issue #6853 , but the problem was broader