### PR TITLE
Fix typo in union error: excepts -> accepts

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -5202,7 +5202,7 @@ gb_internal void convert_to_typed(CheckerContext *c, Operand *operand, Type *tar
 				operand->mode = Addressing_Invalid;
 				convert_untyped_error(c, operand, target_type, true);
 				if (count > 0) {
-					error_line("'%s' is a union which only excepts the following types:\n", type_str);
+					error_line("'%s' is a union which only accepts the following types:\n", type_str);
 
 					error_line("\t");
 					for (i32 i = 0; i < count; i++) {


### PR DESCRIPTION
Before:
```
foo.odin(4:24) Error: Cannot convert untyped value '""' to 'union {int, bool}' from 'untyped string'
	u: union{int, bool} = ""
	                      ^^
'union {int, bool}' is a union which only excepts the following types:
	'int' or 'bool'
```
After:
```
foo.odin(4:24) Error: Cannot convert untyped value '""' to 'union {int, bool}' from 'untyped string'
	u: union{int, bool} = ""
	                      ^^
'union {int, bool}' is a union which only accepts the following types:
	'int' or 'bool'
```