### PR TITLE
make build scripts portable and pwd independent + fix instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           ./vendor/stb/src/build_stb.sh
           ./vendor/cgltf/src/build_cgltf.sh
           ./vendor/miniaudio/src/build_miniaudio.sh
+          ./vendor/kb_text_shape/src/build_unix.sh
           ./odin check examples/all -vet -vet-tabs -strict-style -vet-style -warnings-as-errors -disallow-do -target:netbsd_amd64
           ./odin check examples/all -vet -vet-tabs -strict-style -vet-style -warnings-as-errors -disallow-do -target:netbsd_arm64
           ./odin check examples/all/sdl3 -vet -vet-tabs -strict-style -vet-style -warnings-as-errors -disallow-do -target:netbsd_amd64 -no-entry-point
@@ -65,6 +66,7 @@ jobs:
           ./vendor/stb/src/build_stb.sh
           ./vendor/cgltf/src/build_cgltf.sh
           ./vendor/miniaudio/src/build_miniaudio.sh
+          ./vendor/kb_text_shape/src/build_unix.sh
           ./odin check examples/all -vet -vet-tabs -strict-style -vet-style -warnings-as-errors -disallow-do -target:freebsd_amd64
           ./odin check examples/all/sdl3 -vet -vet-tabs -strict-style -vet-style -warnings-as-errors -disallow-do -target:freebsd_amd64 -no-entry-point
           ./odin test tests/core/normal.odin -file -all-packages -vet -vet-tabs -strict-style -vet-style -warnings-as-errors -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true
@@ -128,6 +130,10 @@ jobs:
           ./vendor/stb/src/build_stb.sh
           ./vendor/cgltf/src/build_cgltf.sh
           ./vendor/miniaudio/src/build_miniaudio.sh
+          ./vendor/kb_text_shape/src/build_unix.sh
+      - name: Compile Box3D (Ubuntu ARM)
+        if: matrix.os == 'ubuntu-24.04-arm'
+        run: ./vendor/box3d/src/build.sh
       - name: Odin check
         run: ./odin check examples/demo -vet
       - name: Odin run
@@ -327,6 +333,7 @@ jobs:
           ./vendor/stb/src/build_stb.sh
           ./vendor/cgltf/src/build_cgltf.sh
           ./vendor/miniaudio/src/build_miniaudio.sh
+          ./vendor/kb_text_shape/src/build_unix.sh
 
       - name: Odin check examples/all
         run: ./odin check examples/all -target:linux_riscv64 -vet -vet-tabs -strict-style -vet-style -warnings-as-errors -disallow-do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,12 @@ jobs:
           set -e -x
           git config --global --add safe.directory $(pwd)
           gmake release
+          export ODIN_ROOT="$(pwd)"
           ./odin version
           ./odin report
-          (cd ./vendor/stb/src/; ./build_stb.sh)
-          (cd ./vendor/cgltf/src/; ./build_cgltf.sh)
-          (cd ./vendor/miniaudio/src/; ./build_miniaudio.sh)
+          ./vendor/stb/src/build_stb.sh
+          ./vendor/cgltf/src/build_cgltf.sh
+          ./vendor/miniaudio/src/build_miniaudio.sh
           ./odin check examples/all -vet -vet-tabs -strict-style -vet-style -warnings-as-errors -disallow-do -target:netbsd_amd64
           ./odin check examples/all -vet -vet-tabs -strict-style -vet-style -warnings-as-errors -disallow-do -target:netbsd_arm64
           ./odin check examples/all/sdl3 -vet -vet-tabs -strict-style -vet-style -warnings-as-errors -disallow-do -target:netbsd_amd64 -no-entry-point
@@ -60,9 +61,10 @@ jobs:
           gmake release
           ./odin version
           ./odin report
-          (cd ./vendor/stb/src/; ./build_stb.sh)
-          (cd ./vendor/cgltf/src/; ./build_cgltf.sh)
-          (cd ./vendor/miniaudio/src/; ./build_miniaudio.sh)
+          export ODIN_ROOT="$(pwd)"
+          ./vendor/stb/src/build_stb.sh
+          ./vendor/cgltf/src/build_cgltf.sh
+          ./vendor/miniaudio/src/build_miniaudio.sh
           ./odin check examples/all -vet -vet-tabs -strict-style -vet-style -warnings-as-errors -disallow-do -target:freebsd_amd64
           ./odin check examples/all/sdl3 -vet -vet-tabs -strict-style -vet-style -warnings-as-errors -disallow-do -target:freebsd_amd64 -no-entry-point
           ./odin test tests/core/normal.odin -file -all-packages -vet -vet-tabs -strict-style -vet-style -warnings-as-errors -disallow-do -define:ODIN_TEST_FANCY=false -define:ODIN_TEST_FAIL_ON_BAD_MEMORY=true
