### PR TITLE
Add soa variants to the unordered_remove and ordered_remove proc groups

### DIFF
--- a/base/runtime/core_builtin.odin
+++ b/base/runtime/core_builtin.odin
@@ -215,6 +215,7 @@ remove_range_fixed_capacity_dynamic_array :: proc(array: ^$D/[dynamic; $N]$E, #a
 unordered_remove :: proc{
 	unordered_remove_dynamic_array,
 	unordered_remove_fixed_capacity_dynamic_array,
+	unordered_remove_soa,
 }
 
 
@@ -222,6 +223,7 @@ unordered_remove :: proc{
 ordered_remove :: proc{
 	ordered_remove_dynamic_array,
 	ordered_remove_fixed_capacity_dynamic_array,
+	ordered_remove_soa,
 }
 
 @builtin


### PR DESCRIPTION
I was looking for these procs and incorrectly thought they didn't exist since they weren't in the proc groups. Adding them here to prevent future confusion