### PR TITLE
[vendor:raylib] Add moved note.

### DIFF
--- a/vendor/raylib/moved.odin
+++ b/vendor/raylib/moved.odin
@@ -1,0 +1,3 @@
+package vendor_raylib_moved
+
+#panic("With the addition of Raylib v6.0. `vendor:raylib` has moved to `vendor:raylib/v55`, and v6.0 added to `vendor:raylib/v6`")


### PR DESCRIPTION
Adds a `#painc` note saying `vendor:raylib` was moved to `vendor:raylib/v55`.