### PR TITLE
Enfore `#must_tail` can only be used at toplevel procedure scopes

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -8940,6 +8940,11 @@ gb_internal ExprKind check_call_expr(CheckerContext *c, Operand *operand, Ast *c
 			gb_string_free(b);
 			gb_string_free(a);
 		}
+		// BlockStmt -> ProcType chain when call is at top level scope of proc
+		bool toplevel_proc_scope = c->scope->parent != nullptr && c->scope->parent->node->kind == Ast_ProcType;
+		if (!toplevel_proc_scope) {
+			error(call, "'#must_tail' can only be used at a top level procedure scope");
+		}
 		break;
 	}
 


### PR DESCRIPTION
Fixes #6640 (llvm codegen failure when using #must_tail on non toplevel proc scopes)

Tested this fix with the following code:
```go
package main

main :: proc() {
	// some comment
	s()
	#must_tail s()
	
	call :: proc() {
		{
			s()
			#must_tail p() // error
		}
		
		#must_tail s()
		
		p :: proc() {
			
			{}
			{
				
				#must_tail s() // error
			}
		}
		for _ in 1..<3 {
			#must_tail s() // error
		}
	}
}

s :: proc() {}

```

Which now results in the following errors:

```sh
/home/cluster2/Projects/odin/OdinDebug/main.odin(11:15) Error: '#must_tail' can only be used at a top level procedure scope
	#must_tail p()
	           ^~^

/home/cluster2/Projects/odin/OdinDebug/main.odin(21:16) Error: '#must_tail' can only be used at a top level procedure scope
	#must_tail s()
	           ^~^

/home/cluster2/Projects/odin/OdinDebug/main.odin(25:15) Error: '#must_tail' can only be used at a top level procedure scope
	#must_tail s()
```


   
--
I intended to fix #6529 as well, but I'm not sure what the desired behavior should be of using deferred statements in combination with a #must_tail, simply disallowing it?