### PR TITLE
Make diverging or_else inherit load lhs type

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -9899,6 +9899,7 @@ gb_internal ExprKind check_or_else_expr(CheckerContext *c, Operand *o, Ast *node
 				if (is_diverging_expr(y.expr)) {
 					// Allow
 					y.mode = Addressing_Value;
+					y.type = x.type;
 					y_is_diverging = true;
 				} else {
 					error_operand_no_value(&y);


### PR DESCRIPTION
Allow diverging operand in or_else directive to inherit the type of the load directive so that return operand inherits this type too

Resolves #6675 