### PR TITLE
A fix to the issue #7153 and a test

### DIFF
--- a/core/text/scanner/scanner.odin
+++ b/core/text/scanner/scanner.odin
@@ -377,8 +377,13 @@ scan_number :: proc(s: ^Scanner, ch: rune, seen_dot: bool) -> (rune, rune) {
 		ch, ds = digits(s, ch, base, &invalid)
 		digsep |= ds
 		if ch == '.' && .Scan_Floats in s.flags {
+			prev_s := s^
 			ch = advance(s)
-			seen_dot = true
+			if ch == '.' {
+				s^ = prev_s
+			} else {
+				seen_dot = true
+			}
 		}
 	}
 

--- a/tests/core/text/scanner/test_core_text_scanner.odin
+++ b/tests/core/text/scanner/test_core_text_scanner.odin
@@ -1,0 +1,18 @@
+package test_core_text_scanner
+
+import "core:testing"
+import s "core:text/scanner"
+
+@test 
+range_operator :: proc(t: ^testing.T) {
+	data := "0x00..=0xff"
+	h: s.Scanner
+	s.init(&h, data, "string")
+	h.flags = s.Odin_Like_Tokens - {.Skip_Comments}
+	testing.expect(t, s.Int == s.scan(&h), "token should be Int")
+	testing.expect(t, '.' == s.scan(&h), "token should be '.'")
+	testing.expect(t, '.' == s.scan(&h), "token should be '.'")
+	testing.expect(t, '=' == s.scan(&h), "token should be '='")
+	testing.expect(t, s.Int == s.scan(&h), "token should be Int")
+	testing.expect(t, s.EOF == s.scan(&h), "token should be EOF")
+}


### PR DESCRIPTION
The code used to not handle completely the odin range operator `..=` and `..<`, even for a case with decimal numbers. The change stops the code from counting first `.` of a couple `..` as a part of a number. 