### PR TITLE
Fixes growth check for SoA dynamic arrays

### DIFF
--- a/base/runtime/core_builtin_soa.odin
+++ b/base/runtime/core_builtin_soa.odin
@@ -393,7 +393,7 @@ _append_soa_elem :: proc(array: ^$T/#soa[dynamic]$E, zero_memory: bool, #no_broa
 		return 0, nil
 	}
 
-	if cap(array) <= len(array) + 1 {
+	if cap(array) < len(array) + 1 {
 		// Same behavior as append_soa_elems but there's only one arg, so we always just add DEFAULT_DYNAMIC_ARRAY_CAPACITY.
 		cap := 2 * cap(array) + DEFAULT_DYNAMIC_ARRAY_CAPACITY
 		err = _reserve_soa(array, cap, zero_memory, loc) // do not 'or_return' here as it could be a partial success
@@ -456,7 +456,7 @@ _append_soa_elems :: proc(array: ^$T/#soa[dynamic]$E, zero_memory: bool, #no_bro
 		return
 	}
 
-	if cap(array) <= len(array)+arg_len {
+	if cap(array) < len(array)+arg_len {
 		cap := 2 * cap(array) + max(DEFAULT_DYNAMIC_ARRAY_CAPACITY, arg_len)
 		err = _reserve_soa(array, cap, zero_memory, loc) // do not 'or_return' here as it could be a partial success
 	}


### PR DESCRIPTION
SoA growth check is off by one, which triggers capacity reserve one append too early, resulting in an unnecessary realloc for exactly pre-reserved arrays. (This also messed my soa array benchmarks and caused some head scratching.)

```odin
package main

import "core:fmt"

Foo :: struct {x, y: int}

main :: proc() {
	N :: 8
	{
		a: #soa[dynamic]Foo
		defer delete(a)
		reserve(&a, N)
		initial_cap := cap(a)
		for i in 0..<N {
			append(&a, Foo{0, 0})
		}
		fmt.printfln("SoA appends: reserved %d, cap %d, appended %d -> cap: %d", 
					N, initial_cap, N, cap(a))      //  -> cap goes to 24
	}

	{	// AoS control
		a: [dynamic]Foo
		defer delete(a)
		reserve(&a, N)
		initial_cap := cap(a)
		for i in 0..<N {
			append(&a, Foo{0, 0})
		}
		fmt.printfln("AoS appends: reserved %d, cap %d, appended %d -> cap: %d",
					N, initial_cap, N, cap(a))     //  -> cap correctly stays at 8
	}	
}
```