### PR TITLE
compress/gzip: Fix example code

### DIFF
--- a/core/compress/gzip/doc.odin
+++ b/core/compress/gzip/doc.odin
@@ -53,7 +53,7 @@ Example:
 			if file == "-" {
 				// Read from stdin
 				ctx := &compress.Context_Stream_Input{
-					input = os.stdin.stream,
+					input = os.to_stream(os.stdin),
 				}
 				err = gzip.load(ctx, &buf)
 			} else {


### PR DESCRIPTION
I tried to compile this example and received the following error:

```
Error: Cannot assign value 'os.stdin.stream' of type 'File_Stream' to 'Stream' in a structure literal
        input = os.stdin.stream,
                ^~~~~~~~~~~~~~^
```

The example was fixed by passing the File_Stream to `os.to_stream`.