### PR TITLE
[core:mem/virtual] close dangling handle in `map` implementation on Windows

### DIFF
--- a/core/mem/virtual/virtual_windows.odin
+++ b/core/mem/virtual/virtual_windows.odin
@@ -84,6 +84,8 @@ foreign Kernel32 {
 	) -> rawptr ---
 
 	UnmapViewOfFile :: proc(lpBaseAddress: rawptr) -> b32 ---
+
+	CloseHandle :: proc(hObject: rawptr) -> b32 ---
 }
 
 @(no_sanitize_address)
@@ -163,6 +165,7 @@ _map_file :: proc "contextless" (fd: uintptr, size: i64, flags: Map_File_Flags) 
 	if handle == nil {
 		return nil, .Map_Failure
 	}
+	defer CloseHandle(handle)
 
 	desired_access: u32
 	if .Read in flags {


### PR DESCRIPTION
`_map_file` creates a section object with `CreateFileMappingW` and never closes the handle, nor returns it. Since `_unmap_file` only receives the view slice, a caller cannot close it either, so it leaks for the lifetime of the process. Which means that even if the user unmaps the file, the handle remains open, and the file remains in use.

It is legal to close the handle and still use the mapped file memory according to MSDN see here: https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-unmapviewoffile?redirectedfrom=MSDN

> Although an application may close the file handle used to create a file mapping object, the system holds the corresponding file open until the last view of the file is unmapped. Files for which the last view has not yet been unmapped are held open with no sharing restrictions.