### PR TITLE
string16 oob

### DIFF
--- a/src/string.cpp
+++ b/src/string.cpp
@@ -959,9 +959,10 @@ gb_internal String quote_to_ascii(gbAllocator a, String16 str, u8 quote='"') {
 		}
 		if (width == 1 && r == GB_RUNE_INVALID) {
 			array_add(&buf, cast(u8)'\\');
-			array_add(&buf, cast(u8)'x');
-			array_add(&buf, cast(u8)lower_hex[s[0]>>4]);
-			array_add(&buf, cast(u8)lower_hex[s[0]&0xf]);
+			array_add(&buf, cast(u8)'u');
+			for (isize i = 12; i >= 0; i -= 4) {
+				array_add(&buf, cast(u8)lower_hex[(s[0]>>i)&0xf]);
+			}
 			continue;
 		}
 


### PR DESCRIPTION
Fix out-of-bounds read in `quote_to_ascii(String16)`

`src/string.cpp:963` indexes the 16-entry `lower_hex` table with `s[0]>>4`, where `s[0]` is a
`u16`, so the index ranges over 0..4095, reading up to 4080 bytes past the table.

Confirmed under ASAN