### PR TITLE
Fix grammar in simd.odin doc comment

### DIFF
--- a/core/simd/simd.odin
+++ b/core/simd/simd.odin
@@ -2,7 +2,7 @@
 Cross-platform `SIMD` support types and procedures.
 
 SIMD (Single Instruction Multiple Data), is a CPU hardware feature that
-introduce special registers and instructions which operate on multiple units
+introduces special registers and instructions which operate on multiple units
 of data at the same time, which enables faster data processing for
 applications with heavy computational workloads.
 


### PR DESCRIPTION
Fix subject-verb agreement in the simd.odin documentation comment: 'a CPU hardware feature that introduces special registers...'.