### PR TITLE
Fixes a compiler segfault with zero sized parameters on targets that ignore these in the llvm signature

### DIFF
--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -653,7 +653,8 @@ gb_internal void lb_begin_procedure_body(lbProcedure *p) {
 
 			bool is_odin_cc = is_calling_convention_odin(ft->calling_convention);
 
-			unsigned param_index = 0;
+			unsigned param_index = 0;      // index into ft->args and the source param position used for debug info
+			unsigned llvm_param_index = 0; // 0-based position among the Odin proc params in the LLVM function signature
 			for_array(i, params->variables) {
 				Entity *e = params->variables[i];
 				if (e->kind != Entity_Variable) {
@@ -667,6 +668,9 @@ gb_internal void lb_begin_procedure_body(lbProcedure *p) {
 
 				lbArgType *arg_type = &ft->args[param_index];
 				defer (param_index += 1);
+				// lbArg_Ignore params are not present in the LLVM function signature, 
+				// so they don't advance the LLVM signature position
+				defer (if (arg_type->kind != lbArg_Ignore) { llvm_param_index += 1; });
 
 				if (arg_type->kind == lbArg_Ignore) {
 					// Even though it is an ignored argument, it might still be referenced in the
@@ -676,7 +680,7 @@ gb_internal void lb_begin_procedure_body(lbProcedure *p) {
 				} else if (arg_type->kind == lbArg_Direct) {
 					if (e->token.string.len != 0 && !is_blank_ident(e->token.string)) {
 						LLVMTypeRef param_type = lb_type(p->module, e->type);
-						LLVMValueRef original_value = LLVMGetParam(p->value, param_offset+param_index);
+						LLVMValueRef original_value = LLVMGetParam(p->value, param_offset+llvm_param_index);
 						LLVMValueRef value = OdinLLVMBuildTransmute(p, original_value, param_type);
 
 						lbValue param = {};
@@ -703,7 +707,7 @@ gb_internal void lb_begin_procedure_body(lbProcedure *p) {
 						}
 
 						lbValue ptr = {};
-						ptr.value = LLVMGetParam(p->value, param_offset+param_index);
+						ptr.value = LLVMGetParam(p->value, param_offset+llvm_param_index);
 						ptr.type = alloc_type_pointer(e->type);
 
 						if (do_callee_copy) {


### PR DESCRIPTION
As a followup to https://github.com/odin-lang/Odin/pull/7214, I was poking around to see how other backend code traverses parameters, and noticed an obscure bug in lb_begin_procedure_body. This crashes the compiler when building for targets where the abi doesn't output zero sized parameters down to llvm (looks like wasm and i386 currently, probably a good idea to unify abi handling of empty params across all targets?):

(build with -target:wasi_wasm32)

```odin
package main

import "core:fmt"

// add one more zero sized param to crash the compiler with the odin calling convention
// a single zero sized param won't crash with odin cc,
// but every following param is off by one then
f :: #force_no_inline proc "contextless" (zero_size_param: struct {}, y: ^i64) -> i64 {  
	y^ = 3
	return y^
}

main :: proc() {
	y: i64
	fmt.println(f(struct{}{}, &y))
}
```

Fixed the same way as https://github.com/odin-lang/Odin/pull/7214, following the lb_emit_call() traversing method that honors lbArg_Ignore parameters (zero size params on these targets).