### PR TITLE
Fix for @(objc_implement) being broken in 2026-07

### DIFF
--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -1571,7 +1571,10 @@ gb_internal void lb_finalize_objc_names(lbGenerator *gen, lbProcedure *p) {
 	for (Entity *e = {}; mpsc_dequeue(&gen->info->objc_class_implementations, &e); /**/) {
 		GB_ASSERT(e->kind == Entity_TypeName && e->TypeName.objc_is_implementation);
 		lb_handle_objc_find_or_register_class(p, e->TypeName.objc_class_name, e->type);
-		error(e->token, "Objective-C related things are not allowed with '-bedrock'");
+
+		if (build_context.bedrock) {
+			error(e->token, "Objective-C related things are not allowed with '-bedrock'");
+		}
 	}
 
 	// Ensure classes that have been implicitly referenced through
@@ -1684,7 +1687,7 @@ gb_internal void lb_finalize_objc_names(lbGenerator *gen, lbProcedure *p) {
 			Type *superclass = tn.objc_superclass;
 
 			if (superclass != nullptr) {
-				auto& superclass_global = string_map_must_get(&global_class_map, tn.objc_class_name);
+				auto &superclass_global = string_map_must_get(&global_class_map, superclass->Named.type_name->TypeName.objc_class_name);
 				superclass_value = superclass_global.class_value;
 			}
 


### PR DESCRIPTION
Fix for two bugs I found in [dbb62f2](https://github.com/odin-lang/Odin/commit/dbb62f240a07f441e1dc5d9a33ee567c128337e6):
- `superclass->Named.type_name->TypeName.objc_class_name` was replaced with `tn.objc_class_name` in `lb_finalize_objc_names`. But tn is the class being registered, not its superclass. Eventually LLVM dereferences a null pointer as the superclass arg and the compiler crashes
- Fix a missing check for the `bedrock` flag, the compiler errors uconditionally whether or not the flag is passed.

This reproduces the first bug, and then with that bug fixed, the second bug:

```
package main
import NS "core:sys/darwin/Foundation"

@(objc_implement, objc_class="ReproClass", objc_superclass=NS.View)
ReproClass :: struct { using _: NS.View }

main :: proc() {
}
```