### PR TITLE
Fixes compile error due to #no_alias shifting position in procs with indirect return

### DIFF
--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -278,13 +278,17 @@ gb_internal lbProcedure *lb_create_procedure(lbModule *m, Entity *entity, bool i
 
 	// NOTE(bill): offset==0 is the return value
 	isize offset = 1;
-	if (pt->Proc.return_by_pointer) {
+	lbFunctionType *ft = p->abi_function_type;
+	GB_ASSERT(ft != nullptr);
+	if (ft->ret.kind == lbArg_Indirect) {
+		// return by pointer prepends an sret param
 		offset = 2;
 	}
 
-	isize parameter_index = 0;
 	if (pt->Proc.param_count) {
 		TypeTuple *params = &pt->Proc.params->Tuple;
+		isize parameter_index = 0;   // 0-based position among the Odin proc params in the LLVM function signature
+		isize ft_args_index = 0;     // index into ft->args
 		for (isize i = 0; i < pt->Proc.param_count; i++) {
 			Entity *e = params->variables[i];
 			if (e->kind != Entity_Variable) {
@@ -292,6 +296,13 @@ gb_internal lbProcedure *lb_create_procedure(lbModule *m, Entity *entity, bool i
 			}
 
 			if (i+1 == params->variables.count && pt->Proc.c_vararg) {
+				continue;
+			}
+
+			GB_ASSERT(ft_args_index < ft->args.count);
+			lbArgType *arg = &ft->args[ft_args_index++];
+			if (arg->kind == lbArg_Ignore) {
+				// these are not present in the LLVM function signature, don't advance parameter_index
 				continue;
 			}
 


### PR DESCRIPTION
When a procedure does indirect return by pointer, #no_alias gets applied off by one.

```odin
package main

import "core:fmt"

Big :: struct {a, _, _: i64} // large enough to be returned by pointer

f :: proc(x: i64, #no_alias y: ^i64) -> Big {
	y^ = 2
	return Big{a = y^}
}

main :: proc() {
	x, y: i64
	r := f(x, &y)
	fmt.printf("%d", r.a)
}
```

Here the attribute moves forward to the x parameter and the compiler errors with
`Attribute 'noalias' applied to incompatible type!`

Code in lb_create_procedure() checks pt->Proc.return_by_pointer which is never set. The fix follows the method used in lb_emit_call() and gets the return kind from p->abi_function_type instead.

Note that pt->Proc.return_by_pointer is also used in lb_create_dummy_procedure(), but I didn't fix it there, cause it looks like it would panic in `lb_add_proc_attribute_at_index(p, 1, "sret")`, which dispatches to this explicitly guarded branch in lb_create_enum_attribute():
`if (s == "sret") {
		GB_PANIC("lb_create_enum_attribute_with_type should be used for %s", name);
	}`
