### PR TITLE
Fix #6786

### DIFF
--- a/src/llvm_backend_const.cpp
+++ b/src/llvm_backend_const.cpp
@@ -2103,7 +2103,7 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, Ty
 									}
 								}
 								if (is_constant) {
-									LLVMValueRef elem_value = lb_const_value(m, tav.type, tav.value, tav.type, cc).value;
+									LLVMValueRef elem_value = lb_const_value(m, cv_type, tav.value, tav.type, cc).value;
 									if (LLVMIsConstant(elem_value) && LLVMIsConstant(values[index])) {
 										values[index] = llvm_const_insert_value(m, values[index], elem_value, idx_list, idx_list_len);
 									} else if (is_local) {


### PR DESCRIPTION
We weren't coercing the constant to the type of the field we're trying to assign to.

This resulted in union tags not being set when assigned through `using`.

I'm fairly certain there is no case in which not coercing the type is desirable.