### PR TITLE
Fixes fast_math attribute plumbing to llvm

### DIFF
--- a/src/llvm_backend_opt.cpp
+++ b/src/llvm_backend_opt.cpp
@@ -51,6 +51,8 @@
 **************************************************************************/
 
 gb_internal void lb_run_fast_float_math_pass(lbProcedure *p) {
+#if LLVM_VERSION_MAJOR >= 18
+
 	Entity *e = p->entity;
 	if (e == nullptr) {
 		return;
@@ -60,13 +62,13 @@ gb_internal void lb_run_fast_float_math_pass(lbProcedure *p) {
 
 	u64 fast_math_flags = e->Procedure.fast_math_flags;
 	LLVMFastMathFlags llvm_flags = 0;
-	if (fast_math_flags & OdinFastMath_Allow_Reassoc)    llvm_flags |= LLVMFastMathAllowReassoc;
-	if (fast_math_flags & OdinFastMath_No_NaNs)          llvm_flags |= LLVMFastMathNoNaNs;
-	if (fast_math_flags & OdinFastMath_No_Infs)          llvm_flags |= LLVMFastMathNoInfs;
-	if (fast_math_flags & OdinFastMath_No_Signed_Zeros)  llvm_flags |= LLVMFastMathNoSignedZeros;
-	if (fast_math_flags & OdinFastMath_Allow_Reciprocal) llvm_flags |= LLVMFastMathAllowReciprocal;
-	if (fast_math_flags & OdinFastMath_Allow_Contract)   llvm_flags |= LLVMFastMathAllowContract;
-	if (fast_math_flags & OdinFastMath_Approx_Func)      llvm_flags |= LLVMFastMathApproxFunc;
+	if (fast_math_flags & (1 << OdinFastMath_Allow_Reassoc))    llvm_flags |= LLVMFastMathAllowReassoc;
+	if (fast_math_flags & (1 << OdinFastMath_No_NaNs))          llvm_flags |= LLVMFastMathNoNaNs;
+	if (fast_math_flags & (1 << OdinFastMath_No_Infs))          llvm_flags |= LLVMFastMathNoInfs;
+	if (fast_math_flags & (1 << OdinFastMath_No_Signed_Zeros))  llvm_flags |= LLVMFastMathNoSignedZeros;
+	if (fast_math_flags & (1 << OdinFastMath_Allow_Reciprocal)) llvm_flags |= LLVMFastMathAllowReciprocal;
+	if (fast_math_flags & (1 << OdinFastMath_Allow_Contract))   llvm_flags |= LLVMFastMathAllowContract;
+	if (fast_math_flags & (1 << OdinFastMath_Approx_Func))      llvm_flags |= LLVMFastMathApproxFunc;
 
 	if (llvm_flags == 0) {
 		return;
@@ -77,26 +79,17 @@ gb_internal void lb_run_fast_float_math_pass(lbProcedure *p) {
 	     block = LLVMGetNextBasicBlock(block)) {
 		for (LLVMValueRef instr = LLVMGetFirstInstruction(block);
 		     instr != nullptr;
-		     instr = LLVMGetNextInstruction(instr))  {
-			switch (LLVMGetInstructionOpcode(instr)) {
-			case LLVMFNeg:
-			case LLVMFAdd:
-			case LLVMFSub:
-			case LLVMFMul:
-			case LLVMFDiv:
-			case LLVMFRem:
-			case LLVMFPToUI:
-			case LLVMFPToSI:
-			case LLVMUIToFP:
-			case LLVMSIToFP:
-			case LLVMFPTrunc:
-			case LLVMFPExt:
-			case LLVMFCmp:
+		     instr = LLVMGetNextInstruction(instr))  {			
+			if (LLVMCanValueUseFastMathFlags(instr)) {
 				LLVMSetFastMathFlags(instr, llvm_flags);
-				break;
 			}
 		}
 	}
+#else
+	// LLVMSetFastMathFlags doesn't seem to exist in LLVM 17,
+	// so @(fast_math) becomes no op on older LLVM
+	gb_unused(p);
+#endif
 }
 
 gb_internal void lb_run_remove_dead_instruction_pass(lbProcedure *p) {


### PR DESCRIPTION
The (@fast_math) supplied flags get incorrectly passed to LLVM in lb_run_fast_float_math_pass(), because fast_math_flags is tested against ordinals instead of the corresponding bit positions.

Fixing it unmasks another issue. Some of the flags can't be applied to some of the LLVM instructions in the switch [here](https://github.com/odin-lang/Odin/blob/master/src/llvm_backend_opt.cpp?#L81), because they alias other flags. Here is a minimal example (for LLVMUIToFP) of reassoc aliasing nneg and turning unsigned conversions to signed conversions (build with -o:speed AFTER fixing the flags in lb_run_fast_float_math_pass(), otherwise it is essentially passing a random combination of flags):

```odin
package fast_math_test

import "core:fmt"
import "core:os"

@(fast_math={.Allow_Reassoc})
to_f64_fast :: proc(x: u64) -> f64 {
	return f64(x) // emits signed conversion because reassoc aliases nneg
}

main :: proc() {
	x := u64(0x8000_0000_0000_0000) + u64(len(os.args)) // runtime dependent so that conversion isn't optimized out
	fast := #force_no_inline to_f64_fast(x)

	fmt.printfln("reference: %f", f64(x))
	fmt.printfln("fast math: %f", fast)
}
```

To fix this, the commit replaces the explicit switch with a call to LLVMCanValueUseFastMathFlags() which should exclude conversions (and likely include a few other benefiting cases not in the switch) and should be more future proof.

All this is guarded by an LLVM version check in the commit, cause [LLVM 17](https://github.com/llvm/llvm-project/blob/release/17.x/llvm/include/llvm-c/Core.h) doesn't seem to have support for fast math flags.