### PR TITLE
fix segfault on polymorphic arguments when no arguments are expected

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -8217,7 +8217,7 @@ gb_internal CallArgumentError check_polymorphic_record_type(CheckerContext *c, O
 
 	TypeTuple *tuple = get_record_polymorphic_params(original_type);
 	if (tuple == nullptr) {
-		error(call, "No params are expected!");
+		error(call, "Type '%s' does not expect any polymorphic parameters",type_to_string(operand->type));
 		err = CallArgumentError_TooManyArguments;
 		return err;
 	}

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -8216,6 +8216,11 @@ gb_internal CallArgumentError check_polymorphic_record_type(CheckerContext *c, O
 	}
 
 	TypeTuple *tuple = get_record_polymorphic_params(original_type);
+	if (tuple == nullptr) {
+		error(call, "No params are expected!");
+		err = CallArgumentError_TooManyArguments;
+		return err;
+	}
 	isize param_count = tuple->variables.count;
 	isize minimum_param_count = param_count;
 	for (; minimum_param_count > 0; minimum_param_count--) {


### PR DESCRIPTION
Hi, I've been learning Odin and trying to build an ECS with it and stumbled upon a segfault while compiling my code.

Bug
---
```odin
package main

ArchetypeRow :: struct($Components: typeid) {
}

Archetype :: struct {
  components: ArchetypeRow
}

Player :: struct {
}

spawn :: proc(entity: Entity) {
  archetype := Archetype(entity) 
}

ecs :: proc() {
  player := Player {}
  spawn(player)
}

```
output:
```bash
odin check -file bug.odin                                                                                                                                                                                                     [13:47:17]
[1]    31783 segmentation fault  odin check -file bug.odin
```
This happens with the latest release and main.

        Odin:    dev-2026-07:819fdc7a8
        OS:      macOS Tahoe 26.5.2 (build 25F84, kernel 25.5.0)
        CPU:     Apple M4 Pro
        RAM:     49152 MiB
        Backend: LLVM 22.1.8

Fix
---
Since I would like to contribute in the future, I tried to find and fix the error in the compiler.

From my understanding, the problem lies in the struct 'Archetype' which should have a generic input like 'ArcheTypeRow' and which the compiler expects, but the naive user (me) forgot it in the struct definition but not in the initialization of it.

This is the following error message the user now gets:
```bash
.../bug.odin(14:16) Error: No params are expected!
        archetype := Archetype(entity)
                     ^~~~~~~~~~~~~~~~^
```