### PR TITLE
Compare mmap result to MAP_FAILED rather than nullptr

### DIFF
--- a/src/common_memory.cpp
+++ b/src/common_memory.cpp
@@ -284,11 +284,11 @@ gb_internal bool  platform_virtual_memory_commit_internal(void *data, isize comm
 
 	gb_internal void *platform_virtual_memory_alloc_internal(isize total_size, bool commit) {
 		void *mem = mmap(nullptr, total_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
-		if (mem == nullptr) {
+		if (mem == MAP_FAILED) {
 			gb_printf_err("Out of Virtual memory, oh no...\n");
 			gb_printf_err("Requested: %lld bytes\n", cast(long long)total_size);
 			gb_printf_err("Total Usage: %lld bytes\n", cast(long long)global_platform_memory_total_usage);
-			GB_ASSERT_MSG(mem != nullptr, "Out of Virtual Memory, oh no...");
+			GB_ASSERT_MSG(mem != MAP_FAILED, "Out of Virtual Memory, oh no...");
 		}
 		return mem;
 	}


### PR DESCRIPTION
Fixes a bug I noticed while investigating Issue #7053, in [platform_virtual_memory_alloc_internal](https://github.com/odin-lang/Odin/blob/0051152f7662d14f458849160d5c92bc0390921e/src/common_memory.cpp#L285) the result of `mmap` is compared to `nullptr` when it should in fact be compared to [`MAP_FAIL`](https://man.archlinux.org/man/mmap64.3.en#RETURN_VALUE).

This means that a failed `mmap` will go undetected until the resulting pointer is used, instead of the error being reported immediately.