### PR TITLE
fix new line suppression

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -7131,7 +7131,9 @@ gb_internal bool evaluate_where_clauses(CheckerContext *ctx, Ast *call_expr, Sco
 							Entity *e = entry.value;
 							switch (e->kind) {
 							case Entity_TypeName: {
-								// if (print_count == 0) error_line("\n\tWith the following definitions:\n");
+								// NOTE: the leading "  " is required; a genuinely empty line
+								// terminates the error message when it is printed.
+								if (print_count == 0) error_line("  \n\tWith the following definitions:\n");
 
 								gbString str = type_to_string(e->type);
 								error_line("\t\t%.*s :: %s;\n", LIT(e->token.string), str);
@@ -7140,7 +7142,7 @@ gb_internal bool evaluate_where_clauses(CheckerContext *ctx, Ast *call_expr, Sco
 								break;
 							}
 							case Entity_Constant: {
-								if (print_count == 0) error_line("\n\tWith the following definitions:\n");
+								if (print_count == 0) error_line("  \n\tWith the following definitions:\n");
 
 								gbString str = exact_value_to_string(e->Constant.value);
 								if (is_type_untyped(e->type)) {


### PR DESCRIPTION
Two entity kinds can contribute lines to the definitions block, and they share one counter:

```cpp
isize print_count = 0;
for (auto const &entry : scope->elements) {
	Entity *e = entry.value;
	switch (e->kind) {
	case Entity_TypeName: {
		// if (print_count == 0) error_line("\n\tWith the following definitions:\n");   // :7125

		gbString str = type_to_string(e->type);
		error_line("\t\t%.*s :: %s;\n", LIT(e->token.string), str);
		gb_string_free(str);
		print_count += 1;                                                              // still counts
		break;
	}
	case Entity_Constant: {
		if (print_count == 0) error_line("\n\tWith the following definitions:\n");      // :7134
		...
		print_count += 1;
		break;
	}
	}
}
```

There are **two** interacting defects:

Item 1: the commented-out header

In the `Entity_TypeName` arm the header line is commented out, but `print_count += 1` remains. So a type name emits its definition line, bumps the counter, and the `Entity_Constant` arm's `print_count == 0` guard is false from then on.

Item 2: a leading newline truncates the rest of the error

The header string begins with `\n`, so it emits a genuinely **empty** line. The printer at
`src/error.cpp:1015` walks the accumulated message line by line:

```cpp
String line = string_split_iterator(&it, '\n');
if (line.len == 0) {
	break;
}
```

`string_split_iterator` returns `""` both for an empty line *and* at end-of-string
(`src/string.cpp:280`), so `line.len == 0` conflates "blank line" with "no more input". 
