### PR TITLE
Treat form feed character as whitespace in lexer

### DIFF
--- a/core/text/scanner/scanner.odin
+++ b/core/text/scanner/scanner.odin
@@ -73,7 +73,7 @@ C_Like_Tokens    :: Scan_Flags{.Scan_Idents, .Scan_Ints, .Scan_C_Int_Prefixes, .
 Whitespace :: distinct bit_set['\x00'..<utf8.RUNE_SELF; u128]
 
 // Odin_Whitespace is the default value for the Scanner's whitespace field
-Odin_Whitespace :: Whitespace{'\t', '\n', '\r', ' '}
+Odin_Whitespace :: Whitespace{'\t', '\n', '\r', '\f', ' '}
 C_Whitespace    :: Whitespace{'\t', '\n', '\r', '\v', '\f', ' '}
 
 

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -662,6 +662,7 @@ gb_internal gb_inline void tokenizer_skip_whitespace(Tokenizer *t, bool on_newli
 			case ' ':
 			case '\t':
 			case '\r':
+			case '\f':
 				advance_to_next_rune(t);
 				continue;
 			}
@@ -674,6 +675,7 @@ gb_internal gb_inline void tokenizer_skip_whitespace(Tokenizer *t, bool on_newli
 			case ' ':
 			case '\t':
 			case '\r':
+			case '\f':
 				advance_to_next_rune(t);
 				continue;
 			}

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -66,6 +66,7 @@ gb_internal bool rune_is_whitespace(Rune r) {
 	case '\t':
 	case '\n':
 	case '\r':
+	case '\f':
 		return true;
 	}
 	return false;


### PR DESCRIPTION
Currently, the lexer rejects the form feed character (`\f`) when it appears between tokens. This PR adds support for treating it as whitespace.

Form feed is conventionally used as a file-section separator by editors such as [Emacs](https://www.gnu.org/software/emacs/manual/html_node/emacs/Pages.html) and [Vim](https://vimhelp.org/motion.txt.html#section). This can be useful in large source files, where it provides a simple way to organize related declarations into sections and quickly navigate between them.

I also checked Sublime Text, VSCode, and CLion. They render this character explicitly so it is clearly distinguishable from space or tab characters. As far as I'm aware, there is no built-in support for navigating through file using form feed characters in those editors.

Although this changes the language’s lexical grammar, the implementation is very small. I opened a PR rather than only starting a discussion so that the proposed behavior and implementation can be reviewed and discussed together.