### PR TITLE
Allow assigning union casts of constant values inside compound literals

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -12741,22 +12741,19 @@ gb_internal bool is_exact_value_zero(ExactValue const &v) {
 
 }
 
-
-
 gb_internal bool compare_exact_values_compound_lit(TokenKind op, ExactValue x, ExactValue y) {
 	ast_node(x_cl, CompoundLit, x.value_compound);
 	ast_node(y_cl, CompoundLit, y.value_compound);
 
-	if (x_cl->elems.count != y_cl->elems.count) {
-		return false;
-	}
-
 	bool test = op == Token_CmpEq;
+	if (x_cl->elems.count != y_cl->elems.count) {
+		return !test;
+	}
 
 	for (isize i = 0; i < x_cl->elems.count; i++) {
 		Ast *lhs = x_cl->elems[i];
 		Ast *rhs = y_cl->elems[i];
-		if (compare_exact_values(op, lhs->tav.value, rhs->tav.value) != test) {
+		if (compare_exact_values(Token_NotEq, lhs->tav.value, rhs->tav.value)) {
 			return !test;
 		}
 	}

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -8579,6 +8579,9 @@ gb_internal ExprKind check_call_expr_as_type_cast(CheckerContext *c, Operand *op
 				update_untyped_expr_type(c, arg, t, false);
 				check_representable_as_constant(c, operand->value, t, &operand->value);
 			}
+			if (operand->mode == Addressing_Constant && is_type_union(t)) {
+				operand->value.variant = arg->tav.type;
+			}
 			break;
 		}
 		}

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -8580,7 +8580,7 @@ gb_internal ExprKind check_call_expr_as_type_cast(CheckerContext *c, Operand *op
 				check_representable_as_constant(c, operand->value, t, &operand->value);
 			}
 			if (operand->mode == Addressing_Constant && is_type_union(t)) {
-				operand->value.variant = arg->tav.type;
+				operand->value = exact_value_typecast(operand->expr);
 			}
 			break;
 		}
@@ -12389,6 +12389,9 @@ gb_internal ExprKind check_expr_base_internal(CheckerContext *c, Operand *o, Ast
 				break;
 			}
 		}
+		if (o->mode == Addressing_Constant && is_type_union(type)) {
+			o->value = exact_value_typecast(tc->expr);
+		}
 		return Expr_Expr;
 	case_end;
 
@@ -12744,6 +12747,7 @@ gb_internal bool is_exact_value_zero(ExactValue const &v) {
 
 }
 
+
 gb_internal bool compare_exact_values_compound_lit(TokenKind op, ExactValue x, ExactValue y) {
 	ast_node(x_cl, CompoundLit, x.value_compound);
 	ast_node(y_cl, CompoundLit, y.value_compound);
@@ -12763,7 +12767,10 @@ gb_internal bool compare_exact_values_compound_lit(TokenKind op, ExactValue x, E
 	return test;
 }
 
-
+gb_internal bool compare_exact_values_typecast(TokenKind op, ExactValue x, ExactValue y) {
+	// TODO(tf2spi): Probably not the proper way to compare typecasts...
+	return compare_exact_values(op, x.value_typecast->tav.value, y.value_typecast->tav.value);
+}
 
 
 gb_internal gbString write_expr_to_string(gbString str, Ast *node, bool shorthand);

--- a/src/exact_value.cpp
+++ b/src/exact_value.cpp
@@ -1078,7 +1078,7 @@ gb_internal bool compare_exact_values(TokenKind op, ExactValue x, ExactValue y) 
 		}
 
 		if (x.kind != y.kind) {
-			return false;
+			return op == Token_NotEq;
 		}
 		return compare_exact_values_compound_lit(op, x, y);
 	}

