### PR TITLE
`core:log`: make multi logger use all loggers instead of breaking on first non match

### DIFF
--- a/core/log/multi_logger.odin
+++ b/core/log/multi_logger.odin
@@ -48,7 +48,7 @@ multi_logger_proc :: proc(logger_data: rawptr, level: Level, text: string,
 	data := cast(^Multi_Logger_Data)logger_data
 	for log in data.loggers {
 		if level < log.lowest_level {
-			return
+			continue
 		}
 		log.procedure(log.data, level, text, log.options, location)
 	}


### PR DESCRIPTION
Fixes #6622

Currently a multi logger (log.create_multi_logger) "attempts" to log to all loggers that were passed, and it aborts whenever it encounters one that has a lower log level than the log record emitted (so effectively making the order of the passed loggers important to whether a log is actually generated or not).

This pr addresses that to always use all stored loggers, as the documentation states:
https://github.com/odin-lang/Odin/blob/7c2b21925901d1b125ddc9fb290b6a7e7ed9dd0d/core/log/multi_logger.odin#L9-L12

Example code and output:

```go
package main

import "core:log"

main :: proc() {
    console_logger_info := log.create_console_logger(lowest = .Info, ident = "LOGGER 1")
    console_logger_error := log.create_console_logger(lowest = .Error, ident = "logger 2")

    context.logger = log.create_multi_logger(console_logger_error, console_logger_info)
    log.error("emitting error")
    log.warn("emitting warn")
    log.info("emitting info")
}
```

Output:
```log
[ERROR] --- [2026-07-15 15:47:05] [main.odin:10:main()] [logger 2] emitting error
[ERROR] --- [2026-07-15 15:47:05] [main.odin:10:main()] [LOGGER 1] emitting error
[WARN ] --- [2026-07-15 15:47:05] [main.odin:11:main()] [LOGGER 1] emitting warn
[INFO ] --- [2026-07-15 15:47:05] [main.odin:12:main()] [LOGGER 1] emitting info
```

Broken output from before this pr:
```log
[ERROR] --- [2026-07-15 15:47:01] [main.odin:10:main()] [logger 2] emitting error
[ERROR] --- [2026-07-15 15:47:01] [main.odin:10:main()] [LOGGER 1] emitting error
```
(Changing the order in create_multi_logger generates more logs this way)