### PR TITLE
Increase stack size for threads

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -881,7 +881,7 @@ gb_global TargetMetrics target_freestanding_arm32 = {
 	TargetOs_freestanding,
 	TargetArch_arm32,
 	4, 4, 8, 16,
-	str_lit("arm-unknown-unknown-gnueabihf"),
+	str_lit("arm-none-eabihf"),
 };
 gb_global TargetMetrics target_freestanding_riscv64 = {
 	TargetOs_freestanding,

--- a/src/threading.cpp
+++ b/src/threading.cpp
@@ -643,7 +643,7 @@ gb_internal void thread_init(ThreadPool *pool, Thread *t, isize idx) {
 
 gb_internal void thread_init_and_start(ThreadPool *pool, Thread *t, isize idx) {
 	thread_init(pool, t, idx);
-	isize stack_size = 0;
+	isize stack_size = 1 * 1024 * 1024; // 1 MiB (LLVM takes a lot of stack space)
 
 #if defined(GB_SYSTEM_WINDOWS)
 	t->win32_handle = CreateThread(NULL, stack_size, internal_thread_proc, t, 0, NULL);


### PR DESCRIPTION
LLVM ARM32 emission code seemed to have taken up too much stack space for MUSL's default stack size, so increase it to about 1MB, which is >2x the stack space MUSL allocates by default.

Resolves #6981
Resolves #6823 