### PR TITLE
Fixes spurious #no_alias compile errors during polymorphic overload resolution

### DIFF
--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -2228,9 +2228,13 @@ gb_internal Type *check_get_params(CheckerContext *ctx, Scope *scope, Ast *_para
 				}
 
 				if (p->flags&FieldFlag_no_alias) {
-					bool ok = is_type_internally_pointer_like(type);
-					if (!ok) {
-						error(name, "'#no_alias' can only be applied pointer-like type parameters");
+					// If type == t_invalid, we either already errored (and erroring again here is just log
+					// noise) or we are rejecting a polymorphic proc group overload candidate.
+					// If no_polymorphic_errors is set, we are speculatively checking a candidate and
+					// erroring+stripping is premature: the chosen candidate will be re-checked with errors enabled,
+					// so a true error isn't lost.
+					if (type != t_invalid && !is_type_internally_pointer_like(type) && !ctx->no_polymorphic_errors) {
+						error(name, "'#no_alias' can only be applied to pointer-like type parameters");
 						p->flags &= ~FieldFlag_no_alias; // Remove the flag
 					}
 				}


### PR DESCRIPTION
While playing with codegen optimizations on dynamic arrays, I stumbled on the following bug. When matching the procedure group members the compiler errors (somewhat confusingly) on otherwise legit polymorphic members, which are not a match but happen to use the #no_alias attribute:
```
Error: '#no_alias' can only be applied pointer or multi-pointer typed parameters
```

```odin
package main

f1 :: proc(#no_alias arr: ^$T/#soa[dynamic]$E, arg: E ) {}
f2 :: proc(arr: ^$T/[dynamic]$E, arg: E) {}

append_like :: proc{f1, f2}

Foo :: struct {
	a: int,
	b: int
}

main :: proc() {
	arr: [dynamic]Foo  // arr: #soa[dynamic]Foo here would correctly compile with no errors
	append_like(&arr, Foo {1, 1})  // -> #no_alias compile error
}
```