### PR TITLE
Add procedures for Darwin application presentation options

### DIFF
--- a/core/sys/darwin/Foundation/NSApplication.odin
+++ b/core/sys/darwin/Foundation/NSApplication.odin
@@ -199,6 +199,16 @@ Application_sendAction :: proc "c" (self: ^Application, action: SEL, to: id, fro
 	msgSend(nil, self, "sendAction:to:from:", action, to, from)
 }
 
+@(objc_type=Application, objc_name="presentationOptions")
+Application_presentationOptions :: proc "c" (self: ^Application) -> ^ApplicationPresentationOptions {
+	return msgSend(^ApplicationPresentationOptions, self, "presentationOptions")
+}
+
+@(objc_type=Application, objc_name="setPresentationOptions")
+Application_setPresentationOptions :: proc "c" (self: ^Application, presentationOptions: ApplicationPresentationOptions) {
+	msgSend(nil, self, "setPresentationOptions:", presentationOptions)
+}
+
 
 
 


### PR DESCRIPTION
This PR adds the procedures for getting and setting the presentation options on a Darwin application.

The bitset and flags are already defined, it just looks like the procedures are missing.

I tested it the following way.

```odin
import ns "core:sys/darwin/Foundation"

app := ns.Application.sharedApplication()
...
presentation_options := ns.ApplicationPresentationOptions { .DisableHideApplication }
app->setPresentationOptions(presentation_options)
```

And I can confirm, hiding the application with `CMD + H` is disabled.

Related documentation:
https://developer.apple.com/documentation/appkit/nsapplication/presentationoptions-swift.property