### PR TITLE
Remove non-exported `joystick_lock` symbol

### DIFF
--- a/vendor/sdl3/sdl3_joystick.odin
+++ b/vendor/sdl3/sdl3_joystick.odin
@@ -2,10 +2,6 @@ package sdl3
 
 import "core:c"
 
-@(link_prefix="SDL_")
-foreign lib {
-	joystick_lock: ^Mutex
-}
 
 Joystick :: struct {}
 JoystickID :: distinct Uint32


### PR DESCRIPTION
As per the header, `SDL_joystick_lock` isn't an exported symbol. It's also defined as `static` is the source, when the header defines it.
https://github.com/libsdl-org/SDL/blob/release-3.4.2/include/SDL3/SDL_joystick.h#L78-L85
https://github.com/libsdl-org/SDL/blob/release-3.4.2/src/joystick/SDL_joystick.c#L114-L117

Additionally, as part of the 3.6.0 release it'll likely be removed entirely. Replaced by a global event lock. https://github.com/libsdl-org/SDL/commit/f9d49358d27f55fb9a9128f1bc18efb034becabb