### PR TITLE
Fix Quat math and #by_ptr hiccups in `vendor:box3d`

### DIFF
--- a/tests/vendor/all.odin
+++ b/tests/vendor/all.odin
@@ -3,3 +3,4 @@ package tests_vendor
 @(require) import   "glfw"
 @(require) import _ "lua/5.4"
 @(require) import _ "curl"
+@(require) import _ "box3d"

--- a/tests/vendor/box3d/test_vendor_box3d.odin
+++ b/tests/vendor/box3d/test_vendor_box3d.odin
@@ -1,0 +1,121 @@
+#+build windows, linux, darwin
+package test_vendor_box3d
+
+import "core:math"
+import "core:math/linalg"
+import "core:os"
+import "core:strings"
+import "core:testing"
+
+import b3 "vendor:box3d"
+
+// Helper: record 8 steps of a falling sphere. The caller owns the returned handles.
+record_falling_sphere :: proc() -> (b3.WorldId, ^b3.Recording) {
+	world_def := b3.DefaultWorldDef()
+	world := b3.CreateWorld(world_def)
+
+	body_def := b3.DefaultBodyDef()
+	body_def.type = .dynamicBody
+	body_def.position = b3.Pos{0, 4, 0}
+	body := b3.CreateBody(world, body_def)
+
+	shape_def := b3.DefaultShapeDef()
+	sphere := b3.Sphere{center = {0, 0, 0}, radius = 0.5}
+	_ = b3.CreateSphereShape(body, shape_def, &sphere)
+
+	rec := b3.CreateRecording(0)
+	b3.World_StartRecording(world, rec)
+	for _ in 0..<8 {
+		b3.World_Step(world, 1.0 / 60, 4)
+	}
+	b3.World_StopRecording(world)
+
+	return world, rec
+}
+
+// RotateVector, InvRotateVector, and InvMulQuat must match the C reference.
+@(test)
+test_quat_rotate_math :: proc(t: ^testing.T) {
+	v := b3.Vec3{1, -2, 3}
+
+	// The identity quaternion leaves any vector untouched (exactly).
+	testing.expect(t, b3.RotateVector(b3.Quat(1), v) == v, "RotateVector with identity quaternion changed the vector")
+	testing.expect(t, b3.InvRotateVector(b3.Quat(1), v) == v, "InvRotateVector with identity quaternion changed the vector")
+
+	// A 90-degree rotation about +Z maps +X to +Y.
+	q90 := linalg.quaternion_angle_axis_f32(math.PI / 2, b3.Vec3{0, 0, 1})
+	rotated := b3.RotateVector(q90, b3.Vec3{1, 0, 0})
+	testing.expect(t, linalg.distance(rotated, b3.Vec3{0, 1, 0}) < 1e-5, "RotateVector 90 degrees about +Z did not map +X to +Y")
+
+	axis := linalg.normalize(b3.Vec3{0.3, 0.8, -0.5})
+	q := linalg.quaternion_angle_axis_f32(0.9, axis)
+
+	// RotateVector agrees with the linalg reference rotation.
+	reference := linalg.quaternion_mul_vector3(q, v)
+	testing.expect(t, linalg.distance(b3.RotateVector(q, v), reference) < 1e-5, "RotateVector disagrees with the linalg reference")
+
+	// InvRotateVector inverts RotateVector for a normalized quaternion.
+	round_trip := b3.InvRotateVector(q, b3.RotateVector(q, v))
+	testing.expect(t, linalg.distance(round_trip, v) < 1e-5, "InvRotateVector did not invert RotateVector")
+
+	// inv(q) * q is the identity quaternion.
+	identity := b3.InvMulQuat(q, q)
+	testing.expect(t, linalg.length(identity.xyz) < 1e-5, "InvMulQuat(q, q) has a non-zero vector part")
+	testing.expect(t, math.abs(identity.w - 1) < 1e-5, "InvMulQuat(q, q) does not have w == 1")
+}
+
+// Recording and RecPlayer handle round-trip.
+@(test)
+test_recording_and_recplayer_round_trip :: proc(t: ^testing.T) {
+	world, rec := record_falling_sphere()
+	defer b3.DestroyWorld(world)
+	defer b3.DestroyRecording(rec)
+
+	size := b3.Recording_GetSize(rec)
+	testing.expect(t, size > 0, "recording is empty after 8 steps")
+	data := b3.Recording_GetData(rec)
+	testing.expect(t, data != nil, "recording data is nil")
+
+	path := "test_vendor_box3d_recording.b3rec"
+	cpath := strings.clone_to_cstring(path, context.temp_allocator)
+	testing.expect(t, b3.SaveRecordingToFile(rec, cpath), "SaveRecordingToFile failed")
+
+	loaded := b3.LoadRecordingFromFile(cpath)
+	defer b3.DestroyRecording(loaded)
+	testing.expect(t, b3.Recording_GetSize(loaded) == size, "loaded recording size differs from saved recording")
+
+	_ = os.remove(path)
+
+	player := b3.RecPlayer_Create(rawptr(data), size, 1)
+	testing.expect(t, player != nil, "RecPlayer_Create returned nil")
+	if player == nil {
+		return
+	}
+	defer b3.RecPlayer_Destroy(player)
+
+	info := b3.RecPlayer_GetInfo(player)
+	testing.expect(t, info.frameCount == 8, "unexpected recorded frame count in RecPlayerInfo")
+	testing.expect(t, b3.RecPlayer_GetFrameCount(player) == 8, "unexpected frame count")
+
+	testing.expect(t, b3.RecPlayer_StepFrame(player), "StepFrame failed on the first frame")
+	testing.expect(t, b3.RecPlayer_GetFrame(player) == 1, "player did not advance to frame 1")
+
+	replay_world := b3.RecPlayer_GetWorldId(player)
+	testing.expect(t, b3.World_IsValid(replay_world), "replay world is not valid")
+	testing.expect(t, !b3.RecPlayer_HasDiverged(player), "replay diverged from the recording")
+}
+
+// Body_SetUserData round-trips through Body_GetUserData.
+@(test)
+test_body_user_data_round_trip :: proc(t: ^testing.T) {
+	world_def := b3.DefaultWorldDef()
+	world := b3.CreateWorld(world_def)
+	defer b3.DestroyWorld(world)
+
+	body_def := b3.DefaultBodyDef()
+	body := b3.CreateBody(world, body_def)
+
+	sentinel := 42
+	b3.Body_SetUserData(body, &sentinel)
+	testing.expect(t, b3.Body_GetUserData(body) == &sentinel, "Body_GetUserData did not return the pointer set with Body_SetUserData")
+}