@@ -122,9 +124,10 @@ jobs:
           brew install curl mbedtls
       - name: Compile needed Vendor
         run: |
-          (cd ./vendor/stb/src/; ./build_stb.sh)
-          (cd ./vendor/cgltf/src/; ./build_cgltf.sh)
-          (cd ./vendor/miniaudio/src/; ./build_miniaudio.sh)
+          export ODIN_ROOT="$(pwd)"
+          ./vendor/stb/src/build_stb.sh
+          ./vendor/cgltf/src/build_cgltf.sh
+          ./vendor/miniaudio/src/build_miniaudio.sh
       - name: Odin check
         run: ./odin check examples/demo -vet
       - name: Odin run
@@ -320,9 +323,10 @@ jobs:
 
       - name: Compile needed Vendor
         run: |
-          (cd ./vendor/stb/src/; ./build_stb.sh)
-          (cd ./vendor/cgltf/src/; ./build_cgltf.sh)
-          (cd ./vendor/miniaudio/src/; ./build_miniaudio.sh)
+          export ODIN_ROOT="$(pwd)"
+          ./vendor/stb/src/build_stb.sh
+          ./vendor/cgltf/src/build_cgltf.sh
+          ./vendor/miniaudio/src/build_miniaudio.sh
 
       - name: Odin check examples/all
         run: ./odin check examples/all -target:linux_riscv64 -vet -vet-tabs -strict-style -vet-style -warnings-as-errors -disallow-do

--- a/vendor/box2d/box2d.odin
+++ b/vendor/box2d/box2d.odin
@@ -27,7 +27,7 @@ when ODIN_OS == .Windows {
 }
 
 when !#exists(LIB_PATH) {
