### PR TITLE
Fixes SoA dynamic arrays not zeroing all elements after shrink + grow

### DIFF
--- a/base/runtime/core_builtin_soa.odin
+++ b/base/runtime/core_builtin_soa.odin
@@ -180,10 +180,17 @@ resize_soa :: proc(array: ^$T/#soa[dynamic]$E, #any_int length: int, loc := #cal
 	}
 
 	footer := raw_soa_footer(array)
+	old_len := footer.len
+	old_cap := footer.cap
 
-	if length > footer.cap {
+	if length > old_cap {
 		reserve_soa(array, length, loc) or_return
-	} else if size_of(E) > 0 && length > footer.len {
+	}
+
+	// reserve_soa has zeroed any newly allocated [old_cap, length)
+	// reused [old_len, min(old_cap, length)) still needs zeroing
+	to_zero_end := min(old_cap, length)
+	if size_of(E) > 0 && to_zero_end > old_len {
 		ti := type_info_base(type_info_of(typeid_of(T)))
 		si := &ti.variant.(Type_Info_Struct)
 
@@ -197,13 +204,13 @@ resize_soa :: proc(array: ^$T/#soa[dynamic]$E, #any_int length: int, loc := #cal
 
 			soa_offset = align_forward_int(soa_offset, align_of(E))
 
-			mem_zero(rawptr(uintptr(data) + uintptr(soa_offset) + uintptr(type.size * footer.len)), type.size * (length - footer.len))
+			mem_zero(rawptr(uintptr(data) + uintptr(soa_offset) + uintptr(type.size * old_len)), type.size * (to_zero_end - old_len))
 
 			soa_offset += type.size * footer.cap
 		}
 	}
 
-	footer.len = length
+	footer.len = max(length, 0)
 	return nil
 }
 
@@ -214,7 +221,7 @@ non_zero_resize_soa :: proc(array: ^$T/#soa[dynamic]$E, #any_int length: int, lo
 	}
 	non_zero_reserve_soa(array, length, loc) or_return
 	footer := raw_soa_footer(array)
-	footer.len = length
+	footer.len = max(length, 0)
 	return nil
 }
 


### PR DESCRIPTION
Shrinking + growing a SoA dynamic array doesn't zero any free but previously used capacity (only newly allocated capacity), whenever both are to be used in the resized array.

```odin
package main

import "core:fmt"

Foo :: struct {
	a: int,
	b: int,
}

main :: proc() {
	arr: #soa[dynamic]Foo = make(#soa[dynamic]Foo, 4, 4)
	defer delete(arr)
	for i in 0..<4 {
		arr[i] = Foo{a = 1, b = 1} // init with non-zero values
	}
	resize(&arr, 2) // shrink below used len
	resize(&arr, 6) // grow beyond initial cap to trigger reserve
	for v, i in arr {
		if i >= 2 && (v.a != 0 || v.b != 0) {
			fmt.printfln("arr[%d] = {{%d, %d}} (expected 0, 0)", i, v.a, v.b)   // -> leaks previous values
		}
	}
}
```

The commit also guards against negative length, matching AoS.