### PR TITLE
Allow custom `-collection`s to be used for `foreign import`s.

### DIFF
--- a/src/gb/gb.h
+++ b/src/gb/gb.h
@@ -5613,7 +5613,7 @@ gb_inline b32 gb_path_is_absolute(char const *path) {
 	b32 result = false;
 	GB_ASSERT(path != NULL);
 #if defined(GB_SYSTEM_WINDOWS)
-	result == (gb_strlen(path) > 2) &&
+	result = (gb_strlen(path) > 2) &&
 	          gb_char_is_alpha(path[0]) &&
 	          (path[1] == ':' && path[2] == GB_PATH_SEPARATOR);
 #else

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -648,6 +648,9 @@ try_cross_linking:;
 							//                local to the executable (unless the system collection is used, in which case we search
 							//                the system library paths for the library file).
 							if (string_ends_with(lib, str_lit(".a")) || string_ends_with(lib, str_lit(".o")) || string_ends_with(lib, str_lit(".so")) || string_contains_string(lib, str_lit(".so."))) {
+								if (lib.len > 0 && lib[0] == '/') {
+									lib = substring(lib, 1, lib.len);
+								}
 								lib_str = gb_string_append_fmt(lib_str, " -l:\"%.*s\" ", LIT(lib));
 							} else {
 								// dynamic or static system lib, just link regularly searching system library paths

--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -648,9 +648,6 @@ try_cross_linking:;
 							//                local to the executable (unless the system collection is used, in which case we search
 							//                the system library paths for the library file).
 							if (string_ends_with(lib, str_lit(".a")) || string_ends_with(lib, str_lit(".o")) || string_ends_with(lib, str_lit(".so")) || string_contains_string(lib, str_lit(".so."))) {
-								if (lib.len > 0 && lib[0] == '/') {
-									lib = substring(lib, 1, lib.len);
-								}
 								lib_str = gb_string_append_fmt(lib_str, " -l:\"%.*s\" ", LIT(lib));
 							} else {
 								// dynamic or static system lib, just link regularly searching system library paths

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2743,10 +2743,11 @@ gb_internal int print_show_help(String const arg0, String command, String option
 
 	if (check) {
 		if (print_flag("-collection:<name>=<filepath>")) {
-			print_usage_line(2, "Defines a library collection used for imports.");
+			print_usage_line(2, "Defines a library collection used for imports and foreign imports.");
 			print_usage_line(2, "Example: -collection:shared=dir/to/shared");
 			print_usage_line(2, "Usage in Code:");
 				print_usage_line(3, "import \"shared:foo\"");
+				print_usage_line(3, "foreign import lib \"shared:libfoo.a\"");
 		}
 
 		if (print_flag("-custom-attribute:<string>")) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -6132,15 +6132,22 @@ gb_internal bool determine_path_from_string(BlockingMutex *file_mutex, Ast *node
 	}
 
 	bool has_windows_drive = false;
-#if defined(GB_SYSTEM_WINDOWS)
-	if (file_mutex == nullptr) {
-		if (colon_pos == 1 && original_string.len > 2) {
+	bool is_absolute = false;
+	bool allow_absolute_path = file_mutex == nullptr || node->kind == Ast_ForeignImportDecl;
+
+	if (allow_absolute_path) {
+		if (colon_pos == 1 && original_string.len > 2 &&
+		    gb_char_is_alpha(original_string[0])) {
 			if (original_string[2] == '/' || original_string[2] == '\\') {
 				colon_pos = -1;
 				has_windows_drive = true;
+				is_absolute = true;
 			}
 		}
+	}
 
+#if defined(GB_SYSTEM_WINDOWS)
+	if (allow_absolute_path) {
 		for (isize i = 0; i < original_string.len; i++) {
 			if (original_string.text[i] == '\\') {
 				original_string.text[i] = '/';
@@ -6161,6 +6168,12 @@ gb_internal bool determine_path_from_string(BlockingMutex *file_mutex, Ast *node
 	} else {
 		file_str = original_string;
 	}
+
+#if !defined(GB_SYSTEM_WINDOWS)
+	if (allow_absolute_path && (file_str.len > 0 && file_str[0] == '/')) {
+		is_absolute = true;
+	}
+#endif
 
 
 	if (has_windows_drive) {
@@ -6231,7 +6244,7 @@ gb_internal bool determine_path_from_string(BlockingMutex *file_mutex, Ast *node
 		node->ForeignImportDecl.collection_name = collection_name;
 	}
 
-	if (has_windows_drive) {
+	if (is_absolute) {
 		*path = file_str;
 	} else {
 		bool ok = false;
@@ -7100,4 +7113,3 @@ gb_internal ParseFileError parse_packages(Parser *p, String init_filename) {
 
 	return ParseFile_None;
 }
-

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -6024,10 +6024,6 @@ gb_global Rune illegal_import_runes[] = {
 
 gb_internal bool is_import_path_valid(String const &path) {
 	if (path.len > 0) {
-		if (path[0] == '/') {
-			return false;
-		}
-
 		u8 *start = path.text;
 		u8 *end = path.text + path.len;
 		u8 *curr = start;
@@ -6053,6 +6049,19 @@ gb_internal bool is_import_path_valid(String const &path) {
 			curr += width;
 		}
 
+		return true;
+	}
+	return false;
+}
+
+gb_internal bool is_import_path_absolute(String const &path) {
+	if (path.len > 0 && path[0] == '/') {
+		return true;
+	}
+	if (path.len > 2 &&
+	    gb_char_is_alpha(path[0]) &&
+	    path[1] == ':' &&
+	    (path[2] == '/' || path[2] == '\\')) {
 		return true;
 	}
 	return false;
@@ -6271,6 +6280,12 @@ gb_internal void parse_setup_file_decls(Parser *p, AstFile *f, String const &bas
 			ast_node(id, ImportDecl, node);
 
 			String original_string = string_trim_whitespace(string_value_from_token(f, id->relpath));
+			if (is_import_path_absolute(original_string)) {
+				syntax_error(node, "Invalid import path: '%.*s'", LIT(original_string));
+				decls[i] = ast_bad_decl(f, id->relpath, id->relpath);
+				continue;
+			}
+
 			String import_path = {};
 			bool ok = determine_path_from_string(&p->file_decl_mutex, node, base_dir, original_string, &import_path);
 			if (!ok) {
@@ -6297,6 +6312,12 @@ gb_internal void parse_setup_file_decls(Parser *p, AstFile *f, String const &bas
 				GB_ASSERT(fp->kind == Ast_BasicLit);
 				Token fp_token = fp->BasicLit.token;
 				String file_str = string_trim_whitespace(string_value_from_token(f, fp_token));
+				if (is_import_path_absolute(file_str)) {
+					syntax_error(node, "Invalid import path: '%.*s'", LIT(file_str));
+					decls[i] = ast_bad_decl(f, fp_token, fp_token);
+					goto end;
+				}
+
 				String fullpath = file_str;
 				if (!is_arch_wasm() || string_ends_with(fullpath, str_lit(".o"))) {
 					String foreign_path = {};

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -6024,6 +6024,10 @@ gb_global Rune illegal_import_runes[] = {
 
 gb_internal bool is_import_path_valid(String const &path) {
 	if (path.len > 0) {
+		if (path[0] == '/') {
+			return false;
+		}
+
 		u8 *start = path.text;
 		u8 *end = path.text + path.len;
 		u8 *curr = start;
@@ -6131,23 +6135,8 @@ gb_internal bool determine_path_from_string(BlockingMutex *file_mutex, Ast *node
 		}
 	}
 
-	bool has_windows_drive = false;
-	bool is_absolute = false;
-	bool allow_absolute_path = file_mutex == nullptr || node->kind == Ast_ForeignImportDecl;
-
-	if (allow_absolute_path) {
-		if (colon_pos == 1 && original_string.len > 2 &&
-		    gb_char_is_alpha(original_string[0])) {
-			if (original_string[2] == '/' || original_string[2] == '\\') {
-				colon_pos = -1;
-				has_windows_drive = true;
-				is_absolute = true;
-			}
-		}
-	}
-
 #if defined(GB_SYSTEM_WINDOWS)
-	if (allow_absolute_path) {
+	if (file_mutex == nullptr) {
 		for (isize i = 0; i < original_string.len; i++) {
 			if (original_string.text[i] == '\\') {
 				original_string.text[i] = '/';
@@ -6169,20 +6158,7 @@ gb_internal bool determine_path_from_string(BlockingMutex *file_mutex, Ast *node
 		file_str = original_string;
 	}
 
-#if !defined(GB_SYSTEM_WINDOWS)
-	if (allow_absolute_path && (file_str.len > 0 && file_str[0] == '/')) {
-		is_absolute = true;
-	}
-#endif
-
-
-	if (has_windows_drive) {
-		String sub_file_path = substring(file_str, 3, file_str.len);
-		if (!is_import_path_valid(sub_file_path)) {
-			do_error(node, "Invalid import path: '%.*s'", LIT(file_str));
-			return false;
-		}
-	} else if (!is_import_path_valid(file_str)) {
+	if (!is_import_path_valid(file_str)) {
 		do_error(node, "Invalid import path: '%.*s'", LIT(file_str));
 		return false;
 	}
@@ -6244,13 +6220,8 @@ gb_internal bool determine_path_from_string(BlockingMutex *file_mutex, Ast *node
 		node->ForeignImportDecl.collection_name = collection_name;
 	}
 
-	if (is_absolute) {
-		*path = file_str;
-	} else {
-		bool ok = false;
-		String fullpath = string_trim_whitespace(get_fullpath_relative(permanent_allocator(), base_dir, file_str, &ok));
-		*path = fullpath;
-	}
+	String fullpath = string_trim_whitespace(get_fullpath_relative(permanent_allocator(), base_dir, file_str, nullptr));
+	*path = fullpath;
 	return true;
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -6129,12 +6129,13 @@ gb_internal bool determine_path_from_string(BlockingMutex *file_mutex, Ast *node
 	do_warning = &syntax_warning;
 	if (use_check_errors) {
 		do_error = &error;
-		do_error = &warning;
+		do_warning = &warning;
 	}
 
 	// NOTE(bill): if file_mutex == nullptr, this means that the code is used within the semantics stage
 
 	String collection_name = {};
+	bool is_import_decl_path = node->kind == Ast_ImportDecl || node->kind == Ast_ForeignImportDecl;
 
 	isize colon_pos = -1;
 	for (isize j = 0; j < original_string.len; j++) {
@@ -6144,8 +6145,18 @@ gb_internal bool determine_path_from_string(BlockingMutex *file_mutex, Ast *node
 		}
 	}
 
+	bool has_windows_drive = false;
 #if defined(GB_SYSTEM_WINDOWS)
 	if (file_mutex == nullptr) {
+		if (!is_import_decl_path &&
+		    colon_pos == 1 &&
+		    original_string.len > 2 &&
+		    gb_char_is_alpha(original_string[0]) &&
+		    (original_string[2] == '/' || original_string[2] == '\\')) {
+			colon_pos = -1;
+			has_windows_drive = true;
+		}
+
 		for (isize i = 0; i < original_string.len; i++) {
 			if (original_string.text[i] == '\\') {
 				original_string.text[i] = '/';
@@ -6167,7 +6178,18 @@ gb_internal bool determine_path_from_string(BlockingMutex *file_mutex, Ast *node
 		file_str = original_string;
 	}
 
-	if (!is_import_path_valid(file_str)) {
+	if (is_import_decl_path && is_import_path_absolute(file_str)) {
+		do_error(node, "Invalid import path: '%.*s'", LIT(file_str));
+		return false;
+	}
+
+	if (has_windows_drive) {
+		String sub_file_path = substring(file_str, 3, file_str.len);
+		if (!is_import_path_valid(sub_file_path)) {
+			do_error(node, "Invalid import path: '%.*s'", LIT(file_str));
+			return false;
+		}
+	} else if (!is_import_path_valid(file_str)) {
 		do_error(node, "Invalid import path: '%.*s'", LIT(file_str));
 		return false;
 	}
@@ -6229,8 +6251,12 @@ gb_internal bool determine_path_from_string(BlockingMutex *file_mutex, Ast *node
 		node->ForeignImportDecl.collection_name = collection_name;
 	}
 
-	String fullpath = string_trim_whitespace(get_fullpath_relative(permanent_allocator(), base_dir, file_str, nullptr));
-	*path = fullpath;
+	if (has_windows_drive) {
+		*path = file_str;
+	} else {
+		String fullpath = string_trim_whitespace(get_fullpath_relative(permanent_allocator(), base_dir, file_str, nullptr));
+		*path = fullpath;
+	}
 	return true;
 }
 


### PR DESCRIPTION
I noticed that foreign imports with absolute paths weren't working on Linux. After looking through the implementation, I found that absolute foreign imports were only permitted on Windows.

This PR changes that behavior so that foreign import now accepts absolute paths on both Windows and POSIX platforms. It also allows Windows-style absolute paths to be recognized from POSIX.

While investigating how absolute paths are detected, I came across what appears to be a bug in gb.h, which this PR also fixes.

I'm open to discussion if there's a reason the previous behavior was intentional.