--- a/src/exact_value.cpp
+++ b/src/exact_value.cpp
@@ -50,6 +50,7 @@ gb_global char const *exact_value_kind_string[ExactValue_Count] = {
 
 struct ExactValue {
 	ExactValueKind kind;
+	Type *variant;
 	union {
 		bool           value_bool;
 		String         value_string;

--- a/src/exact_value.cpp
+++ b/src/exact_value.cpp
@@ -5,6 +5,7 @@ struct Ast;
 struct HashKey;
 struct Type;
 struct Entity;
+struct TypeAndValue;
 gb_internal bool are_types_identical(Type *x, Type *y);
 
 struct Complex128 {
@@ -28,6 +29,7 @@ enum ExactValueKind {
 	ExactValue_Procedure  = 9,
 	ExactValue_Typeid     = 10,
 	ExactValue_String16   = 11,
+	ExactValue_TypeCast   = 12,
 
 	ExactValue_Count,
 };
@@ -46,6 +48,7 @@ gb_global char const *exact_value_kind_string[ExactValue_Count] = {
 	"Procedure",
 	"Typeid",
 	"String16",
+	"TypeCast",
 };
 
 struct ExactValue {
@@ -63,6 +66,7 @@ struct ExactValue {
 		Ast *          value_procedure;
 		Type *         value_typeid;
 		String16       value_string16;
+		Ast *          value_typecast;
 	};
 };
 
@@ -111,12 +115,21 @@ gb_internal uintptr hash_exact_value(ExactValue v) {
 	case ExactValue_Typeid:
 		res = ptr_map_hash_key(v.value_typeid);
 		break;
+	case ExactValue_TypeCast:
+		res = ptr_map_hash_key(v.value_typecast);
+		break;
 	default:
 		res = gb_fnv32a(&v, gb_size_of(ExactValue));
 	}
 	return res & 0x7fffffff;
 }
 
+
+gb_internal ExactValue exact_value_typecast(Ast *typecast) {
+	ExactValue result = {ExactValue_TypeCast};
+	result.value_typecast = typecast;
+	return result;
+}
 
 gb_internal ExactValue exact_value_compound(Ast *node) {
 	ExactValue result = {ExactValue_Compound};
@@ -678,6 +691,7 @@ gb_internal i32 exact_value_order(ExactValue const &v) {
 	switch (v.kind) {
 	case ExactValue_Invalid:
 	case ExactValue_Compound:
+	case ExactValue_TypeCast:
 		return 0;
 	case ExactValue_Bool:
 	case ExactValue_String:
@@ -719,6 +733,7 @@ gb_internal void match_exact_values(ExactValue *x, ExactValue *y) {
 	case ExactValue_Quaternion:
 	case ExactValue_Pointer:
 	case ExactValue_Compound:
+	case ExactValue_TypeCast:
 	case ExactValue_Procedure:
 	case ExactValue_Typeid:
 		return;
@@ -963,6 +978,7 @@ gb_internal gb_inline i32 cmp_f64(f64 a, f64 b) {
 }
 
 gb_internal bool compare_exact_values_compound_lit(TokenKind op, ExactValue x, ExactValue y);
+gb_internal bool compare_exact_values_typecast(TokenKind op, ExactValue x, ExactValue y);
 
 gb_internal bool compare_exact_values(TokenKind op, ExactValue x, ExactValue y) {
 	match_exact_values(&x, &y);
@@ -1082,6 +1098,15 @@ gb_internal bool compare_exact_values(TokenKind op, ExactValue x, ExactValue y) 
 			return op == Token_NotEq;
 		}
 		return compare_exact_values_compound_lit(op, x, y);
+	case ExactValue_TypeCast:
+		if (op != Token_CmpEq && op != Token_NotEq) {
+			return false;
+		}
+
+		if (x.kind != y.kind) {
+			return op == Token_NotEq;
+		}
+		return compare_exact_values_typecast(op, x, y);
 	}
 
 	GB_PANIC("Invalid comparison: %d", x.kind);
@@ -1142,6 +1167,8 @@ gb_internal gbString write_exact_value_to_string(gbString str, ExactValue const 
 
 	case ExactValue_Pointer:
 		return str;
+	case ExactValue_TypeCast:
+		return write_expr_to_string(str, v.value_typecast, false);
 	case ExactValue_Compound:
 		return write_expr_to_string(str, v.value_compound, false);
 	case ExactValue_Procedure:

--- a/src/llvm_backend_const.cpp
+++ b/src/llvm_backend_const.cpp
@@ -1037,6 +1037,9 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, Ty
 					         expr_to_string(value.value_compound),
 					         temp_canonical_string(value_type), temp_canonical_string(original_type));
 
+				} else if (value.variant != nullptr) {
+					value_type = value.variant;
+					break;
 				} else if (value.kind == ExactValue_Invalid) {
 					return lb_const_nil(m, original_type);
 				}

--- a/src/llvm_backend_const.cpp
+++ b/src/llvm_backend_const.cpp
@@ -1037,9 +1037,23 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, Ty
 					         expr_to_string(value.value_compound),
 					         temp_canonical_string(value_type), temp_canonical_string(original_type));
 
-				} else if (value.variant != nullptr) {
-					value_type = value.variant;
-					break;
+				} else if (value.kind == ExactValue_TypeCast) {
+					Ast *expr = value.value_typecast;
+					if (expr->kind == Ast_CallExpr && expr->CallExpr.proc->tav.mode == Addressing_Type) {
+						expr = expr->CallExpr.args[0];
+					} else if (expr->kind == Ast_TypeCast) {
+						expr = expr->TypeCast.expr;
+					}
+					Type *variant = type_of_expr(expr);
+					if (union_is_variant_of(value_type, variant)) {
+						value_type = variant;
+						if (is_type_union(variant)) {
+							value.value_typecast = expr;
+						} else {
+							value = expr->tav.value;
+						}
+						break;
+					}
 				} else if (value.kind == ExactValue_Invalid) {
 					return lb_const_nil(m, original_type);
 				}

--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -4388,20 +4388,6 @@ gb_internal lbValue lb_build_expr(lbProcedure *p, Ast *expr) {
 	return res;
 }
 
-gb_internal Type *lb_build_expr_original_const_type(Ast *expr) {
-	expr = unparen_expr(expr);
-	Type *type = type_of_expr(expr);
-	if (is_type_union(type)) {
-		if (expr->kind == Ast_CallExpr) {
-			if (expr->CallExpr.proc->tav.mode == Addressing_Type) {
-				Type *res = lb_build_expr_original_const_type(expr->CallExpr.args[0]);
-				return res;
-			}
-		}
-	}
-	return type_of_expr(expr);
-}
-
 gb_internal lbValue lb_build_expr_internal(lbProcedure *p, Ast *expr) {
 	lbModule *m = p->module;
 

--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -4414,9 +4414,8 @@ gb_internal lbValue lb_build_expr_internal(lbProcedure *p, Ast *expr) {
 
 
 	if (tv.value.kind != ExactValue_Invalid) {
-		Type *original_type = lb_build_expr_original_const_type(expr);
 		// NOTE(bill): Short on constant values
-		return lb_const_value(p->module, type, tv.value, original_type, LB_CONST_CONTEXT_DEFAULT_ALLOW_LOCAL);
+		return lb_const_value(p->module, type, tv.value, tv.type, LB_CONST_CONTEXT_DEFAULT_ALLOW_LOCAL);
 	} else if (tv.mode == Addressing_Type) {
 		// NOTE(bill, 2023-01-16): is this correct? I hope so at least
 		return lb_typeid(m, tv.type);

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -53,7 +53,6 @@ struct TypeAndValue {
 	ExactValue     value;
 };
 
-
 enum ParseFileError {
 	ParseFile_None,
 


### PR DESCRIPTION
An initial implementation of allowing casting of constant values to unions by adding a wrapper ``lb_const_expr`` function that will take an AST and extract union variants before calling ``lb_const_value``.

Resolves #6896
Resolves #6895 