### PR TITLE
Add diverging, optional_ok to proc canon name

### DIFF
--- a/src/name_canonicalization.cpp
+++ b/src/name_canonicalization.cpp
@@ -972,6 +972,12 @@ gb_internal void write_type_to_canonical_string(TypeWriter *w, Type *type) {
 			type_writer_appendc(w, "->");
 			write_canonical_params(w, type->Proc.results);
 		}
+		if (type->Proc.diverging) {
+			type_writer_appendc(w, "!");
+		}
+		if (type->Proc.optional_ok) {
+			type_writer_appendc(w, "#optional_ok");
+		}
 		return;
 
 	case Type_Generic:


### PR DESCRIPTION
Add diverging and optional_ok properties to name canonicalization for procedures

It is related to issue 6872 but I don't know if this resolves it or not