### PR TITLE
vendor:box3d: fix ShapeDef layout by adding missing name field

### DIFF
--- a/vendor/box3d/box3d_types.odin
+++ b/vendor/box3d/box3d_types.odin
@@ -507,6 +507,9 @@ ShapeType :: enum c.int {
 // Used to create a shape
 // @ingroup shape
 ShapeDef :: struct {
+	/// Optional shape name for debugging
+	name:                  cstring,
+
 	// Use this to store application specific shape data.
 	userData: rawptr,
 


### PR DESCRIPTION
# vendor:box3d: fix ShapeDef layout by adding missing name field

## Summary

`vendor:box3d`'s `ShapeDef` is missing the first field from Box3D's C
definition:

```c
const char* name;
```

The generated Odin binding represents this field as:

```odin
name: cstring,
```

Because `ShapeDef` is passed to C by pointer, the missing 8-byte pointer
changes the layout of every following field. Box3D then reads incorrect
values from the structure.

This PR adds the missing `name: cstring` field to `ShapeDef` so that the
Odin structure layout matches the C definition.

## Reproduction

```odin
package main

import b3 "vendor:box3d"

main :: proc() {
    worldDef := b3.DefaultWorldDef()
    worldId := b3.CreateWorld(worldDef)

    bodyDef := b3.DefaultBodyDef()
    bodyId := b3.CreateBody(worldId, bodyDef)

    hull := b3.MakeBoxHull(50.0, 10.0, 50.0)

    shapeDef := b3.DefaultShapeDef()

    b3.CreateHullShape(bodyId, shapeDef, &hull.base)
}
```

## Actual result

```
BOX3D ASSERTION: def->internalValue == B3_SECRET_COOKIE,
/Users/defton/box3d/src/shape.c, line 263

zsh: trace trap  odin run .
```

## Investigation

The current `vendor:box3d` binding contains:

```odin
ShapeDef :: struct {
    userData: rawptr,
    materials: [^]SurfaceMaterial `fmt:"v,materialCount"`,
    materialCount: c.int,
    baseMaterial: SurfaceMaterial,
    density: f32,
    explosionScale: f32,
    filter: Filter,
    enableCustomFiltering: bool,
    isSensor: bool,
    enableSensorEvents: bool,
    enableContactEvents: bool,
    enableHitEvents: bool,
    enablePreSolveEvents: bool,
    invokeContactCreation: bool,
    updateBodyMass: bool,
    internalValue: c.int,
}
```

Regenerating bindings directly from Box3D's headers using
`odin-c-bindgen` produces:

```odin
ShapeDef :: struct {
    name: cstring,
    userData: rawptr,
    materials: ^SurfaceMaterial,
    materialCount: i32,
    baseMaterial: SurfaceMaterial,
    density: f32,
    explosionScale: f32,
    filter: Filter,
    enableCustomFiltering: bool,
    isSensor: bool,
    enableSensorEvents: bool,
    enableContactEvents: bool,
    enableHitEvents: bool,
    enablePreSolveEvents: bool,
    invokeContactCreation: bool,
    updateBodyMass: bool,
    internalValue: i32,
}
```

The regenerated bindings work correctly with the same `box3d.a` binary.
The library binary was verified to be identical by MD5, so this is not a
library version mismatch.

## Fix

Add the missing field as the first member of `ShapeDef`:

```odin
ShapeDef :: struct {
    /// Optional shape name for debugging
    name: cstring,

    userData: rawptr,
    ...
}
```

This restores the correct C ABI layout.