### PR TITLE
Add ways to diff anon procs with same signature

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -12833,6 +12833,12 @@ gb_internal gbString write_expr_to_string(gbString str, Ast *node, bool shorthan
 		} else {
 			str = gb_string_appendc(str, " ---");
 		}
+		// NOTE(tf2spi):
+		// Two proc literals with the same signature output the same expr above
+		// which poses challenges for name canonicalization. Include the below
+		// discriminator with the file ID and offset to help with this.
+		TokenPos pos = ast_token(node).pos;
+		str = gb_string_append_fmt(str, " /* %d!%d */", pos.file_id, pos.offset);
 	case_end;
 
 	case_ast_node(cl, CompoundLit, node);

--- a/src/exact_value.cpp
+++ b/src/exact_value.cpp
@@ -1067,8 +1067,8 @@ gb_internal bool compare_exact_values(TokenKind op, ExactValue x, ExactValue y) 
 
 	case ExactValue_Procedure:
 		switch (op) {
-		case Token_CmpEq: return x.value_typeid == y.value_typeid;
-		case Token_NotEq: return x.value_typeid != y.value_typeid;
+		case Token_CmpEq: return x.value_procedure == y.value_procedure;
+		case Token_NotEq: return x.value_procedure != y.value_procedure;
 		}
 		break;
 


### PR DESCRIPTION
Previously, two different anonymous procedures with the same signature had the same name canonicalizations
This PR makes such anonymous procedures no longer have the same canonicalization

Resolves #6674