--- a/vendor/box3d/box3d.odin
+++ b/vendor/box3d/box3d.odin
@@ -427,7 +427,7 @@ foreign lib {
 	// Create a recording buffer with an optional initial byte capacity.
 	// Pass 0 to use the default (64 KiB). The buffer grows on demand.
 	// @return a new recording, owned by the caller
-	 CreateRecording :: proc(byteCapacity: c.int) -> Recording ---
+	 CreateRecording :: proc(byteCapacity: c.int) -> ^Recording ---
 
 	// Destroy a recording and free its buffer.
 	// @param recording may be NULL
@@ -437,11 +437,11 @@ foreign lib {
 	// Valid until the recording buffer is modified or destroyed.
 	// @param recording the recording handle
 	// @return pointer to the byte buffer, or NULL if no bytes have been written
-	Recording_GetData :: proc(#by_ptr recording: Recording) -> [^]u8 ---
+	Recording_GetData :: proc(recording: ^Recording) -> [^]u8 ---
 
 	// Get the number of bytes currently in the recording buffer.
 	// @param recording the recording handle
-	Recording_GetSize :: proc(#by_ptr recording: Recording) -> c.int ---
+	Recording_GetSize :: proc(recording: ^Recording) -> c.int ---
 
 	// Begin recording world mutations into the provided buffer.
 	// The buffer is reset on each call so a single Recording can be reused for multiple sessions.
@@ -457,12 +457,12 @@ foreign lib {
 	// Save the recording buffer to a file. Returns true on success.
 	// @param recording the recording to save
 	// @param path file path to write
-	SaveRecordingToFile :: proc(#by_ptr recording: Recording, path: cstring) -> bool ---
+	SaveRecordingToFile :: proc(recording: ^Recording, path: cstring) -> bool ---
 
 	// Load a recording from a file. Returns NULL on failure (file not found, wrong magic).
 	// The caller owns the returned recording and must destroy it with DestroyRecording.
 	// @param path file path to read
-	 LoadRecordingFromFile :: proc(path: cstring) -> Recording ---
+	 LoadRecordingFromFile :: proc(path: cstring) -> ^Recording ---
 
 	// Replay a recording from memory and verify it reproduces the same world-state hashes.
 	// Stands up a fresh world, restores the seed snapshot, replays every op, and checks each embedded
@@ -480,7 +480,7 @@ foreign lib {
 	// Replaying at a different count re-partitions the constraint graph, so the StateHash check
 	// becomes a cross-thread determinism test. Adjustable later with RecPlayer_SetWorkerCount.
 	// @return a new player, or NULL on bad header or deserialization failure
-	RecPlayer_Create :: proc(data: rawptr, size: c.int, workerCount: c.int) -> RecPlayer ---
+	RecPlayer_Create :: proc(data: rawptr, size: c.int, workerCount: c.int) -> ^RecPlayer ---
 
 	// Destroy the player and free all memory. Restores the previous global length scale.
 	RecPlayer_Destroy :: proc(player: ^RecPlayer) ---
@@ -503,28 +503,28 @@ foreign lib {
 	RecPlayer_SeekFrame :: proc(player: ^RecPlayer, targetFrame: c.int) ---
 
 	// @return the world currently driven by this player
-	RecPlayer_GetWorldId :: proc(#by_ptr player: RecPlayer) -> WorldId ---
+	RecPlayer_GetWorldId :: proc(player: ^RecPlayer) -> WorldId ---
 
 	// @return the last fully-stepped frame index (0 before any step)
-	RecPlayer_GetFrame :: proc(#by_ptr player: RecPlayer) -> c.int ---
+	RecPlayer_GetFrame :: proc(player: ^RecPlayer) -> c.int ---
 
 	// @return total number of recorded frames
-	RecPlayer_GetFrameCount :: proc(#by_ptr player: RecPlayer) -> c.int ---
+	RecPlayer_GetFrameCount :: proc(player: ^RecPlayer) -> c.int ---
 
 	// @return true when the op stream is exhausted
-	RecPlayer_IsAtEnd :: proc(#by_ptr player: RecPlayer) -> bool ---
+	RecPlayer_IsAtEnd :: proc(player: ^RecPlayer) -> bool ---
 
 	// @return true when the op stream is paused between body creation and world step.
-	RecPlayer_IsAtPreStep :: proc(#by_ptr player: RecPlayer) -> bool ---
+	RecPlayer_IsAtPreStep :: proc(player: ^RecPlayer) -> bool ---
 
 	// @return true when any StateHash mismatch has been detected
-	RecPlayer_HasDiverged :: proc(#by_ptr player: RecPlayer) -> bool ---
+	RecPlayer_HasDiverged :: proc(player: ^RecPlayer) -> bool ---
 
 	// @return a summary of the recording read at open: frame count, recorded tuning, and bounds
-	RecPlayer_GetInfo :: proc(#by_ptr player: RecPlayer) -> RecPlayerInfo ---
+	RecPlayer_GetInfo :: proc(player: ^RecPlayer) -> RecPlayerInfo ---
 
 	// @return the first frame at which replay diverged, or -1 if it has not diverged
-	RecPlayer_GetDivergeFrame :: proc(#by_ptr player: RecPlayer) -> c.int ---
+	RecPlayer_GetDivergeFrame :: proc(player: ^RecPlayer) -> c.int ---
 
 	// Set the worker count of the replay world. Clamped to [1, B3_MAX_WORKERS]. Applied to the live
 	// world at once and reused whenever the player rebuilds its world on Restart or a backward seek.
@@ -542,24 +542,24 @@ foreign lib {
 	RecPlayer_SetKeyframePolicy :: proc(player: ^RecPlayer, budgetBytes: uint, minIntervalFrames: c.int) ---
 
 	// @return the keyframe memory budget in bytes
-	RecPlayer_GetKeyframeBudget :: proc(#by_ptr player: RecPlayer) -> uint ---
+	RecPlayer_GetKeyframeBudget :: proc(player: ^RecPlayer) -> uint ---
 
 	// @return the finest keyframe spacing in frames
-	RecPlayer_GetKeyframeMinInterval :: proc(#by_ptr player: RecPlayer) -> c.int ---
+	RecPlayer_GetKeyframeMinInterval :: proc(player: ^RecPlayer) -> c.int ---
 
 	// @return the current keyframe spacing in frames; starts at the min interval and doubles as the
 	// ring evicts to stay under budget, so it reflects the effective backward-seek granularity now
-	RecPlayer_GetKeyframeInterval :: proc(#by_ptr player: RecPlayer) -> c.int ---
+	RecPlayer_GetKeyframeInterval :: proc(player: ^RecPlayer) -> c.int ---
 
 	// @return the memory currently held by keyframe snapshots, in bytes
-	RecPlayer_GetKeyframeBytes :: proc(#by_ptr player: RecPlayer) -> uint ---
+	RecPlayer_GetKeyframeBytes :: proc(player: ^RecPlayer) -> uint ---
 
 	// @return the number of bodies tracked in creation order (including holes for destroyed bodies)
-	RecPlayer_GetBodyCount :: proc(#by_ptr player: RecPlayer) -> c.int ---
+	RecPlayer_GetBodyCount :: proc(player: ^RecPlayer) -> c.int ---
 
 	// Resolve a creation ordinal to the live body id at the current frame.
 	// @return the body id, or a null id if that ordinal is out of range or its body is destroyed
-	RecPlayer_GetBodyId :: proc(#by_ptr player: RecPlayer, index: c.int) -> BodyId ---
+	RecPlayer_GetBodyId :: proc(player: ^RecPlayer, index: c.int) -> BodyId ---
 
 	// Wire host debug-shape callbacks into the player's replay world so a renderer can build
 	// per-shape draw resources (the 3D sample needs this or the replay world draws nothing).
@@ -582,13 +582,13 @@ foreign lib {
 
 
 	// @return the number of spatial queries recorded for the most recently replayed frame
-	RecPlayer_GetFrameQueryCount :: proc(#by_ptr player: RecPlayer) -> c.int ---
+	RecPlayer_GetFrameQueryCount :: proc(player: ^RecPlayer) -> c.int ---
 
 	// Get a recorded query from the most recently replayed frame by index.
-	RecPlayer_GetFrameQuery :: proc(#by_ptr player: RecPlayer, index: c.int) -> RecQueryInfo ---
+	RecPlayer_GetFrameQuery :: proc(player: ^RecPlayer, index: c.int) -> RecQueryInfo ---
 
 	// Get one result of a recorded query from the most recently replayed frame.
-	RecPlayer_GetFrameQueryHit :: proc(#by_ptr player: RecPlayer, queryIndex: c.int, hitIndex: c.int) -> RecQueryHit ---
+	RecPlayer_GetFrameQueryHit :: proc(player: ^RecPlayer, queryIndex: c.int, hitIndex: c.int) -> RecQueryHit ---
 
 	/**@}*/ // recording
 

--- a/vendor/box3d/box3d_math.odin
+++ b/vendor/box3d/box3d_math.odin
@@ -291,9 +291,9 @@ RotateVector :: proc "c" (q: Quat, v: Vec3) -> Vec3 {
 	// v + 2 * cross(q.xyz, cross(q.xyz, v) + q.w * v)
 	// B3_ASSERT(IsNormalizedQuat(q));
 	t1 := Cross(q.xyz, v)
-	t2 := t1 * q.w + v
+	t2 := t1 + q.w * v
 	t3 := Cross(q.xyz, t2)
-	return v * 2.0 + t3
+	return v + 2.0 * t3
 }
 
 // Inverse rotate a vector.
@@ -302,9 +302,9 @@ InvRotateVector :: proc "c" (q: Quat, v: Vec3) -> Vec3 {
 	// v + 2 * cross(q.xyz, cross(q.xyz, v) - q.w * v)
 	// B3_ASSERT(IsNormalizedQuat(q));
 	t1 := Cross(q.xyz, v)
-	t2 := t1 * q.w - v
+	t2 := t1 - q.w * v
 	t3 := Cross(q.xyz, t2)
-	return v * 2.0 + t3
+	return v + 2.0 * t3
 }
 
 // Compute dot product of two quaternions. Useful for polarity tests.
@@ -322,8 +322,8 @@ MulQuat :: proc "c" (q1, q2: Quat) -> Quat {
 @(require_results)
 InvMulQuat :: proc "c" (q1, q2: Quat) -> Quat {
 	t1 := Cross(q2.xyz, q1.xyz)
-	t2 := t1 * q1.w + q2.xyz
-	t3 := t2 * q2.w - q1.xyz
+	t2 := t1 + q1.w * q2.xyz
+	t3 := t2 - q2.w * q1.xyz
 	return quaternion(x=t3.x, y=t3.y, z=t3.z, w=q1.w * q2.w + Dot(q1.xyz, q2.xyz))
 }
 


### PR DESCRIPTION
Hey there, I've been into Box3D on a game project and ran into a few visual hiccups and crashes. Really loving Odin so I wanted to contribute my fixes back upstream.

If I'm not mistaken I think I've found a handful of binding bugs. I'm open to being wrong on any of these — especially the `#by_ptr` bits, since I may just be misunderstanding how that feature is intended to be used.

I've put standalone repro scripts on a companion branch so you can see the failures against unpatched master without cluttering this PR; they can be run with `./odin run repro/<case-file>.odin -file`

## Quat math helpers

I first noticed that some of my debug shapes were drifting out of position. Looking closely at `RotateVector`, in  [`vendor/box3d/box3d_math.odin`](vendor/box3d/box3d_math.odin) it seems like the operators for `MulAdd` and `MullSub` operations were transposed from `a ± s*b` to `a*s ± b`, leading a rotated identity Quat to yield `2*v`. (the elusive off-by-2x error :smile:)

```diff
RotateVector :: proc "c" (q: Quat, v: Vec3) -> Vec3 {
    t1 := Cross(q.xyz, v)
-   t2 := t1 * q.w + v
+   t2 := t1 + q.w * v
    t3 := Cross(q.xyz, t2)
-   return v * 2.0 + t3
+   return v + 2.0 * t3
}
```

`InvRotateVector` and `InvMulQuat` get the same correction, tested in [test_vendor_box3d.odin](tests/vendor/box3d/test_vendor_box3d.odin)'s `test_quat_rotate_math`.

### Reproduction Sample: [`repro/box3d_wrong_quat_math.odin`](https://github.com/qtrfeast/Odin/blob/vendor-box3d-binding-fixes-repro-sh/repro/box3d_wrong_quat_math.odin)
[`repro/box3d_wrong_quat_math.odin`](https://github.com/qtrfeast/Odin/blob/vendor-box3d-binding-fixes-repro-sh/repro/box3d_wrong_quat_math.odin)

```sh
> ./odin run repro/box3d_wrong_quat_math.odin -file
# box3d_wrong_quat_math
RotateVector(identity, [1, -2, 3]) = [2, -4, 6] (want [1, -2, 3])
RotateVector(90deg about +Z, +X) = [1.6464467, 0.70710677, 0] (want [0 1 0])
InvRotateVector(q, RotateVector(q, +X)) = [3.2107866, 0, 0] (want [1 0 0])
InvMulQuat(q, q) = (xyz=[0, 0, -0.2071068], w=0.99999994) (want xyz=[0 0 0], w=1)
```

## `#by_ptr` -> explicit pointers for for `Recording` and `RecPlayer`

I also ran into some compilation errors and crashes interacting with `Recording` and `RecPlayer`s. Imitating 79bd50cac ("Fix `#by_ptr` usage for shape definitions"), the two types become explicit pointers in [vendor/box3d/box3d.odin](vendor/box3d/box3d.odin)

### Reproduction Samples

- [`repro/box3d_compile_error_recording.odin`](https://github.com/qtrfeast/Odin/blob/vendor-box3d-binding-fixes-repro-sh/repro/box3d_compile_error_recording.odin)

    ```sh
    > odin run repro/box3d_compile_error_recording.odin -file
    repro/box3d_compile_error_recording.odin(13:33) Error: Cannot assign value 'rec' of type 'Recording' to '^Recording' in a procedure argument
        b3.World_StartRecording(world, rec)
                                       ^~^
     Suggestion: Did you mean `&rec`
    repro/box3d_compile_error_recording.odin(21:22) Error: Cannot assign value 'rec' of type 'Recording' to '^Recording' in a procedure argument
        b3.DestroyRecording(rec)
                            ^~^
     Suggestion: Did you mean `&rec`
     ```
- [`repro/box3d_crash_recording_andrec.odin`](https://github.com/qtrfeast/Odin/blob/vendor-box3d-binding-fixes-repro-sh/repro/box3d_crash_recording_andrec.odin)

    ```sh
    > odin run box3d_crash_recording_andrec.odin -file
    starting recording (forced &rec workaround)...
    free(): invalid pointer
    zsh: IOT instruction (core dumped)  odin run box3d_crash_recording_andrec.odin -file
    ```
- [`repro/box3d_compile_error_recplayer.odin`](https://github.com/qtrfeast/Odin/blob/vendor-box3d-binding-fixes-repro-sh/repro/box3d_compile_error_recplayer.odin)

    ```sh
    > odin run box3d_compile_error_recplayer.odin -file
    repro/box3d_compile_error_recplayer.odin(21:33) Error: Cannot assign value 'rec' of type 'Recording' to '^Recording' in a procedure argument
            b3.World_StartRecording(world, rec)
                                           ^~^
         Suggestion: Did you mean `&rec`
    repro/box3d_compile_error_recplayer.odin(32:15) Error: Cannot convert untyped value 'nil' to 'RecPlayer' from 'untyped nil'
            if player == nil {
                         ^~^

    repro/box3d_compile_error_recplayer.odin(37:52) Error: Cannot assign value 'player' of type 'RecPlayer' to '^RecPlayer' in a procedure argument
            fmt.printfln("stepped=%v", b3.RecPlayer_StepFrame(player))
                                                              ^~~~~^
         Suggestion: Did you mean `&player`
    repro/box3d_compile_error_recplayer.odin(39:23) Error: Cannot assign value 'player' of type 'RecPlayer' to '^RecPlayer' in a procedure argument
            b3.RecPlayer_Destroy(player)
                                 ^~~~~^
         Suggestion: Did you mean `&player`
    repro/box3d_compile_error_recplayer.odin(40:22) Error: Cannot assign value 'rec' of type 'Recording' to '^Recording' in a procedure argument
            b3.DestroyRecording(rec)
                                ^~^
         Suggestion: Did you mean `&rec`
     ```

## Tests added

This PR  adds regression tests under `tests/vendor/box3d`:

- `test_quat_rotate_math` — identity, reference rotation, round-trip for `RotateVector`, `InvRotateVector` and `InvMulQuat`.
- `test_recording_and_recplayer_round_trip` — recording save/load plus player create, step, and state query.
- `test_body_user_data_round_trip` — regression guard for the already-correct `Body_GetUserData` return type.

`tests/vendor/all.odin` is updated to import the new package.

### Output

```sh
./odin test tests/vendor/box3d -all-packages -vet -vet-tabs -strict-style \
  -vet-style -warnings-as-errors -disallow-do \
  -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true

Finished 3 tests ... All tests were successful.
```