### PR TITLE
Expose memory block resizing in core:mem/virtual

### DIFF
--- a/core/mem/virtual/virtual.odin
+++ b/core/mem/virtual/virtual.odin
@@ -114,15 +114,15 @@ memory_block_alloc :: proc(committed, reserved: uint, alignment: uint = 0, flags
 	return &pmblock.block, nil
 }
 
-@(require_results, no_sanitize_address)
-_memory_block_resize :: proc(block: ^Memory_Block, new_size: uint, default_commit_size: uint) -> (err: Allocator_Error) {
-	if block.committed < new_size {
+@(private="file", require_results, no_sanitize_address)
+memory_block_ensure_capacity :: proc(block: ^Memory_Block, capacity: uint, default_commit_size: uint) -> (err: Allocator_Error) {
+	if block.committed < capacity {
 		pmblock := (^Platform_Memory_Block)(block)
 		base_offset := uint(uintptr(pmblock.block.base) - uintptr(pmblock))
 
 		// NOTE(bill): [Heuristic] grow the commit size larger than needed
 		// TODO(bill): determine a better heuristic for this behaviour
-		new_committed := max(new_size, block.committed<<1)
+		new_committed := max(capacity, block.committed<<1)
 		platform_total_commit := base_offset + new_committed
 		platform_total_commit = align_formula(platform_total_commit, uint(mem.PAGE_SIZE))
 		platform_total_commit = min(max(platform_total_commit, default_commit_size), pmblock.reserved)
@@ -144,8 +144,9 @@ memory_block_resize :: proc(block: ^Memory_Block, new_size: uint, default_commit
 	if block == nil || new_size > block.reserved {
 		return .Out_Of_Memory
     }
-	_memory_block_resize(block, new_size, default_commit_size) or_return
+	memory_block_ensure_capacity(block, new_size, default_commit_size) or_return
     block.used = new_size
+    return
 }
 
 @(require_results, no_sanitize_address)
@@ -179,7 +180,7 @@ alloc_from_memory_block :: proc(block: ^Memory_Block, min_size, alignment: uint,
 	}
 
 	new_size := block.used + size
-	_memory_block_resize(block, new_size, default_commit_size) or_return
+	memory_block_ensure_capacity(block, new_size, default_commit_size) or_return
 
 	data = block.base[block.used+alignment_offset:][:min_size]
 	block.used = new_size

--- a/core/mem/virtual/virtual.odin
+++ b/core/mem/virtual/virtual.odin
@@ -115,6 +115,40 @@ memory_block_alloc :: proc(committed, reserved: uint, alignment: uint = 0, flags
 }
 
 @(require_results, no_sanitize_address)
+_memory_block_resize :: proc(block: ^Memory_Block, new_size: uint, default_commit_size: uint) -> (err: Allocator_Error) {
+	if block.committed < new_size {
+		pmblock := (^Platform_Memory_Block)(block)
+		base_offset := uint(uintptr(pmblock.block.base) - uintptr(pmblock))
+
+		// NOTE(bill): [Heuristic] grow the commit size larger than needed
+		// TODO(bill): determine a better heuristic for this behaviour
+		new_committed := max(new_size, block.committed<<1)
+		platform_total_commit := base_offset + new_committed
+		platform_total_commit = align_formula(platform_total_commit, uint(mem.PAGE_SIZE))
+		platform_total_commit = min(max(platform_total_commit, default_commit_size), pmblock.reserved)
+
+		assert(pmblock.committed <= pmblock.reserved)
+		assert(pmblock.committed < platform_total_commit)
+
+		platform_memory_commit(pmblock, platform_total_commit) or_return
+
+		pmblock.committed = platform_total_commit
+		block.committed = pmblock.committed - base_offset
+		assert(block.committed <= block.reserved)
+	}
+	return
+}
+
+@(require_results, no_sanitize_address)
+memory_block_resize :: proc(block: ^Memory_Block, new_size: uint, default_commit_size: uint = 0) -> (err: Allocator_Error) {
+	if block == nil || new_size > block.reserved {
+		return .Out_Of_Memory
+    }
+	_memory_block_resize(block, new_size, default_commit_size) or_return
+    block.used = new_size
+}
+
+@(require_results, no_sanitize_address)
 alloc_from_memory_block :: proc(block: ^Memory_Block, min_size, alignment: uint, default_commit_size: uint = 0) -> (data: []byte, err: Allocator_Error) {
 	@(no_sanitize_address)
 	calc_alignment_offset :: proc "contextless" (block: ^Memory_Block, alignment: uintptr) -> uint {
@@ -126,30 +160,6 @@ alloc_from_memory_block :: proc(block: ^Memory_Block, min_size, alignment: uint,
 		}
 		return alignment_offset
 		
-	}
-	@(no_sanitize_address)
-	do_commit_if_necessary :: proc(block: ^Memory_Block, size: uint, default_commit_size: uint) -> (err: Allocator_Error) {
-		if block.committed - block.used < size {
-			pmblock := (^Platform_Memory_Block)(block)
-			base_offset := uint(uintptr(pmblock.block.base) - uintptr(pmblock))
-
-			// NOTE(bill): [Heuristic] grow the commit size larger than needed
-			// TODO(bill): determine a better heuristic for this behaviour
-			extra_size := max(size, block.committed>>1)
-			platform_total_commit := base_offset + block.used + extra_size
-			platform_total_commit = align_formula(platform_total_commit, uint(mem.PAGE_SIZE))
-			platform_total_commit = min(max(platform_total_commit, default_commit_size), pmblock.reserved)
-
-			assert(pmblock.committed <= pmblock.reserved)
-			assert(pmblock.committed < platform_total_commit)
-
-			platform_memory_commit(pmblock, platform_total_commit) or_return
-
-			pmblock.committed = platform_total_commit
-			block.committed = pmblock.committed - base_offset
-			assert(block.committed <= block.reserved)
-		}
-		return
 	}
 
 	if block == nil {
@@ -168,10 +178,11 @@ alloc_from_memory_block :: proc(block: ^Memory_Block, min_size, alignment: uint,
 		return
 	}
 
-	do_commit_if_necessary(block, size, default_commit_size) or_return
+	new_size := block.used + size
+	_memory_block_resize(block, new_size, default_commit_size) or_return
 
 	data = block.base[block.used+alignment_offset:][:min_size]
-	block.used += size
+	block.used = new_size
 	// sanitizer.address_unpoison(data)
 	return
 }

--- a/core/mem/virtual/virtual.odin
+++ b/core/mem/virtual/virtual.odin
@@ -145,8 +145,8 @@ memory_block_resize :: proc(block: ^Memory_Block, new_size: uint, default_commit
 		return .Out_Of_Memory
     }
 	memory_block_ensure_capacity(block, new_size, default_commit_size) or_return
-    block.used = new_size
-    return
+	block.used = new_size
+	return
 }
 
 @(require_results, no_sanitize_address)


### PR DESCRIPTION
See my use case at https://discord.com/channels/568138951836172421/1526888907747102812
I'm quite new to such low-level programming, and it's entirely possible that this change in the standard library is completely unnecessary for my use case.