### PR TITLE
Fix a deadlock in the backend where the holder of the `func_raw_types_mutex` and `types_mutex` were waiting for each other

### DIFF
--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -1781,12 +1781,14 @@ gb_internal LLVMTypeRef lb_type_internal_for_procedures_raw(lbModule *m, Type *t
 	GB_ASSERT(type->kind == Type_Proc);
 
 	mutex_lock(&m->func_raw_types_mutex);
-	defer (mutex_unlock(&m->func_raw_types_mutex));
 
 	LLVMTypeRef *found = map_get(&m->func_raw_types, type);
 	if (found) {
+		mutex_unlock(&m->func_raw_types_mutex);
 		return *found;
 	}
+
+	mutex_unlock(&m->func_raw_types_mutex);
 
 	unsigned param_count = 0;
 
@@ -1896,7 +1898,9 @@ gb_internal LLVMTypeRef lb_type_internal_for_procedures_raw(lbModule *m, Type *t
 	              "\n\tFuncTypeCtx: %p\n\tCurrentCtx:  %p\n\tGlobalCtx:   %p",
 	              LLVMGetTypeContext(new_abi_fn_type), m->ctx);
 
+	mutex_lock(&m->func_raw_types_mutex);
 	map_set(&m->func_raw_types, type, new_abi_fn_type);
+	mutex_unlock(&m->func_raw_types_mutex);
 
 	return new_abi_fn_type;
 }


### PR DESCRIPTION
Previously you could have thread A start doing `lb_type_internal_for_procedures_raw` without holding the `types_mutex` and then thread B comes in, locks the `types_mutex`, calls `lb_type_internal_for_procedures_raw` (which blocks because thread A holds the `func_raw_types_mutex`), but then thread A will also block because it will now wait on the `types_mutex`.

### The following section is no longer accurate, as the performance regression is now avoided by shrinking the critical section of `func_raw_types_mutex` instead:

This does mean that there will be a bit more time spent waiting for the `types_mutex` (around 5/10ms from some crude measurements on projects where `LLVM API Code Gen` is usually around 300/400ms respectively), but that is still better than waiting infinitely imo :upside_down_face: (if there is a smarter solution that does not require locking the `types_mutex` that would obviously be great). I guess the `types_mutex` could be unlocked before calling `lb_type_internal_for_procedures_raw`, but given that it is a recursive mutex that feels really hacky.

I'm making this a draft because of the mentioned performance considerations.