### PR TITLE
Fix os.glob not cloning pattern when no meta characters present

### DIFF
--- a/core/os/path.odin
+++ b/core/os/path.odin
@@ -746,7 +746,7 @@ glob :: proc(pattern: string, allocator := context.allocator) -> (matches: []str
 	if !has_meta(pattern) {
 		// TODO(bill): os.lstat on here to check for error
 		m := make([]string, 1)
-		m[0] = pattern
+		m[0] = strings.clone(pattern)
 		return m[:], nil
 	}
 

--- a/tests/core/os/path.odin
+++ b/tests/core/os/path.odin
@@ -380,6 +380,13 @@ glob_tests := []Glob_Test{
 		},
 		err     = {},
 	},
+	{
+		pattern = ODIN_ROOT + "tests/core/os/path.odin",
+		matches = {
+			ODIN_ROOT + "tests/core/os/path.odin",
+		},
+		err     = {},
+	},
 }
 
 @(test)


### PR DESCRIPTION
`os.glob` returns the pattern string directly in the result slice when the pattern contains no glob meta-characters (`*`, `?`, `[`). Callers iterating over results and calling `delete()` on each string will invalidly free the original pattern string's backing memory.

This clones the pattern via `strings.clone` so the returned slice is safe to free.

Fixes #7190 