-	#panic("Could not find the compiled box2d libraries at \"" + LIB_PATH + "\", they can be compiled by running the `build_box2d.sh` script at `" + ODIN_ROOT + "vendor/box2d/build_box2d.sh\"`")
+	#panic("Could not find the compiled box2d libraries at \"" + LIB_PATH + "\", they can be compiled by running `\"" + ODIN_ROOT + "vendor/box2d/build_box2d.sh\"`")
 }
 
 foreign import lib {

--- a/vendor/box2d/wasm.Makefile
+++ b/vendor/box2d/wasm.Makefile
@@ -11,7 +11,8 @@ VERSION   = 3.1.1
 SRCS      = $(wildcard box2d-$(VERSION)/src/*.c)
 OBJS_SIMD = $(SRCS:.c=_simd.o)
 OBJS      = $(SRCS:.c=.o)
-SYSROOT   = $(shell odin root)/vendor/libc-shim
+ODIN_ROOT ?= ../..
+SYSROOT   = $(ODIN_ROOT)/vendor/libc-shim
 CFLAGS    = -Ibox2d-$(VERSION)/include --target=wasm32 -D__EMSCRIPTEN__ -DNDEBUG -O3 --sysroot=$(SYSROOT)
 
 all: lib/box2d_wasm.o lib/box2d_wasm_simd.o

--- a/vendor/box3d/box3d.odin
+++ b/vendor/box3d/box3d.odin
@@ -9,31 +9,27 @@ ENABLE_VALIDATION :: false
 
 BOX3D_SHARED :: #config(BOX3D_SHARED, false)
 
+@(private)
+LIB_PATH :: (
+	     "lib/linux-amd64/libbox3d.a" when ODIN_OS == .Linux && ODIN_ARCH == .amd64 && !BOX3D_SHARED
+	else "lib/linux-arm64/libbox3d.a" when ODIN_OS == .Linux && ODIN_ARCH == .arm64 && !BOX3D_SHARED
+	else "lib/darwin/libbox3d.a"      when ODIN_OS == .Darwin && (ODIN_ARCH == .amd64 || ODIN_ARCH == .arm64) && !BOX3D_SHARED
+	else ""
+)
+
 when ODIN_OS == .Windows {
 	@(export)
-	foreign import lib {
-		"lib/box3d.lib",
+	foreign import lib "lib/box3d.lib"
+} else when LIB_PATH != "" {
+	when !#exists(LIB_PATH) {
+		#panic("Could not find the compiled Box3D library at \"" + LIB_PATH + "\", it can be compiled by running `\"" + ODIN_ROOT + "vendor/box3d/src/build.sh\"`")
 	}
-} else when ODIN_OS == .Linux && ODIN_ARCH == .amd64 && !BOX3D_SHARED {
+
 	@(export)
-	foreign import lib {
-		"lib/linux-amd64/libbox3d.a",
-	}
-} else when ODIN_OS == .Linux && ODIN_ARCH == .arm64 && !BOX3D_SHARED {
-	@(export)
-	foreign import lib {
-		"lib/linux-arm64/libbox3d.a",
-	}
-} else when ODIN_OS == .Darwin && (ODIN_ARCH == .amd64 || ODIN_ARCH == .arm64) && !BOX3D_SHARED {
-	@(export)
-	foreign import lib {
-		"lib/darwin/libbox3d.a",
-	}
+	foreign import lib { LIB_PATH }
 } else {
 	@(export)
-	foreign import lib {
-		"system:box3d",
-	}
+	foreign import lib "system:box3d"
 }
 
 // This is used to indicate null for interfaces that work with indices instead of pointers

--- a/vendor/box3d/src/build.bat
+++ b/vendor/box3d/src/build.bat
@@ -1,8 +1,21 @@
 @echo off
+setlocal
 
-if not exist "..\lib" mkdir ..\lib
+pushd "%~dp0" || exit /b 1
 
-cl -nologo -MT -TC -O2 -c -std:c17 -I "include" src\*.c
+if not exist "..\lib" mkdir "..\lib"
+
+cl -nologo -MT -TC -O2 -c -std:c17 -I"include" src\*.c
+if errorlevel 1 (
+    popd
+    exit /b 1
+)
+
 lib -nologo *.obj -out:..\lib\box3d.lib
+if errorlevel 1 (
+    popd
+    exit /b 1
+)
 
-del *.obj
+del "*.obj"
+popd

--- a/vendor/box3d/src/build.sh
+++ b/vendor/box3d/src/build.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+set -e
+
+cc=${CC:-cc}
+ar=${AR:-ar}
+ranlib=${RANLIB:-ranlib}
+lipo=${LIPO:-lipo}
+ODIN_ROOT=${ODIN_ROOT:-$(cd "$(dirname "$0")/../../.." && pwd)}
+
+cd "$ODIN_ROOT/vendor/box3d/src" || exit 1
 
 LIB_NAME="libbox3d.a"
 # Detect architecture
@@ -17,14 +26,15 @@ case "$ARCH" in
 esac
 
 # Detect OS
-if [[ "$OSTYPE" == "darwin"* ]]; then
+case "$(uname -s)" in
+Darwin)
 	INSTALL_DIR="../lib/darwin"
 	mkdir -p "$INSTALL_DIR" build/x86_64 build/arm64
 
 	# Building box3d for amd64
 	for src in src/*.c; do
 		obj="build/x86_64/$(basename "${src%.c}.o")"
-		clang -c -O2 -std=c17 -fPIC \
+		$cc -c -O2 -std=c17 -fPIC \
 			-arch x86_64 \
 			-mmacosx-version-min=11.0 \
 			-Iinclude \
@@ -34,7 +44,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 	# Building box3d for arm64
 	for src in src/*.c; do
 		obj="build/arm64/$(basename "${src%.c}.o")"
-		clang -c -O2 -std=c17 -fPIC \
+		$cc -c -O2 -std=c17 -fPIC \
 			-arch arm64 \
 			-mmacosx-version-min=11.0 \
 			-Iinclude \
@@ -42,14 +52,14 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 	done
 
 	# Turn them into their respective *.a files
-	ar rcs "$INSTALL_DIR/libbox3d_x86_64.a" build/x86_64/*.o
-	ar rcs "$INSTALL_DIR/libbox3d_arm64.a"  build/arm64/*.o
+	$ar rcs "$INSTALL_DIR/libbox3d_x86_64.a" build/x86_64/*.o
+	$ar rcs "$INSTALL_DIR/libbox3d_arm64.a" build/arm64/*.o
 
-	ranlib "$INSTALL_DIR/libbox3d_x86_64.a"
-	ranlib "$INSTALL_DIR/libbox3d_arm64.a"
-
+	$ranlib "$INSTALL_DIR/libbox3d_x86_64.a"
+	$ranlib "$INSTALL_DIR/libbox3d_arm64.a"
+	
 	# Bundle them into a universal library
-	lipo -create \
+	$lipo -create \
 		"$INSTALL_DIR/libbox3d_x86_64.a" \
 		"$INSTALL_DIR/libbox3d_arm64.a" \
 		-output "$INSTALL_DIR/$LIB_NAME"
@@ -57,16 +67,16 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 	# Clean up the single arch .a files and build temp
 	rm "$INSTALL_DIR/libbox3d_x86_64.a" "$INSTALL_DIR/libbox3d_arm64.a"
 	rm -rf build
-
-elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-	OS="linux"
-	LIB_DIR="../lib/${OS}-${ARCH}"
+	;;
+Linux)
+	LIB_DIR="../lib/linux-$ARCH"
 	mkdir -p "$LIB_DIR"
-	cc -c -O2 -std=c17 -fPIC -Iinclude src/*.c
-	ar rcs "$LIB_DIR/$LIB_NAME" *.o
-	rm -f *.o
-
-else
-	echo "Error: Unsupported operating system: $OSTYPE"
+	$cc -c -O2 -std=c17 -fPIC -Iinclude src/*.c
+	$ar rcs "$LIB_DIR/$LIB_NAME" ./*.o
+	rm ./*.o
+	;;
+*)
+	echo "Error: Unsupported operating system: $(uname -s)"
 	exit 1
-fi
+	;;
+esac

--- a/vendor/cgltf/cgltf.odin
+++ b/vendor/cgltf/cgltf.odin
@@ -13,7 +13,7 @@ LIB :: (
 when LIB != "" {
 	when !#exists(LIB) {
 		// Windows library is shipped with the compiler, so a Windows specific message should not be needed.
-		// #panic("Could not find the compiled cgltf library, it can be compiled by running `make -C \"" + ODIN_ROOT + "vendor/cgltf/src\"`")
+		#panic("Could not find the compiled cgltf library, it can be compiled by running `\"" + ODIN_ROOT + "vendor/cgltf/src/build_cgltf.sh\"`")
 	}
 }
 
@@ -767,4 +767,3 @@ foreign lib {
 	@(require_results)
 	write      :: proc(#by_ptr options: options, buffer: [^]byte, size: uint, data: ^data) -> uint ---
 }
-

--- a/vendor/cgltf/src/build.bat
+++ b/vendor/cgltf/src/build.bat
@@ -1,8 +1,21 @@
 @echo off
+setlocal
 
-if not exist "..\lib" mkdir ..\lib
+pushd "%~dp0" || exit /b 1
+
+if not exist "..\lib" mkdir "..\lib"
 
 cl -nologo -MT -TC -O2 -c cgltf.c
-lib -nologo cgltf.obj -out:..\lib\cgltf.lib
+if errorlevel 1 (
+    popd
+    exit /b 1
+)
 
-del *.obj
+lib -nologo cgltf.obj -out:..\lib\cgltf.lib
+if errorlevel 1 (
+    popd
+    exit /b 1
+)
+
+del "*.obj"
+popd

--- a/vendor/cgltf/src/build_cgltf.sh
+++ b/vendor/cgltf/src/build_cgltf.sh
@@ -1,18 +1,22 @@
 #!/usr/bin/env sh
+set -e
 
 cc=${CC:-cc}
 ar=${AR:-ar}
+ODIN_ROOT=${ODIN_ROOT:-$(cd "$(dirname "$0")/../../.." && pwd)}
+
+cd "$ODIN_ROOT/vendor/cgltf/src" || exit 1
 
 build_wasm() {
 	mkdir -p ../lib
-	$cc -c -Os --target=wasm32 --sysroot=$(shell odin root)/vendor/libc-shim cgltf.c -o ../lib/cgltf_wasm.o
+	$cc -c -Os --target=wasm32 --sysroot="$ODIN_ROOT/vendor/libc-shim" cgltf.c -o ../lib/cgltf_wasm.o
 }
 
 build_unix() {
 	mkdir -p ../lib
 	$cc -c -O2 -Os -fPIC cgltf.c 	
 	$ar rcs ../lib/cgltf.a        cgltf.o
-	rm *.o
+	rm ./*.o
 }
 
 build_darwin() {
@@ -20,7 +24,7 @@ build_darwin() {
 	$cc -arch x86_64 -c -O2 -Os -fPIC cgltf.c -o cgltf-x86_64.o -mmacosx-version-min=10.12
 	$cc -arch arm64  -c -O2 -Os -fPIC cgltf.c -o cgltf-arm64.o -mmacosx-version-min=10.12
 	lipo -create cgltf-x86_64.o cgltf-arm64.o -output ../lib/darwin/cgltf.a
-	rm *.o
+	rm ./*.o
 }
 
 case $1 in
@@ -31,7 +35,7 @@ unix)
 darwin)
 	build_darwin ;;
 *)
-	if [ `uname -s` == 'Darwin' ]; then
+	if [ "$(uname -s)" = 'Darwin' ]; then
 		build_darwin
 	else
 		build_unix

--- a/vendor/kb_text_shape/kb_text_shape_procs.odin
+++ b/vendor/kb_text_shape/kb_text_shape_procs.odin
@@ -1,13 +1,16 @@
 package vendor_kb_text_shape
 
 when ODIN_OS == .Windows {
-	foreign import lib {
-		"lib/kb_text_shape.lib",
-	}
+	foreign import lib "lib/kb_text_shape.lib"
 } else {
-	foreign import lib {
-		"lib/kb_text_shape.a",
+	@(private)
+	LIB_PATH :: "lib/kb_text_shape.a"
+
+	when !#exists(LIB_PATH) {
+		#panic("Could not find the compiled kb_text_shape library at \"" + LIB_PATH + "\", it can be compiled by running `\"" + ODIN_ROOT + "vendor/kb_text_shape/src/build_unix.sh\"`")
 	}
+
+	foreign import lib { LIB_PATH }
 }
 
 import "base:runtime"

--- a/vendor/kb_text_shape/src/build.bat
+++ b/vendor/kb_text_shape/src/build.bat
@@ -1,8 +1,21 @@
 @echo off
+setlocal
 
-if not exist "..\lib" mkdir ..\lib
+pushd "%~dp0" || exit /b 1
+
+if not exist "..\lib" mkdir "..\lib"
 
 cl -nologo -MT -TC -O2 -c kb_text_shape.c
-lib -nologo kb_text_shape.obj -out:..\lib\kb_text_shape.lib
+if errorlevel 1 (
+    popd
+    exit /b 1
+)
 
-del *.obj
+lib -nologo kb_text_shape.obj -out:..\lib\kb_text_shape.lib
+if errorlevel 1 (
+    popd
+    exit /b 1
+)
+
+del "*.obj"
+popd

--- a/vendor/kb_text_shape/src/build_unix.sh
+++ b/vendor/kb_text_shape/src/build_unix.sh
@@ -1,7 +1,13 @@
 #!/bin/sh
 set -e
 
+cc=${CC:-cc}
+ar=${AR:-ar}
+ODIN_ROOT=${ODIN_ROOT:-$(cd "$(dirname "$0")/../../.." && pwd)}
+
+cd "$ODIN_ROOT/vendor/kb_text_shape/src" || exit 1
+
 mkdir -p "../lib"
-cc -O2 -fPIC -c kb_text_shape.c
-ar -rcs ../lib/kb_text_shape.a kb_text_shape.o
-rm *.o
+$cc -O2 -fPIC -c kb_text_shape.c
+$ar -rcs ../lib/kb_text_shape.a kb_text_shape.o
+rm ./*.o

--- a/vendor/miniaudio/common.odin
+++ b/vendor/miniaudio/common.odin
@@ -35,12 +35,12 @@ version_check :: proc "contextless" () {
 		n += copy(buf[n:], BINDINGS_VERSION_STRING)
 		n += copy(buf[n:], ", but version ")
 		n += copy(buf[n:], string(version_string()))
-		n += copy(buf[n:], " is linked, make sure to compile the correct miniaudio version by going to `vendor/miniaudio/src` ")
+		n += copy(buf[n:], " is linked, make sure to compile the correct miniaudio version by executing `")
 
 		when ODIN_OS == .Windows {
-			n += copy(buf[n:], "and executing `build.bat`")
+			n += copy(buf[n:], "vendor\\miniaudio\\src\\build.bat`")
 		} else {
-			n += copy(buf[n:], "and executing `build_miniaudio.sh`")
+			n += copy(buf[n:], "vendor/miniaudio/src/build_miniaudio.sh`")
 		}
 
 		panic_contextless(string(buf[:n]))

--- a/vendor/miniaudio/common.odin
+++ b/vendor/miniaudio/common.odin
@@ -13,7 +13,7 @@ LIB :: "lib/miniaudio.lib" when ODIN_OS == .Windows else "lib/miniaudio.a"
 
 when !#exists(LIB) {
 	// Windows library is shipped with the compiler, so a Windows specific message should not be needed.
-	#panic("Could not find the compiled miniaudio library, it can be compiled by running `make -C \"" + ODIN_ROOT + "vendor/miniaudio/src\"`")
+	#panic("Could not find the compiled miniaudio library, it can be compiled by running `\"" + ODIN_ROOT + "vendor/miniaudio/src/build_miniaudio.sh\"`")
 }
 
 foreign import lib { LIB }
@@ -40,7 +40,7 @@ version_check :: proc "contextless" () {
 		when ODIN_OS == .Windows {
 			n += copy(buf[n:], "and executing `build.bat`")
 		} else {
-			n += copy(buf[n:], "and executing `make`")
+			n += copy(buf[n:], "and executing `build_miniaudio.sh`")
 		}
 
 		panic_contextless(string(buf[:n]))

--- a/vendor/miniaudio/src/build.bat
+++ b/vendor/miniaudio/src/build.bat
@@ -1,8 +1,21 @@
 @echo off
+setlocal
 
-if not exist "..\lib" mkdir ..\lib
+pushd "%~dp0" || exit /b 1
+
+if not exist "..\lib" mkdir "..\lib"
 
 cl -nologo -MT -TC -O2 -c miniaudio.c
-lib -nologo miniaudio.obj -out:..\lib\miniaudio.lib
+if errorlevel 1 (
+    popd
+    exit /b 1
+)
 
-del *.obj
+lib -nologo miniaudio.obj -out:..\lib\miniaudio.lib
+if errorlevel 1 (
+    popd
+    exit /b 1
+)
+
+del "*.obj"
+popd

--- a/vendor/miniaudio/src/build_miniaudio.sh
+++ b/vendor/miniaudio/src/build_miniaudio.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env sh
+set -e
 
 cc=${CC:-cc}
 ar=${AR:-ar}
+ODIN_ROOT=${ODIN_ROOT:-$(cd "$(dirname "$0")/../../.." && pwd)}
+
+cd "$ODIN_ROOT/vendor/miniaudio/src" || exit 1
 
 mkdir -p ../lib
 $cc -c -O2 -Os -fPIC miniaudio.c

--- a/vendor/stb/image/stb_image.odin
+++ b/vendor/stb/image/stb_image.odin
@@ -15,7 +15,7 @@ LIB :: (
 when LIB != "" {
 	when !#exists(LIB) {
 		// The STB libraries are shipped with the compiler on Windows so a Windows specific message should not be needed.
-		#panic("Could not find the compiled STB libraries, they can be compiled by running `make -C \"" + ODIN_ROOT + "vendor/stb/src\"`")
+		#panic("Could not find the compiled STB libraries, they can be compiled by running `\"" + ODIN_ROOT + "vendor/stb/src/build_stb.sh\"`")
 	}
 }
 

--- a/vendor/stb/image/stb_image_resize.odin
+++ b/vendor/stb/image/stb_image_resize.odin
@@ -14,7 +14,7 @@ RESIZE_LIB :: (
 when RESIZE_LIB != "" {
 	when !#exists(RESIZE_LIB) {
 		// The STB libraries are shipped with the compiler on Windows so a Windows specific message should not be needed.
-		#panic("Could not find the compiled STB libraries, they can be compiled by running `make -C \"" + ODIN_ROOT + "vendor/stb/src\"`")
+		#panic("Could not find the compiled STB libraries, they can be compiled by running `\"" + ODIN_ROOT + "vendor/stb/src/build_stb.sh\"`")
 	}
 }
 

--- a/vendor/stb/image/stb_image_write.odin
+++ b/vendor/stb/image/stb_image_write.odin
@@ -14,7 +14,7 @@ WRITE_LIB :: (
 when WRITE_LIB != "" {
 	when !#exists(WRITE_LIB) {
 		// The STB libraries are shipped with the compiler on Windows so a Windows specific message should not be needed.
-		#panic("Could not find the compiled STB libraries, they can be compiled by running `make -C \"" + ODIN_ROOT + "vendor/stb/src\"`")
+		#panic("Could not find the compiled STB libraries, they can be compiled by running `\"" + ODIN_ROOT + "vendor/stb/src/build_stb.sh\"`")
 	}
 }
 

--- a/vendor/stb/rect_pack/stb_rect_pack.odin
+++ b/vendor/stb/rect_pack/stb_rect_pack.odin
@@ -16,7 +16,7 @@ LIB :: (
 
 when LIB != "" {
 	when !#exists(LIB) {
-		#panic("Could not find the compiled STB libraries, they can be compiled by running `make -C \"" + ODIN_ROOT + "vendor/stb/src\"`")
+		#panic("Could not find the compiled STB libraries, they can be compiled by running `\"" + ODIN_ROOT + "vendor/stb/src/build_stb.sh\"`")
 	}
 }
 

--- a/vendor/stb/sprintf/stb_sprintf.odin
+++ b/vendor/stb/sprintf/stb_sprintf.odin
@@ -13,7 +13,7 @@ LIB :: (
 
 when LIB != "" {
 	when !#exists(LIB) {
-		#panic("Could not find the compiled STB libraries, they can be compiled by running `make -C \"" + ODIN_ROOT + "vendor/stb/src\"`")
+		#panic("Could not find the compiled STB libraries, they can be compiled by running `\"" + ODIN_ROOT + "vendor/stb/src/build_stb.sh\"`")
 	}
 }
 

--- a/vendor/stb/src/build.bat
+++ b/vendor/stb/src/build.bat
@@ -1,14 +1,51 @@
 @echo off
+setlocal
 
-if not exist "..\lib" mkdir ..\lib
+pushd "%~dp0" || exit /b 1
+
+if not exist "..\lib" mkdir "..\lib"
 
 cl -nologo -MT -TC -O2 -c stb_image.c stb_image_write.c stb_image_resize.c stb_truetype.c stb_rect_pack.c stb_vorbis.c stb_sprintf.c
-lib -nologo stb_image.obj -out:..\lib\stb_image.lib
-lib -nologo stb_image_write.obj -out:..\lib\stb_image_write.lib
-lib -nologo stb_image_resize.obj -out:..\lib\stb_image_resize.lib
-lib -nologo stb_truetype.obj -out:..\lib\stb_truetype.lib
-lib -nologo stb_rect_pack.obj -out:..\lib\stb_rect_pack.lib
-lib -nologo stb_vorbis.obj -out:..\lib\stb_vorbis.lib
-lib -nologo stb_sprintf.obj -out:..\lib\stb_sprintf.lib
+if errorlevel 1 (
+    popd
+    exit /b 1
+)
 
-del *.obj
+lib -nologo stb_image.obj -out:..\lib\stb_image.lib
+if errorlevel 1 (
+    popd
+    exit /b 1
+)
+lib -nologo stb_image_write.obj -out:..\lib\stb_image_write.lib
+if errorlevel 1 (
+    popd
+    exit /b 1
+)
+lib -nologo stb_image_resize.obj -out:..\lib\stb_image_resize.lib
+if errorlevel 1 (
+    popd
+    exit /b 1
+)
+lib -nologo stb_truetype.obj -out:..\lib\stb_truetype.lib
+if errorlevel 1 (
+    popd
+    exit /b 1
+)
+lib -nologo stb_rect_pack.obj -out:..\lib\stb_rect_pack.lib
+if errorlevel 1 (
+    popd
+    exit /b 1
+)
+lib -nologo stb_vorbis.obj -out:..\lib\stb_vorbis.lib
+if errorlevel 1 (
+    popd
+    exit /b 1
+)
+lib -nologo stb_sprintf.obj -out:..\lib\stb_sprintf.lib
+if errorlevel 1 (
+    popd
+    exit /b 1
+)
+
+del "*.obj"
+popd

--- a/vendor/stb/src/build_stb.sh
+++ b/vendor/stb/src/build_stb.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env sh
+set -e
 
 cc=${CC:-cc}
 ar=${AR:-ar}
+ODIN_ROOT=${ODIN_ROOT:-$(cd "$(dirname "$0")/../../.." && pwd)}
 
 build_wasm() {
 	mkdir -p ../lib
-	$cc -c -Os --target=wasm32 --sysroot=$(shell odin root)/vendor/libc-shim stb_image.c        -o ../lib/stb_image_wasm.o        -DSTBI_NO_STDIO
-	$cc -c -Os --target=wasm32 --sysroot=$(shell odin root)/vendor/libc-shim stb_image_write.c  -o ../lib/stb_image_write_wasm.o  -DSTBI_WRITE_NO_STDIO 
-	$cc -c -Os --target=wasm32 --sysroot=$(shell odin root)/vendor/libc-shim stb_image_resize.c -o ../lib/stb_image_resize_wasm.o
-	$cc -c -Os --target=wasm32 --sysroot=$(shell odin root)/vendor/libc-shim stb_truetype.c     -o ../lib/stb_truetype_wasm.o
+	$cc -c -Os --target=wasm32 --sysroot="$ODIN_ROOT"/vendor/libc-shim stb_image.c        -o ../lib/stb_image_wasm.o        -DSTBI_NO_STDIO
+	$cc -c -Os --target=wasm32 --sysroot="$ODIN_ROOT"/vendor/libc-shim stb_image_write.c  -o ../lib/stb_image_write_wasm.o  -DSTBI_WRITE_NO_STDIO 
+	$cc -c -Os --target=wasm32 --sysroot="$ODIN_ROOT"/vendor/libc-shim stb_image_resize.c -o ../lib/stb_image_resize_wasm.o
+	$cc -c -Os --target=wasm32 --sysroot="$ODIN_ROOT"/vendor/libc-shim stb_truetype.c     -o ../lib/stb_truetype_wasm.o
 	# Pretends to be emscripten so stb vorbis takes the right code path for including alloca.h
-	$cc -c -Os --target=wasm32 --sysroot=$(shell odin root)/vendor/libc-shim stb_vorbis.c       -o ../lib/stb_vorbis_wasm.o       -DSTB_VORBIS_NO_STDIO -D__EMSCRIPTEN__
-	$cc -c -Os --target=wasm32 --sysroot=$(shell odin root)/vendor/libc-shim stb_rect_pack.c    -o ../lib/stb_rect_pack_wasm.o
+	$cc -c -Os --target=wasm32 --sysroot="$ODIN_ROOT"/vendor/libc-shim stb_vorbis.c       -o ../lib/stb_vorbis_wasm.o       -DSTB_VORBIS_NO_STDIO -D__EMSCRIPTEN__
+	$cc -c -Os --target=wasm32 --sysroot="$ODIN_ROOT"/vendor/libc-shim stb_rect_pack.c    -o ../lib/stb_rect_pack_wasm.o
 	$cc -c -Os --target=wasm32                                          stb_sprintf.c      -o ../lib/stb_sprintf_wasm.o
 }
 
@@ -57,8 +59,10 @@ build_darwin() {
 	$cc -arch x86_64 -c -O2 -Os -fPIC stb_sprintf.c -o stb_sprintf-x86_64.o -mmacosx-version-min=10.12
 	$cc -arch arm64  -c -O2 -Os -fPIC stb_sprintf.c -o stb_sprintf-arm64.o -mmacosx-version-min=10.12
 	lipo -create stb_sprintf-x86_64.o stb_sprintf-arm64.o -output ../lib/darwin/stb_sprintf.a
-	rm *.o
+	rm ./*.o
 }
+
+cd "$ODIN_ROOT/vendor/stb/src" || exit 1
 
 case $1 in
 wasm)
@@ -68,7 +72,8 @@ unix)
 darwin)
 	build_darwin ;;
 *)
-	if [ `uname -s` == 'Darwin' ]; then
+	# Don't care about word splitting here
+	if [ $(uname -s) = 'Darwin' ]; then
 		build_darwin
 	else
 		build_unix

--- a/vendor/stb/truetype/stb_truetype.odin
+++ b/vendor/stb/truetype/stb_truetype.odin
@@ -15,7 +15,7 @@ LIB :: (
 
 when LIB != "" {
 	when !#exists(LIB) {
-		#panic("Could not find the compiled STB libraries, they can be compiled by running `make -C \"" + ODIN_ROOT + "vendor/stb/src\"`")
+		#panic("Could not find the compiled STB libraries, they can be compiled by running `\"" + ODIN_ROOT + "vendor/stb/src/build_stb.sh\"`")
 	}
 }
 

--- a/vendor/stb/vorbis/stb_vorbis.odin
+++ b/vendor/stb/vorbis/stb_vorbis.odin
@@ -14,7 +14,7 @@ LIB :: (
 
 when LIB != "" {
 	when !#exists(LIB) {
-		#panic("Could not find the compiled STB libraries, they can be compiled by running `make -C \"" + ODIN_ROOT + "vendor/stb/src\"`")
+		#panic("Could not find the compiled STB libraries, they can be compiled by running `\"" + ODIN_ROOT + "vendor/stb/src/build_stb.sh\"`")
 	}
 }
 


### PR DESCRIPTION
Also addressed some linter warnings on the script. it seems that the wasm target was using a Makefile-only `shell` thing.