### PR TITLE
Fix compiler segmentation fault when field names start with '.'

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -10226,7 +10226,7 @@ gb_internal void check_compound_literal_field_values(CheckerContext *c, Slice<As
 		Ast *ident = fv->field;
 		if (ident->kind == Ast_ImplicitSelectorExpr) {
 			gbString expr_str = expr_to_string(ident);
-			error(ident, "Field names do not start with a '.', remove the '.' in %.*s", expr_str, LIT(assignment_str));
+			error(ident, "Field names do not start with a '.', remove the '.' from '%s' in %.*s", expr_str, LIT(assignment_str));
 			gb_string_free(expr_str);
 
 			ident = ident->ImplicitSelectorExpr.selector;


### PR DESCRIPTION
Compiler segfaults when field name starts with '.'
Resolves https://github.com/odin-lang/Odin/issues/6927