### PR TITLE
Fix error hint for vet tag

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -6586,7 +6586,8 @@ gb_internal u64 parse_vet_tag(Token token_for_pos, String s, u64 base_vet_flags)
 			error_line("\tusing-stmt\n");
 			error_line("\tusing-param\n");
 			error_line("\tstyle\n");
-			error_line("\textra\n");
+			error_line("\tsemicolon\n");
+			error_line("\tdeprecated\n");
 			error_line("\tcast\n");
 			error_line("\ttabs\n");
 			error_line("\texplicit-allocators\n");

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -6586,6 +6586,7 @@ gb_internal u64 parse_vet_tag(Token token_for_pos, String s, u64 base_vet_flags)
 			error_line("\tusing-stmt\n");
 			error_line("\tusing-param\n");
 			error_line("\tstyle\n");
+			error_line("\textra\n");
 			error_line("\tsemicolon\n");
 			error_line("\tdeprecated\n");
 			error_line("\tcast\n");


### PR DESCRIPTION
My first contribution to this awesome language 😃 Just a fix for outdated error hint in cases like that:

```odin
#+vet foo
package main
//...
```