### PR TITLE
Make soa builtins go vroom

### DIFF
--- a/base/runtime/core_builtin_soa.odin
+++ b/base/runtime/core_builtin_soa.odin
@@ -50,13 +50,18 @@ Raw_SOA_Footer_Dynamic_Array :: struct {
 	allocator: Allocator,
 }
 
+// Note: When casting array to access footer/fields
+// uintptr(array) lowers to LLVM ptrtoint and captures pointer provenance,
+// whcih defeats #no_alias on the array in any code following (including in callers).
+// Multipointer indexing lowers to GEP and doesn't capture, so prefer that throughout.
+
 @(builtin, require_results)
 raw_soa_footer_slice :: proc(array: ^$T/#soa[]$E) -> (footer: ^Raw_SOA_Footer_Slice) {
 	if array == nil {
 		return nil
 	}
-	field_count := uintptr(len(E) when intrinsics.type_is_array(E) else intrinsics.type_struct_field_count(E))
-	footer = (^Raw_SOA_Footer_Slice)(uintptr(array) + field_count*size_of(rawptr))
+	field_count := len(E) when intrinsics.type_is_array(E) else intrinsics.type_struct_field_count(E)
+	footer = (^Raw_SOA_Footer_Slice)(&([^]byte)(array)[field_count*size_of(rawptr)])
 	return
 }
 @(builtin, require_results)
