### PR TITLE
updated slice.ptr_rotate() to include a small rotation with buffer

### DIFF
--- a/core/slice/ptr.odin
+++ b/core/slice/ptr.odin
@@ -68,8 +68,6 @@ ptr_swap_overlapping :: proc "contextless" (x, y: rawptr, len: int) {
 }
 
 
-
-
 ptr_rotate :: proc  "contextless"  (left: int, mid: ^$T, right: int) {
 	when size_of(T) != 0 {
 		left, mid, right := left, mid, right
@@ -79,8 +77,8 @@ ptr_rotate :: proc  "contextless"  (left: int, mid: ^$T, right: int) {
 		for left * size_of(T) > SWAP && right * size_of(T)  > SWAP {
 			if left >= right {
 				for {
-					slice.ptr_swap_non_overlapping(slice.ptr_sub(mid, right), mid, right * size_of(T))
-					mid = slice.ptr_sub(mid, right)
+					ptr_swap_non_overlapping(ptr_sub(mid, right), mid, right * size_of(T))
+					mid = ptr_sub(mid, right)
 
 					left -= right
 					if left < right {
@@ -89,8 +87,8 @@ ptr_rotate :: proc  "contextless"  (left: int, mid: ^$T, right: int) {
 				}
 			} else {
 				for {
-					slice.ptr_swap_non_overlapping(slice.ptr_sub(mid, left), mid, left * size_of(T))
-					mid = slice.ptr_add(mid, left)
+					ptr_swap_non_overlapping(ptr_sub(mid, left), mid, left * size_of(T))
+					mid = ptr_add(mid, left)
 
 					right -= left
 					if right < left {
@@ -99,18 +97,16 @@ ptr_rotate :: proc  "contextless"  (left: int, mid: ^$T, right: int) {
 				}
 			}
 		}
-		swap : [SWAP]byte = ---
-		if left <= right {
-			start := slice.ptr_sub(mid, left)
-			end := slice.ptr_add(start, right)
 
+		swap : [SWAP]byte = ---
+		start := ptr_sub(mid, left)
+		end := ptr_add(start, right)
+
+		if left <= right {
 			runtime.mem_copy(&swap, start, left * size_of(T))
 			runtime.mem_copy(start, mid, right * size_of(T))
 			runtime.mem_copy(end, &swap, left * size_of(T))
 		} else {
-			start := slice.ptr_sub(mid, left)
-			end := slice.ptr_add(start, right)
-
 			runtime.mem_copy(&swap, mid, right * size_of(T))
 			runtime.mem_copy(end, start, left * size_of(T))
 			runtime.mem_copy(start, &swap, right * size_of(T))

--- a/core/slice/ptr.odin
+++ b/core/slice/ptr.odin
@@ -68,13 +68,13 @@ ptr_swap_overlapping :: proc "contextless" (x, y: rawptr, len: int) {
 }
 
 
-ptr_rotate :: proc  "contextless"  (left: int, mid: ^$T, right: int) {
+ptr_rotate :: proc "contextless" (left: int, mid: ^$T, right: int) {
 	when size_of(T) != 0 {
 		left, mid, right := left, mid, right
 
 		SWAP :: 256
 
-		for left * size_of(T) > SWAP && right * size_of(T)  > SWAP {
+		for left * size_of(T) > SWAP && right * size_of(T) > SWAP {
 			if left >= right {
 				for {
 					ptr_swap_non_overlapping(ptr_sub(mid, right), mid, right * size_of(T))

--- a/core/slice/ptr.odin
+++ b/core/slice/ptr.odin
@@ -68,51 +68,52 @@ ptr_swap_overlapping :: proc "contextless" (x, y: rawptr, len: int) {
 }
 
 
+
+
 ptr_rotate :: proc  "contextless"  (left: int, mid: ^$T, right: int) {
 	when size_of(T) != 0 {
 		left, mid, right := left, mid, right
 
 		SWAP :: 256
-		if left <= right && left * size_of(T) <= SWAP {
-			swap : [SWAP]byte = ---
+
+		for left * size_of(T) > SWAP && right * size_of(T)  > SWAP {
+			if left >= right {
+				for {
+					slice.ptr_swap_non_overlapping(slice.ptr_sub(mid, right), mid, right * size_of(T))
+					mid = slice.ptr_sub(mid, right)
+
+					left -= right
+					if left < right {
+						break
+					}
+				}
+			} else {
+				for {
+					slice.ptr_swap_non_overlapping(slice.ptr_sub(mid, left), mid, left * size_of(T))
+					mid = slice.ptr_add(mid, left)
+
+					right -= left
+					if right < left {
+						break
+					}
+				}
+			}
+		}
+		swap : [SWAP]byte = ---
+		if left <= right {
 			start := slice.ptr_sub(mid, left)
 			end := slice.ptr_add(start, right)
 
 			runtime.mem_copy(&swap, start, left * size_of(T))
 			runtime.mem_copy(start, mid, right * size_of(T))
 			runtime.mem_copy(end, &swap, left * size_of(T))
-		} else if right < left && right * size_of(T) <= SWAP {
-			swap : [SWAP]byte = ---
+		} else {
 			start := slice.ptr_sub(mid, left)
 			end := slice.ptr_add(start, right)
 
 			runtime.mem_copy(&swap, mid, right * size_of(T))
 			runtime.mem_copy(end, start, left * size_of(T))
 			runtime.mem_copy(start, &swap, right * size_of(T))
-		} else {
-			for left > 0 && right > 0 {
-				if left >= right {
-					for {
-						ptr_swap_non_overlapping(ptr_sub(mid, right), mid, right * size_of(T))
-						mid = ptr_sub(mid, right)
-
-						left -= right
-						if left < right {
-							break
-						}
-					}
-				} else {
-					for {
-						ptr_swap_non_overlapping(ptr_sub(mid, left), mid, left * size_of(T))
-						mid = ptr_add(mid, left)
-
-						right -= left
-						if right < left {
-							break
-						}
-					}
-				}
-			}
 		}
 	}
 }

--- a/core/slice/ptr.odin
+++ b/core/slice/ptr.odin
@@ -68,30 +68,49 @@ ptr_swap_overlapping :: proc "contextless" (x, y: rawptr, len: int) {
 }
 
 
-ptr_rotate :: proc "contextless" (left: int, mid: ^$T, right: int) {
+
+ptr_rotate :: proc  "contextless"  (left: int, mid: ^$T, right: int) {
 	when size_of(T) != 0 {
 		left, mid, right := left, mid, right
 
-		// TODO(bill): Optimization with a buffer for smaller ranges
-		for left > 0 && right > 0 {
-			if left >= right {
-				for {
-					ptr_swap_non_overlapping(ptr_sub(mid, right), mid, right * size_of(T))
-					mid = ptr_sub(mid, right)
+		SWAP :: 256
+		if left < right && left * size_of(T) <= SWAP {
+			swap : [SWAP]byte = ---
+			a := ptr_sub(mid, left)
+			b := mid
+			c := ptr_add(a, right)
+			runtime.mem_copy(&swap, a, left * size_of(T))
+			runtime.mem_copy(a, b, right * size_of(T))
+			runtime.mem_copy(c, &swap, left * size_of(T))
+		} else if right < left && right * size_of(T) <= SWAP {
+			swap : [SWAP]byte = ---
+			a := ptr_sub(mid, left)
+			b := mid
+			c := ptr_add(a, right)
+			runtime.mem_copy(&swap, b, right * size_of(T))
+			runtime.mem_copy(c, a, left * size_of(T))
+			runtime.mem_copy(a, &swap, right * size_of(T))
+		} else {
+			for left > 0 && right > 0 {
+				if left >= right {
+					for {
+						ptr_swap_non_overlapping(ptr_sub(mid, right), mid, right * size_of(T))
+						mid = ptr_sub(mid, right)
 
-					left -= right
-					if left < right {
-						break
+						left -= right
+						if left < right {
+							break
+						}
 					}
-				}
-			} else {
-				for {
-					ptr_swap_non_overlapping(ptr_sub(mid, left), mid, left * size_of(T))
-					mid = ptr_add(mid, left)
+				} else {
+					for {
+						ptr_swap_non_overlapping(ptr_sub(mid, left), mid, left * size_of(T))
+						mid = ptr_add(mid, left)
 
-					right -= left
-					if right < left {
-						break
+						right -= left
+						if right < left {
+							break
+						}
 					}
 				}
 			}

--- a/core/slice/ptr.odin
+++ b/core/slice/ptr.odin
@@ -68,28 +68,27 @@ ptr_swap_overlapping :: proc "contextless" (x, y: rawptr, len: int) {
 }
 
 
-
 ptr_rotate :: proc  "contextless"  (left: int, mid: ^$T, right: int) {
 	when size_of(T) != 0 {
 		left, mid, right := left, mid, right
 
 		SWAP :: 256
-		if left < right && left * size_of(T) <= SWAP {
+		if left <= right && left * size_of(T) <= SWAP {
 			swap : [SWAP]byte = ---
-			a := ptr_sub(mid, left)
-			b := mid
-			c := ptr_add(a, right)
-			runtime.mem_copy(&swap, a, left * size_of(T))
-			runtime.mem_copy(a, b, right * size_of(T))
-			runtime.mem_copy(c, &swap, left * size_of(T))
+			start := slice.ptr_sub(mid, left)
+			end := slice.ptr_add(start, right)
+
+			runtime.mem_copy(&swap, start, left * size_of(T))
+			runtime.mem_copy(start, mid, right * size_of(T))
+			runtime.mem_copy(end, &swap, left * size_of(T))
 		} else if right < left && right * size_of(T) <= SWAP {
 			swap : [SWAP]byte = ---
-			a := ptr_sub(mid, left)
-			b := mid
-			c := ptr_add(a, right)
-			runtime.mem_copy(&swap, b, right * size_of(T))
-			runtime.mem_copy(c, a, left * size_of(T))
-			runtime.mem_copy(a, &swap, right * size_of(T))
+			start := slice.ptr_sub(mid, left)
+			end := slice.ptr_add(start, right)
+
+			runtime.mem_copy(&swap, mid, right * size_of(T))
+			runtime.mem_copy(end, start, left * size_of(T))
+			runtime.mem_copy(start, &swap, right * size_of(T))
 		} else {
 			for left > 0 && right > 0 {
 				if left >= right {


### PR DESCRIPTION
Change
---
Added a stack rotate for small rotations,
Buffer is set to [256]byte by default, but bigger would be better
Gries-Mill automatically exits when the rest fits in 256 bytes

Motivation
---
1. Small Slices are much faster to rotate with a buffer
2. Gries-Mills has a bad performance when one side is much smaller than the other side and so copying a small enough range outside the slice and shifting everything over by that amount mitigates the worst case for Gries-Mills.
test: https://github.com/TheRadischen/odin-utils/tree/main/rotate

Benchmarks
---
average,  type: int, many different rotation length
`size: 10 iter: 10000 slice.rotate:  3┬Ás small_rotate:  1.1┬Ás diff:  2.727272727272727`
`size: 100 iter: 1000 slice.rotate:  12.2┬Ás small_rotate:  5.5┬Ás diff:  2.2181818181818183`
`size: 1000 iter: 100 slice.rotate:  52┬Ás small_rotate:  48.9┬Ás diff:  1.0633946830265848`
`size: 10000 iter: 10 slice.rotate:  489.4┬Ás small_rotate:  491.6┬Ás diff:  0.9955248169243287`
`size: 100000 iter: 5 slice.rotate:  4.9433ms small_rotate:  4.964ms diff:  0.9958299758259468`
`size: 1000000 iter: 5 slice.rotate:  105.5177ms small_rotate:  106.5284ms diff:  0.9905123891844804`


worse case: type: int, small left rotation (0 to 32)
`size: 10 iter: 100000 slice.rotate:  900ns small_rotate:  300ns diff:  3`
`size: 100 iter: 10000 slice.rotate:  3.7┬Ás small_rotate:  700ns diff:  5.285714285714286`
`size: 1000 iter: 1000 slice.rotate:  31.7┬Ás small_rotate:  2.4┬Ás diff:  13.208333333333334`
`size: 10000 iter: 100 slice.rotate:  309.3┬Ás small_rotate:  30.4┬Ás diff:  10.174342105263158`
`size: 100000 iter: 10 slice.rotate:  3.2229ms small_rotate:  362.1┬Ás diff:  8.900579950289975`
`size: 1000000 iter: 5 slice.rotate:  43.7188ms small_rotate:  22.3035ms diff:  1.9601766538884031`


worste case: type: u8, small left rotation (0 to 100)
`size: 10 iter: 10000 slice.rotate:  3.3┬Ás small_rotate:  1┬Ás diff:  3.3`
`size: 100 iter: 1000 slice.rotate:  12.5┬Ás small_rotate:  1.4┬Ás diff:  8.928571428571429`
`size: 1000 iter: 100 slice.rotate:  50.3┬Ás small_rotate:  2┬Ás diff:  25.15`
`size: 10000 iter: 10 slice.rotate:  409.2┬Ás small_rotate:  8.8┬Ás diff:  46.5`
`size: 100000 iter: 5 slice.rotate:  3.9645ms small_rotate:  123.6┬Ás diff:  32.0752427184466`
`size: 1000000 iter: 5 slice.rotate:  40.0785ms small_rotate:  1.6411ms diff:  24.42172932788983`
