### PR TITLE
Allow #caller-expression on constant parameters which are procedures

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -2447,7 +2447,7 @@ gb_internal bool check_builtin_procedure_directive(CheckerContext *c, Operand *o
 			} else {
 				Operand o = {};
 				Entity *e = check_ident(c, &o, arg, nullptr, nullptr, true);
-				if (e == nullptr || (e->flags & EntityFlag_Param) == 0) {
+				if (e == nullptr || (e->kind != Entity_Procedure && (e->flags & EntityFlag_Param) == 0)) {
 					error(arg, "'#caller_expression' expected a valid earlier parameter name");
 				}
 				arg->Ident.entity = e;


### PR DESCRIPTION
_This is my first PR on this repo; please let me know if I've missed any guidelines or expectations._

Hi, I've been really enjoying Odin and have been programming a game engine as a hobby project/language learning exercise (a fool's errand, I know). In doing that, I learned that the following does not compile:
```
package main
import "core:log"

main :: proc() {
    context.logger = log.create_console_logger()
    fab(1 - 5)              // compiles
    fab(BAB)                // compiles
    foo(BAR)                // does not compile without this change
    foo(bar)                // does not compile without this change
    foo(proc() {            // does not compile without this change
        log.info("test")
    })
}

fab :: proc($t: int, n: string = #caller_expression(t)) {
    log.info(n)
}

BAB :: 3 + 10

foo :: proc($p: proc(), n: string = #caller_expression(p)) {
	log.info(n)
}

bar :: proc() {}

BAR :: bar
```

Compiler output without this PR:
```
main.odin(21:56) Error: '#caller_expression' expected a valid earlier parameter name
	foo :: proc($p: proc(), n: string = #caller_expression(p)) {
```

I'd very much like it to work. This PR makes it so. Output of compiling and running the example:
```
[INFO ] --- [2026-07-24 05:38:11] [main.odin:16:fab()] 1 - 5
[INFO ] --- [2026-07-24 05:38:11] [main.odin:16:fab()] BAB
[INFO ] --- [2026-07-24 05:38:11] [main.odin:22:foo()] BAR
[INFO ] --- [2026-07-24 05:38:11] [main.odin:22:foo()] bar
[INFO ] --- [2026-07-24 05:38:11] [main.odin:22:foo()] proc() {...} /* 33!282 */
```

The root cause in the example is that the entity for expression `p` in the example is missing `EntityFlag_Param`. `p` has kind `Entity_Procedure`, which makes me think that it should not have `EntityFlag_Param`. Investigating with the debugger showed me that aliases like `BAR :: bar` also have kind `Entity_Procedure`. 