### PR TITLE
testing: fix fancy progress UI overwriting test stdout

### DIFF
--- a/core/testing/runner.odin
+++ b/core/testing/runner.odin
@@ -8,6 +8,7 @@ package testing
 	List of contributors:
 		Ginger Bill: Initial implementation.
 		Feoramund:   Total rewrite.
+		John Bakhmat: Fancy-mode stdout capture.
 */
 
 import            "base:intrinsics"
@@ -493,6 +494,36 @@ runner :: proc(internal_tests: []Internal_Test) -> bool {
 	fmt.assertf(alloc_error == nil, "Error allocating memory for log message queue: %v", alloc_error)
 	defer delete(log_messages)
 
+	stdout_pending: [dynamic]Stdout_Message = ---
+	stdout_pending, alloc_error = make([dynamic]Stdout_Message, 0, RESERVED_LOG_MESSAGES)
+	fmt.assertf(alloc_error == nil, "Error allocating memory for stdout pending queue: %v", alloc_error)
+	defer free_stdout_messages(&stdout_pending)
+
+	test_stdout_ctx: Test_Stdout_Ctx
+	stdout_channel: Stdout_Channel = ---
+	saved_real_stdout := os.stdout
+
+	if should_show_animations {
+		stdout_buffer_size := BUFFERED_EVENTS_PER_CHANNEL * max(1, thread_count)
+		stdout_channel, alloc_error = chan.create_buffered(Stdout_Channel, stdout_buffer_size, context.allocator)
+		fmt.assertf(alloc_error == nil, "Error allocating memory for stdout channel: %v", alloc_error)
+
+		init_test_stdout_ctx(
+			&test_stdout_ctx,
+			saved_real_stdout,
+			chan.as_send(stdout_channel),
+			context.allocator,
+		)
+
+		os.stdout = &test_stdout_ctx.file
+	}
+	defer if should_show_animations {
+		if os.stdout == &test_stdout_ctx.file {
+			os.stdout = saved_real_stdout
+		}
+		chan.destroy(&stdout_channel)
+	}
+
 	sorted_failed_test_reasons: [dynamic]int = ---
 	sorted_failed_test_reasons, alloc_error = make([dynamic]int, 0, RESERVED_TEST_FAILURES)
 	fmt.assertf(alloc_error == nil, "Error allocating memory for sorted failed test reasons: %v", alloc_error)
@@ -621,6 +652,12 @@ runner :: proc(internal_tests: []Internal_Test) -> bool {
 				}
 			}
 
+			if !events_pending && should_show_animations {
+				if chan.len(stdout_channel) > 0 {
+					events_pending = true
+				}
+			}
+
 			if !events_pending {
 				// Keep the main thread from pegging a core at 100% usage.
 				time.sleep(1 * time.Microsecond)
@@ -730,6 +767,11 @@ runner :: proc(internal_tests: []Internal_Test) -> bool {
 					}
 				}
 			}
