### PR TITLE
fix: hang for poly procs with default proc literal params

### DIFF
--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -6735,8 +6735,11 @@ gb_internal bool consume_proc_info(Checker *c, ProcInfo *pi, UntypedExprInfoMap 
 		// This is prevent any possible race conditions in evaluation when multithreaded
 		// NOTE(bill): In single threaded mode, this should never happen
 		if (parent->kind == Entity_Procedure && (parent->flags & EntityFlag_ProcBodyChecked) == 0) {
-			check_procedure_later(c, pi);
-			return false;
+			Type *pt = base_type(parent->type);
+			if (!pt->Proc.is_polymorphic || pt->Proc.is_poly_specialized) {
+				check_procedure_later(c, pi);
+				return false;
+			}
 		}
 	}
 	if (untyped) {
@@ -6770,8 +6773,11 @@ gb_internal WORKER_TASK_PROC(check_proc_info_worker_proc) {
 		// This is prevent any possible race conditions in evaluation when multithreaded
 		// NOTE(bill): In single threaded mode, this should never happen
 		if (parent->kind == Entity_Procedure && (parent->flags & EntityFlag_ProcBodyChecked) == 0) {
-			thread_pool_add_task(check_proc_info_worker_proc, pi);
-			return 1;
+			Type *pt = base_type(parent->type);
+			if (!pt->Proc.is_polymorphic || pt->Proc.is_poly_specialized) {
+				thread_pool_add_task(check_proc_info_worker_proc, pi);
+				return 1;
+			}
 		}
 	}
 	map_clear(untyped);

--- a/tests/issues/run.bat
+++ b/tests/issues/run.bat
@@ -32,6 +32,7 @@ set COMMON=-define:ODIN_TEST_FANCY=false -file -vet -strict-style -ignore-unused
 ..\..\..\odin test ..\test_issue_6165.odin %COMMON%  || exit /b
 ..\..\..\odin build ..\test_issue_6240.odin %COMMON% 2>&1 | find /c "Error:" | findstr /x "3" || exit /b
 ..\..\..\odin build ..\test_issue_6401.odin %COMMON% 2>&1 | find /c "Error:" | findstr /x "3" || exit /b
+..\..\..\odin test ..\test_issue_6419.odin %COMMON%  || exit /b
 ..\..\..\odin test ..\test_pr_6470.odin %COMMON%  || exit /b
 ..\..\..\odin test ..\test_pr_6470.odin -define:TEST_EXPECT_FAILURE=true %COMMON% 2>&1 | find /c "Error:" | findstr /x "1" || exit /b
 ..\..\..\odin test ..\test_pr_6476.odin %COMMON%  || exit /b

--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -65,6 +65,7 @@ else
 	echo "SUCCESSFUL 0/1"
 	exit 1
 fi
+$ODIN test ../test_issue_6419.odin $COMMON
 $ODIN test ../test_pr_6470.odin $COMMON
 if [[ $($ODIN test ../test_pr_6470.odin -define:TEST_EXPECT_FAILURE=true $COMMON 2>&1 >/dev/null | grep -c "Error:") -eq 1 ]] ; then
 	echo "SUCCESSFUL 1/1"

--- a/tests/issues/test_issue_6419.odin
+++ b/tests/issues/test_issue_6419.odin
@@ -1,0 +1,40 @@
+// Tests issue #6419 https://github.com/odin-lang/Odin/issues/6419
+// A polymorphic procedure with default procedure literal parameters
+// should not cause the compiler to hang.
+package test_issues
+
+import "core:testing"
+
+// The proc that triggered the hang: polymorphic pointer param + default proc() {} params
+undo_push :: proc(data: ^$T, undo_proc := proc() {}, redo_proc := proc() {}) {}
+
+// Sanity check: non-polymorphic version still works
+undo_push_int :: proc(data: ^int, undo_proc := proc() {}, redo_proc := proc() {}) {}
+
+// Sanity check: non-polymorphic without pointer still works
+undo_push_no_ptr :: proc(data: int, undo_proc := proc() {}, redo_proc := proc() {}) {}
+
+// Sanity check: no data param at all still works
+undo_push_no_data :: proc(undo_proc := proc() {}, redo_proc := proc() {}) {}
+
+@(test)
+test_issue_6419_polymorphic_default_proc_params :: proc(t: ^testing.T) {
+	hey: int = 5
+	undo_push(&hey)
+	undo_push(&hey, proc() {}, proc() {})
+	undo_push(
+		&hey,
+		proc() {},
+		proc() {
+			// non-empty body
+		},
+	)
+}
+
+@(test)
+test_issue_6419_non_polymorphic_sanity :: proc(t: ^testing.T) {
+	x: int = 10
+	undo_push_int(&x)
+	undo_push_no_ptr(42)
+	undo_push_no_data()
+}


### PR DESCRIPTION
(#6419) A polymorphic procedure with default procedure-literal parameters causes the compiler to hang in `thread_pool_wait`.

During declaration checking, the default `proc() {}` values are processed as nested procedure literals and their parent is set to the original polymorphic procedure.

When `check_procedure_bodies` runs, worker threads try to check these nested default procs. Each worker checks if the parent's body has been checked first. If not, it re-queues the task and tries again later. However, unspecialized polymorphic procedures are never queued for body checking and are explicitly skipped. Since the parent is never checked, `EntityFlag_ProcBodyChecked` is never set, and the nested default procs keep re-queuing themselves infinitely.

The fix is to detect whether the parent is an unspecialized polymorphic procedure, and skip the re-queuing of the children.