### PR TITLE
zero tracking_allocator.allocation_map and tracking_allocator.bad_free_array in destroy

### DIFF
--- a/core/mem/tracking_allocator.odin
+++ b/core/mem/tracking_allocator.odin
@@ -82,6 +82,8 @@ Destroy the tracking allocator.
 tracking_allocator_destroy :: proc(t: ^Tracking_Allocator) {
 	delete(t.allocation_map)
 	delete(t.bad_free_array)
+	t.allocation_map = {}
+	t.bad_free_array = {}
 }
 
 /*


### PR DESCRIPTION
Allows for re-using the struct again after an init. Otherwise, there would be dangling references. e.g. to tracking_allocator.allocation_map.data