### PR TITLE
Fix errors in encoding/csv example docs

### DIFF
--- a/core/encoding/csv/doc.odin
+++ b/core/encoding/csv/doc.odin
@@ -49,7 +49,7 @@ Example:
 			fmt.eprintfln("Unable to open file: %v. Error: %v", filename, err)
 			return
 		}
-		csv.reader_init(&r, handle.stream)
+		csv.reader_init(&r, os.to_stream(handle))
 
 		for r, i in csv.iterator_next(&r) {
 			for f, j in r {
@@ -67,7 +67,7 @@ Example:
 
 		csv_data, csv_err := os.read_entire_file(filename, context.allocator)
 		defer delete(csv_data, context.allocator)
-		if err != nil {
+		if csv_err != nil {
 			fmt.eprintfln("Unable to open file: %v. Error: %v", filename, csv_err)
 			return
 		}


### PR DESCRIPTION
Hello Odin maintainers! Firstly, thanks for the awesome language - I couldn't have gotten so far in my current game project without Odin :)

I was using the CSV module in a project and had to fix the `reader_init` call from the example docs to what I have in this PR. I also checked if the rest of the docs satisfied my LSP and found the second fix here.

Please let me know if anything needs changed or if these fixes are incorrect!