### PR TITLE
Make object and assembly file extensions user-changeable again

### DIFF
--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -2734,7 +2734,7 @@ gb_internal String lb_filepath_obj_for_module(lbModule *m) {
 	gbString path = gb_string_make_length(heap_allocator(), basename.text, basename.len);
 	path = gb_string_appendc(path, "/");
 
-	bool output_is_directory = path_is_directory(make_string_c(path));
+	bool output_is_directory = path_is_directory(build_context.build_paths[BuildPath_Output]);
 
 	if (USE_SEPARATE_MODULES) {
 		GB_ASSERT(m->module_name != nullptr);


### PR DESCRIPTION
Since dev-2026-07, the file extensions for object and assembly files can no longer be changed with `-out:file.o` or `-out:file.asm`. This is caused by testing if the basename of the given output string is a directory, which is always true.

This PR changes the directory test to the full output string and so allows changing the extension again.