@@ -64,8 +69,8 @@ raw_soa_footer_dynamic_array :: proc(array: ^$T/#soa[dynamic]$E) -> (footer: ^Ra
 	if array == nil {
 		return nil
 	}
-	field_count := uintptr(len(E) when intrinsics.type_is_array(E) else intrinsics.type_struct_field_count(E))
-	footer = (^Raw_SOA_Footer_Dynamic_Array)(uintptr(array) + field_count*size_of(rawptr))
+	field_count := len(E) when intrinsics.type_is_array(E) else intrinsics.type_struct_field_count(E)
+	footer = (^Raw_SOA_Footer_Dynamic_Array)(&([^]byte)(array)[field_count*size_of(rawptr)])
 	return
 }
 raw_soa_footer :: proc{
@@ -118,15 +123,13 @@ make_soa_aligned :: proc($T: typeid/#soa[]$E, #any_int length, alignment: int, a
 	}
 	new_data := raw_data(new_bytes)
 
-	data := uintptr(&array)
 	offset := 0
 	for i in 0..<field_count {
 		type := si.types[i].variant.(Type_Info_Multi_Pointer).elem
 
 		offset = align_forward_int(offset, max_align)
 
-		(^uintptr)(data)^ = uintptr(new_data) + uintptr(offset)
-		data += size_of(rawptr)
+		([^]rawptr)(&array)[i] = rawptr(uintptr(new_data) + uintptr(offset))
 		offset += type.size * length
 	}
 	footer.len = length
@@ -174,7 +177,7 @@ make_soa :: proc{
 
 
 @builtin
-resize_soa :: proc(array: ^$T/#soa[dynamic]$E, #any_int length: int, loc := #caller_location) -> Allocator_Error {
+resize_soa :: proc(#no_alias array: ^$T/#soa[dynamic]$E, #any_int length: int, loc := #caller_location) -> Allocator_Error {
 	if array == nil {
 		return nil
 	}
@@ -215,7 +218,7 @@ resize_soa :: proc(array: ^$T/#soa[dynamic]$E, #any_int length: int, loc := #cal
 }
 
 @builtin
-non_zero_resize_soa :: proc(array: ^$T/#soa[dynamic]$E, #any_int length: int, loc := #caller_location) -> Allocator_Error {
+non_zero_resize_soa :: proc(#no_alias array: ^$T/#soa[dynamic]$E, #any_int length: int, loc := #caller_location) -> Allocator_Error {
 	if array == nil {
 		return nil
 	}
@@ -225,6 +228,15 @@ non_zero_resize_soa :: proc(array: ^$T/#soa[dynamic]$E, #any_int length: int, lo
 	return nil
 }
 
+// `reserve_soa` will try to reserve memory of a passed SOA dynamic array to the requested element count (setting the `cap`).
+//
+// For maximizing performance it is recommended to avoid power-of-2 capacities
+// when manually reserving memory for SOA arrays, more so for sizes above 512.
+// For element types with several fields, prefer padding such capacities by at
+// least the number of fields that fit in a CPU cache line.
+// Modern cache lines are typically 64 (Intel/AMD/Arm64) or 128 bytes (Apple Silicon),
+// so pad requested capacity with e.g. `128 / size_of(field)` (for the smallest field when field sizes differ),
+// that is, prefer capacity of 4128 instead of 4096 for 4-byte fields.
 @builtin
 reserve_soa :: proc(array: ^$T/#soa[dynamic]$E, #any_int capacity: int, loc := #caller_location) -> Allocator_Error {
 	return _reserve_soa(array, capacity, true, loc)
@@ -235,7 +247,33 @@ non_zero_reserve_soa :: proc(array: ^$T/#soa[dynamic]$E, #any_int capacity: int,
 	return _reserve_soa(array, capacity, false, loc)
 }
 
-_reserve_soa :: proc(array: ^$T/#soa[dynamic]$E, capacity: int, zero_memory: bool, loc := #caller_location) -> Allocator_Error {
+
+// Note: capacity and performance
+// Each field is stored in contiguous memory with stride between fields capacity * size_of(field) (+ alignment).
+// When the stride is a multiple of 4KB, e.g. a power-of-2 capacity >= 1024 with 4-byte fields,
+// every same-size field's cache line for a given index maps to the same L1 set, and
+// per-element operations degrade (e.g. append_soa, inject_at_soa).
+// It is worst past 8 same-size fields where the burst exceeds the common
+// L1 8-way associativity and the fields collide (measured up to ~7-8x degradation
+// on a type with 18 same-size fields; fields of different sizes advance through
+// the sets at different rates, so they don't collide persistently).
+// Common SoA iterative flows may also be affected, when the loop touches multiple fields
+// and other hot data aliases the same L1 set.
+// So, for types with several fields, prefer padding such capacities by at
+// least the number of fields that fit in a CPU cache line.
+// Modern cache lines are typically 64 (Intel/AMD/Arm64) or 128 bytes (Apple Silicon),
+// so pad with e.g. 128 / size_of(field) (for the smallest field when field sizes differ),
+// so prefer 4128 instead of 4096 for 4-byte fields. Setting cap to e.g. 4097 is NOT enough
+// (it shifts field memory by only 4 bytes (same cache line) and fields keep colliding).
+// Note: 4KB stride in the discussion above is the x86 L1 set period (32–48KB/8–12-way);
+// Apple Silicon (128KB/8-way) has a 16KB period, so cap 4096 × 4 = 16KB stride
+// is still pathological there and the recommended 128-byte pad fixes it.
+// Note: struct size also plays a role, but the user facing padding recommendation
+// on reserve_soa() will handle up to 256 fields (of 4 bytes) decently on 8-way caches.
+// Note: Ideally, this should be handled internally by allowing allocated capacity to exceed requested capacity.
+// This would break current runtime tests though, they explicitly test requested cap.
+// Note: Capacities produced by append growth all the way from empty (2*cap + 8) are not affected.
+_reserve_soa :: #force_no_inline proc(array: ^$T/#soa[dynamic]$E, capacity: int, zero_memory: bool, loc := #caller_location) -> Allocator_Error {
 	if array == nil {
 		return nil
 	}
@@ -322,7 +360,7 @@ _reserve_soa :: proc(array: ^$T/#soa[dynamic]$E, capacity: int, zero_memory: boo
 
 			mem_copy(new_data_elem, old_data_elem, old_size_elem)
 
-			(^rawptr)(uintptr(array) + i*size_of(rawptr))^ = new_data_elem
+			([^]rawptr)(array)[i] = new_data_elem
 
 			if zero_memory {
 				mem_zero(rawptr(uintptr(new_data_elem) + uintptr(old_size_elem)), new_size_elem - old_size_elem)
@@ -361,7 +399,7 @@ _reserve_soa :: proc(array: ^$T/#soa[dynamic]$E, capacity: int, zero_memory: boo
 
 		mem_copy(new_data_elem, old_data_elem, type.size * old_cap)
 
-		(^rawptr)(uintptr(array) + i*size_of(rawptr))^ = new_data_elem
+		([^]rawptr)(array)[i] = new_data_elem
 
 		old_offset += type.size * old_cap
 		new_offset += type.size * capacity
@@ -388,7 +426,7 @@ non_zero_append_soa_elem :: proc(array: ^$T/#soa[dynamic]$E, #no_broadcast arg: 
 	return _append_soa_elem(array, false, arg, loc)
 }
 
-_append_soa_elem :: proc(array: ^$T/#soa[dynamic]$E, zero_memory: bool, #no_broadcast arg: E, loc := #caller_location) -> (n: int, err: Allocator_Error) #optional_allocator_error {
+_append_soa_elem :: proc(#no_alias array: ^$T/#soa[dynamic]$E, zero_memory: bool, #no_broadcast arg: E, loc := #caller_location) -> (n: int, err: Allocator_Error) #optional_allocator_error {
 	if array == nil {
 		return 0, nil
 	}
@@ -399,35 +437,13 @@ _append_soa_elem :: proc(array: ^$T/#soa[dynamic]$E, zero_memory: bool, #no_broa
 		err = _reserve_soa(array, cap, zero_memory, loc) // do not 'or_return' here as it could be a partial success
 	}
 
-	footer := raw_soa_footer(array)
-
 	if size_of(E) > 0 && cap(array)-len(array) > 0 {
-		ti := type_info_of(T)
-		ti = type_info_base(ti)
-		si := &ti.variant.(Type_Info_Struct)
-		field_count := uintptr(len(E) when intrinsics.type_is_array(E) else intrinsics.type_struct_field_count(E))
-
-		data := (^rawptr)(array)^
-
-		soa_offset := 0
-		item_offset := 0
-
-		arg_copy := arg
-		arg_ptr := &arg_copy
-
-		max_align :: align_of(E)
-		for i in 0..<field_count {
-			type := si.types[i].variant.(Type_Info_Multi_Pointer).elem
-
-			soa_offset  = align_forward_int(soa_offset, max_align)
-			item_offset = align_forward_int(item_offset, type.align)
-
-			dst := rawptr(uintptr(data) + uintptr(soa_offset) + uintptr(type.size * footer.len))
-			src := rawptr(uintptr(arg_ptr) + uintptr(item_offset))
-			mem_copy(dst, src, type.size)
-
-			soa_offset  += type.size * cap(array)
-			item_offset += type.size
+		footer := raw_soa_footer(array)
+		// Field stores are generated by the compiler's #soa
+		// element store lowering, specialized for E.
+		// Note that #no_bounds_check is not optional, we write at index == len.
+		#no_bounds_check {
+			array[footer.len] = arg
 		}
 		footer.len += 1
 		return 1, err
@@ -446,7 +462,7 @@ non_zero_append_soa_elems :: proc(array: ^$T/#soa[dynamic]$E, #no_broadcast args
 }
 
 
-_append_soa_elems :: proc(array: ^$T/#soa[dynamic]$E, zero_memory: bool, #no_broadcast args: []E, loc := #caller_location) -> (n: int, err: Allocator_Error) #optional_allocator_error {
+_append_soa_elems :: proc(#no_alias array: ^$T/#soa[dynamic]$E, zero_memory: bool, #no_broadcast args: []E, loc := #caller_location) -> (n: int, err: Allocator_Error) #optional_allocator_error {
 	if array == nil {
 		return
 	}
@@ -464,39 +480,265 @@ _append_soa_elems :: proc(array: ^$T/#soa[dynamic]$E, zero_memory: bool, #no_bro
 
 	footer := raw_soa_footer(array)
 	if size_of(E) > 0 && arg_len > 0 {
-		ti := type_info_of(typeid_of(T))
-		ti = type_info_base(ti)
-		si := &ti.variant.(Type_Info_Struct)
-		field_count := uintptr(len(E) when intrinsics.type_is_array(E) else intrinsics.type_struct_field_count(E))
-
-		data := (^rawptr)(array)^
-
-		soa_offset := 0
-		item_offset := 0
-
-		args_ptr := &args[0]
-
-		max_align :: align_of(E)
-		for i in 0..<field_count {
-			type := si.types[i].variant.(Type_Info_Multi_Pointer).elem
-
-			soa_offset  = align_forward_int(soa_offset, max_align)
-			item_offset = align_forward_int(item_offset, type.align)
-
-			dst := uintptr(data) + uintptr(soa_offset) + uintptr(type.size * footer.len)
-			src := uintptr(args_ptr) + uintptr(item_offset)
-			for j in 0..<arg_len {
-				d := rawptr(dst + uintptr(j*type.size))
-				s := rawptr(src + uintptr(j*size_of(E)))
-				mem_copy(d, s, type.size)
+		// For the common case where E has no more than 16 fields:
+		// At ODIN_OPTIMIZATION_MODE >= .Speed do per-field copy passes that bind
+		// the SOA struct's multipointers and each incoming element's fields by
+		// position via expand_values with compile-time known types.
+		// At ODIN_OPTIMIZATION_MODE <= .Size the compiler's lowering is
+		// used, because it is the most compact at these field counts.
+		// When E has >16 fields:
+		// Type erased per-field loop using RTTI, with one mem_copy per element per field (codegen size is field count invariant).
+		// (Note that offset and the multipointers must be read after _reserve_soa, because any growth moves them.)
+		offset := footer.len
+		FIELD_COUNT :: len(E) when intrinsics.type_is_array(E) else intrinsics.type_struct_field_count(E)
+		when FIELD_COUNT <= 16 {
+			when ODIN_OPTIMIZATION_MODE <= .Size {
+				// Use the compiler's #soa element store lowering.
+				// Note that #no_bounds_check is not optional, we write at index == len.
+				#no_bounds_check {
+					for j in 0..<arg_len {
+						array[offset + j] = args[j]
+					}
+				}
+			} else when FIELD_COUNT >= 1 { // nothing to do if field count is 0
+				_append_soa_elems_per_field_expanded(array, offset, args[:arg_len])
 			}
+		} else { // FIELD_COUNT > 16
+			ti := type_info_base(type_info_of(typeid_of(T)))
+			si := &ti.variant.(Type_Info_Struct)
+			// si describes the SOA struct (fields are multipointers), so E's
+			// field offsets are not available in it; read them from E's own RTTI (si.soa_base_type).
+			// Note that basing on default struct layout here instead
+			// would misplace the fields of #packed elements.
+			// (> 16 fields is struct-only: array element types are capped at length 4.)
+			se := &type_info_base(si.soa_base_type).variant.(Type_Info_Struct)
 
-			soa_offset  += type.size * cap(array)
-			item_offset += type.size
+			src_base := uintptr(raw_data(args))
+			for i in 0..<uintptr(FIELD_COUNT) {
+				type := si.types[i].variant.(Type_Info_Multi_Pointer).elem
+
+				dst := uintptr(([^]rawptr)(array)[i]) + uintptr(type.size*offset)
+				src := src_base + se.offsets[i]
+				for j in 0..<arg_len {
+					mem_copy(rawptr(dst + uintptr(j*type.size)), rawptr(src + uintptr(j*size_of(E))), type.size)
+				}
+			}
 		}
 	}
 	footer.len += arg_len
 	return arg_len, err
+}
+
+// 1..16-field expnaded copy arms for _append_soa_elems.
+// this only exists to keep _append_soa_elems more readable.
+// args MUST already be clamped to capacity by the caller.
+_append_soa_elems_per_field_expanded :: #force_inline proc(#no_alias array: ^$T/#soa[dynamic]$E, offset: int, #no_broadcast args: []E) {
+	arg_len := len(args)
+	FIELD_COUNT :: len(E) when intrinsics.type_is_array(E) else intrinsics.type_struct_field_count(E)
+	when FIELD_COUNT == 1 {
+		// here and below the ignored last 3 values comprise the footer
+		p0, _, _, _ := expand_values(array^)
+		#no_bounds_check {
+			for j in 0..<arg_len { v := expand_values(args[j]); p0[offset+j] = v }
+		}
+	} else when FIELD_COUNT == 2 {
+		p0, p1, _, _, _ := expand_values(array^)
+		#no_bounds_check {
+			for j in 0..<arg_len { v, _ := expand_values(args[j]); p0[offset+j] = v }
+			for j in 0..<arg_len { _, v := expand_values(args[j]); p1[offset+j] = v }
+		}
+	} else when FIELD_COUNT == 3 {
+		p0, p1, p2, _, _, _ := expand_values(array^)
+		#no_bounds_check {
+			for j in 0..<arg_len { v, _, _ := expand_values(args[j]); p0[offset+j] = v }
+			for j in 0..<arg_len { _, v, _ := expand_values(args[j]); p1[offset+j] = v }
+			for j in 0..<arg_len { _, _, v := expand_values(args[j]); p2[offset+j] = v }
+		}
+	} else when FIELD_COUNT == 4 {
+		p0, p1, p2, p3, _, _, _ := expand_values(array^)
+		#no_bounds_check {
+			for j in 0..<arg_len { v, _, _, _ := expand_values(args[j]); p0[offset+j] = v }
+			for j in 0..<arg_len { _, v, _, _ := expand_values(args[j]); p1[offset+j] = v }
+			for j in 0..<arg_len { _, _, v, _ := expand_values(args[j]); p2[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, v := expand_values(args[j]); p3[offset+j] = v }
+		}
+	} else when FIELD_COUNT == 5 {
+		p0, p1, p2, p3, p4, _, _, _ := expand_values(array^)
+		#no_bounds_check {
+			for j in 0..<arg_len { v, _, _, _, _ := expand_values(args[j]); p0[offset+j] = v }
+			for j in 0..<arg_len { _, v, _, _, _ := expand_values(args[j]); p1[offset+j] = v }
+			for j in 0..<arg_len { _, _, v, _, _ := expand_values(args[j]); p2[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, v, _ := expand_values(args[j]); p3[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, v := expand_values(args[j]); p4[offset+j] = v }
+		}
+	} else when FIELD_COUNT == 6 {
+		p0, p1, p2, p3, p4, p5, _, _, _ := expand_values(array^)
+		#no_bounds_check {
+			for j in 0..<arg_len { v, _, _, _, _, _ := expand_values(args[j]); p0[offset+j] = v }
+			for j in 0..<arg_len { _, v, _, _, _, _ := expand_values(args[j]); p1[offset+j] = v }
+			for j in 0..<arg_len { _, _, v, _, _, _ := expand_values(args[j]); p2[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, v, _, _ := expand_values(args[j]); p3[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, v, _ := expand_values(args[j]); p4[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, v := expand_values(args[j]); p5[offset+j] = v }
+		}
+	} else when FIELD_COUNT == 7 {
+		p0, p1, p2, p3, p4, p5, p6, _, _, _ := expand_values(array^)
+		#no_bounds_check {
+			for j in 0..<arg_len { v, _, _, _, _, _, _ := expand_values(args[j]); p0[offset+j] = v }
+			for j in 0..<arg_len { _, v, _, _, _, _, _ := expand_values(args[j]); p1[offset+j] = v }
+			for j in 0..<arg_len { _, _, v, _, _, _, _ := expand_values(args[j]); p2[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, v, _, _, _ := expand_values(args[j]); p3[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, v, _, _ := expand_values(args[j]); p4[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, v, _ := expand_values(args[j]); p5[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, v := expand_values(args[j]); p6[offset+j] = v }
+		}
+	} else when FIELD_COUNT == 8 {
+		p0, p1, p2, p3, p4, p5, p6, p7, _, _, _ := expand_values(array^)
+		#no_bounds_check {
+			for j in 0..<arg_len { v, _, _, _, _, _, _, _ := expand_values(args[j]); p0[offset+j] = v }
+			for j in 0..<arg_len { _, v, _, _, _, _, _, _ := expand_values(args[j]); p1[offset+j] = v }
+			for j in 0..<arg_len { _, _, v, _, _, _, _, _ := expand_values(args[j]); p2[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, v, _, _, _, _ := expand_values(args[j]); p3[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, v, _, _, _ := expand_values(args[j]); p4[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, v, _, _ := expand_values(args[j]); p5[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, v, _ := expand_values(args[j]); p6[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, v := expand_values(args[j]); p7[offset+j] = v }
+		}
+	} else when FIELD_COUNT == 9 {
+		p0, p1, p2, p3, p4, p5, p6, p7, p8, _, _, _ := expand_values(array^)
+		#no_bounds_check {
+			for j in 0..<arg_len { v, _, _, _, _, _, _, _, _ := expand_values(args[j]); p0[offset+j] = v }
+			for j in 0..<arg_len { _, v, _, _, _, _, _, _, _ := expand_values(args[j]); p1[offset+j] = v }
+			for j in 0..<arg_len { _, _, v, _, _, _, _, _, _ := expand_values(args[j]); p2[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, v, _, _, _, _, _ := expand_values(args[j]); p3[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, v, _, _, _, _ := expand_values(args[j]); p4[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, v, _, _, _ := expand_values(args[j]); p5[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, v, _, _ := expand_values(args[j]); p6[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, v, _ := expand_values(args[j]); p7[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, v := expand_values(args[j]); p8[offset+j] = v }
+		}
+	} else when FIELD_COUNT == 10 {
+		p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, _, _, _ := expand_values(array^)
+		#no_bounds_check {
+			for j in 0..<arg_len { v, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p0[offset+j] = v }
+			for j in 0..<arg_len { _, v, _, _, _, _, _, _, _, _ := expand_values(args[j]); p1[offset+j] = v }
+			for j in 0..<arg_len { _, _, v, _, _, _, _, _, _, _ := expand_values(args[j]); p2[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, v, _, _, _, _, _, _ := expand_values(args[j]); p3[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, v, _, _, _, _, _ := expand_values(args[j]); p4[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, v, _, _, _, _ := expand_values(args[j]); p5[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, v, _, _, _ := expand_values(args[j]); p6[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, v, _, _ := expand_values(args[j]); p7[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, v, _ := expand_values(args[j]); p8[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, v := expand_values(args[j]); p9[offset+j] = v }
+		}
+	} else when FIELD_COUNT == 11 {
+		p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, _, _, _ := expand_values(array^)
+		#no_bounds_check {
+			for j in 0..<arg_len { v, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p0[offset+j] = v }
+			for j in 0..<arg_len { _, v, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p1[offset+j] = v }
+			for j in 0..<arg_len { _, _, v, _, _, _, _, _, _, _, _ := expand_values(args[j]); p2[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, v, _, _, _, _, _, _, _ := expand_values(args[j]); p3[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, v, _, _, _, _, _, _ := expand_values(args[j]); p4[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, v, _, _, _, _, _ := expand_values(args[j]); p5[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, v, _, _, _, _ := expand_values(args[j]); p6[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, v, _, _, _ := expand_values(args[j]); p7[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, v, _, _ := expand_values(args[j]); p8[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, v, _ := expand_values(args[j]); p9[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, v := expand_values(args[j]); p10[offset+j] = v }
+		}
+	} else when FIELD_COUNT == 12 {
+		p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, _, _, _ := expand_values(array^)
+		#no_bounds_check {
+			for j in 0..<arg_len { v, _, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p0[offset+j] = v }
+			for j in 0..<arg_len { _, v, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p1[offset+j] = v }
+			for j in 0..<arg_len { _, _, v, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p2[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, v, _, _, _, _, _, _, _, _ := expand_values(args[j]); p3[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, v, _, _, _, _, _, _, _ := expand_values(args[j]); p4[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, v, _, _, _, _, _, _ := expand_values(args[j]); p5[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, v, _, _, _, _, _ := expand_values(args[j]); p6[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, v, _, _, _, _ := expand_values(args[j]); p7[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, v, _, _, _ := expand_values(args[j]); p8[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, v, _, _ := expand_values(args[j]); p9[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, v, _ := expand_values(args[j]); p10[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, _, v := expand_values(args[j]); p11[offset+j] = v }
+		}
+	} else when FIELD_COUNT == 13 {
+		p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, _, _, _ := expand_values(array^)
+		#no_bounds_check {
+			for j in 0..<arg_len { v, _, _, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p0[offset+j] = v }
+			for j in 0..<arg_len { _, v, _, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p1[offset+j] = v }
+			for j in 0..<arg_len { _, _, v, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p2[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, v, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p3[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, v, _, _, _, _, _, _, _, _ := expand_values(args[j]); p4[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, v, _, _, _, _, _, _, _ := expand_values(args[j]); p5[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, v, _, _, _, _, _, _ := expand_values(args[j]); p6[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, v, _, _, _, _, _ := expand_values(args[j]); p7[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, v, _, _, _, _ := expand_values(args[j]); p8[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, v, _, _, _ := expand_values(args[j]); p9[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, v, _, _ := expand_values(args[j]); p10[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, _, v, _ := expand_values(args[j]); p11[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, _, _, v := expand_values(args[j]); p12[offset+j] = v }
+		}
+	} else when FIELD_COUNT == 14 {
+		p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, _, _, _ := expand_values(array^)
+		#no_bounds_check {
+			for j in 0..<arg_len { v, _, _, _, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p0[offset+j] = v }
+			for j in 0..<arg_len { _, v, _, _, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p1[offset+j] = v }
+			for j in 0..<arg_len { _, _, v, _, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p2[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, v, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p3[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, v, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p4[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, v, _, _, _, _, _, _, _, _ := expand_values(args[j]); p5[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, v, _, _, _, _, _, _, _ := expand_values(args[j]); p6[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, v, _, _, _, _, _, _ := expand_values(args[j]); p7[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, v, _, _, _, _, _ := expand_values(args[j]); p8[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, v, _, _, _, _ := expand_values(args[j]); p9[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, v, _, _, _ := expand_values(args[j]); p10[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, _, v, _, _ := expand_values(args[j]); p11[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, _, _, v, _ := expand_values(args[j]); p12[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, _, _, _, v := expand_values(args[j]); p13[offset+j] = v }
+		}
+	} else when FIELD_COUNT == 15 {
+		p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, _, _, _ := expand_values(array^)
+		#no_bounds_check {
+			for j in 0..<arg_len { v, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p0[offset+j] = v }
+			for j in 0..<arg_len { _, v, _, _, _, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p1[offset+j] = v }
+			for j in 0..<arg_len { _, _, v, _, _, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p2[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, v, _, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p3[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, v, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p4[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, v, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p5[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, v, _, _, _, _, _, _, _, _ := expand_values(args[j]); p6[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, v, _, _, _, _, _, _, _ := expand_values(args[j]); p7[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, v, _, _, _, _, _, _ := expand_values(args[j]); p8[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, v, _, _, _, _, _ := expand_values(args[j]); p9[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, v, _, _, _, _ := expand_values(args[j]); p10[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, _, v, _, _, _ := expand_values(args[j]); p11[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, _, _, v, _, _ := expand_values(args[j]); p12[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, _, _, _, v, _ := expand_values(args[j]); p13[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, _, _, _, _, v := expand_values(args[j]); p14[offset+j] = v }
+		}
+	} else when FIELD_COUNT == 16 {
+		p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, _, _, _ := expand_values(array^)
+		#no_bounds_check {
+			for j in 0..<arg_len { v, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p0[offset+j] = v }
+			for j in 0..<arg_len { _, v, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p1[offset+j] = v }
+			for j in 0..<arg_len { _, _, v, _, _, _, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p2[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, v, _, _, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p3[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, v, _, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p4[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, v, _, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p5[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, v, _, _, _, _, _, _, _, _, _ := expand_values(args[j]); p6[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, v, _, _, _, _, _, _, _, _ := expand_values(args[j]); p7[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, v, _, _, _, _, _, _, _ := expand_values(args[j]); p8[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, v, _, _, _, _, _, _ := expand_values(args[j]); p9[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, v, _, _, _, _, _ := expand_values(args[j]); p10[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, _, v, _, _, _, _ := expand_values(args[j]); p11[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, _, _, v, _, _, _ := expand_values(args[j]); p12[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, _, _, _, v, _, _ := expand_values(args[j]); p13[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, _, _, _, _, v, _ := expand_values(args[j]); p14[offset+j] = v }
+			for j in 0..<arg_len { _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, v := expand_values(args[j]); p15[offset+j] = v }
+		}
+	} else {
+		#panic("_append_soa_elems_per_field_expanded instantiated with an unsupported field count")
+	}
 }
 
 
@@ -523,43 +765,44 @@ append_nothing_soa :: proc(array: ^$T/#soa[dynamic]$E, loc := #caller_location) 
 
 // `inject_at_elem_soa` injects an element in a dynamic SOA array at a specified index and moves the previous elements after that index "across"
 @builtin
-inject_at_elem_soa :: proc(array: ^$T/#soa[dynamic]$E, #any_int index: int, #no_broadcast arg: E, loc := #caller_location) -> (ok: bool, err: Allocator_Error) #no_bounds_check #optional_allocator_error {
+inject_at_elem_soa :: proc(#no_alias array: ^$T/#soa[dynamic]$E, #any_int index: int, #no_broadcast arg: E, loc := #caller_location) -> (ok: bool, err: Allocator_Error) #no_bounds_check #optional_allocator_error {
 	when !ODIN_NO_BOUNDS_CHECK {
 		ensure(index >= 0, "Index must be positive.", loc)
 	}
 	if array == nil {
 		return
 	}
-	n := max(len(array), index)
+	old_len := len(array)
+	n := max(old_len, index)
 	m :: 1
 	new_len := n + m
 
-	resize_soa(array, new_len, loc) or_return
+	// The tail shift and the stored element cover every new slot,
+	// except a gap of [old_len, index) when injecting past the end, which is
+	// zeroed explicitly below.
+	non_zero_resize_soa(array, new_len, loc) or_return
 
 	when size_of(E) != 0 {
 		ti := type_info_base(type_info_of(typeid_of(T)))
 		si := &ti.variant.(Type_Info_Struct)
 
-		field_count := len(E) when intrinsics.type_is_array(E) else intrinsics.type_struct_field_count(E)
+		FIELD_COUNT :: len(E) when intrinsics.type_is_array(E) else intrinsics.type_struct_field_count(E)
 
-		item_offset := 0
-
-		arg_copy := arg
-		arg_ptr := &arg_copy
-
-		for i in 0..<field_count {
-			data := (^uintptr)(uintptr(array) + uintptr(si.offsets[i]))^
+		for i in 0..<FIELD_COUNT {
+			data := uintptr(([^]rawptr)(array)[i])
 			type := si.types[i].variant.(Type_Info_Multi_Pointer).elem
-			item_offset = align_forward_int(item_offset, type.align)
+
+			if index > old_len { // zero the gap left by injecting past the end
+				mem_zero(rawptr(data + uintptr(old_len * type.size)), (index - old_len) * type.size)
+			}
 
 			src := data + uintptr(index * type.size)
 			dst := data + uintptr((index + m) * type.size)
 			mem_copy(rawptr(dst), rawptr(src), (n - index) * type.size)
-
-			mem_copy(rawptr(src), rawptr(uintptr(arg_ptr) + uintptr(item_offset)), type.size)
-
-			item_offset += type.size
 		}
+
+		// store the new element via the compiler's #soa element store lowering
+		array[index] = arg
 	}
 
 	ok = true
@@ -568,7 +811,7 @@ inject_at_elem_soa :: proc(array: ^$T/#soa[dynamic]$E, #any_int index: int, #no_
 
 // `inject_at_elems_soa` injects multiple elements in a dynamic SOA array at a specified index and moves the previous elements after that index "across"
 @builtin
-inject_at_elems_soa :: proc(array: ^$T/#soa[dynamic]$E, #any_int index: int, #no_broadcast args: ..E, loc := #caller_location) -> (ok: bool, err: Allocator_Error) #no_bounds_check #optional_allocator_error {
+inject_at_elems_soa :: proc(#no_alias array: ^$T/#soa[dynamic]$E, #any_int index: int, #no_broadcast args: ..E, loc := #caller_location) -> (ok: bool, err: Allocator_Error) #no_bounds_check #optional_allocator_error {
 	when !ODIN_NO_BOUNDS_CHECK {
 		ensure(index >= 0, "Index must be positive.", loc)
 	}
@@ -580,11 +823,15 @@ inject_at_elems_soa :: proc(array: ^$T/#soa[dynamic]$E, #any_int index: int, #no
 		return
 	}
 
-	n := max(len(array), index)
+	old_len := len(array)
+	n := max(old_len, index)
 	m := len(args)
 	new_len := n + m
 
-	resize_soa(array, new_len, loc) or_return
+	// The tail shift and the stored elements cover every new slot,
+	// except a gap of [old_len, index) when injecting past the end, which is
+	// zeroed explicitly below.
+	non_zero_resize_soa(array, new_len, loc) or_return
 
 	when size_of(E) != 0 {
 		ti := type_info_base(type_info_of(typeid_of(T)))
@@ -592,14 +839,28 @@ inject_at_elems_soa :: proc(array: ^$T/#soa[dynamic]$E, #any_int index: int, #no
 
 		field_count := len(E) when intrinsics.type_is_array(E) else intrinsics.type_struct_field_count(E)
 
-		item_offset := 0
-
 		args_ptr := &args[0]
 
+		when !intrinsics.type_is_array(E) {
+			// E's field offsets come from E's own RTTI (si describes the SOA
+			// struct, whose fields are multipointers); basing on default struct
+			// layout here would misplace the fields of #packed elements.
+			se := &type_info_base(si.soa_base_type).variant.(Type_Info_Struct)
+		}
+
 		for i in 0..<field_count {
-			data := (^uintptr)(uintptr(array) + uintptr(si.offsets[i]))^
+			data := uintptr(([^]rawptr)(array)[i])
 			type := si.types[i].variant.(Type_Info_Multi_Pointer).elem
-			item_offset = align_forward_int(item_offset, type.align)
+			when intrinsics.type_is_array(E) {
+				// array lanes are uniform, so offsets are just i * stride
+				item_offset := uintptr(i * type.size)
+			} else {
+				item_offset := se.offsets[i]
+			}
+
+			if index > old_len { // zero the gap left by injecting past the end
+				mem_zero(rawptr(data + uintptr(old_len * type.size)), (index - old_len) * type.size)
+			}
 
 			src := data + uintptr(index * type.size)
 			dst := data + uintptr((index + m) * type.size)
@@ -607,11 +868,9 @@ inject_at_elems_soa :: proc(array: ^$T/#soa[dynamic]$E, #any_int index: int, #no
 
 			for j in 0..<len(args) {
 				d := rawptr(src + uintptr(j*type.size))
-				s := rawptr(uintptr(args_ptr) + uintptr(item_offset) + uintptr(j*size_of(E)))
+				s := rawptr(uintptr(args_ptr) + item_offset + uintptr(j*size_of(E)))
 				mem_copy(d, s, type.size)
 			}
-
-			item_offset += type.size
 		}
 	}
 
@@ -694,24 +953,11 @@ into_dynamic_soa :: proc(array: $T/#soa[]$E) -> #soa[dynamic]E {
 // Note: If you the elements to remain in their order, use `ordered_remove_soa`.
 // Note: If the index is out of bounds, this procedure will panic.
 @builtin
-unordered_remove_soa :: proc(array: ^$T/#soa[dynamic]$E, #any_int index: int, loc := #caller_location) #no_bounds_check {
+unordered_remove_soa :: proc(#no_alias array: ^$T/#soa[dynamic]$E, #any_int index: int, loc := #caller_location) #no_bounds_check {
 	bounds_check_error_loc(loc, index, len(array))
 	if index+1 < len(array) {
-		ti := type_info_of(typeid_of(T))
-		ti = type_info_base(ti)
-		si := &ti.variant.(Type_Info_Struct)
-
-		field_count := uintptr(len(E) when intrinsics.type_is_array(E) else intrinsics.type_struct_field_count(E))
-
-		data := uintptr(array)
-		for i in 0..<field_count {
-			type := si.types[i].variant.(Type_Info_Multi_Pointer).elem
-
-			offset := rawptr((^uintptr)(data)^ + uintptr(index*type.size))
-			final := rawptr((^uintptr)(data)^ + uintptr((len(array)-1)*type.size))
-			mem_copy(offset, final, type.size)
-			data += size_of(rawptr)
-		}
+		// Use the compiler's #soa element load and store lowering.
+		array[index] = array[len(array)-1]
 	}
 	raw_soa_footer_dynamic_array(array).len -= 1
 }
@@ -722,23 +968,21 @@ unordered_remove_soa :: proc(array: ^$T/#soa[dynamic]$E, #any_int index: int, lo
 // Note: If you the elements do not have to remain in their order, prefer `unordered_remove_soa`.
 // Note: If the index is out of bounds, this procedure will panic.
 @builtin
-ordered_remove_soa :: proc(array: ^$T/#soa[dynamic]$E, #any_int index: int, loc := #caller_location) #no_bounds_check {
+ordered_remove_soa :: proc(#no_alias array: ^$T/#soa[dynamic]$E, #any_int index: int, loc := #caller_location) #no_bounds_check {
 	bounds_check_error_loc(loc, index, len(array))
 	if index+1 < len(array) {
 		ti := type_info_of(typeid_of(T))
 		ti = type_info_base(ti)
 		si := &ti.variant.(Type_Info_Struct)
 
+		l1 := len(array)-1
 		field_count := uintptr(len(E) when intrinsics.type_is_array(E) else intrinsics.type_struct_field_count(E))
-
-		data := uintptr(array)
 		for i in 0..<field_count {
 			type := si.types[i].variant.(Type_Info_Multi_Pointer).elem
 
-			offset := (^uintptr)(data)^ + uintptr(index*type.size)
-			length := type.size*(len(array) - index - 1)
+			offset := uintptr(([^]rawptr)(array)[i]) + uintptr(index*type.size)
+			length := type.size*(l1 - index)
 			mem_copy(rawptr(offset), rawptr(offset + uintptr(type.size)), length)
-			data += size_of(rawptr)
 		}
 	}
 	raw_soa_footer_dynamic_array(array).len -= 1

--- a/tests/core/runtime/test_core_runtime.odin
+++ b/tests/core/runtime/test_core_runtime.odin
@@ -425,3 +425,196 @@ test_memory_compare_zero :: proc(t: ^testing.T) {
 		}
 	}
 }
+
+// Runs identical append/inject/remove sequences for a #soa[dynamic] array
+// and an AoS [dynamic] reference, comparing all elements after each
+// stage. Covers appends, injections (interior, at the end, and past the
+// end where the gap must read as zero elements), unordered and ordered
+// removes.
+@(test)
+test_soa_array_append_inject_remove :: proc(t: ^testing.T) {
+	check :: proc(t: ^testing.T, $E: typeid, mk: proc(i: int) -> E) {
+		expect_same :: proc(t: ^testing.T, soa: #soa[dynamic]$T, model: [dynamic]T) {
+			testing.expect_value(t, len(soa), len(model))
+			for i in 0..<min(len(soa), len(model)) {
+				testing.expect_value(t, soa[i], model[i])
+			}
+		}
+
+		soa: #soa[dynamic]E
+		defer delete(soa)
+		ref: [dynamic]E
+		defer delete(ref)
+
+		// single appends
+		for i in 0..<10 {
+			n, err := append(&soa, mk(i))
+			testing.expect_value(t, n, 1)
+			testing.expect_value(t, err, nil)
+			append(&ref, mk(i))
+		}
+		expect_same(t, soa, ref)
+
+		// batch appends
+		buf: [32]E
+		for i in 0..<32 { buf[i] = mk(123 + i) }
+		BATCH_LEN :: 5
+		n, err := append(&soa, ..buf[:BATCH_LEN])
+		testing.expect_value(t, n, BATCH_LEN)
+		testing.expect_value(t, err, nil)
+		append(&ref, ..buf[:BATCH_LEN])
+		expect_same(t, soa, ref)
+
+		n, err = append(&soa, ..buf[:])
+		testing.expect_value(t, n, 32)
+		testing.expect_value(t, err, nil)
+		append(&ref, ..buf[:])
+		expect_same(t, soa, ref)
+
+		// single injections
+		ok: bool
+		ok, err = inject_at_soa(&soa, 0, mk(300))
+		testing.expect(t, ok)
+		testing.expect_value(t, err, nil)
+		inject_at(&ref, 0, mk(300))
+		expect_same(t, soa, ref)
+
+		ok, err = inject_at_soa(&soa, len(soa)/2, mk(301))
+		testing.expect(t, ok)
+		testing.expect_value(t, err, nil)
+		inject_at(&ref, len(ref)/2, mk(301))
+		expect_same(t, soa, ref)
+
+		// inject at the end
+		ok, err = inject_at_soa(&soa, len(soa), mk(302))
+		testing.expect(t, ok)
+		testing.expect_value(t, err, nil)
+		inject_at(&ref, len(ref), mk(302))
+		expect_same(t, soa, ref)
+
+		// batch injections
+		ok, err = inject_at_soa(&soa, 3, ..buf[:BATCH_LEN])
+		testing.expect(t, ok)
+		testing.expect_value(t, err, nil)
+		inject_at(&ref, 3, ..buf[:BATCH_LEN])
+		expect_same(t, soa, ref)
+
+		ok, err = inject_at_soa(&soa, len(soa), ..buf[:])
+		testing.expect(t, ok)
+		testing.expect_value(t, err, nil)
+		inject_at(&ref, len(ref), ..buf[:])
+		expect_same(t, soa, ref)
+
+		// injecting nothing is a no-op
+		ok, err = inject_at_soa(&soa, 4, ..buf[:0])
+		testing.expect(t, ok)
+		testing.expect_value(t, err, nil)
+		inject_at(&ref, 4, ..buf[:0])
+		expect_same(t, soa, ref)
+
+		// single injection past the end: the gap [len, index) reads as zero
+		// elements. Poison the spare capacity first (fresh heap pages are
+		// already zero, which would hide a missing gap zero), then shrink back.
+		for i in 0..<8 {
+			n, err = append(&soa, mk(900 + i))
+			testing.expect_value(t, n, 1)
+			testing.expect_value(t, err, nil)
+		}
+		testing.expect_value(t, resize_soa(&soa, len(soa) - 8), nil)
+		ok, err = inject_at_soa(&soa, len(soa) + 3, mk(500))
+		testing.expect(t, ok)
+		testing.expect_value(t, err, nil)
+		inject_at(&ref, len(ref) + 3, mk(500))
+		expect_same(t, soa, ref)
+
+		// batch injection past the end (its gap slots reuse the poison above)
+		ok, err = inject_at_soa(&soa, len(soa) + 2, ..buf[:BATCH_LEN])
+		testing.expect(t, ok)
+		testing.expect_value(t, err, nil)
+		inject_at(&ref, len(ref) + 2, ..buf[:BATCH_LEN])
+		expect_same(t, soa, ref)
+
+		// unordered removes
+		unordered_remove_soa(&soa, 20)
+		unordered_remove(&ref, 20)
+		unordered_remove_soa(&soa, 0)
+		unordered_remove(&ref, 0)
+		unordered_remove_soa(&soa, len(soa)-1)
+		unordered_remove(&ref, len(ref)-1)
+		expect_same(t, soa, ref)
+
+		// ordered removes
+		ordered_remove_soa(&soa, 17)
+		ordered_remove(&ref, 17)
+		ordered_remove_soa(&soa, 0)
+		ordered_remove(&ref, 0)
+		ordered_remove_soa(&soa, len(soa)-1)
+		ordered_remove(&ref, len(ref)-1)
+		expect_same(t, soa, ref)
+
+		// interleaved removes, appends and injections
+		for i in 0..<8 {
+			unordered_remove_soa(&soa, i)
+			unordered_remove(&ref, i)
+			n, err = append(&soa, mk(200 + i))
+			testing.expect_value(t, n, 1)
+			testing.expect_value(t, err, nil)
+			append(&ref, mk(200 + i))
+			ok, err = inject_at_soa(&soa, i, mk(400 + i))
+			testing.expect(t, ok)
+			testing.expect_value(t, err, nil)
+			inject_at(&ref, i, mk(400 + i))
+		}
+		expect_same(t, soa, ref)
+
+		// remove till empty, then reuse
+		for len(soa) > 0 {
+			unordered_remove_soa(&soa, 0)
+			unordered_remove(&ref, 0)
+		}
+		testing.expect_value(t, len(soa), 0)
+
+		// inject into an empty array
+		ok, err = inject_at_soa(&soa, 0, mk(998))
+		testing.expect(t, ok)
+		testing.expect_value(t, err, nil)
+		inject_at(&ref, 0, mk(998))
+		expect_same(t, soa, ref)
+
+		// non-zero append
+		n, err = non_zero_append(&soa, mk(42))
+		testing.expect_value(t, n, 1)
+		testing.expect_value(t, err, nil)
+		non_zero_append(&ref, mk(42))
+		expect_same(t, soa, ref)
+	}
+
+	// mixed field widths + padding
+	Padded :: struct { a: u8, b: u64, c: u16 }
+	check(t, Padded, proc(i: int) -> Padded { return {u8(i*3), u64(i)*257 + 7, u16(i*5 + 1)} })
+	// array element type
+	check(t, [4]u16, proc(i: int) -> [4]u16 { return {u16(i), u16(i + 1), u16(i*3), u16(i*7)} })
+	// eight fields at varying widths, no two neighbouring fields share a stride
+	Eight :: struct { a: u8, b: u16, c: u32, d: u64, e: i8, f: i16, g: f32, h: f64 }
+	check(t, Eight, proc(i: int) -> Eight {
+		return {
+			u8(i), u16(i*3 + 1), u32(i)*5 + 2, u64(i)*7 + 3,
+			i8(i >> 1), i16(i*11 + 4), f32(i)*1.5, f64(i)*2.25,
+		}
+	})
+	// #packed struct with > 16 fields, field offsets diverging from default
+	// layout (u8/u64 alternate, align_of == 1), and the field count takes
+	// the type-erased batch appends compile time branch.
+	Packed17 :: struct #packed {
+		f0: u8, f1: u64, f2: u8, f3: u64, f4: u8, f5: u64, f6: u8, f7: u64,
+		f8: u8, f9: u64, f10: u8, f11: u64, f12: u8, f13: u64, f14: u8, f15: u64,
+		f16: u8,
+	}
+	check(t, Packed17, proc(i: int) -> Packed17 {
+		return {
+			u8(i), u64(i)*3 + 1, u8(i >> 1), u64(i)*5 + 2, u8(i >> 2), u64(i)*7 + 3, u8(i >> 3), u64(i)*11 + 4,
+			u8(i >> 4), u64(i)*13 + 5, u8(i >> 5), u64(i)*17 + 6, u8(i >> 6), u64(i)*19 + 7, u8(i >> 7), u64(i)*23 + 8,
+			u8(i*3),
+		}
+	})
+}

--- a/tests/core/speed.odin
+++ b/tests/core/speed.odin
@@ -6,3 +6,4 @@ package tests_core
 @(require) import "hash"
 @(require) import "image"
 @(require) import "math/big"
+@(require) import "runtime"


### PR DESCRIPTION
This PR is the result of extensive review, iteration, testing and benchmarking of the #soa dynamic arrays over the course of a couple of weeks. It introduces significant performance optimizations and incidentally fixes #soa arrays from #packed structs.

The #soa builtins currently still use the approach of their original implementation (6-7 years old?), where every element operation loops through the element type's fields through runtime type info, copying each field with a mem_copy. Meanwhile the compiler gained #soa store/load lowering (lb_addr_soa_variable), which the builtins haven't adopted. This PR uses it for the single-element operations (append_soa_elem, unordered_remove_soa, inject_at_elem_soa) and adds typed vectorizer-friendly per-field copy passes for batch appends (for types with up to 16 fields). In my benchmark this is up to ~11× faster on single appends, batch appends and unordered removes and up to ~3x on single injections. The PR additionally fixes a correctness bug where the existing type-erased loops assume default struct layout, so #soa arrays of #packed structs read and write the wrong field offsets and corrupt data.

Result tables first, because a number is worth a thousand words. (not really :)

(All benchmarks here done on Win10, LLVM 20.1, i7-4770, -o:speed, default odin compiler target (which is SSE capable, but not AVX capable); benchmark code (a bit tidied up to be more presentable) in this [gist](https://gist.github.com/corleypc/868e3f3d14b3b3151fd1207ddcf7ab8e))

**Single element appends (array size = 4128)**

| elem type | SOA fields | bytes/elem | speedup |
|---|---|---:|---:|
| `Vec2_f64` | 2 x 8B | 16 | **1.92x** |
| `Vec3_f64` | 3 x 8B | 24 | **4.89x** |
| `Vec4_f32` | 4 x 4B | 16 | **4.94x** |
| `Mixed` | 3 (1/8/2B) | 11 | **5.17x** |
| `RGBA` | 4 x 1B | 4 | **3.98x** |
| `Particle` | 4 (12/12/16/4B) | 44 | **2.88x** |
| `Fat` | 8 x 4B | 32 |  **11.05x** |
| `Fatter` | 12 x 4B | 48 |  **10.06x** |
| `VeryFat` | 16 x 4B | 64 | **6.24x** |
| `Fattest` | 18 x 4B | 72 | **5.96x** |
| `[2]f32` | 2 x 4B | 8 | **1.93x** |
| `[4]u16` | 4 x 2B | 8 | **4.56x** |

**Single element appends (varying array size)**

| elem type | SOA fields | bytes/elem | n | speedup |
|---|---|---:|---:|---:|
| `Vec3_f64` | 3 x 8B | 24 | 64  | **5.02x** |
| `Vec3_f64` | 3 x 8B | 24 | 65,536 | **3.05x** |
| `Vec3_f64` | 3 x 8B | 24 | 1,048,576 | **2.67x** |


**Batch appends speedups (array size = 4128)**

| elem type | batch of 4 | batch of 8 | batch of 15 | batch of 32 | batch of 61 |
|---|---:|---:|---:|---:|---:|
| `Vec2_f64` | 4.32x | 5.48x | 5.39x | 7.83x | 8.23x |
| `Vec3_f64` | 1.36x | 1.46x | 1.41x | 2.05x | 1.95x |
| `Vec4_f32` | 3.82x | 5.74x | 4.66x | 9.82x | 9.11x |
| `Mixed` | 3.56x | 5.06x | 4.97x | 10.27x | 9.46x |
| `RGBA` | 2.98x | 4.41x | 5.02x | 9.42x | 8.78x |
| `Particle` | 2.99x | 3.32x | 3.85x | 4.43x | 4.68x |
| `Fat` | 4.15x | 5.81x | 4.55x | 9.74x | 8.92x |
| `Fatter` | 3.93x | 5.02x | 3.74x | 9.80x | 7.36x |
| `VeryFat` | 3.66x | 5.37x | 3.56x | 9.81x | 6.85x |
| `[2]f32` | 5.19x | 6.75x | 5.90x | 11.38x | 10.85x |
| `[4]u16` | 3.57x | 5.40x | 6.02x | 10.19x | 9.62x |


**Unordered removes (array size = 4128)**

| elem type | SOA fields | bytes/elem | speedup |
|---|---|---:|---:|
| `Vec2_f64` | 2 x 8B | 16 | **10.17x** |
| `Vec3_f64` | 3 x 8B | 24 | **2.65x** |
| `Vec4_f32` | 4 x 4B | 16 | **2.93x** |
| `Mixed` | 3 (1/8/2B) | 11 | **9.15x** |
| `RGBA` | 4 x 1B | 4 | **2.12x** |
| `Particle` | 4 (12/12/16/4B) | 44 | **2.06x** |
| `Fat` | 8 x 4B | 32 | **1.69x** |
| `Fatter` | 12 x 4B | 48 | **3.89x** |
| `VeryFat` | 16 x 4B | 64 | **3.58x** |
| `Fattest` | 18 x 4B | 72 | **3.45x** |
| `[2]f32` | 2 x 4B | 8 | **11.85x** |
| `[4]u16` | 4 x 2B | 8 | **2.77x** |


*Scroll down for a list of specific changes in the commit.*


**Where the gains come from**

As said in the prologue, the curremt implementation of the #soa builtins is now quite old, and in the meantime there's been compiler lowering imlemeneted through the LLVM backend SOA addressing (lb_addr_soa_variable), which is not used by the builtins. The builtins extensively use type-erased loops over the fields. These type-erased loops nevertheless get instantiated per element type, so they don't deliver type erasure's full size benefit of a single shared implementation. They read the RTTI on every invocation per every field, which particularly affects the single-element operations, where there is no batch to amortize over.

The other significant addition in the PR is typed copies for batch appends (append_soa_elems, non_zero_append_soa_elems), using expand_values. This sidesteps RTTI altogeter, cause everything is compile-time known. It is vectorizer friendly and is significantly faster than the compiler generated lowering. The downside is that code size scales at around ~80-85 asm instructions per field (x64, -o:speed, default target), so this is currently limited to 16 fields and conditioned on .ODIN_OPTIMIZATION_MODE >= .Speed. At >16 fields, the type erased loop is kept and at these field counts its field count invariant size is also smaller for .Size targets. (this is also the reason there is no row for the 18-field type in the batch appends table, it's pretty much the same code with minor tweaks)

<details>
<summary>Deeper dive for the curious soul</summary>
If the spread of speedups in the tables in relation to field count had you raise an eyebrow, congratulations, you rightly did so. There is no apparent monotonicity of speedups over field count. Currently, every #soa builtin copies each field with <code>mem_copy(..., ..., type.size)</code>, with type.size read from RTTI. The type info table is emitted as LLVM constant globals, so those loads are foldable in principle, but the index into it is the field loop counter, so the size only becomes a compile-time constant if that loop is fully unrolled first. Whether it unrolls is decided per instantiation by the unroller. When it unrolls, the copies lower to inline movs. When it doesn't, mem_copy stays a CRT memmove call, one per field in the single-element paths, and one per field per element in the batch ones, where the call is in the inner loop. And not-unrolling is where the largest speedups in the tables come from.

This isn't a property of the type layout. An isolated append_soa_elem unrolls up to 4 fields and doesn't unroll at 5+, but the same e.g. 3-field element may not unroll when append_soa_elem is in an actual program. Ditto for unordered_remove_soa, which doesn't even seem to have a threshold for unrolling. So the unrolling decision depends on the surrounding code rather than type layout.

The compiler #soa lowering this commit uses for the single element paths and the typed per-field copies it uses for append_soa_elems, have no such dependency. Offsets and sizes are compile-time constants, with no loop that has to be unrolled to expose them. Cost is monotonic in field count: usually ~2-4x against the current unrolled case, 8–12x against the current slower non-unrolled case.

Now, you may be wondering "Can't we force unroll the type erased loop so that the index is compile-time known all the time?". Yes, we can, using <code>#unroll for</code> with the compile-time known field count, and this was an intermediate step tried before arriving at the uniformly faster typed copies in the commit. Note that #unroll doesn't 100% reliably force unrolling, but boosts the odds of it happening significantly.

"Hmm, somehow it seems to fill my head with ideas, only I don’t exactly know what they are!" Ah, welcome. :)
While scratching my head, trying to squeeze the numbers, I got another bright idea. In the batched appends, the mem_copy is in the inner loop. What if we have a switch on type.size and do a simple fixed width copy for the common field sizes, falling back to mem_copy for uncommon field sizes? Here is a [gist](https://gist.github.com/corleypc/1845a592d1b0bf95472dc70f4aa44527).
So #unroll tries to force type.size itself as a compile-time constant, by unrolling so that the index is folded. It is still subject to the unroller's cost decisions (hence not 100% predictable) and code size is O(field count).
The switch leaves type.size as a runtime value and dispatches to one of several statically-sized copy loops, and code size is field count invariant.
The switch actually does better than #unroll for the common field sizes (it does vectorize), but still falls off the cliff for the "uncommon" ones (the default switch case). And still not close to the typed copies, but it remains a viable idea for the >16 fields types, if they ever come to need a faster treatment.
</details>

**Injections and ordered remove**

These didn't get the same attention as appends and unordered removes, because they should better be avoided altogether.

Single injection got a significant boost mostly due to the committed version avoiding redundant zeroing of the reused memory. Using compiler lowering for the injected copy also boosts performance, particularly for injecting near the end. Measured speedup up to ~2.7x for injecting within ~16 elements from the end.

Batch injections also benefit from avoiding zeroing of reused memory, but this is dominated by doing the copy when injecting larger batches, and the copy is still done with a type erased loop, cause I judged the added complexity wouldn't match the gain for an operation destined to be avoided. Ordered removes get (mostly) small gains (up to ~1.4x) due to the #no_alias changes and minor changes to the tails loops that hoist len above the loop. 


**Important note on array capacity and performance**

By design, each field is stored in contiguous memory with stride between fields of `capacity * size_of(field)`  (+alignment). When the stride is a multiple of 4KB, e.g. a power-of-2 capacity >= 1024 with 4-byte fields, every same-size field's cache line for a given index maps to the same L1 set, and per-element operations degrade (e.g. append_soa, inject_at_soa). It is worst past 8 same-size fields where the burst exceeds the common L1 8-way associativity and the fields collide (measured up to ~7-8x degradation on a type with 18 same-size fields; fields of different sizes advance through the sets at different rates, so they don't collide persistently). SoA iterative flows may also be affected, particularly when the loop touches multiple fields and other hot data aliases the same L1 set. And SoA iterative flows is what we use SoA for in the first place.

So, for types with several fields, code should pad such capacities by at least the number of fields that fit in a CPU cache line.
Modern cache lines are typically 64 (Intel/AMD/Arm64) or 128 bytes (Apple Silicon), so pad with e.g. `128 / size_of(field)` (for the smallest field when field sizes differ), that is, prefer 4128 instead of 4096 for 4-byte fields. Setting cap to e.g. 4097 is NOT enough (it shifts field memory by only 4 bytes (same cache line) and fields keep colliding). The discussion above mentions a 4KB stride and degradation at >8 fields. 4KB is the x86 L1 set period, and some newer Intel cores are 12-way (32–48KB/8–12-way), so the hit would come harder at >12 fields. Apple Silicon (128KB/8-way) has a 16KB period, so 4096 × 4 = 16KB stride is still pathological there and the blanket recommendation of a 128-byte pad fixes it.


**Single element appends (array cap 4096 vs array cap 4128)**

| elem type | SOA fields | slowdown at 4096|
|---|---:|---:|
| `Vec4_f32` | 4 x 4B | **1.77x** |
| `Fat` | 8 x 4B | **3.45x** |
| `Fattest` | 18 x 4B | **7.26x** |

This effect already exists with the current code, there appends for the 18 field struct are ~2x slower at 4096 cap compared to 4128 cap, but the leaner code in the commit exposes the problem much sooner and with a much higher impact on the gains. (In case you wonder, the patched code is still 2-3x faster than current at capacity of 4096 for Fat and Fattest).

Accordingly, the commit adds the power-of-2 warning and the padding recommendation to the doc comment of reserve_soa.

Ideally, this should be handled internally in reserve_soa by allowing allocated capacity to exceed requested capacity.
I didn't do it, since this would break current runtime tests. They explicitly test for the requested cap.

Also note that capacities produced by append growth all the way from empty do `2*cap + 8` per grow and are not affected. (But pre-reserving memory is the proper way.)


**Changes, more specifically**

* Code now takes advantage of the compiler implemented lowering of #soa stores and loads, particularly on operations that do single element stores (append_soa_elem, unordered_remove_soa, inject_at_elem_soa). 
* Typed vectorizer friendly store handling for batch appends (append_soa_elems, non_zero_append_soa_elems) for structs with up to 16 fields. This are enabled for ODIN_OPTIMIZATION_MODE >= .Speed, and, conversely, the compiler lowering is used for ODIN_OPTIMIZATION_MODE <= .Size.
* Tweaked type erased loops over fields, where these loops still remain. While doing this, I realised the existing loops also break silently for #packed structs and introduce corruption. They assume default struct layout. So I took extra care to fix this, with the new version also resulting in an extra 10-15% performance gain.
* Judicious use of #no_alias on the array parameter. In order to have the annotation flow freely, uintptr casts are replaced with multipointer indexing, wherever array is cast for access to fields or footer. uintptr lowers to LLVM's ptrtoint which is conservatively treated as opaque during LLVM alias analysis, multipointer indexing lowers to getelementptr and is transparent during alias analysis.
* Injection procedures (inject_at_elem_soa and inject_at_elems_soa) now call non_zero_resize_soa instead of resize_soa to avoid redundant zeroing, with an explicit mem_zero added for the potential gap that would appear when injecting beyond the last element.
* _reserve_soa() is now #force_no_inline. It is not on the hot path, but the inliner had no scruples inlining it, so this is now explicitly disabled.
* Doc comment on reserve_soa() warns against power-of-2 manual cap reservations.
* The PR adds an extensive test that does a sequence of appends, removes, injections and compares to a mirror reference AoS array at each step.
* The PR now imports runtime in tests/core/speed.odin so that runtime tests are also run at -o:speed. I beleive this should be done even without the changes in the PR, cause there was -o:speed conditioned code in the runtime package already (e.g. AoS dynamic arrays).

Potential improvements not done:
* Overallocating in _reserve_soa() on capacities for which cap * size_of(field) is multiple of 4096. This will prevent cache associativity related performance degradation and I recommend doing it. (And, of course, volunteer to do it.)
* Switch over type.size with compile-time known fixed sizes for append_soa_elems for types with >16 fields, if such field counts ever come to matter.
* Typed store arms for inject_at_elems_soa, similar to append_soa_elems. I deemed the complexity too big, considering this is not a core operation for SoA, and it should generally be avoided.

**Finale**

If you did read all of this, thank you for taking the time. I left most details of what-led-to-what out, as well as oher tried and discarded ideas, cause, really, this would be of interest to performance junkies only. But it still took significant effort to write it down and even bigger one to beautify it, so that the text is remotely readable. :) 