### PR TITLE
Add more constant type cases

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1471,6 +1471,10 @@ gb_internal bool is_type_constant_type(Type *t) {
 		return is_type_constant_type(t->Array.elem);
 	case Type_EnumeratedArray:
 		return is_type_constant_type(t->EnumeratedArray.elem);
+	case Type_SimdVector:
+		return is_type_constant_type(t->SimdVector.elem);
+	case Type_Matrix:
+		return is_type_constant_type(t->Matrix.elem);
 	}
 	return false;
 }


### PR DESCRIPTION
SIMD vector types are not checked if they're constant, so add this case in order to improve accuracy of other checks enough to resolve #6831 