### PR TITLE
Correct end position for fields with a specialization

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -2651,7 +2651,7 @@ parse_operand :: proc(p: ^Parser, lhs: bool) -> ^ast.Expr {
 		specialization: ^ast.Expr
 		if allow_token(p, .Quo) {
 			specialization = parse_type(p)
-			end = specialization.pos
+			end = specialization.end
 		}
 		if is_blank_ident(type) {
 			error(p, type.pos, "invalid polymorphic type definition with a blank identifier")


### PR DESCRIPTION
We had this issue raised in ols https://github.com/DanielGavin/ols/issues/1589, which is due to the end position of the field being set to the start of the specialization, rather than the end. The cpp parser correctly handles this so this is just fixing that drift.