### PR TITLE
Add documentation and small improvements to `core:container/topological_sort`

### DIFF
--- a/core/container/topological_sort/doc.odin
+++ b/core/container/topological_sort/doc.odin
@@ -1,0 +1,36 @@
+/*
+// A generic `O(V+E)` topological sorter implementation.
+// This is the fastest known method for topological sorting.
+
+Example:
+	import "core:container/topological_sort"
+	import "core:fmt"
+
+	Step :: enum {Compile, Link, Run, Test}
+
+	main :: proc() {
+		sorter: topological_sort.Sorter(Step)
+		topological_sort.init(&sorter)
+
+		topological_sort.add_dependency(&sorter, Step.Link, Step.Compile)  // Link depends on Compile
+		topological_sort.add_dependency(&sorter, Step.Test,  Step.Compile) // Test depends on Compile
+		topological_sort.add_dependency(&sorter, Step.Run,   Step.Link)    // Run depends on Link
+
+		sorted, cycled, _ := topological_sort.sort(&sorter)
+		defer delete(sorted)
+		defer delete(cycled)
+
+		fmt.println("Sorted:")
+		for t in sorted {
+			fmt.println("  ", t)
+		}
+	}
+
+Output:
+	Sorted:
+	  Compile
+	  Test
+	  Link
+	  Run
+*/
+package container_topological_sort

--- a/core/container/topological_sort/topological_sort.odin
+++ b/core/container/topological_sort/topological_sort.odin
@@ -2,34 +2,39 @@
 // Odin's map type is being used to accelerate lookups.
 package container_topological_sort
 
-import "base:intrinsics"
-import "base:runtime"
-_ :: intrinsics
-_ :: runtime
+@(require) import "base:intrinsics"
+@(require) import "base:runtime"
 
+/*
+Topological sorter over a set of keys with directed dependencies.
 
-Relations :: struct($K: typeid) where intrinsics.type_is_valid_map_key(K) {
-	dependents:   map[K]bool,
-	dependencies: int,
+For every relation `key -> dependency` produces an ordering in which `dependency` precedes `key`.
+*/
+Sorter :: struct(K: typeid) where intrinsics.type_is_valid_map_key(K) {
+	relations: map[K]Relations(K),
 }
 
