### PR TITLE
[core:test] Windows: Prevent exception handler from continuing.

### DIFF
--- a/core/sys/windows/kernel32.odin
+++ b/core/sys/windows/kernel32.odin
@@ -185,6 +185,7 @@ foreign kernel32 {
 	GetExitCodeThread    :: proc(thread: HANDLE, exit_code: ^DWORD) -> BOOL ---
 	TerminateThread      :: proc(thread: HANDLE, exit_code: DWORD) -> BOOL ---
 	SuspendThread        :: proc(hThread: HANDLE) -> DWORD ---
+	ExitThread           :: proc(dwExitCode: DWORD) ---
 
 	GetProcessAffinityMask :: proc(
 		hProcess: HANDLE,

--- a/core/testing/signal_handler_windows.odin
+++ b/core/testing/signal_handler_windows.odin
@@ -146,10 +146,19 @@ This is a dire bug and should be reported to the Odin developers.
 		intrinsics.atomic_store(&stop_test_passed, passed)
 		intrinsics.atomic_store(&stop_test_alert, 1)
 
+		for {
+			// Idle until this thread is terminated by the runner,
+			// otherwise we will crash after the base handler is run.
+			win32.SwitchToThread()
+		}
+
+		// As a fallback, we exit the thread.
+		// This should never be reached.
+		win32.ExitThread(1)
 	}
 
-	// Pass on the exeption to the next handler. As we don't wont to recover from it.
-	// This also allows debuggers handle it properly.
+	// Pass on the exeption to the next handler.
+	// This should never be reached.
 	return win32.EXCEPTION_CONTINUE_SEARCH
 }
 


### PR DESCRIPTION
Mirror POSIX and idle in our Exception Handler. Instead of continuing to next handler.  This prevent Windows from close the process before the runner is done with its reporting.

I thought it was already doing this, but must of been getting lucky with Window's handler being or something.

Fixes #7035