### PR TITLE
Reject chained deferred procedures.

### DIFF
--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -6884,6 +6884,13 @@ gb_internal void check_deferred_procedures(Checker *c) {
 			continue;
 		}
 
+		if (entity_has_deferred_procedure(dst)) {
+			error(src->token,
+			      "Deferred procedure '%.*s' cannot be used as the target of '%.*s' because it has a deferred procedure itself (deferred procedure chaining is not allowed)",
+			      LIT(dst->token.string), LIT(src->token.string));
+			continue;
+		}
+
 		if (is_type_polymorphic(src->type) || is_type_polymorphic(dst->type)) {
 			error(src->token, "'%s' cannot be used with a polymorphic procedure", attribute);
 			continue;


### PR DESCRIPTION
This PR rejects chained deferred procedures.

Code like the program below will be reject with the message:

> foo.odin(19:1) Error: Deferred procedure 'unlike' cannot be used as the target of 'like' because it has a deferred procedure itself (deferred procedure chaining is not allowed)
        like :: proc(n: int) {
        ^

I believe this change makes sense, since I don't think the feature of deferred procedures was designed with chains of them in mind. The code generated from this program is in fact not even correct. If we actually _do_ want to support chains of deferred procedures we need to fix the code gen instead.

```
package foo

import "core:fmt"

_n: int

unlike2 :: proc() {
        fmt.println("Unlike 2.")
        _n -= 1
}

@(deferred_none = unlike2)
unlike :: proc() {
        fmt.println("Unlike.")
        _n -= 1
}

@(deferred_none = unlike)
like :: proc(n: int) {
        fmt.println("Like.")
        _n = n
}

main :: proc() {
        {
                fmt.println("like scope enter")
                like(123)
        }
        {
                fmt.println("unlike scope enter")
                unlike()
        }
        {
                fmt.println("Value scope enter")
                fmt.println(_n)
        }
}
```
