### PR TITLE
Don't assert on -define: values with an exponent

### DIFF
--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -249,13 +249,28 @@ gb_internal void big_int_from_string(BigInt *dst, String const &s, bool *success
 	}
 	if (i < len && (text[i] == 'e' || text[i] == 'E')) {
 		i += 1;
-		GB_ASSERT(base == 10);
-		GB_ASSERT(text[i] != '-');
+		if (base != 10) {
+			// An exponent is only meaningful for a base 10 literal.
+			*success = false;
+			return;
+		}
+		if (i >= len) {
+			// Nothing follows the exponent marker.
+			*success = false;
+			return;
+		}
+		if (text[i] == '-') {
+			// A negative exponent is never an integer.
+			// The caller is expected to parse the value as a float instead.
+			*success = false;
+			return;
+		}
 		if (text[i] == '+') {
 			i += 1;
 		}
 
 		u64 exp = 0;
+		isize exp_digits = 0;
 		for (; i < len; i++) {
 			char r = cast(char)text[i];
 			if (r == '_') {
@@ -270,6 +285,11 @@ gb_internal void big_int_from_string(BigInt *dst, String const &s, bool *success
 			}
 			exp *= 10;
 			exp += v;
+			exp_digits += 1;
+		}
+		if (exp_digits == 0) {
+			*success = false;
+			return;
 		}
 
 		// NOTE(Jeroen): A valid integer can never have an exponent larger than 308 (per `max(f64)`).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -537,6 +537,27 @@ gb_internal void add_flag(Array<BuildFlag> *build_flags, BuildFlagKind kind, Str
 	array_add(build_flags, flag);
 }
 
+// A value such as `1e-5` is a float, not an integer. Base prefixed literals are excluded because
+// `e` is a valid digit in bases 16 and above, e.g. `0x1e`.
+gb_internal bool build_param_looks_like_float(String const &param) {
+	if (string_contains_char(param, '.')) {
+		return true;
+	}
+	isize i = 0;
+	if (param.len > 0 && (param[0] == '-' || param[0] == '+')) {
+		i = 1;
+	}
+	if (param.len > i+1 && param[i] == '0' && !gb_char_is_digit(cast(char)param[i+1])) {
+		return false;
+	}
+	for (; i < param.len; i++) {
+		if (param[i] == 'e' || param[i] == 'E') {
+			return true;
+		}
+	}
+	return false;
+}
+
 gb_internal ExactValue build_param_to_exact_value(String name, String param) {
 	ExactValue value = {};
 
@@ -562,7 +583,7 @@ gb_internal ExactValue build_param_to_exact_value(String name, String param) {
 		Try to parse as an integer or float
 	*/
 	if (param[0] == '-' || param[0] == '+' || gb_is_between(param[0], '0', '9')) {
-		if (string_contains_char(param, '.')) {
+		if (build_param_looks_like_float(param)) {
 			value = exact_value_float_from_string(param);
 		} else {
 			value = exact_value_integer_from_string(param);


### PR DESCRIPTION
Fixes #7163.

`-define:X=1e-5` aborts the compiler in `big_int_from_string`. The
exponent branch there asserts `base == 10` and `text[i] != '-'`, which
holds for anything the lexer produced but not for a `-define:` value,
which is arbitrary text. `-define:X=0b1e5` hits the first assert the
same way: `e` is not a base 2 digit, so the digit loop breaks into the
exponent path. `7e` read one byte past the end.

Both asserts become parse failures, and the exponent now has to have at
least one digit.

That alone would make `1e-5` an error rather than a crash, so the second
change is in `build_param_to_exact_value`, which only sent a value to
the float parser if it contained a `.`. It now also does so for a base
10 exponent, skipping prefixed literals since `e` is a hex digit.

```
-define:X=1e-5           1e-05 (f64)
-define:X=1e5            100000 (int)
-define:X=0x1e           30 (int)
-define:X=781377e-dirty  781377e-dirty (string)
-define:X=0b1e5          0b1e5 (string)
```

The last one is the case that started this: `git describe` output ending
in `e` no longer has to be quoted.

`tests/core/math` and `tests/core/strconv` pass, and `1e-5`, `1e5`,
`0x1e` and `1.5e+3` as source literals are unchanged.
