### PR TITLE
Fix literal integer `%%`

### DIFF
--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -448,6 +448,17 @@ gb_internal void big_int_euclidean_mod(BigInt *z, BigInt const *x, BigInt const 
 	}
 }
 
+gb_internal void big_int_floor_mod(BigInt *z, BigInt const *x, BigInt const *y) {
+	BigInt y0 = {};
+	big_int_init(&y0, y);
+
+	BigInt q = {};
+	big_int_quo_rem(x, y, &q, z);
+	if (z->sign != y0.sign && !mp_iszero(z)) {
+		big_int_add(z, z, &y0);
+	}
+	big_int_dealloc(&q);
+}
 
 
 gb_internal void big_int_and(BigInt *dst, BigInt const *x, BigInt const *y) {

--- a/src/exact_value.cpp
+++ b/src/exact_value.cpp
@@ -780,7 +780,7 @@ gb_internal ExactValue exact_binary_operator_value(TokenKind op, ExactValue x, E
 		case Token_Quo:    return exact_value_float(fmod(big_int_to_f64(a), big_int_to_f64(b)));
 		case Token_QuoEq:  big_int_quo(&c, a, b); break; // NOTE(bill): Integer division
 		case Token_Mod:    big_int_rem(&c, a, b); break;
-		case Token_ModMod: big_int_euclidean_mod(&c, a, b); break;
+		case Token_ModMod: big_int_floor_mod(&c, a, b); break;
 		case Token_And:    big_int_and(&c, a, b);     break;
 		case Token_Or:     big_int_or(&c, a, b);      break;
 		case Token_Xor:    big_int_xor(&c, a, b);     break;


### PR DESCRIPTION
According to overview, `%%` is "remainder (floored)". So it `%%` for literals should not use `big_int_euclidean_mod`.
I implemented `big_int_floor_mod` and use it instead.

These two printfln should be the same.
```odin
package main
import "core:fmt"

main :: proc() {
	x, y: int = 1, -3
	fmt.printfln("%v mod %v = %v", x, y, x %% y)
	fmt.printfln("%v mod %v = %v", 1, -3, 1 %% -3)
	assert(x %% y == 1 %% -3)
}
```

Where should I add test for this PR?

close #6877 