### PR TITLE
Fix `-vet-packages` not working in certain cases

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -6,13 +6,35 @@ gb_internal bool in_vet_packages(AstFile *file) {
 	if (file == nullptr) {
 		return true;
 	}
+
 	if (file->pkg == nullptr) {
 		return true;
 	}
+
+	if (file->pkg_decl == nullptr) {
+		return true;
+	}
+
 	if (build_context.vet_packages.entries.count == 0) {
 		return true;
 	}
-	return string_set_exists(&build_context.vet_packages, file->pkg->name);
+
+	String pkg_name = {};
+
+	if (file->pkg->name.len > 0) {
+		pkg_name = file->pkg->name;
+	} else if (file->pkg_decl->kind == Ast_PackageDecl) {
+		Token name_token = file->pkg_decl->PackageDecl.name;
+		if (name_token.kind == Token_Ident) {
+			pkg_name = name_token.string;
+		}
+	}
+
+	if (pkg_name.len == 0) {
+		return true;
+	}
+
+	return string_set_exists(&build_context.vet_packages, pkg_name);
 }
 
 gb_internal u64 ast_file_vet_flags(AstFile *f) {


### PR DESCRIPTION
Fixes #6793.

I don't really know what I'm doing when it comes to the compiler, so please review this with extra scrutiny.

I noticed that in most cases, `pkg_name = file->pkg->name` evaluated to `""` and was thus skipped from being vetted. Notably, this happened when there was *any* file tag, such as `#+vet explicit-allocators` above the package declaration.

The added checks should fall back to the `PackageDecl.name`, as that is resolved before the `pkg->name`.

The final check:
```cpp
    if (pkg_name.len == 0) {
        return true;
    }
```
is *probably* not needed, but I'm not entire sure.

Thanks in advance!
Cheers


## Example
Compare before and after, with `odin check . -vet-packages:main -vet-tabs -vet-semicolon`
```odin
#+vet explicit-allocators
package main

main :: proc () {
    x := new(int);
}
```