### PR TITLE
Raise child process error signal if `odin run` child gets terminated.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -206,6 +206,9 @@ int run_subprocess(const char *name, const char **args) {
 		if (WIFEXITED(status)) {
 			return WEXITSTATUS(status);
 		} else if (WIFSIGNALED(status)) {
+			struct rlimit limit = { 0, 0, };
+			setrlimit(RLIMIT_CORE, &limit);
+			raise(WTERMSIG(status));
 			return -1;
 		} else if (WIFSTOPPED(status)) {
 			return -1;


### PR DESCRIPTION
Previously one would get a nice `$ <pid> segmentation fault (core dumped) odin run .` message, but this behaviour was (probably unintentionally) removed in #6848.
Just like in `system_exec_command_line_app_internal` a coredump of the odin compiler is not emitted.