### PR TITLE
fix: delete FilePathList.capacity field from the raylib bindings

### DIFF
--- a/vendor/raylib/raylib.odin
+++ b/vendor/raylib/raylib.odin
@@ -468,7 +468,6 @@ VrStereoConfig :: struct #align(4) {
 
 // File path list
 FilePathList :: struct {
-	capacity: c.uint,                     // Filepaths max entries
 	count:    c.uint,                     // Filepaths entries count
 	paths:    [^]cstring,                 // Filepaths entries
 }


### PR DESCRIPTION
Now layout FilePathList should match the c one. I don't know how did that even work for so long

<img width="1027" height="266" alt="Screenshot 2026-07-07 at 12 58 23" src="https://github.com/user-attachments/assets/0678332b-5c0e-4298-9e8e-f653f203c540" />