-Sorter :: struct(K: typeid) where intrinsics.type_is_valid_map_key(K)  {
-	relations: map[K]Relations(K),
-	dependents_allocator: runtime.Allocator,
+// per-key record tracked by a `Sorter`.
+Relations :: struct($K: typeid) where intrinsics.type_is_valid_map_key(K) {
+	dependents:   map[K]struct {}, // the set of keys that depend on this key
+	dependencies: int,             // number of direct dependencies
+}
+
+/*
+initializes a `Sorter` with the given `allocator`, which is used for
+the relations map and for each key's `dependents` set.
+*/
+init :: proc(sorter: ^$S/Sorter($K), allocator := context.allocator) {
+	sorter.relations.allocator = allocator
 }
 
 @(private="file")
-make_relations :: proc(sorter: ^$S/Sorter($K)) -> (r: Relations(K)) {
-	r.dependents.allocator = sorter.dependents_allocator
+_make_relations :: proc(sorter: ^$S/Sorter($K)) -> (r: Relations(K)) {
+	r.dependents.allocator = sorter.relations.allocator
 	return
 }
 
-
-init :: proc(sorter: ^$S/Sorter($K)) {
-	sorter.relations = make(map[K]Relations(K))
-	sorter.dependents_allocator = context.allocator
-}
-
+// Frees the memory owned by a `Sorter`.
 destroy :: proc(sorter: ^$S/Sorter($K)) {
 	for _, v in sorter.relations {
 		delete(v.dependents)
@@ -37,32 +42,47 @@ destroy :: proc(sorter: ^$S/Sorter($K)) {
 	delete(sorter.relations)
 }
 
+/*
+Registers a new key with the sorter.
+
+Returns `true` if the key was newly added,
+     or `false` if it was already present.
+*/
 add_key :: proc(sorter: ^$S/Sorter($K), key: K) -> bool {
 	if key in sorter.relations {
 		return false
 	}
-	sorter.relations[key] = make_relations(sorter)
+	sorter.relations[key] = _make_relations(sorter)
 	return true
 }
 
+/*
+Records that `key` depends on `dependency`.
+Both keys will be added to the sorter if they are not already present.
+
+Returns `true` if the relation was recorded,
+     or `false` if it would be a self-loop.
+*/
 add_dependency :: proc(sorter: ^$S/Sorter($K), key, dependency: K) -> bool {
 	if key == dependency {
 		return false
 	}
 
+	r := _make_relations(sorter)
+
 	find := &sorter.relations[dependency]
 	if find == nil {
-		find = map_insert(&sorter.relations, dependency, make_relations(sorter))
+		find = map_insert(&sorter.relations, dependency, r)
 	}
 
-	if find.dependents[key] {
+	if key in find.dependents[key] {
 		return true
 	}
-	find.dependents[key] = true
+	find.dependents[key] = {}
 
 	find = &sorter.relations[key]
 	if find == nil {
-		find = map_insert(&sorter.relations, key, make_relations(sorter))
+		find = map_insert(&sorter.relations, key, r)
 	}
 
 	find.dependencies += 1
@@ -70,30 +90,49 @@ add_dependency :: proc(sorter: ^$S/Sorter($K), key, dependency: K) -> bool {
 	return true
 }
 
-sort :: proc(sorter: ^$S/Sorter($K)) -> (sorted, cycled: [dynamic]K) {
+/*
+Runs Kahn's algorithm to produce a topological ordering of the keys.
+
+Returns:
+- `sorted`: keys in topological order; for every edge `key -> dependency`
+- `cycled`: keys that are part of (or downstream of) a dependency cycle
+- `err`:    an `Allocator_Error` if the backing slices could not be allocated
+
+The caller owns the returned slices and must free them with the same `allocator`.
+
+Note: The returned slices are always valid topological orderings,
+      but their specific ordering is not guaranteed.
+*/
+sort :: proc(sorter: ^$S/Sorter($K), allocator := context.allocator) -> (sorted, cycled: []K, err: runtime.Allocator_Error) {
 	relations := &sorter.relations
+
+	sorted_da := make([dynamic]K, 0, len(relations), allocator) or_return
+	defer shrink(&sorted_da)
+
+	cycled_da := make([dynamic]K, 0, len(relations), allocator) or_return
+	defer shrink(&cycled_da)
 
 	for k, v in relations {
 		if v.dependencies == 0 {
-			append(&sorted, k)
+			append(&sorted_da, k)
 		}
 	}
 
-	for root in sorted {
+	for root in sorted_da {
 		for k, _ in relations[root].dependents {
 			relation := &relations[k]
 			relation.dependencies -= 1
 			if relation.dependencies == 0 {
-				append(&sorted, k)
+				append(&sorted_da, k)
 			}
 		}
 	}
 
 	for k, v in relations {
 		if v.dependencies != 0 {
-			append(&cycled, k)
+			append(&cycled_da, k)
 		}
 	}
 
-	return
+	return sorted_da[:], cycled_da[:], err
 }

--- a/core/container/topological_sort/topological_sort.odin
+++ b/core/container/topological_sort/topological_sort.odin
@@ -96,7 +96,7 @@ Runs Kahn's algorithm to produce a topological ordering of the keys.
 Returns:
 - `sorted`: keys in topological order; for every edge `key -> dependency`
 - `cycled`: keys that are part of (or downstream of) a dependency cycle
-- `err`:    an `Allocator_Error` if the backing slices could not be allocated
+- `err`:    an `Allocator_Error` if the backing buffer could not be allocated
 
 The caller owns the returned slices and must free them with the same `allocator`.
 
@@ -106,33 +106,37 @@ Note: The returned slices are always valid topological orderings,
 sort :: proc(sorter: ^$S/Sorter($K), allocator := context.allocator) -> (sorted, cycled: []K, err: runtime.Allocator_Error) {
 	relations := &sorter.relations
 
-	sorted_da := make([dynamic]K, 0, len(relations), allocator) or_return
-	defer shrink(&sorted_da)
+	buf := make([]K, len(relations), allocator) or_return
 
-	cycled_da := make([dynamic]K, 0, len(relations), allocator) or_return
-	defer shrink(&cycled_da)
+	sorted_end, cycled_start := 0, len(relations)
 
 	for k, v in relations {
 		if v.dependencies == 0 {
-			append(&sorted_da, k)
+			buf[sorted_end] = k
+			sorted_end += 1
 		}
 	}
 
-	for root in sorted_da {
+	for i in 0..<sorted_end {
+		root := buf[i]
 		for k, _ in relations[root].dependents {
 			relation := &relations[k]
 			relation.dependencies -= 1
 			if relation.dependencies == 0 {
-				append(&sorted_da, k)
+				buf[sorted_end] = k
+				sorted_end += 1
 			}
 		}
 	}
 
 	for k, v in relations {
 		if v.dependencies != 0 {
-			append(&cycled_da, k)
+			cycled_start -= 1
+			buf[cycled_start] = k
 		}
 	}
 
-	return sorted_da[:], cycled_da[:], err
+	sorted = buf[:sorted_end]
+	cycled = buf[cycled_start:]
+	return
 }

--- a/core/container/topological_sort/topological_sort.odin
+++ b/core/container/topological_sort/topological_sort.odin
@@ -103,6 +103,7 @@ The caller owns the returned slices and must free them with the same `allocator`
 Note: The returned slices are always valid topological orderings,
       but their specific ordering is not guaranteed.
 */
+@require_results
 sort :: proc(sorter: ^$S/Sorter($K), allocator := context.allocator) -> (sorted, cycled: []K, err: runtime.Allocator_Error) {
 	relations := &sorter.relations
 

--- a/core/container/topological_sort/topological_sort.odin
+++ b/core/container/topological_sort/topological_sort.odin
@@ -75,7 +75,7 @@ add_dependency :: proc(sorter: ^$S/Sorter($K), key, dependency: K) -> bool {
 		find = map_insert(&sorter.relations, dependency, r)
 	}
 
-	if key in find.dependents[key] {
+	if key in find.dependents {
 		return true
 	}
 	find.dependents[key] = {}


### PR DESCRIPTION
I've used the topological sort package recently and noticed that it doesn't follow the same "quality" as other and newer packages.
This PR:
- adds small docs for each procedure
- adds `doc.odin` file with a small usage example
- Reuses `Sorter.relations.allocator` for allocating Relations.dependents map instead of storing additional allocator in Sorter
- Adds `allocator := context.allocator` param to `init` and `sort`
- Adds `err: runtime.Allocator_Error` result to `sort`
- Returns slices from `sort` instead of dynamic arrays
- Allocates a single continuous buffer for `sorted` and `cycled` slices instead of having two separate dynamic arrays
- Uses `@require` instead of `_ :: pkg`
- Adds `require_results` attr to `sort`

The change should be mostly backwards compatible with the exception of added `err: runtime.Allocator_Error` result which needs to be handled.