### PR TITLE
crash fix on poly

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -7605,7 +7605,9 @@ gb_internal CallArgumentData check_call_arguments_proc_group(CheckerContext *c, 
 
 	if (max_matched_features > 0) {
 		for_array(i, valids) {
-			Entity *p = procs[valids[i].index];
+			// NOTE: A polymorphic candidate appends its instantiated entity to proc_entities above,
+			// so valids[i].index can be >= procs.count.
+			Entity *p = proc_entities[valids[i].index];
 			Type *t = base_type(p->type);
 			GB_ASSERT(t->kind == Type_Proc);
 


### PR DESCRIPTION
Fixes:

```odin
package p

@(require_target_feature="sse2")
foo :: proc(x: $T) {}
bar :: proc(x: int) {}

g :: proc{foo, bar}

call :: proc() {
	g(1)
}
```

```
$ odin check . -no-entry-point
src/array.cpp(13): Assertion Failure: `cast(usize)index < cast(usize)count` Index 2 is out of bounds ranges 0..<2
This is a compiler error. Please report this.
Illegal instruction (core dumped)      # rc 132
```
