### PR TITLE
fix SDL3 render name

### DIFF
--- a/vendor/sdl3/sdl3_render.odin
+++ b/vendor/sdl3/sdl3_render.odin
@@ -253,8 +253,8 @@ foreign lib {
 	GetRenderVSync                   :: proc(renderer: ^Renderer, vsync: ^c.int) -> bool ---
 	RenderDebugText                  :: proc(renderer: ^Renderer, x, y: f32, str: cstring) -> bool ---
 	RenderDebugTextFormat            :: proc(renderer: ^Renderer, x, y: f32, fmt: cstring, #c_vararg args: ..any) -> bool ---
-	SetDefaultTextureAddressMode     :: proc(renderer: ^Renderer, scale_mode: ScaleMode) -> bool ---
-	GetDefaultTextureAddressMode     :: proc(renderer: ^Renderer, scale_mode: ^ScaleMode) -> bool ---
+	SetDefaultTextureScaleMode       :: proc(renderer: ^Renderer, scale_mode: ScaleMode) -> bool ---
+	GetDefaultTextureScaleMode       :: proc(renderer: ^Renderer, scale_mode: ^ScaleMode) -> bool ---
 }
 
 


### PR DESCRIPTION
Fix typo in the name of the SDL3 functions

[SDL_GetDefaultTextureScaleMode](https://wiki.libsdl.org/SDL3/SDL_GetDefaultTextureScaleMode) [SDL_SetDefaultTextureScaleMode](https://wiki.libsdl.org/SDL3/SDL_SetDefaultTextureScaleMode)