### PR TITLE
Resolve panic on 64-bit overflow

### DIFF
--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -296,8 +296,7 @@ gb_internal void big_int_from_string(BigInt *dst, String const &s, bool *success
 
 
 gb_internal bool big_int_can_be_represented_in_64_bits(BigInt const *x) {
-	int bits_used = (x->used-1) * MP_DIGIT_BIT;
-	return bits_used <= 64;
+	return mp_count_bits(x) <= 64;
 }
 
 gb_internal u64 big_int_to_u64(BigInt const *x) {

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -3421,6 +3421,8 @@ gb_internal void check_shift(CheckerContext *c, Operand *x, Operand *y, Ast *nod
 				x->expr = node;
 				x->value = exact_value_shift(be->op.kind, exact_value_to_integer(x->value), exact_value_to_integer(y->value));
 
+				check_is_expressible(c, x, x->type);
+
 				return;
 			}
 


### PR DESCRIPTION
Patch logic causing a panic when an integer constant overflows 64-bits in a shift expression

Resolves #6889 