### PR TITLE
Improve error message for never executed statements after a divergin proc call

### DIFF
--- a/src/check_stmt.cpp
+++ b/src/check_stmt.cpp
@@ -121,7 +121,9 @@ gb_internal void check_stmt_list(CheckerContext *ctx, Slice<Ast *> const &stmts,
 
 			case Ast_ExprStmt:
 				if (is_diverging_stmt(n)) {
-					error(n, "Statements after a diverging procedure call are never executed");
+					Ast *n_after = stmts[i + 1];
+					gbString n_string = expr_to_string(n->ExprStmt.expr);
+					error(n_after, "Statements after diverging procedure call \"%s\" are never executed", n_string);
 				}
 				break;
 			}


### PR DESCRIPTION
Statements that are never executed after a diverging procedure calls produce the error at the proc call site, which sometimes misleads the user to thinking the error being in the call itself

Example:
```odin
main :: proc() {
  os.exit(0)
  return
}
```
The mistake is obviously the useless `return` but the current error message would have you thinking otherwise.

Current message: `Statements after a diverging procedure call are never executed` pointing at the **call_expr**
Proposed message: `Statements after divergin procedure call "<call_expr>" are never executed` pointing at the **stmt**