### PR TITLE
Fix UTF-8 decode error check

### DIFF
--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -127,7 +127,7 @@ gb_internal isize utf8_decode(u8 const *str, isize str_len, Rune *codepoint_out)
 
 		sz = x&7;
 		accept = global__utf8_accept_ranges[x>>4];
-		if (str_len < gb_size_of(sz))
+		if (str_len < sz)
 			goto invalid_codepoint;
 
 		b1 = str[1];


### PR DESCRIPTION
This line mistakenly checks the size of the variable size, which will always return 1 as sz is u8, instead of checking against the actual value.

With current behavior this line will always be false. This also would have meant an invalid UTF-8 character at the end of a string could potentially read past what it should.