### PR TITLE
[debug/trace] sync allocator with `core:mem`

### DIFF
--- a/core/debug/trace/allocator.odin
+++ b/core/debug/trace/allocator.odin
@@ -97,6 +97,8 @@ tracking_allocator_init :: proc(
 tracking_allocator_destroy :: proc(t: ^Tracking_Allocator) {
 	delete(t.allocation_map)
 	delete(t.bad_free_array)
+	t.allocation_map = {}
+	t.bad_free_array = {}
 }
 
 @(no_sanitize_address)


### PR DESCRIPTION
syncs the tracking allocator in `debug/trace` with the changes made in https://github.com/odin-lang/Odin/pull/7195