### PR TITLE
Fix for SoA arrays of structs with nested using structs crashing the compiler

### DIFF
--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -6571,11 +6571,12 @@ gb_internal lbAddr lb_build_addr_internal(lbProcedure *p, Ast *expr) {
 					} else {
 						item = lb_emit_ptr_offset(p, lb_emit_load(p, arr), index);
 					}
+
+					// make sure it's ^T and not [^]T
+					item.type = alloc_type_multi_pointer_to_pointer(item.type);
 					if (sub_sel.index.count > 0) {
 						item = lb_emit_deep_field_gep(p, item, sub_sel);
 					}
-				// make sure it's ^T and not [^]T
-				item.type = alloc_type_multi_pointer_to_pointer(item.type);
 
 					return lb_addr(item);
 				} else if (addr.kind == lbAddr_Swizzle) {


### PR DESCRIPTION
now without whitespaces..


there are a few open issues about this, examples:

https://github.com/odin-lang/Odin/issues/6725
https://github.com/odin-lang/Odin/issues/6798
https://github.com/odin-lang/Odin/issues/4943

just searching for "using soa" in the open issues finds a lot more.

the fix seems to be very simple: just making sure the element is a ^T instead of [^]T before getting the element pointer fixes this. tried it out and seems to fix it properly even with nested of nested structs (working example after the fix):

```
First :: struct {
    i: i32,
}

Second :: struct {
    using first: First,
    j:           i32,
}

Third :: struct {
    using second: Second,
    k:            i32,
}


main :: proc() {

    data: #soa[dynamic]Third
    append(&data, Third{i = 1, j = 2, k = 3})

    fmt.printfln("data: {}", data[0].i)
    fmt.printfln("data: {}", data[0].j)
    fmt.printfln("data: {}", data[0].k)
}
```