### PR TITLE
Allow casts to change mode for array programming

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -3926,6 +3926,11 @@ gb_internal void check_cast(CheckerContext *c, Operand *x, Type *type, bool forb
 		}
 	}
 
+	// In this case, the cast involves array programming
+	// so the operand needs to be a computed value
+	if (!is_type_array_like(x->type) && is_type_array_like(type)) {
+		x->mode = Addressing_Value;
+	}
 	x->type = type;
 }
 


### PR DESCRIPTION
Casts do not currently detect when a constant value needs to be a computed value for array programming, so add the logic to do so

Resolves #6757 