### PR TITLE
fix: Signed Int Constants permitted to exceed size

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -2391,14 +2391,18 @@ gb_internal bool check_representable_as_constant(CheckerContext *c, ExactValue i
 		case Basic_i32be:
 		case Basic_i64be:
 			if (c->bit_field_bit_size == 0) {
-				// return imin <= i && i <= imax;
+				// NOTE: the check below is a magnitude test (mp_count_bits() <= 64), 
+				// big_int_to_i64 would wrap u64 max to -1 and pass for any signed type.
+				// Compare magnitudes instead
 				if (!big_int_can_be_represented_in_64_bits(&i)) {
 					return false;
 				}
 
-				i64 val64 = big_int_to_i64(&i);
-
-				return imin_64 <= val64 && val64 <= imax_64;
+				u64 mag = mp_get_mag_u64(&i);
+				if (big_int_is_neg(&i)) {
+					return mag <= cast(u64)-(imin_64+1) + 1; // |imin_64|, without overflowing i64
+				}
+				return mag <= cast(u64)imax_64;
 			}
 			/*fallthrough*/
 		case Basic_i128le:


### PR DESCRIPTION
A constant that cannot be represented in its declared type is accepted silently, and keeps its
true value:
```odin
package rng

A : i8  : 18446744073709551615
B : i64 : 18446744073709551615

#assert(A == 18446744073709551615)  // holds
#assert(A > 0)                      // holds
#assert(B == 18446744073709551615)  // holds
```

**The gate is a magnitude test.** `big_int_can_be_represented_in_64_bits` is
`mp_count_bits(x) <= 64`, which ignores sign and so admits the whole *unsigned* 64-bit range.

**The narrowing then wraps.** `big_int_to_i64` is `mp_get_i64`, so `max(u64)` becomes `-1`, `max(u64) - 1` becomes `-2`, and so on. Those wrapped values are small, so they satisfy the bounds check for `i8` just as readily as for `i64`. 


| declaration | | before | after |
|---|---|---|---|
| `X : i8 : 127` | i8 max | accepted | accepted |
| `X : i8 : 128` | i8 max + 1 | rejected | rejected |
| `X : i8 : -128` | i8 min | accepted | accepted |
| `X : i8 : -129` | i8 min - 1 | rejected | rejected |
| `X : i8 : 18446744073709551615` | u64 max | accepted | **rejected** |
| `X : i16 : 32767` | i16 max | accepted | accepted |
| `X : i16 : 32768` | i16 max + 1 | rejected | rejected |
| `X : i16 : -32768` | i16 min | accepted | accepted |
| `X : i16 : -32769` | i16 min - 1 | rejected | rejected |
| `X : i16 : 18446744073709551615` | u64 max | accepted | **rejected** |
| `X : i32 : 2147483647` | i32 max | accepted | accepted |
| `X : i32 : 2147483648` | i32 max + 1 | rejected | rejected |
| `X : i32 : -2147483648` | i32 min | accepted | accepted |
| `X : i32 : -2147483649` | i32 min - 1 | rejected | rejected |
| `X : i32 : 4294967295` | u32 max | rejected | rejected |
| `X : i32 : 9223372036854775808` | 2^63 | rejected | rejected |
| `X : i32 : 18446744073709551614` | u64 max - 1 | accepted | **rejected** |
| `X : i32 : 18446744073709551615` | u64 max | accepted | **rejected** |
| `X : i64 : 9223372036854775807` | i64 max | accepted | accepted |
| `X : i64 : 9223372036854775808` | i64 max + 1 | accepted | **rejected** |
| `X : i64 : -9223372036854775808` | i64 min | accepted | accepted |
| `X : i64 : -9223372036854775809` | i64 min - 1 | accepted | **rejected** |
| `X : i64 : 18446744073709551615` | u64 max | accepted | **rejected** |
| `X : i64 : 18446744073709551616` | 2^64 | rejected | rejected |
| `X : int : 18446744073709551615` | u64 max | accepted | **rejected** |
| `X : i64le : 18446744073709551615` | u64 max | accepted | **rejected** |
| `X : i64be : 18446744073709551615` | u64 max | accepted | **rejected** |
| `X : rune : 65` | valid rune | accepted | accepted |
| `X : rune : 18446744073709551615` | u64 max | accepted | **rejected** |
| `X : u8 : 255` | u8 max | accepted | accepted |
| `X : u8 : 256` | u8 max + 1 | rejected | rejected |
| `X : u8 : 18446744073709551615` | u64 max | rejected | rejected |
| `X : u32 : 4294967295` | u32 max | accepted | accepted |
| `X : u64 : 18446744073709551615` | u64 max | accepted | accepted |
| `X : u64 : 18446744073709551616` | 2^64 | rejected | rejected |
| `X : u64 : -1` | negative | rejected | rejected |
| `X : uint : 18446744073709551615` | u64 max | accepted | accepted |
| `X : i128 : 170141183460469231731687303715884105727` | i128 max | accepted | accepted |
| `X : i128 : 170141183460469231731687303715884105728` | i128 max + 1 | rejected | rejected |
| `X : u128 : 340282366920938463463374607431768211455` | u128 max | accepted | accepted |
