### PR TITLE
Disallow proc group assignment to blank identifier

### DIFF
--- a/src/check_stmt.cpp
+++ b/src/check_stmt.cpp
@@ -432,11 +432,24 @@ gb_internal Type *check_assignment_variable(CheckerContext *ctx, Operand *lhs, O
 
 	// NOTE(bill): Ignore assignments to '_'
 	if (is_blank_ident(node)) {
-		check_assignment(ctx, rhs, nullptr, str_lit("assignment to '_' identifier"));
-		if (rhs->mode == Addressing_Invalid) {
-			return nullptr;
+		String context_name = str_lit("assignment to '_' identifier");
+		check_assignment(ctx, rhs, nullptr, context_name);
+		switch (rhs->mode) {
+		case Addressing_ProcGroup: {
+			gbString expr_str = expr_to_string(rhs->expr);
+			defer (gb_string_free(expr_str));
+
+			error(rhs->expr,
+			      "Cannot assign procedure group '%s' in %.*s",
+			      expr_str,
+			      LIT(context_name));
+			rhs->mode = Addressing_Invalid;
 		}
-		return rhs->type;
+		case Addressing_Invalid:
+			return nullptr;
+		default:
+			return rhs->type;
+		}
 	}
 
 	Entity *e = nullptr;


### PR DESCRIPTION
We avoid LLVM build panic caused by the proc group not having an entity via disallowing the assignment in the first place.

Fixes #6862 