+		}
+
+		if should_show_animations {
+			alloc_error = drain_stdout_channel(stdout_channel, &stdout_pending)
+			fmt.assertf(alloc_error == nil, "Error draining stdout channel: %v", alloc_error)
 		}
 
 		check_timeouts: for i := len(task_timeouts) - 1; i >= 0; i -= 1 {
@@ -855,12 +897,18 @@ runner :: proc(internal_tests: []Internal_Test) -> bool {
 		// -- Redraw.
 
 		if should_show_animations {
-			if len(log_messages) == 0 && !needs_to_redraw(report) {
+			if len(log_messages) == 0 && len(stdout_pending) == 0 && !needs_to_redraw(report) {
 				continue main_loop
 			}
 
 			if !bypass_progress_overwrite {
 				fmt.wprintf(stdout, ansi_redraw_string, total_done_count, total_test_count)
+			}
+
+			if len(stdout_pending) > 0 {
+				if !emit_stdout_messages(stdout, &stdout_pending) {
+					fmt.wprintln(stdout)
+				}
 			}
 		} else {
 			if total_done_count != last_done_count {
@@ -909,6 +957,27 @@ runner :: proc(internal_tests: []Internal_Test) -> bool {
 	// At the time of writing, the thread library is undergoing a rewrite that
 	// should solve this problem; it is not an issue with the test runner itself.
 	thread.pool_join(&pool)
+
+	if should_show_animations {
+		alloc_error = drain_stdout_channel(stdout_channel, &stdout_pending)
+		fmt.assertf(alloc_error == nil, "Error draining stdout channel after join: %v", alloc_error)
+
+		if len(stdout_pending) > 0 {
+			// The pool may become empty before the main loop observes the last
+			// stdout writes. Clear the progress block before emitting them,
+			// then restore the final progress frame below the output.
+			fmt.wprintf(stdout, ansi_redraw_string, total_done_count, total_test_count)
+
+			if !emit_stdout_messages(stdout, &stdout_pending) {
+				fmt.wprintln(stdout)
+			}
+
+			redraw_report(batch_writer, report)
+			draw_status_bar(batch_writer, thread_count_status_string, total_done_count, total_test_count)
+			fmt.wprint(stdout, bytes.buffer_to_string(&batch_buffer))
+			bytes.buffer_reset(&batch_buffer)
+		}
+	}
 
 	finished_in := time.since(start_time)
 

--- a/core/testing/stdout.odin
+++ b/core/testing/stdout.odin
@@ -1,0 +1,112 @@
+#+private
+package testing
+
+import "base:runtime"
+import "core:fmt"
+import "core:io"
+import "core:strings"
+import "core:os"
+import "core:sync/chan"
+
+Stdout_Message :: struct {
+	text: string,
+	allocator: runtime.Allocator,
+}
+
+Stdout_Channel :: chan.Chan(Stdout_Message)
+Stdout_Channel_Sender :: chan.Chan(Stdout_Message, .Send)
+
+Test_Stdout_Ctx :: struct {
+	file: os.File,
+	real_stdout: ^os.File,
+	channel: Stdout_Channel_Sender,
+	allocator: runtime.Allocator,
+}
+
+init_test_stdout_ctx :: proc(
+	ctx: ^Test_Stdout_Ctx,
+	real_stdout: ^os.File,
+	channel: Stdout_Channel_Sender,
+	allocator: runtime.Allocator,
+) {
+	assert(real_stdout != nil)
+	ctx^ = {
+		real_stdout = real_stdout,
+		channel = channel,
+		allocator = allocator,
+		file = real_stdout^,
+	}
+	ctx.file.stream = {
+		procedure = test_stdout_stream_proc,
+		data = ctx,
+	}
+}
+
+test_stdout_stream_proc :: proc(
+	stream_data: rawptr,
+	mode: os.File_Stream_Mode,
+	p: []byte,
+	offset: i64,
+	whence: io.Seek_From,
+	allocator: runtime.Allocator,
+) -> (n: i64, err: os.Error) {
+	f := (^os.File)(stream_data)
+	ctx := (^Test_Stdout_Ctx)(f.stream.data)
+
+	#partial switch mode {
+	case .Write:
+		if len(p) == 0 {
+			return 0, nil
+		}
+
+		cloned, clone_err := strings.clone(string(p), ctx.allocator)
+		assert(clone_err == nil, "Error cloning stdout write buffer in test runner.")
+
+		chan.send(ctx.channel, Stdout_Message {
+			text = cloned,
+			allocator = ctx.allocator,
+		})
+		return i64(len(p)), nil
+
+	case .Flush:
+		return 0, nil
+	}
+
+	return ctx.real_stdout.stream.procedure(ctx.real_stdout, mode, p, offset, whence, allocator)
+}
+
+drain_stdout_channel :: proc(
+	channel: Stdout_Channel,
+	messages: ^[dynamic]Stdout_Message,
+) -> runtime.Allocator_Error {
+	for {
+		message, ok := chan.try_recv(channel)
+		if !ok {
+			return nil
+		}
+		_, err := append(messages, message)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+emit_stdout_messages :: proc(w: io.Writer, messages: ^[dynamic]Stdout_Message) -> (ends_with_newline: bool) {
+	ends_with_newline = true
+	for message in messages {
+		fmt.wprint(w, message.text)
+		if len(message.text) > 0 {
+			ends_with_newline = message.text[len(message.text)-1] == '\n'
+		}
+		delete(message.text, message.allocator)
+	}
+	clear(messages)
+	return
+}
+
+free_stdout_messages :: proc(messages: ^[dynamic]Stdout_Message) {
+	for message in messages {
+		delete(message.text, message.allocator)
+	}
+	clear(messages)
+}


### PR DESCRIPTION
Fixes #6316

# TLDR
With `ODIN_TEST_FANCY=true` in a TTY, the test runner redraws progress using a fixed cursor-up count. Test output written directly to `os.stdout` via `fmt.print*` lands below that block and gets erased on the final redraw.
This intercepts test-thread stdout writes and emits them on the main thread before redrawing progress.

# gist for testing and bug reproduction
```odin
// repro.odin

package formats

import "core:fmt"
import "core:testing"

@(test)
repro_stdout_overwrite :: proc(t: ^testing.T) {
	for i in 1 ..= 5 {
		fmt.printfln("line %i", i)
	}
}
```

```justfile

run-expected:
	./odin/odin test ./repro.odin -file -define:ODIN_TEST_FANCY=true | cat
	
run-fancy:
	./odin/odin test ./repro.odin -file -define:ODIN_TEST_FANCY=true

```


# Console output before the patch

#### Expected (piped into cat)
```
[INFO ] --- [2026-07-15 14:41:01] Starting test runner with 1 thread. Set with -define:ODIN_TEST_THREADS=n.
[INFO ] --- [2026-07-15 14:41:01] The random seed sent to every test is: 15754497140737. Set with -define:ODIN_TEST_RANDOM_SEED=n.
[INFO ] --- [2026-07-15 14:41:01] Memory tracking is enabled. Tests will log their memory usage if there's an issue.
[INFO ] --- [2026-07-15 14:41:01] < Final Mem/ Total Mem> <  Peak Mem> (#Free/Alloc) :: [package.test_name]
line 1
line 2
line 3
line 4
line 5

Finished 1 test in 50µs. The test was successful.
```

#### Fancy (weird one)

```
formats  [|                       ]    0/   1 :: repro_stdout_overwrite
line 5
[INFO ] --- [2026-07-15 14:42:01] Starting test runner with 1 thread. Set with -define:ODIN_TEST_THREADS=n.
[INFO ] --- [2026-07-15 14:42:01] The random seed sent to every test is: 15755933034312. Set with -define:ODIN_TEST_RANDOM_SEED=n.
[INFO ] --- [2026-07-15 14:42:01] Memory tracking is enabled. Tests will log their memory usage if there's an issue.
[INFO ] --- [2026-07-15 14:42:01] < Final Mem/ Total Mem> <  Peak Mem> (#Free/Alloc) :: [package.test_name]
formats  [|                       ]         1 :: [package done]

Finished 1 test in 59µs. The test was successful.
```


# Console output now 
```
./odin/odin test ./repro.odin -file -define:ODIN_TEST_FANCY=true
[INFO ] --- [2026-07-15 14:45:45] Starting test runner with 1 thread. Set with -define:ODIN_TEST_THREADS=n.
[INFO ] --- [2026-07-15 14:45:45] The random seed sent to every test is: 15761303873954. Set with -define:ODIN_TEST_RANDOM_SEED=n.
[INFO ] --- [2026-07-15 14:45:45] Memory tracking is enabled. Tests will log their memory usage if there's an issue.
[INFO ] --- [2026-07-15 14:45:45] < Final Mem/ Total Mem> <  Peak Mem> (#Free/Alloc) :: [package.test_name]
line 1
line 2
line 3
line 4
line 5
formats  [|                       ]         1 :: [package done]

Finished 1 test in 180µs. The test was successful.
```
