### PR TITLE
Fixes file open emulation of posix open behavior on mode/perm mismatch on windows

### DIFF
--- a/core/nbio/impl_windows.odin
+++ b/core/nbio/impl_windows.odin
@@ -542,7 +542,7 @@ _open_sync :: proc(l: ^Event_Loop, name: string, dir: Handle, mode: File_Flags, 
 				association_err: Association_Error
 				handle, association_err = _associate_handle(uintptr(h), l)
 				// This shouldn't fail, we just created this file, with correct flags.
-				assert(association_err != nil)
+				assert(association_err == nil)
 				return
 			case:
 				err = FS_Error(syserr)

--- a/core/os/file_windows.odin
+++ b/core/os/file_windows.odin
@@ -130,16 +130,17 @@ _open_internal :: proc(name: string, flags: File_Flags, perm: Permissions) -> (h
 			if .Non_Blocking in flags {
 				nix_attrs |= win32.FILE_FLAG_OVERLAPPED
 			}
-			h := win32.CreateFileW(path, access, share_mode, &sa, win32.TRUNCATE_EXISTING, nix_attrs, nil)
-			if h == win32.INVALID_HANDLE {
-				switch e := win32.GetLastError(); e {
-				case win32.ERROR_FILE_NOT_FOUND, _ERROR_BAD_NETPATH, win32.ERROR_PATH_NOT_FOUND:
-					// file does not exist, create the file
-				case 0:
-					return uintptr(h), nil
-				case:
-					return 0, _get_platform_error()
-				}
+
+			h := win32.CreateFileW(path, access | win32.GENERIC_WRITE, share_mode, &sa, win32.TRUNCATE_EXISTING, nix_attrs, nil)
+			if h != win32.INVALID_HANDLE {
+				// File exists and is now truncated, preserving attributes.
+				return uintptr(h), nil
+			}
+			switch e := win32.GetLastError(); e {
+			case win32.ERROR_FILE_NOT_FOUND, _ERROR_BAD_NETPATH, win32.ERROR_PATH_NOT_FOUND:
+				// File does not exist, fall through and create it.
+			case:
+				return 0, _get_platform_error()
 			}
 		}
 	}


### PR DESCRIPTION
Opening a file only for reading while truncating fails on Windows with invalid params error, which is normal on Windows, but doesn't do the attempted posix emulation. (Even on a hypothetical successful CreateFile the code would leak the handle and CreateFile again, due to never checking for success and falling through.)

```odin
package main

import "core:fmt"
import "core:os"

main :: proc() {
    TEST_FILE :: "testfile.txt"
    _ = os.write_entire_file(TEST_FILE, "hey")

    // posix equivalent would be open(TEST_FILE, O_CREAT|O_TRUNC, 0444)
    // this should succeed and truncate
    f, err := os.open(TEST_FILE, {.Create, .Trunc}, os.Permissions_Read_All)
    if err != nil {
        fmt.println("open err:", err) // -> INVALID_PARAMETER
    } else { os.close(f) }
    os.remove(TEST_FILE)
}
```
Note that the GENERIC_WRITE access flag added in the commit is required, otherwise CreateFile fails matching. GENERIC_WRITE doesn't increase permissions, since we already have FILE_GENERIC_WRITE in the access flags if we are in that branch.


While fixing this I also stumbled upon the corresponding nbio code path which sidesteps CreateFile by using NtCreateFile. But there is a different problem with the assert testing the opposite condition for association_err , so that got fixed too:
```odin
package main

import "core:nbio"
import "core:fmt"
import "core:os"

main :: proc () {
	aerr := nbio.acquire_thread_event_loop()
	defer nbio.release_thread_event_loop()

	TEST_FILE :: "nbio.txt"
	_ = os.write_entire_file(TEST_FILE, "hey")

	// again, this should succeed and truncate
	h, err := nbio.open_sync(TEST_FILE, mode = {.Trunc, .Create}, perm = nbio.Permissions_Read_All) // -> asserts
	if err != nil {
		fmt.println("open_sync err:", err)
	} else {
		nbio.close(h)
		run_err := nbio.run()
		if run_err != nil {
			fmt.println("run err:", run_err)
		}
	}

	os.remove(TEST_FILE)
}
```