### PR TITLE
🐛 Prevent git output with signature information

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -21,7 +21,7 @@ if "%VSCMD_ARG_TGT_ARCH%" neq "x64" (
 
 where /Q git.exe || goto skip_git_hash
 if not exist .git\ goto skip_git_hash
-for /f "tokens=1,2" %%i IN ('git show "--pretty=%%cd %%h" "--date=format:%%Y-%%m-%%d" --no-patch --no-notes HEAD') do (
+for /f "tokens=1,2" %%i IN ('git -c log.showSignature=false show "--pretty=%%cd %%h" "--date=format:%%Y-%%m-%%d" --no-patch --no-notes HEAD') do (
 	set CURR_DATE_TIME=%%i
 	set GIT_SHA=%%j
 )

--- a/build_odin.sh
+++ b/build_odin.sh
@@ -17,8 +17,10 @@ OS_ARCH="$(uname -m)"
 OS_NAME="$(uname -s)"
 
 if [ -d ".git" ] && [ -n "$(command -v git)" ]; then
-	GIT_SHA=$(git show --pretty='%h' --no-patch --no-notes HEAD)
-	GIT_DATE=$(git show "--pretty=%cd" "--date=format:%Y-%m" --no-patch --no-notes HEAD)
+	# Counter the user's git config to show the signature in logs.
+	gitnosig="-c log.showSignature=false"
+	GIT_SHA=$(git $gitnosig show --pretty='%h' --no-patch --no-notes HEAD)
+	GIT_DATE=$(git $gitnosig show "--pretty=%cd" "--date=format:%Y-%m" --no-patch --no-notes HEAD)
 	CPPFLAGS="$CPPFLAGS -DGIT_SHA=\"$GIT_SHA\""
 else
 	GIT_DATE=$(date +"%Y-%m")


### PR DESCRIPTION
When users have something like

[log]
        showSignature = true

in their .gitconfig files, invocations of the log or show git sub-command emit additional information about signatures.  This additional output disturbs the generation of the GIT_SHA and GIT_DATE values for the compiler command line.  The additional text is copied verbatim into the file in unexpected places.  The result is a parse error when invocing the compiler.

To fix it always suppress the output of the signature information.  This has no effects when the setting is disabled anyway.