### PR TITLE
[core:slice] Myers' Difference Algorithm

### DIFF
--- a/core/slice/diff.odin
+++ b/core/slice/diff.odin
@@ -8,26 +8,20 @@ import "base:intrinsics"
 
 import "core:mem"
 
-// An edit script command to insert a value.
-Diff_Insert :: struct($T: typeid) {
-	value: T,
-}
-
-// An edit script command to delete a value.
-Diff_Delete :: struct($T: typeid) {
-	value: T,
-}
-
-// An edit script command to keep a value.
-Diff_Keep :: struct($T: typeid) {
-	value: T,
+// A kind of difference in an edit script.
+Diff_Kind :: enum {
+	// A value should be inserted in the original slice.
+	Insert,
+	// A value should be deleted from the original slice.
+	Delete,
+	// A value should be kept in the original slice.
+	Keep,
 }
 
 // A difference in an edit script.
-Diff :: union($T: typeid) #no_nil {
-	Diff_Insert(T),
-	Diff_Delete(T),
-	Diff_Keep(T),
+Diff :: struct($T: typeid) {
+	kind:  Diff_Kind,
+	value: T,
 }
 
 /*
@@ -70,7 +64,7 @@ diff :: proc(
 
 	stack := make([dynamic]Subproblem, allocator)
 	defer delete(stack)
-	append(&stack, Subproblem{ax = 0, ay = 0, bx = len(a), by = len(b)})
+	append(&stack, Subproblem{ax = 0, ay = 0, bx = len(a), by = len(b)}) or_return
 
 	for len(stack) != 0 {
 		p := pop(&stack)
@@ -146,21 +140,21 @@ diff :: proc(
 	for i in 0 ..= len(a) {
 		if i in inserts {
 			for insert in inserts[i] {
-				append(&script, Diff(T)(Diff_Insert(T){value = insert})) or_return
+				append(&script, Diff(T){kind = .Insert, value = insert}) or_return
 			}
 		}
 
 		if i < len(a) {
 			if i in deletes {
-				append(&script, Diff(T)(Diff_Delete(T){value = deletes[i]})) or_return
+				append(&script, Diff(T){kind = .Delete, value = deletes[i]}) or_return
 			} else if i in keeps {
-				append(&script, Diff(T)(Diff_Keep(T){value = keeps[i]})) or_return
+				append(&script, Diff(T){kind = .Keep, value = keeps[i]}) or_return
 			}
 		}
 	}
 
 	for insert in end_inserts {
-		append(&script, Diff(T)(Diff_Insert(T){value = insert})) or_return
+		append(&script, Diff(T){kind = .Insert, value = insert}) or_return
 	}
 
 	return script[:], nil

--- a/core/slice/diff.odin
+++ b/core/slice/diff.odin
@@ -187,15 +187,18 @@ diff :: proc(
 		delta := n - m
 		odd := (delta % 2 != 0)
 
-		// TODO: Convert to fixed-length slices.
-		vf := make(map[int]int, allocator)
-		defer delete(vf)
+		max := n + m
+		
+		vf := make([]int, 2 * max + 1, allocator)
+		defer delete(vf, allocator)
+		fill(vf[:], -1)
 
-		vr := make(map[int]int, allocator)
+		vr := make([]int, 2 * max + 1, allocator)
 		defer delete(vr)
+		fill(vr[:], -1)
 
-		vf[1] = 0
-		vr[delta] = n
+		vf[1 + max] = 0
+		vr[delta + max] = n
 
 		max_d := (n + m + 1) / 2
 
@@ -203,11 +206,11 @@ diff :: proc(
 			for k := -d; k <= d; k += 2 {
 				x: int
 				if d == 0 {
-					x = vf[1]
-				} else if k == -d || (k != d && vf[k - 1] < vf[k + 1]) {
-					x = vf[k + 1]
+					x = vf[1 + max]
+				} else if k == -d || (k != d && vf[k - 1 + max] < vf[k + 1 + max]) {
+					x = vf[k + 1 + max]
 				} else {
-					x = vf[k - 1] + 1
+					x = vf[k - 1 + max] + 1
 				}
 
 				y := x - k
@@ -218,10 +221,10 @@ diff :: proc(
 					x += 1
 					y += 1
 				}
-				vf[k] = x
+				vf[k + max] = x
 
 				if odd && (delta - d < k) && (k < delta + d) {
-					if k in vf && vf[k] >= vr[k] {
+					if vf[k + max] >= vr[k + max] {
 						return Middle_Snake {
 								x = p.ax + x_start,
 								y = p.ay + y_start,
@@ -236,11 +239,11 @@ diff :: proc(
 			for k := -d + delta; k <= d + delta; k += 2 {
 				x: int
 				if d == 0 {
-					x = vr[delta]
-				} else if k == d + delta || (k != -d + delta && vr[k - 1] > vr[k + 1]) {
-					x = vr[k - 1]
+					x = vr[delta + max]
+				} else if k == d + delta || (k != -d + delta && vr[k - 1 + max] > vr[k + 1 + max]) {
+					x = vr[k - 1 + max]
 				} else {
-					x = vr[k + 1] - 1
+					x = vr[k + 1 + max] - 1
 				}
 				y := x - k
 
@@ -250,10 +253,10 @@ diff :: proc(
 					x -= 1
 					y -= 1
 				}
-				vr[k] = x
+				vr[k + max] = x
 
 				if !odd && -d <= k && k <= d {
-					if k in vf && vf[k] >= vr[k] {
+					if vf[k + max] >= vr[k + max] {
 						return Middle_Snake {
 								x = p.ax + x,
 								y = p.ay + y,

--- a/core/slice/diff.odin
+++ b/core/slice/diff.odin
@@ -39,7 +39,7 @@ Returns:
 - err: An `Allocator_Error`, if allocation failed.
 */
 diff :: proc(
-	value, expected: []$T,
+	value, expected: $S/[]$T,
 	allocator := context.allocator,
 ) -> (
 	result: []Diff(T),
@@ -274,7 +274,7 @@ diff :: proc(
 
 	append_diff :: proc(
 		diffs: ^[dynamic]Diff(T),
-		a, b: []T,
+		a, b: S,
 		kind: Diff_Kind,
 		position: int,
 	) -> (
@@ -297,7 +297,7 @@ diff :: proc(
 			}
 		}
 
-		values: []T
+		values: S
 		switch kind {
 		case .Insert:
 			values = b[position:position + 1]

--- a/core/slice/diff.odin
+++ b/core/slice/diff.odin
@@ -20,8 +20,9 @@ Diff_Kind :: enum {
 
 // A difference in an edit script.
 Diff :: struct($T: typeid) {
-	kind:  Diff_Kind,
-	value: T,
+	kind:       Diff_Kind,
+	begin, end: int,
+	values:     []T,
 }
 
 /*
@@ -47,9 +48,9 @@ diff :: proc(
 	a := value
 	b := expected
 
-	deletes := make(map[int]T, allocator)
+	deletes := make(map[int]int, allocator)
 	defer delete(deletes)
-	inserts := make(map[int][dynamic]T, allocator)
+	inserts := make(map[int][dynamic]int, allocator)
 	defer {
 		for k in inserts {
 			delete(inserts[k])
@@ -57,9 +58,9 @@ diff :: proc(
 
 		delete(inserts)
 	}
-	keeps := make(map[int]T, allocator)
+	keeps := make(map[int]int, allocator)
 	defer delete(keeps)
-	end_inserts := make([dynamic]T, allocator)
+	end_inserts := make([dynamic]int, allocator)
 	defer delete(end_inserts)
 
 	stack := make([dynamic]Subproblem, allocator)
@@ -74,7 +75,7 @@ diff :: proc(
 
 		if n > 0 && m == 0 {
 			for i in p.ax ..< p.bx {
-				deletes[i] = a[i]
+				deletes[i] = i
 			}
 
 			continue
@@ -83,15 +84,15 @@ diff :: proc(
 		if n == 0 && m > 0 {
 			if p.ax < len(a) {
 				if !(p.ax in inserts) {
-					inserts[p.ax] = make([dynamic]T, allocator)
+					inserts[p.ax] = make([dynamic]int, allocator)
 				}
 
 				for j in p.ay ..< p.by {
-					append(&inserts[p.ax], b[j]) or_return
+					append(&inserts[p.ax], j) or_return
 				}
 			} else {
 				for j in p.ay ..< p.by {
-					append(&end_inserts, b[j]) or_return
+					append(&end_inserts, j) or_return
 				}
 			}
 
@@ -106,20 +107,20 @@ diff :: proc(
 
 		if sms == nil {
 			for i in p.ax ..< p.bx {
-				deletes[i] = a[i]
+				deletes[i] = i
 			}
 
 			if p.ax < len(a) {
 				for j in p.ay ..< p.by {
 					if !(p.ax in inserts) {
-						inserts[p.ax] = make([dynamic]T, allocator)
+						inserts[p.ax] = make([dynamic]int, allocator)
 					}
 
-					append(&inserts[p.ax], b[j]) or_return
+					append(&inserts[p.ax], j) or_return
 				}
 			} else {
 				for j in p.ay ..< p.by {
-					append(&end_inserts, b[j]) or_return
+					append(&end_inserts, j) or_return
 				}
 			}
 
@@ -127,7 +128,7 @@ diff :: proc(
 		}
 
 		for i in sms.?.x ..< sms.?.u {
-			keeps[i] = a[i]
+			keeps[i] = i
 		}
 
 		append(&stack, Subproblem{ax = sms.?.u, ay = sms.?.v, bx = p.bx, by = p.by}) or_return
@@ -140,21 +141,21 @@ diff :: proc(
 	for i in 0 ..= len(a) {
 		if i in inserts {
 			for insert in inserts[i] {
-				append(&script, Diff(T){kind = .Insert, value = insert}) or_return
+				append_diff(&script, a, b, .Insert, insert) or_return
 			}
 		}
 
 		if i < len(a) {
 			if i in deletes {
-				append(&script, Diff(T){kind = .Delete, value = deletes[i]}) or_return
+				append_diff(&script, a, b, .Delete, deletes[i]) or_return
 			} else if i in keeps {
-				append(&script, Diff(T){kind = .Keep, value = keeps[i]}) or_return
+				append_diff(&script, a, b, .Keep, keeps[i]) or_return
 			}
 		}
 	}
 
 	for insert in end_inserts {
-		append(&script, Diff(T){kind = .Insert, value = insert}) or_return
+		append_diff(&script, a, b, .Insert, insert) or_return
 	}
 
 	return script[:], nil
@@ -266,5 +267,43 @@ diff :: proc(
 		}
 
 		return nil, nil
+	}
+
+	append_diff :: proc(
+		diffs: ^[dynamic]Diff(T),
+		a, b: []T,
+		kind: Diff_Kind,
+		position: int,
+	) -> (
+		err: mem.Allocator_Error,
+	) {
+		if len(diffs) > 0 {
+			last := &diffs[len(diffs) - 1]
+
+			if last.kind == kind && last.end == position {
+				last.end = position + 1
+
+				switch last.kind {
+				case .Insert:
+					last.values = b[last.begin:last.end]
+				case .Delete, .Keep:
+					last.values = a[last.begin:last.end]
+				}
+
+				return nil
+			}
+		}
+
+		values: []T
+		switch kind {
+		case .Insert:
+			values = b[position:position+1]
+		case .Delete, .Keep:
+			values = a[position:position+1]
+		}
+
+		append(diffs, Diff(T){kind=kind, begin=position,end=position+1,values=values}) or_return
+
+		return nil
 	}
 }

--- a/core/slice/diff.odin
+++ b/core/slice/diff.odin
@@ -67,6 +67,12 @@ diff :: proc(
 	defer delete(stack)
 	append(&stack, Subproblem{ax = 0, ay = 0, bx = len(a), by = len(b)}) or_return
 
+	max := len(a) + len(b)
+	vf := make([]int, 2 * max + 1, allocator) or_return
+	defer delete(vf, allocator)
+	vr := make([]int, 2 * max + 1, allocator) or_return
+	defer delete(vr, allocator)
+
 	for len(stack) != 0 {
 		p := pop(&stack)
 
@@ -103,7 +109,7 @@ diff :: proc(
 			continue
 		}
 
-		sms := find_middle_snake(a, b, p, allocator) or_return
+		sms := find_middle_snake(a, b, p, vf, vr)
 
 		if sms == nil {
 			for i in p.ax ..< p.bx {
@@ -174,13 +180,12 @@ diff :: proc(
 
 	// Finds the middle snake.
 	@(require_results)
-	find_middle_snake :: proc(
+	find_middle_snake :: proc "contextless" (
 		a, b: []$T,
 		p: Subproblem,
-		allocator := context.allocator,
+		vf_buf, vr_buf: []int,
 	) -> (
 		result: Maybe(Middle_Snake),
-		err: mem.Allocator_Error,
 	) {
 		n := p.bx - p.ax
 		m := p.by - p.ay
@@ -188,14 +193,10 @@ diff :: proc(
 		odd := (delta % 2 != 0)
 
 		max := n + m
-		
-		vf := make([]int, 2 * max + 1, allocator)
-		defer delete(vf, allocator)
-		fill(vf[:], -1)
-
-		vr := make([]int, 2 * max + 1, allocator)
-		defer delete(vr)
-		fill(vr[:], -1)
+		vf := vf_buf[:2 * max + 1]
+		fill(vf, -1)
+		vr := vr_buf[:2 * max + 1]
+		fill(vr, -1)
 
 		vf[1 + max] = 0
 		vr[delta + max] = n
@@ -226,12 +227,11 @@ diff :: proc(
 				if odd && (delta - d < k) && (k < delta + d) {
 					if vf[k + max] >= vr[k + max] {
 						return Middle_Snake {
-								x = p.ax + x_start,
-								y = p.ay + y_start,
-								u = p.ax + x,
-								v = p.ay + y,
-							},
-							nil
+							x = p.ax + x_start,
+							y = p.ay + y_start,
+							u = p.ax + x,
+							v = p.ay + y,
+						}
 					}
 				}
 			}
@@ -240,7 +240,8 @@ diff :: proc(
 				x: int
 				if d == 0 {
 					x = vr[delta + max]
-				} else if k == d + delta || (k != -d + delta && vr[k - 1 + max] > vr[k + 1 + max]) {
+				} else if k == d + delta ||
+				   (k != -d + delta && vr[k - 1 + max] > vr[k + 1 + max]) {
 					x = vr[k - 1 + max]
 				} else {
 					x = vr[k + 1 + max] - 1
@@ -258,18 +259,17 @@ diff :: proc(
 				if !odd && -d <= k && k <= d {
 					if vf[k + max] >= vr[k + max] {
 						return Middle_Snake {
-								x = p.ax + x,
-								y = p.ay + y,
-								u = p.ax + x_start,
-								v = p.ay + y_start,
-							},
-							nil
+							x = p.ax + x,
+							y = p.ay + y,
+							u = p.ax + x_start,
+							v = p.ay + y_start,
+						}
 					}
 				}
 			}
 		}
 
-		return nil, nil
+		return nil
 	}
 
 	append_diff :: proc(
@@ -300,12 +300,15 @@ diff :: proc(
 		values: []T
 		switch kind {
 		case .Insert:
-			values = b[position:position+1]
+			values = b[position:position + 1]
 		case .Delete, .Keep:
-			values = a[position:position+1]
+			values = a[position:position + 1]
 		}
 
-		append(diffs, Diff(T){kind=kind, begin=position,end=position+1,values=values}) or_return
+		append(
+			diffs,
+			Diff(T){kind = kind, begin = position, end = position + 1, values = values},
+		) or_return
 
 		return nil
 	}

--- a/core/slice/diff.odin
+++ b/core/slice/diff.odin
@@ -1,0 +1,276 @@
+// An implementation of Myers' O(ND) Difference Algorithm for slices of
+// arbitrary types that can be simply compared.
+//
+// See https://publications.mpi-cbg.de/Myers_1986_6330.pdf
+package slice
+
+import "base:intrinsics"
+
+import "core:mem"
+
+// An edit script command to insert a value.
+Diff_Insert :: struct($T: typeid) {
+	value: T,
+}
+
+// An edit script command to delete a value.
+Diff_Delete :: struct($T: typeid) {
+	value: T,
+}
+
+// An edit script command to keep a value.
+Diff_Keep :: struct($T: typeid) {
+	value: T,
+}
+
+// A difference in an edit script.
+Diff :: union($T: typeid) #no_nil {
+	Diff_Insert(T),
+	Diff_Delete(T),
+	Diff_Keep(T),
+}
+
+/*
+Calculates the difference list between a given original list and its expected
+sequence of elements as an edit script.
+
+Inputs:
+- value: The original slice.
+- expected: The expected slice.
+- allocator: The allocator used to create the edit script (default is context.allocator).
+
+Returns:
+- result: The edit script to transform the original list in the expected list.
+- err: An `Allocator_Error`, if allocation failed.
+*/
+diff :: proc(
+	value, expected: []$T,
+	allocator := context.allocator,
+) -> (
+	result: []Diff(T),
+	err: mem.Allocator_Error,
+) where intrinsics.type_is_simple_compare(T) #optional_allocator_error {
+	a := value
+	b := expected
+
+	deletes := make(map[int]T, allocator)
+	defer delete(deletes)
+	inserts := make(map[int][dynamic]T, allocator)
+	defer {
+		for k in inserts {
+			delete(inserts[k])
+		}
+
+		delete(inserts)
+	}
+	keeps := make(map[int]T, allocator)
+	defer delete(keeps)
+	end_inserts := make([dynamic]T, allocator)
+	defer delete(end_inserts)
+
+	stack := make([dynamic]Subproblem, allocator)
+	defer delete(stack)
+	append(&stack, Subproblem{ax = 0, ay = 0, bx = len(a), by = len(b)})
+
+	for len(stack) != 0 {
+		p := pop(&stack)
+
+		n := p.bx - p.ax
+		m := p.by - p.ay
+
+		if n > 0 && m == 0 {
+			for i in p.ax ..< p.bx {
+				deletes[i] = a[i]
+			}
+
+			continue
+		}
+
+		if n == 0 && m > 0 {
+			if p.ax < len(a) {
+				if !(p.ax in inserts) {
+					inserts[p.ax] = make([dynamic]T, allocator)
+				}
+
+				for j in p.ay ..< p.by {
+					append(&inserts[p.ax], b[j]) or_return
+				}
+			} else {
+				for j in p.ay ..< p.by {
+					append(&end_inserts, b[j]) or_return
+				}
+			}
+
+			continue
+		}
+
+		if n == 0 && m == 0 {
+			continue
+		}
+
+		sms := find_middle_snake(a, b, p, allocator) or_return
+
+		if sms == nil {
+			for i in p.ax ..< p.bx {
+				deletes[i] = a[i]
+			}
+
+			if p.ax < len(a) {
+				for j in p.ay ..< p.by {
+					if !(p.ax in inserts) {
+						inserts[p.ax] = make([dynamic]T, allocator)
+					}
+
+					append(&inserts[p.ax], b[j]) or_return
+				}
+			} else {
+				for j in p.ay ..< p.by {
+					append(&end_inserts, b[j]) or_return
+				}
+			}
+
+			continue
+		}
+
+		for i in sms.?.x ..< sms.?.u {
+			keeps[i] = a[i]
+		}
+
+		append(&stack, Subproblem{ax = sms.?.u, ay = sms.?.v, bx = p.bx, by = p.by}) or_return
+		append(&stack, Subproblem{ax = p.ax, ay = p.ay, bx = sms.?.x, by = sms.?.y}) or_return
+	}
+
+	script := make([dynamic]Diff(T), allocator)
+	defer if err != nil {delete(script)}
+
+	for i in 0 ..= len(a) {
+		if i in inserts {
+			for insert in inserts[i] {
+				append(&script, Diff(T)(Diff_Insert(T){value = insert})) or_return
+			}
+		}
+
+		if i < len(a) {
+			if i in deletes {
+				append(&script, Diff(T)(Diff_Delete(T){value = deletes[i]})) or_return
+			} else if i in keeps {
+				append(&script, Diff(T)(Diff_Keep(T){value = keeps[i]})) or_return
+			}
+		}
+	}
+
+	for insert in end_inserts {
+		append(&script, Diff(T)(Diff_Insert(T){value = insert})) or_return
+	}
+
+	return script[:], nil
+
+	// A boundary box within the edit graph matrix.
+	Subproblem :: struct {
+		ax, ay: int,
+		bx, by: int,
+	}
+
+	// The overlapping match point that splits the problem.
+	Middle_Snake :: struct {
+		x, y: int,
+		u, v: int,
+	}
+
+	// Finds the middle snake.
+	@(require_results)
+	find_middle_snake :: proc(
+		a, b: []$T,
+		p: Subproblem,
+		allocator := context.allocator,
+	) -> (
+		result: Maybe(Middle_Snake),
+		err: mem.Allocator_Error,
+	) {
+		n := p.bx - p.ax
+		m := p.by - p.ay
+		delta := n - m
+		odd := (delta % 2 != 0)
+
+		// TODO: Convert to fixed-length slices.
+		vf := make(map[int]int, allocator)
+		defer delete(vf)
+
+		vr := make(map[int]int, allocator)
+		defer delete(vr)
+
+		vf[1] = 0
+		vr[delta] = n
+
+		max_d := (n + m + 1) / 2
+
+		for d in 0 ..= max_d {
+			for k := -d; k <= d; k += 2 {
+				x: int
+				if d == 0 {
+					x = vf[1]
+				} else if k == -d || (k != d && vf[k - 1] < vf[k + 1]) {
+					x = vf[k + 1]
+				} else {
+					x = vf[k - 1] + 1
+				}
+
+				y := x - k
+
+				x_start := x
+				y_start := y
+				for x < n && y < m && a[p.ax + x] == b[p.ay + y] {
+					x += 1
+					y += 1
+				}
+				vf[k] = x
+
+				if odd && (delta - d < k) && (k < delta + d) {
+					if k in vf && vf[k] >= vr[k] {
+						return Middle_Snake {
+								x = p.ax + x_start,
+								y = p.ay + y_start,
+								u = p.ax + x,
+								v = p.ay + y,
+							},
+							nil
+					}
+				}
+			}
+
+			for k := -d + delta; k <= d + delta; k += 2 {
+				x: int
+				if d == 0 {
+					x = vr[delta]
+				} else if k == d + delta || (k != -d + delta && vr[k - 1] > vr[k + 1]) {
+					x = vr[k - 1]
+				} else {
+					x = vr[k + 1] - 1
+				}
+				y := x - k
+
+				x_start := x
+				y_start := y
+				for x > 0 && y > 0 && a[p.ax + x - 1] == b[p.ay + y - 1] {
+					x -= 1
+					y -= 1
+				}
+				vr[k] = x
+
+				if !odd && -d <= k && k <= d {
+					if k in vf && vf[k] >= vr[k] {
+						return Middle_Snake {
+								x = p.ax + x,
+								y = p.ay + y,
+								u = p.ax + x_start,
+								v = p.ay + y_start,
+							},
+							nil
+					}
+				}
+			}
+		}
+
+		return nil, nil
+	}
+}

--- a/tests/core/slice/test_core_slice.odin
+++ b/tests/core/slice/test_core_slice.odin
@@ -1,12 +1,13 @@
 #+feature dynamic-literals
 package test_core_slice
 
+import "core:log"
+import "core:math/rand"
+import "core:mem"
 import "core:slice"
 import "core:testing"
-import "core:math/rand"
-import "core:log"
 
-@test
+@(test)
 test_sort_with_indices :: proc(t: ^testing.T) {
 	// Test sizes are all prime.
 	test_sizes :: []int{7, 13, 347, 1031, 10111, 100003}
@@ -14,7 +15,7 @@ test_sort_with_indices :: proc(t: ^testing.T) {
 	for test_size in test_sizes {
 		rand.reset(t.seed)
 
-		vals  := make([]u64, test_size)
+		vals := make([]u64, test_size)
 		r_idx := make([]int, test_size) // Reverse index
 		defer {
 			delete(vals)
@@ -57,7 +58,7 @@ test_sort_with_indices :: proc(t: ^testing.T) {
 	}
 }
 
-@test
+@(test)
 test_sort_by_indices :: proc(t: ^testing.T) {
 	// Test sizes are all prime.
 	test_sizes :: []int{7, 13, 347, 1031, 10111, 100003}
@@ -65,7 +66,7 @@ test_sort_by_indices :: proc(t: ^testing.T) {
 	for test_size in test_sizes {
 		rand.reset(t.seed)
 
-		vals  := make([]u64, test_size)
+		vals := make([]u64, test_size)
 		r_idx := make([]int, test_size) // Reverse index
 		defer {
 			delete(vals)
@@ -95,7 +96,11 @@ test_sort_by_indices :: proc(t: ^testing.T) {
 			defer delete(sorted_indices)
 			for v, i in sorted_indices {
 				idx_pass := v == f_idx[i]
-				testing.expect(t, idx_pass, "Expected the sorted index to be the same as the result from sort_with_indices")
+				testing.expect(
+					t,
+					idx_pass,
+					"Expected the sorted index to be the same as the result from sort_with_indices",
+				)
 				if !idx_pass {
 					break
 				}
@@ -111,7 +116,11 @@ test_sort_by_indices :: proc(t: ^testing.T) {
 			slice.sort_by_indices_overwrite(indices, f_idx)
 			for v, i in indices {
 				idx_pass := v == f_idx[i]
-				testing.expect(t, idx_pass, "Expected the sorted index to be the same as the result from sort_with_indices")
+				testing.expect(
+					t,
+					idx_pass,
+					"Expected the sorted index to be the same as the result from sort_with_indices",
+				)
 				if !idx_pass {
 					break
 				}
@@ -131,7 +140,11 @@ test_sort_by_indices :: proc(t: ^testing.T) {
 			slice.sort_by_indices(indices, swap, f_idx)
 			for v, i in swap {
 				idx_pass := v == f_idx[i]
-				testing.expect(t, idx_pass, "Expected the sorted index to be the same as the result from sort_with_indices")
+				testing.expect(
+					t,
+					idx_pass,
+					"Expected the sorted index to be the same as the result from sort_with_indices",
+				)
 				if !idx_pass {
 					break
 				}
@@ -140,7 +153,7 @@ test_sort_by_indices :: proc(t: ^testing.T) {
 	}
 }
 
-@test
+@(test)
 test_binary_search :: proc(t: ^testing.T) {
 	index: int
 	found: bool
@@ -148,15 +161,15 @@ test_binary_search :: proc(t: ^testing.T) {
 	s := []i32{0, 1, 1, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55}
 
 	index, found = slice.binary_search(s, 13)
-	testing.expect(t, index == 9,    "Expected index to be 9")
+	testing.expect(t, index == 9, "Expected index to be 9")
 	testing.expect(t, found == true, "Expected found to be true")
 
 	index, found = slice.binary_search(s, 4)
-	testing.expect(t, index == 7,     "Expected index to be 7.")
+	testing.expect(t, index == 7, "Expected index to be 7.")
 	testing.expect(t, found == false, "Expected found to be false.")
 
 	index, found = slice.binary_search(s, 100)
-	testing.expect(t, index == 13,    "Expected index to be 13.")
+	testing.expect(t, index == 13, "Expected index to be 13.")
 	testing.expect(t, found == false, "Expected found to be false.")
 
 	index, found = slice.binary_search(s, 1)
@@ -164,31 +177,31 @@ test_binary_search :: proc(t: ^testing.T) {
 	testing.expect(t, found == true, "Expected found to be true.")
 
 	index, found = slice.binary_search(s, -1)
-	testing.expect(t, index == 0,     "Expected index to be 0.")
+	testing.expect(t, index == 0, "Expected index to be 0.")
 	testing.expect(t, found == false, "Expected found to be false.")
 
 	a := []i32{}
 
 	index, found = slice.binary_search(a, 13)
-	testing.expect(t, index == 0,     "Expected index to be 0.")
+	testing.expect(t, index == 0, "Expected index to be 0.")
 	testing.expect(t, found == false, "Expected found to be false.")
 
 	b := []i32{1}
 
 	index, found = slice.binary_search(b, 13)
-	testing.expect(t, index == 1,     "Expected index to be 1.")
+	testing.expect(t, index == 1, "Expected index to be 1.")
 	testing.expect(t, found == false, "Expected found to be false.")
 
 	index, found = slice.binary_search(b, 1)
-	testing.expect(t, index == 0,    "Expected index to be 0.")
+	testing.expect(t, index == 0, "Expected index to be 0.")
 	testing.expect(t, found == true, "Expected found to be true.")
 
 	index, found = slice.binary_search(b, 0)
-	testing.expect(t, index == 0,     "Expected index to be 0.")
+	testing.expect(t, index == 0, "Expected index to be 0.")
 	testing.expect(t, found == false, "Expected found to be false.")
 }
 
-@test
+@(test)
 test_permutation_iterator :: proc(t: ^testing.T) {
 	// Big enough to do some sanity checking but not overly large.
 	FAC_5 :: 120
@@ -219,20 +232,27 @@ test_permutation_iterator :: proc(t: ^testing.T) {
 }
 
 // Test inputs from #3276 and #3769
-UNIQUE_TEST_VECTORS :: [][2][]int{
-	{{2,2,2},             {2}},
-	{{1,1,1,2,2,3,3,3,3}, {1,2,3}},
-	{{1,2,4,4,5},         {1,2,4,5}},
+UNIQUE_TEST_VECTORS :: [][2][]int {
+	{{2, 2, 2}, {2}},
+	{{1, 1, 1, 2, 2, 3, 3, 3, 3}, {1, 2, 3}},
+	{{1, 2, 4, 4, 5}, {1, 2, 4, 5}},
 }
 
-@test
+@(test)
 test_unique :: proc(t: ^testing.T) {
 	for v in UNIQUE_TEST_VECTORS {
 		assorted := v[0]
 		expected := v[1]
 
 		uniq := slice.unique(assorted)
-		testing.expectf(t, slice.equal(uniq, expected), "Expected slice.uniq(%v) == %v, got %v", v[0], v[1], uniq)
+		testing.expectf(
+			t,
+			slice.equal(uniq, expected),
+			"Expected slice.uniq(%v) == %v, got %v",
+			v[0],
+			v[1],
+			uniq,
+		)
 	}
 
 	for v in UNIQUE_TEST_VECTORS {
@@ -240,16 +260,23 @@ test_unique :: proc(t: ^testing.T) {
 		expected := v[1]
 
 		uniq := slice.unique_proc(assorted, proc(a, b: int) -> bool {
-			return a == b
-		})
-		testing.expectf(t, slice.equal(uniq, expected), "Expected slice.unique_proc(%v, ...) == %v, got %v", v[0], v[1], uniq)
+				return a == b
+			})
+		testing.expectf(
+			t,
+			slice.equal(uniq, expected),
+			"Expected slice.unique_proc(%v, ...) == %v, got %v",
+			v[0],
+			v[1],
+			uniq,
+		)
 	}
 
 	r := rand.create(t.seed)
 	context.random_generator = rand.default_random_generator(&r)
 
 	// 10_000 random tests
-	for _ in 0..<10_000 {
+	for _ in 0 ..< 10_000 {
 		assorted: [dynamic]i64
 		expected: [dynamic]i64
 
@@ -259,7 +286,7 @@ test_unique :: proc(t: ^testing.T) {
 		append(&expected, old)
 
 		// Add 99 additional random values
-		for _ in 1..<100 {
+		for _ in 1 ..< 100 {
 			new := rand.int63()
 			append(&assorted, new)
 			if old != new {
@@ -270,7 +297,14 @@ test_unique :: proc(t: ^testing.T) {
 
 		original := slice.clone(assorted[:])
 		uniq := slice.unique(assorted[:])
-		testing.expectf(t, slice.equal(uniq, expected[:]), "Expected slice.uniq(%v) == %v, got %v", original, expected, uniq)
+		testing.expectf(
+			t,
+			slice.equal(uniq, expected[:]),
+			"Expected slice.uniq(%v) == %v, got %v",
+			original,
+			expected,
+			uniq,
+		)
 
 		delete(assorted)
 		delete(original)
@@ -278,12 +312,12 @@ test_unique :: proc(t: ^testing.T) {
 	}
 }
 
-@test
+@(test)
 test_compare_empty :: proc(t: ^testing.T) {
 	a := []int{}
 	b := []int{}
-	c: [dynamic]int = { 0 }
-	d: [dynamic]int = { 1 }
+	c: [dynamic]int = {0}
+	d: [dynamic]int = {1}
 	clear(&c)
 	clear(&d)
 	defer {
@@ -291,24 +325,29 @@ test_compare_empty :: proc(t: ^testing.T) {
 		delete(d)
 	}
 
-	testing.expectf(t, len(a) == 0,
-		"Expected length of slice `a` to be zero")
-	testing.expectf(t, len(c) == 0,
-		"Expected length of dynamic array `c` to be zero")
-	testing.expectf(t, len(d) == 0,
-		"Expected length of dynamic array `d` to be zero")
+	testing.expectf(t, len(a) == 0, "Expected length of slice `a` to be zero")
+	testing.expectf(t, len(c) == 0, "Expected length of dynamic array `c` to be zero")
+	testing.expectf(t, len(d) == 0, "Expected length of dynamic array `d` to be zero")
 
-	testing.expectf(t, slice.equal(a, a),
-		"Expected empty slice to be equal to itself")
-	testing.expectf(t, slice.equal(a, b),
-		"Expected two different but empty stack-based slices to be equivalent")
-	testing.expectf(t, slice.equal(a, c[:]),
-		"Expected empty slice to be equal to slice of empty dynamic array")
-	testing.expectf(t, slice.equal(c[:], d[:]),
-		"Expected two separate empty slices of two dynamic arrays to be equal")
+	testing.expectf(t, slice.equal(a, a), "Expected empty slice to be equal to itself")
+	testing.expectf(
+		t,
+		slice.equal(a, b),
+		"Expected two different but empty stack-based slices to be equivalent",
+	)
+	testing.expectf(
+		t,
+		slice.equal(a, c[:]),
+		"Expected empty slice to be equal to slice of empty dynamic array",
+	)
+	testing.expectf(
+		t,
+		slice.equal(c[:], d[:]),
+		"Expected two separate empty slices of two dynamic arrays to be equal",
+	)
 }
 
-@test
+@(test)
 test_linear_search_reverse :: proc(t: ^testing.T) {
 	index: int
 	found: bool
@@ -341,4 +380,71 @@ test_linear_search_reverse :: proc(t: ^testing.T) {
 	index, found = slice.linear_search_reverse_proc(s, less_than_80)
 	testing.expect(t, found)
 	testing.expect_value(t, index, 2)
+}
+
+@(test)
+test_diff :: proc(t: ^testing.T) {
+	script: []slice.Diff(rune)
+	err: mem.Allocator_Error
+
+	{
+		script, err = slice.diff(
+			[]rune{'A', 'B', 'C', 'A', 'B', 'B', 'A'},
+			[]rune{'C', 'B', 'A', 'B', 'A', 'C'},
+		)
+		defer delete(script)
+
+		testing.expect_value(t, err, nil)
+		if !testing.expect_value(t, len(script), 9) {return}
+		testing.expect_value(t, script[0], slice.Diff_Delete(rune){value = 'A'})
+		testing.expect_value(t, script[1], slice.Diff_Delete(rune){value = 'B'})
+		testing.expect_value(t, script[2], slice.Diff_Keep(rune){value = 'C'})
+		testing.expect_value(t, script[3], slice.Diff_Delete(rune){value = 'A'})
+		testing.expect_value(t, script[4], slice.Diff_Keep(rune){value = 'B'})
+		testing.expect_value(t, script[5], slice.Diff_Insert(rune){value = 'A'})
+		testing.expect_value(t, script[6], slice.Diff_Keep(rune){value = 'B'})
+		testing.expect_value(t, script[7], slice.Diff_Keep(rune){value = 'A'})
+		testing.expect_value(t, script[8], slice.Diff_Insert(rune){value = 'C'})
+	}
+
+	{
+		script, err = slice.diff([]rune{}, []rune{'A', 'B', 'C'})
+		defer delete(script)
+
+		testing.expect_value(t, err, nil)
+		if !testing.expect_value(t, len(script), 3) {return}
+		testing.expect_value(t, script[0], slice.Diff_Insert(rune){value = 'A'})
+		testing.expect_value(t, script[1], slice.Diff_Insert(rune){value = 'B'})
+		testing.expect_value(t, script[2], slice.Diff_Insert(rune){value = 'C'})
+	}
+
+	{
+		script, err = slice.diff([]rune{'A', 'B', 'C'}, []rune{})
+		defer delete(script)
+
+		testing.expect_value(t, err, nil)
+		if !testing.expect_value(t, len(script), 3) {return}
+		testing.expect_value(t, script[0], slice.Diff_Delete(rune){value = 'A'})
+		testing.expect_value(t, script[1], slice.Diff_Delete(rune){value = 'B'})
+		testing.expect_value(t, script[2], slice.Diff_Delete(rune){value = 'C'})
+	}
+
+	{
+		script, err = slice.diff([]rune{'O', 'd', 'i', 'n'}, []rune{'O', 'd', 'i', 'n'})
+		defer delete(script)
+
+		testing.expect_value(t, err, nil)
+		if !testing.expect_value(t, len(script), 4) {return}
+		testing.expect_value(t, script[0], slice.Diff_Keep(rune){value = 'O'})
+		testing.expect_value(t, script[1], slice.Diff_Keep(rune){value = 'd'})
+		testing.expect_value(t, script[2], slice.Diff_Keep(rune){value = 'i'})
+		testing.expect_value(t, script[3], slice.Diff_Keep(rune){value = 'n'})
+	}
+
+	{
+		script, err = slice.diff([]rune{}, []rune{})
+		defer delete(script)
+		testing.expect_value(t, err, nil)
+		if !testing.expect_value(t, len(script), 0) {return}
+	}
 }

--- a/tests/core/slice/test_core_slice.odin
+++ b/tests/core/slice/test_core_slice.odin
@@ -396,15 +396,15 @@ test_diff :: proc(t: ^testing.T) {
 
 		testing.expect_value(t, err, nil)
 		if !testing.expect_value(t, len(script), 9) {return}
-		testing.expect_value(t, script[0], slice.Diff_Delete(rune){value = 'A'})
-		testing.expect_value(t, script[1], slice.Diff_Delete(rune){value = 'B'})
-		testing.expect_value(t, script[2], slice.Diff_Keep(rune){value = 'C'})
-		testing.expect_value(t, script[3], slice.Diff_Delete(rune){value = 'A'})
-		testing.expect_value(t, script[4], slice.Diff_Keep(rune){value = 'B'})
-		testing.expect_value(t, script[5], slice.Diff_Insert(rune){value = 'A'})
-		testing.expect_value(t, script[6], slice.Diff_Keep(rune){value = 'B'})
-		testing.expect_value(t, script[7], slice.Diff_Keep(rune){value = 'A'})
-		testing.expect_value(t, script[8], slice.Diff_Insert(rune){value = 'C'})
+		testing.expect_value(t, script[0], slice.Diff(rune){kind = .Delete, value = 'A'})
+		testing.expect_value(t, script[1], slice.Diff(rune){kind = .Delete, value = 'B'})
+		testing.expect_value(t, script[2], slice.Diff(rune){kind = .Keep, value = 'C'})
+		testing.expect_value(t, script[3], slice.Diff(rune){kind = .Delete, value = 'A'})
+		testing.expect_value(t, script[4], slice.Diff(rune){kind = .Keep, value = 'B'})
+		testing.expect_value(t, script[5], slice.Diff(rune){kind = .Insert, value = 'A'})
+		testing.expect_value(t, script[6], slice.Diff(rune){kind = .Keep, value = 'B'})
+		testing.expect_value(t, script[7], slice.Diff(rune){kind = .Keep, value = 'A'})
+		testing.expect_value(t, script[8], slice.Diff(rune){kind = .Insert, value = 'C'})
 	}
 
 	{
@@ -413,9 +413,9 @@ test_diff :: proc(t: ^testing.T) {
 
 		testing.expect_value(t, err, nil)
 		if !testing.expect_value(t, len(script), 3) {return}
-		testing.expect_value(t, script[0], slice.Diff_Insert(rune){value = 'A'})
-		testing.expect_value(t, script[1], slice.Diff_Insert(rune){value = 'B'})
-		testing.expect_value(t, script[2], slice.Diff_Insert(rune){value = 'C'})
+		testing.expect_value(t, script[0], slice.Diff(rune){kind = .Insert, value = 'A'})
+		testing.expect_value(t, script[1], slice.Diff(rune){kind = .Insert, value = 'B'})
+		testing.expect_value(t, script[2], slice.Diff(rune){kind = .Insert, value = 'C'})
 	}
 
 	{
@@ -424,9 +424,9 @@ test_diff :: proc(t: ^testing.T) {
 
 		testing.expect_value(t, err, nil)
 		if !testing.expect_value(t, len(script), 3) {return}
-		testing.expect_value(t, script[0], slice.Diff_Delete(rune){value = 'A'})
-		testing.expect_value(t, script[1], slice.Diff_Delete(rune){value = 'B'})
-		testing.expect_value(t, script[2], slice.Diff_Delete(rune){value = 'C'})
+		testing.expect_value(t, script[0], slice.Diff(rune){kind = .Delete, value = 'A'})
+		testing.expect_value(t, script[1], slice.Diff(rune){kind = .Delete, value = 'B'})
+		testing.expect_value(t, script[2], slice.Diff(rune){kind = .Delete, value = 'C'})
 	}
 
 	{
@@ -435,10 +435,10 @@ test_diff :: proc(t: ^testing.T) {
 
 		testing.expect_value(t, err, nil)
 		if !testing.expect_value(t, len(script), 4) {return}
-		testing.expect_value(t, script[0], slice.Diff_Keep(rune){value = 'O'})
-		testing.expect_value(t, script[1], slice.Diff_Keep(rune){value = 'd'})
-		testing.expect_value(t, script[2], slice.Diff_Keep(rune){value = 'i'})
-		testing.expect_value(t, script[3], slice.Diff_Keep(rune){value = 'n'})
+		testing.expect_value(t, script[0], slice.Diff(rune){kind = .Keep, value = 'O'})
+		testing.expect_value(t, script[1], slice.Diff(rune){kind = .Keep, value = 'd'})
+		testing.expect_value(t, script[2], slice.Diff(rune){kind = .Keep, value = 'i'})
+		testing.expect_value(t, script[3], slice.Diff(rune){kind = .Keep, value = 'n'})
 	}
 
 	{

--- a/tests/core/slice/test_core_slice.odin
+++ b/tests/core/slice/test_core_slice.odin
@@ -395,16 +395,50 @@ test_diff :: proc(t: ^testing.T) {
 		defer delete(script)
 
 		testing.expect_value(t, err, nil)
-		if !testing.expect_value(t, len(script), 9) {return}
-		testing.expect_value(t, script[0], slice.Diff(rune){kind = .Delete, value = 'A'})
-		testing.expect_value(t, script[1], slice.Diff(rune){kind = .Delete, value = 'B'})
-		testing.expect_value(t, script[2], slice.Diff(rune){kind = .Keep, value = 'C'})
-		testing.expect_value(t, script[3], slice.Diff(rune){kind = .Delete, value = 'A'})
-		testing.expect_value(t, script[4], slice.Diff(rune){kind = .Keep, value = 'B'})
-		testing.expect_value(t, script[5], slice.Diff(rune){kind = .Insert, value = 'A'})
-		testing.expect_value(t, script[6], slice.Diff(rune){kind = .Keep, value = 'B'})
-		testing.expect_value(t, script[7], slice.Diff(rune){kind = .Keep, value = 'A'})
-		testing.expect_value(t, script[8], slice.Diff(rune){kind = .Insert, value = 'C'})
+		if !testing.expect_value(t, len(script), 7) {return}
+		testing.expect_value(t, script[0].kind, slice.Diff_Kind.Delete)
+		testing.expect_value(t, script[0].begin, 0)
+		testing.expect_value(t, script[0].end, 2)
+		if !testing.expect_value(t, len(script[0].values), 2) {return}
+		testing.expect_value(t, script[0].values[0], 'A')
+		testing.expect_value(t, script[0].values[1], 'B')
+
+		testing.expect_value(t, script[1].kind, slice.Diff_Kind.Keep)
+		testing.expect_value(t, script[1].begin, 2)
+		testing.expect_value(t, script[1].end, 3)
+		if !testing.expect_value(t, len(script[1].values), 1) {return}
+		testing.expect_value(t, script[1].values[0], 'C')
+
+		testing.expect_value(t, script[2].kind, slice.Diff_Kind.Delete)
+		testing.expect_value(t, script[2].begin, 3)
+		testing.expect_value(t, script[2].end, 4)
+		if !testing.expect_value(t, len(script[2].values), 1) {return}
+		testing.expect_value(t, script[2].values[0], 'A')
+
+		testing.expect_value(t, script[3].kind, slice.Diff_Kind.Keep)
+		testing.expect_value(t, script[3].begin, 4)
+		testing.expect_value(t, script[3].end, 5)
+		if !testing.expect_value(t, len(script[3].values), 1) {return}
+		testing.expect_value(t, script[3].values[0], 'B')
+
+		testing.expect_value(t, script[4].kind, slice.Diff_Kind.Insert)
+		testing.expect_value(t, script[4].begin, 2)
+		testing.expect_value(t, script[4].end, 3)
+		if !testing.expect_value(t, len(script[4].values), 1) {return}
+		testing.expect_value(t, script[4].values[0], 'A')
+
+		testing.expect_value(t, script[5].kind, slice.Diff_Kind.Keep)
+		testing.expect_value(t, script[5].begin, 5)
+		testing.expect_value(t, script[5].end, 7)
+		if !testing.expect_value(t, len(script[5].values), 2) {return}
+		testing.expect_value(t, script[5].values[0], 'B')
+		testing.expect_value(t, script[5].values[1], 'A')
+
+		testing.expect_value(t, script[6].kind, slice.Diff_Kind.Insert)
+		testing.expect_value(t, script[6].begin, 5)
+		testing.expect_value(t, script[6].end, 6)
+		if !testing.expect_value(t, len(script[6].values), 1) {return}
+		testing.expect_value(t, script[6].values[0], 'C')
 	}
 
 	{
@@ -412,10 +446,14 @@ test_diff :: proc(t: ^testing.T) {
 		defer delete(script)
 
 		testing.expect_value(t, err, nil)
-		if !testing.expect_value(t, len(script), 3) {return}
-		testing.expect_value(t, script[0], slice.Diff(rune){kind = .Insert, value = 'A'})
-		testing.expect_value(t, script[1], slice.Diff(rune){kind = .Insert, value = 'B'})
-		testing.expect_value(t, script[2], slice.Diff(rune){kind = .Insert, value = 'C'})
+		if !testing.expect_value(t, len(script), 1) {return}
+		testing.expect_value(t, script[0].kind, slice.Diff_Kind.Insert)
+		testing.expect_value(t, script[0].begin, 0)
+		testing.expect_value(t, script[0].end, 3)
+		if !testing.expect_value(t, len(script[0].values), 3) {return}
+		testing.expect_value(t, script[0].values[0], 'A')
+		testing.expect_value(t, script[0].values[1], 'B')
+		testing.expect_value(t, script[0].values[2], 'C')
 	}
 
 	{
@@ -423,10 +461,14 @@ test_diff :: proc(t: ^testing.T) {
 		defer delete(script)
 
 		testing.expect_value(t, err, nil)
-		if !testing.expect_value(t, len(script), 3) {return}
-		testing.expect_value(t, script[0], slice.Diff(rune){kind = .Delete, value = 'A'})
-		testing.expect_value(t, script[1], slice.Diff(rune){kind = .Delete, value = 'B'})
-		testing.expect_value(t, script[2], slice.Diff(rune){kind = .Delete, value = 'C'})
+		if !testing.expect_value(t, len(script), 1) {return}
+		testing.expect_value(t, script[0].kind, slice.Diff_Kind.Delete)
+		testing.expect_value(t, script[0].begin, 0)
+		testing.expect_value(t, script[0].end, 3)
+		if !testing.expect_value(t, len(script[0].values), 3) {return}
+		testing.expect_value(t, script[0].values[0], 'A')
+		testing.expect_value(t, script[0].values[1], 'B')
+		testing.expect_value(t, script[0].values[2], 'C')
 	}
 
 	{
@@ -434,11 +476,15 @@ test_diff :: proc(t: ^testing.T) {
 		defer delete(script)
 
 		testing.expect_value(t, err, nil)
-		if !testing.expect_value(t, len(script), 4) {return}
-		testing.expect_value(t, script[0], slice.Diff(rune){kind = .Keep, value = 'O'})
-		testing.expect_value(t, script[1], slice.Diff(rune){kind = .Keep, value = 'd'})
-		testing.expect_value(t, script[2], slice.Diff(rune){kind = .Keep, value = 'i'})
-		testing.expect_value(t, script[3], slice.Diff(rune){kind = .Keep, value = 'n'})
+		if !testing.expect_value(t, len(script), 1) {return}
+		testing.expect_value(t, script[0].kind, slice.Diff_Kind.Keep)
+		testing.expect_value(t, script[0].begin, 0)
+		testing.expect_value(t, script[0].end, 4)
+		if !testing.expect_value(t, len(script[0].values), 4) {return}
+		testing.expect_value(t, script[0].values[0], 'O')
+		testing.expect_value(t, script[0].values[1], 'd')
+		testing.expect_value(t, script[0].values[2], 'i')
+		testing.expect_value(t, script[0].values[3], 'n')
 	}
 
 	{


### PR DESCRIPTION
Implement Myers' Difference Algorithm for slices of simply comparable values. This implies computing a slice of edits to apply to the original slice to obtain the expected slice.

I've been writing a lot of Odin recently, and while I like that testing is builtin, but `testing.expect_value` is making me angry, since I am trying to diff tokens and AST representations of [Valve 220 MAP files](https://book.leveldesignbook.com/appendix/resources/formats/map). (even a simple map file can be around ~200 tokens). 

If this is accepted, I believe that further work can be done to improve `core:testing`'s assertion helpers to also display differences between their `value`, and `expected` argument.  With `os.is_tty`, logic can be applied to use `core:terminal/ansi` instead of prefixes to denote inserted or deleted values.

While the algorithm works and computes differences as expected, I know the number of memory allocations can be drastically reduced (hopefully linear memory usage with fixed number of calls to `make`). If there is interest in this PR, I'll take time to improve the algorithm.