### PR TITLE
fix levenstein_distance

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -885,8 +885,13 @@ gb_internal isize levenstein_distance_case_insensitive(String const &a, String c
 					minimum = substitute;
 				}
 				// Damerau-Levenshtein (transposition extension)
+				// NOTE: this is the "optimal string alignment" variant, which is what this
+				// matrix supports; the transposition discount only applies when the two
+				// characters are actually swapped.
 				#if USE_DAMERAU_LEVENSHTEIN
-				if (i > 1 && j > 1) {
+				if (i > 1 && j > 1 &&
+				    a_c == gb_char_to_lower(cast(char)b.text[j-2]) &&
+				    b_c == gb_char_to_lower(cast(char)a.text[i-2])) {
 					isize transpose = matrix[(i-2)*w + j-2] + 1;
 					if (transpose < minimum) {
 						minimum = transpose;


### PR DESCRIPTION
The Damerau transposition discount was applied at essentially every interior cell without ever checking that the two characters are actually swapped, so computed distances came out lower than the true edit distance. 

Unrelated names could then land inside the acceptance threshold and be offered as suggestions.

The fix withdraws that suggestion. Genuine typos are unaffected: alpha/alpah, length/lenght, field/fielx, count/counts all score 1 both before and after.

```odin
package pd
S :: struct { bar: int }
call :: proc(s: S) {
	_ = s.foo
}
```
```sh
$ odin check . -no-entry-point
main.odin(6:6) Error: 's' of type 'S' has no field 'foo'
	_ = s.foo
	    ^
	Suggestion: Did you mean?
		bar          <-- 'foo' and 'bar' have no character in common

POST-FIX:
main.odin(6:6) Error: 's' of type 'S' has no field 'foo'
	_ = s.foo
	    ^
```