### PR TITLE
Faster win32 directory iteration.

### DIFF
--- a/core/os/dir_windows.odin
+++ b/core/os/dir_windows.odin
@@ -2,8 +2,35 @@
 package os
 
 import "base:runtime"
+import "core:slice"
 import "core:time"
 import win32 "core:sys/windows"
+
+@(private="file")
+find_data_fullpath :: proc(base_path: string, d: ^win32.WIN32_FIND_DATAW, allocator: runtime.Allocator) -> (path, name: string, err: Error) {
+	wname_len := i32(slice.linear_search(d.cFileName[:], 0) or_else len(d.cFileName))
+	wname := cstring16(raw_data(d.cFileName[:]))
+
+	name_len := win32.WideCharToMultiByte(win32.CP_UTF8, win32.WC_ERR_INVALID_CHARS, wname, wname_len, nil, 0, nil, nil)
+	if name_len == 0 {
+		return "", "", _get_platform_error()
+	}
+
+	path_buf := make([]byte, len(base_path)+1+int(name_len), allocator) or_return
+	copy(path_buf, base_path)
+	path_buf[len(base_path)] = '\\'
+
+	name_buf := path_buf[len(base_path)+1:]
+	written := win32.WideCharToMultiByte(win32.CP_UTF8, win32.WC_ERR_INVALID_CHARS, wname, wname_len, raw_data(name_buf), name_len, nil, nil)
+	if written == 0 {
+		delete(path_buf, allocator)
+		return "", "", _get_platform_error()
+	}
+
+	path = string(path_buf)
+	name = string(name_buf[:written])
+	return
+}
 
 @(private="file")
 find_data_to_file_info :: proc(base_path: string, d: ^win32.WIN32_FIND_DATAW, allocator: runtime.Allocator) -> (fi: File_Info, err: Error) {
@@ -15,27 +42,17 @@ find_data_to_file_info :: proc(base_path: string, d: ^win32.WIN32_FIND_DATAW, al
 		return
 	}
 
-	temp_allocator := TEMP_ALLOCATOR_GUARD({ allocator })
-	path := concatenate({base_path, `\`, win32_wstring_to_utf8(cstring16(raw_data(d.cFileName[:])), temp_allocator) or_else ""}, allocator) or_return
-
-	handle := win32.HANDLE(_open_internal(path, {.Read}, Permissions_Read_Write_All) or_else 0)
-	defer win32.CloseHandle(handle)
-
+	path, name := find_data_fullpath(base_path, d, allocator) or_return
 	fi.fullpath = path
-	fi.name = basename(path)
+	fi.name = name
 	fi.size = i64(d.nFileSizeHigh)<<32 + i64(d.nFileSizeLow)
 
-	fi.type, fi.mode = _file_type_mode_from_file_attributes(d.dwFileAttributes, handle, d.dwReserved0)
+	fi.type, fi.mode = _file_type_mode_from_file_attributes(d.dwFileAttributes, nil, d.dwReserved0)
+	if fi.type == .Undetermined { fi.type = .Regular }
 
 	fi.creation_time     = time.unix(0, win32.FILETIME_as_unix_nanoseconds(d.ftCreationTime))
 	fi.modification_time = time.unix(0, win32.FILETIME_as_unix_nanoseconds(d.ftLastWriteTime))
 	fi.access_time       = time.unix(0, win32.FILETIME_as_unix_nanoseconds(d.ftLastAccessTime))
-
-	if file_id_info: win32.FILE_ID_INFO; handle != nil && win32.GetFileInformationByHandleEx(handle, .FileIdInfo, &file_id_info, size_of(file_id_info)) {
-		#assert(size_of(fi.inode) == size_of(file_id_info.FileId))
-		#assert(size_of(fi.inode) == 16)
-		runtime.mem_copy_non_overlapping(&fi.inode, &file_id_info.FileId, 16)
-	}
 
 	return
 }
@@ -98,11 +115,18 @@ _read_directory_iterator_init :: proc(it: ^Read_Directory_Iterator, f: ^File) {
 	if it.impl.find_handle != nil {
 		win32.FindClose(it.impl.find_handle)
 	}
+	it.impl.find_handle = nil
 	if it.impl.path != "" {
 		delete(it.impl.path, file_allocator())
+		it.impl.path = ""
 	}
 
-	if !is_directory(impl.name) {
+	file_info: win32.BY_HANDLE_FILE_INFORMATION
+	if !win32.GetFileInformationByHandle(_handle(f), &file_info) {
+		read_directory_iterator_set_error(it, impl.name, _get_platform_error())
+		return
+	}
+	if file_info.dwFileAttributes & win32.FILE_ATTRIBUTE_DIRECTORY == 0 {
 		read_directory_iterator_set_error(it, impl.name, .Invalid_Dir)
 		return
 	}
@@ -116,13 +140,25 @@ _read_directory_iterator_init :: proc(it: ^Read_Directory_Iterator, f: ^File) {
 	wpath_search[len(wpath)+1] = '*'
 	wpath_search[len(wpath)+2] = 0
 
-	it.impl.find_handle = win32.FindFirstFileW(cstring16(raw_data(wpath_search)), &it.impl.find_data)
+	it.impl.find_handle = win32.FindFirstFileExW(
+		cstring16(raw_data(wpath_search)),
+		.FindExInfoBasic,
+		&it.impl.find_data,
+		.FindExSearchNameMatch,
+		nil,
+		win32.FIND_FIRST_EX_LARGE_FETCH,
+	)
 	if it.impl.find_handle == win32.INVALID_HANDLE_VALUE {
+		it.impl.find_handle = win32.FindFirstFileW(cstring16(raw_data(wpath_search)), &it.impl.find_data)
+	}
+	if it.impl.find_handle == win32.INVALID_HANDLE_VALUE {
+		it.impl.find_handle = nil
 		read_directory_iterator_set_error(it, impl.name, _get_platform_error())
 		return
 	}
 	defer if it.err.err != nil {
 		win32.FindClose(it.impl.find_handle)
+		it.impl.find_handle = nil
 	}
 
 	err: Error
@@ -135,10 +171,10 @@ _read_directory_iterator_init :: proc(it: ^Read_Directory_Iterator, f: ^File) {
 }
 
 _read_directory_iterator_destroy :: proc(it: ^Read_Directory_Iterator) {
-	if it.f == nil {
-		return
-	}
 	file_info_delete(it.impl.prev_fi, file_allocator())
 	delete(it.impl.path, file_allocator())
-	win32.FindClose(it.impl.find_handle)
+	if it.impl.find_handle != nil {
+		win32.FindClose(it.impl.find_handle)
+	}
+	it.impl.find_handle = nil
 }

--- a/core/sys/windows/kernel32.odin
+++ b/core/sys/windows/kernel32.odin
@@ -388,6 +388,14 @@ foreign kernel32 {
 	) -> BOOL ---
 	CompareFileTime :: proc(lpFileTime1: LPFILETIME, lpFileTime2: LPFILETIME) -> LONG ---
 
+	FindFirstFileExW :: proc(
+		lpFileName:            LPCWSTR,
+		fInfoLevelId:          FINDEX_INFO_LEVELS,
+		lpFindFileData:        LPVOID,
+		fSearchOp:             FINDEX_SEARCH_OPS,
+		lpSearchFilter:        LPVOID,
+		dwAdditionalFlags:     DWORD,
+	) -> HANDLE ---
 	FindFirstFileW                  :: proc(fileName: LPCWSTR, findFileData: LPWIN32_FIND_DATAW) -> HANDLE ---
 	FindNextFileW                   :: proc(findFile: HANDLE, findFileData: LPWIN32_FIND_DATAW) -> BOOL ---
 	FindClose                       :: proc(findFile: HANDLE) -> BOOL ---

--- a/core/sys/windows/types.odin
+++ b/core/sys/windows/types.odin
@@ -220,6 +220,21 @@ FILE_ATTRIBUTE_OFFLINE             : DWORD : 0x00001000
 FILE_ATTRIBUTE_NOT_CONTENT_INDEXED : DWORD : 0x00002000
 FILE_ATTRIBUTE_ENCRYPTED           : DWORD : 0x00004000
 
+FINDEX_INFO_LEVELS :: enum c_int {
+	FindExInfoStandard,
+	FindExInfoBasic,
+	FindExInfoMaxInfoLevel,
+}
+
+FINDEX_SEARCH_OPS :: enum c_int {
+	FindExSearchNameMatch,
+	FindExSearchLimitToDirectories,
+	FindExSearchLimitToDevices,
+	FindExSearchMaxSearchOp,
+}
+
+FIND_FIRST_EX_LARGE_FETCH : DWORD : 0x00000002
+
 FILE_SHARE_READ      : DWORD : 0x00000001
 FILE_SHARE_WRITE     : DWORD : 0x00000002
 FILE_SHARE_DELETE    : DWORD : 0x00000004


### PR DESCRIPTION
I noticed that using the `core:os` directory walker was very slow for a folder hierarchy I have on my machine. It's somewhat large, consisting of 289 directories and 558522 files.

This PR brings the directory walking time down from 22-30 s to about 200-300 ms on my machine, so it's a significant improvement in that regard. There are drawbacks however. This will no longer fill in inode information, and it will no longer distinguish between `Named_Pipe`, `Character_Device`, `Regular` or `Undetermined` file types. I choose to have it report only `Regular` as that would mostly be the case I think, but `Undetermined` would be more truthful.

I guess the crux of this is if the speed up is worth the drawbacks for the standard library.

The main changes in this PR are:
1. Use `FindFirstFileExW` to fetch directory data in larger chunks and skip populating the short name. Falls back to the previous `FindFirstFileW` on error.
2. Skip doing `CreateFileW`, `GetFileType`, `GetFileInformationByHandleEx` and `CloseHandle` per entry. This is the main thing that slows the original code down. However we can't find out as much info per entry as per the drawbacks above.
3. Perform less work when building the `fullpath` and `name` fields by putting the basepath, directory separator and utf8 conversion directly into the allocated buffer.