### PR TITLE
Disallow types in #any_int params

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -6784,7 +6784,7 @@ gb_internal CallArgumentError check_call_arguments_internal(CheckerContext *c, A
 		if (!check_is_assignable_to_with_score(c, o, param_type, &s, param_is_variadic, allow_array_programming)) {
 			bool ok = false;
 			if (e && (e->flags & EntityFlag_AnyInt)) {
-				if (is_type_integer(param_type) && (is_type_integer(o->type) || is_type_enum(o->type))) {
+				if (o->mode != Addressing_Type && is_type_integer(param_type) && (is_type_integer(o->type) || is_type_enum(o->type))) {
 					ok = check_is_castable_to(c, o, param_type);
 				}
 			}


### PR DESCRIPTION
Reject ``#any_int`` cast if addressing the type instead of an actual value of that type

Resolves #6840 