### PR TITLE
fixed the import paths for raylib and rlgl.

### DIFF
--- a/vendor/raylib/raylib.odin
+++ b/vendor/raylib/raylib.odin
@@ -115,7 +115,7 @@ when ODIN_OS == .Windows {
 			// multiple copies of raylib.so, but since these bindings are for
 			// particular version of the library, I better specify it. Ideally,
 			// though, it's best specified in terms of major (.so.4)
-			"linux-arm64/libraylib.so.600" when RAYLIB_SHARED else "linux-arm/libraylib.a",
+			"linux-arm64/libraylib.so.600" when RAYLIB_SHARED else "linux-arm64/libraylib.a",
 			"system:dl",
 			"system:pthread",
 			"system:X11",

--- a/vendor/raylib/rlgl/rlgl.odin
+++ b/vendor/raylib/rlgl/rlgl.odin
@@ -135,7 +135,7 @@ when ODIN_OS == .Windows {
 			// multiple copies of raylib.so, but since these bindings are for
 			// particular version of the library, I better specify it. Ideally,
 			// though, it's best specified in terms of major (.so.4)
-			"../linux-arm64/libraylib.so.600" when RAYLIB_SHARED else "../linux-arm/libraylib.a",
+			"../linux-arm64/libraylib.so.600" when RAYLIB_SHARED else "../linux-arm64/libraylib.a",
 			"system:dl",
 			"system:pthread",
 			"system:X11",


### PR DESCRIPTION
both had the issue that they were looking for a directory called "linux-arm" when it's really called "linux-arm64" inside of "vendor/raylib".