### PR TITLE
fix: reject the use of labels as expressions

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -12291,6 +12291,14 @@ gb_internal ExprKind check_expr_base_internal(CheckerContext *c, Operand *o, Ast
 
 	case_ast_node(i, Ident, node);
 		check_ident(c, o, node, nullptr, type_hint, false);
+		{
+			Entity *entity = node->Ident.entity;
+			if (entity != nullptr && entity->kind == Entity_Label) {
+				String name = entity->token.string;
+				error(node, "'%.*s' is a label and cannot be used as an expression", LIT(name));
+				o->mode = Addressing_Invalid;
+			}
+		}
 	case_end;
 
 	case_ast_node(u, Uninit, node);

--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -82,6 +82,12 @@ fi
 $ODIN check ../test_issue_6979.odin -no-entry-point $COMMON
 $ODIN build ../test_issue_7037.odin $COMMON -o:none
 
+if [[ $($ODIN build ../test_issue_7108.odin $COMMON 2>&1 >/dev/null | grep -c "Error:") -eq 2 ]] ; then
+	echo "SUCCESSFUL 1/1"
+else
+	echo "SUCCESSFUL 0/1"
+	exit 1
+fi
 
 clang -c ../test_issue_7010.c -o test_issue_7010_c.o
 $ODIN test ../test_issue_7010.odin $COMMON

--- a/tests/issues/test_issue_7108.odin
+++ b/tests/issues/test_issue_7108.odin
@@ -1,0 +1,19 @@
+// Tests issue #7108, #5830: labels cannot be used as expressions
+// https://github.com/odin-lang/Odin/issues/7108
+// https://github.com/odin-lang/Odin/issues/5830
+//
+// Using a label name as a value expression (e.g. `defer one` where `one` is a label)
+// should produce a compile error, not an assertion failure in the backend.
+package test_issues
+
+main :: proc() {
+	// Issue #5830: defer with label expression
+	one: {
+		defer one
+	}
+
+	// Issue #7108: label used directly as expression
+	named: {
+		named
+	}
+}


### PR DESCRIPTION
This should fix bugs #5830 and #7108