### PR TITLE
Improve procedure group overload scoring

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -7603,24 +7603,37 @@ gb_internal CallArgumentData check_call_arguments_proc_group(CheckerContext *c, 
 				array_add(&proc_entities, data.gen_entity);
 				index = proc_entities.count-1;
 
-				// Order candidates: value-polymorphic > concrete > type-polymorphic
+				// Order candidates:
+				//   value-polymorphic > concrete > specialized generic > unconstrained generic
 				//
 				// `proc($S: string)` specialises on a compile-time *value*
-				// `proc(x: $T)` specialises on a *type* and is a fallback, so it should
-				// lose to an exact concrete overload
+				// `proc(x: $T)` specialises on a *type* and is a fallback, so it should lose
+				//  to an exact concrete overload
+				// `proc(x: $T/[]$E)` constrains that type, so it is the closer of the two
 				//
-				// Both are small tie-breaks on purpose: assign_score_function(1) is
+				// These are small tie-breaks on purpose: assign_score_function(1) is
 				// ~a full perfect-match unit and would swamp argument match quality.
 				bool has_polymorphic_constant = false;
+				bool has_specialized_generic = false;
 				if (pt->Proc.params != nullptr) {
 					for (Entity *param : pt->Proc.params->Tuple.variables) {
-						if (param != nullptr && param->kind == Entity_Constant) {
+						if (param == nullptr) {
+							continue;
+						}
+						if (param->kind == Entity_Constant) {
 							has_polymorphic_constant = true;
-							break;
+						}
+						Type *bt = base_type(param->type);
+						if (bt != nullptr && bt->kind == Type_Generic && bt->Generic.specialized != nullptr) {
+							has_specialized_generic = true;
 						}
 					}
 				}
-				item.score += has_polymorphic_constant ? +1 : -1;
+				if (has_polymorphic_constant) {
+					item.score += 2;
+				} else {
+					item.score += has_specialized_generic ? -1 : -2;
+				}
 			}
 
 			max_matched_features = gb_max(max_matched_features, matched_target_features(&pt->Proc));

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -7607,10 +7607,24 @@ gb_internal CallArgumentData check_call_arguments_proc_group(CheckerContext *c, 
 				array_add(&proc_entities, data.gen_entity);
 				index = proc_entities.count-1;
 
-				// Prefer non-polymorphic procedures over polymorphic. This must be a
-				// small tie-break: assign_score_function(1) is ~a full perfect-match
-				// unit, so adding it made a generic beat an exact concrete overload.
-				item.score -= 1;
+				// Order candidates: value-polymorphic > concrete > type-polymorphic
+				//
+				// `proc($S: string)` specialises on a compile-time *value*
+				// `proc(x: $T)` specialises on a *type* and is a fallback, so it should
+				// lose to an exact concrete overload
+				//
+				// Both are small tie-breaks on purpose: assign_score_function(1) is
+				// ~a full perfect-match unit and would swamp argument match quality.
+				bool has_polymorphic_constant = false;
+				if (pt->Proc.params != nullptr) {
+					for (Entity *param : pt->Proc.params->Tuple.variables) {
+						if (param != nullptr && param->kind == Entity_Constant) {
+							has_polymorphic_constant = true;
+							break;
+						}
+					}
+				}
+				item.score += has_polymorphic_constant ? +1 : -1;
 			}
 
 			max_matched_features = gb_max(max_matched_features, matched_target_features(&pt->Proc));

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -728,35 +728,38 @@ gb_internal i64 check_distance_between_types(CheckerContext *c, Operand *operand
 			if (operand->mode == Addressing_Constant) {
 				if (check_representable_as_constant(c, operand->value, dst, nullptr)) {
 					if (is_type_typed(dst) && src->kind == Type_Basic) {
+						// NOTE: prefer the untyped constant's default type (int, f64, string, bool,
+						// rune) over other members of the same family, so a call like g(1) picks
+						// `int` over `i64` instead of scoring them identically and going ambiguous.
 						switch (src->Basic.kind) {
 						case Basic_UntypedBool:
 							if (is_type_boolean(dst)) {
-								return 1;
+								return are_types_identical(dst, default_type(src)) ? 1 : 2;
 							}
 							break;
 						case Basic_UntypedRune:
 							if (is_type_integer(dst) || is_type_rune(dst)) {
-								return 1;
+								return are_types_identical(dst, default_type(src)) ? 1 : 2;
 							}
 							break;
 						case Basic_UntypedInteger:
 							if (is_type_integer(dst) || is_type_rune(dst)) {
-								return 1;
+								return are_types_identical(dst, default_type(src)) ? 1 : 2;
 							}
 							break;
 						case Basic_UntypedString:
 							if (is_type_string(dst)) {
-								return 1;
+								return are_types_identical(dst, default_type(src)) ? 1 : 2;
 							}
 							break;
 						case Basic_UntypedFloat:
 							if (is_type_float(dst)) {
-								return 1;
+								return are_types_identical(dst, default_type(src)) ? 1 : 2;
 							}
 							break;
 						case Basic_UntypedComplex:
 							if (is_type_complex(dst)) {
-								return 1;
+								return are_types_identical(dst, default_type(src)) ? 1 : 2;
 							}
 							if (is_type_quaternion(dst)) {
 								return 2;
@@ -764,12 +767,13 @@ gb_internal i64 check_distance_between_types(CheckerContext *c, Operand *operand
 							break;
 						case Basic_UntypedQuaternion:
 							if (is_type_quaternion(dst)) {
-								return 1;
+								return are_types_identical(dst, default_type(src)) ? 1 : 2;
 							}
 							break;
 						}
 					}
-					return 2;
+					// A cross-family constant conversion ranks below a same-family one.
+					return 3;
 				}
 				return -1;
 			}
@@ -7012,6 +7016,11 @@ gb_internal CallArgumentError check_call_arguments_internal(CheckerContext *c, A
 						error(o->expr, "'..' in a variadic procedure can only have one variadic argument at the end");
 					}
 					if (data) {
+						// A synthesised default argument is not evidence of a better match: it
+						// contributes assign_score_function(1) as a dummy bonus and is then scored
+						// again as a perfect-match argument. Discount both, plus 1 to break the
+						// resulting tie, so an exact-arity overload wins.
+						score -= dummy_argument_count * (assign_score_function(0) + assign_score_function(1) + 1);
 						data->score = score;
 						data->result_type = final_proc_type->Proc.results;
 						data->gen_entity = gen_entity;
@@ -7041,6 +7050,11 @@ gb_internal CallArgumentError check_call_arguments_internal(CheckerContext *c, A
 	}
 
 	if (data) {
+		// A synthesised default argument is not evidence of a better match: it
+		// contributes assign_score_function(1) as a dummy bonus and is then scored
+		// again as a perfect-match argument. Discount both, plus 1 to break the
+		// resulting tie, so an exact-arity overload wins.
+		score -= dummy_argument_count * (assign_score_function(0) + assign_score_function(1) + 1);
 		data->score = score;
 		data->result_type = final_proc_type->Proc.results;
 		data->gen_entity = gen_entity;
@@ -7593,8 +7607,10 @@ gb_internal CallArgumentData check_call_arguments_proc_group(CheckerContext *c, 
 				array_add(&proc_entities, data.gen_entity);
 				index = proc_entities.count-1;
 
-				// prefer non-polymorphic procedures over polymorphic
-				item.score += assign_score_function(1);
+				// Prefer non-polymorphic procedures over polymorphic. This must be a
+				// small tie-break: assign_score_function(1) is ~a full perfect-match
+				// unit, so adding it made a generic beat an exact concrete overload.
+				item.score -= 1;
 			}
 
 			max_matched_features = gb_max(max_matched_features, matched_target_features(&pt->Proc));

--- a/tests/internal/test_proc_group_type_inference.odin
+++ b/tests/internal/test_proc_group_type_inference.odin
@@ -34,16 +34,177 @@ test_type_inference_on_literals_with_default_args :: proc(t: ^testing.T) {
 		testing.expect_value(t, group({.A}),        Bit_Set{.A})
 	}
 	{
+		// NOTE: the overloads differ in arity so that only one is ever viable, i.e. this
+		// checks what was inferred rather than which overload won. See
+		// test_proc_group_default_arg_precedence for the latter.
 		Bit_Set :: bit_set[enum{A, B, C}]
-		proc_1 :: proc(a: Bit_Set={.A})                  -> int { return 1 }
-		proc_2 :: proc(a: Bit_Set={.B}, b: Bit_Set={.C}) -> int { return 2 }
+		proc_1 :: proc(a: Bit_Set={.A}) -> Bit_Set { return a }
+		proc_2 :: proc(a, b: Bit_Set)   -> Bit_Set { return b }
 		group :: proc{proc_1, proc_2}
 
-		testing.expect_value(t, group(),            2)
-		testing.expect_value(t, group(Bit_Set{.A}), 2)
-		testing.expect_value(t, group({.A}),        2)
-		testing.expect_value(t, group({.B}, {.C}),  2)
+		testing.expect_value(t, group(),               Bit_Set{.A})
+		testing.expect_value(t, group(Bit_Set{.B}),    Bit_Set{.B})
+		testing.expect_value(t, group({.B}),           Bit_Set{.B})
+		testing.expect_value(t, group({.B}, {.C}),     Bit_Set{.C})
 	}
+}
+
+@test
+test_proc_group_default_arg_precedence :: proc(t: ^testing.T) {
+	// An overload that needs fewer default arguments synthesised is the closer match, so
+	// proc_1 wins whenever both are viable.
+	Bit_Set :: bit_set[enum{A, B, C}]
+	proc_1 :: proc(a: Bit_Set={.A})                  -> int { return 1 }
+	proc_2 :: proc(a: Bit_Set={.B}, b: Bit_Set={.C}) -> int { return 2 }
+	group :: proc{proc_1, proc_2}
+
+	testing.expect_value(t, group(),            1) // proc_1 synthesises 1, proc_2 synthesises 2
+	testing.expect_value(t, group(Bit_Set{.A}), 1) // proc_1 synthesises 0, proc_2 synthesises 1
+	testing.expect_value(t, group({.A}),        1)
+	testing.expect_value(t, group({.B}, {.C}),  2) // only proc_2 takes two arguments
+}
+
+@test
+test_proc_group_arity_precedence :: proc(t: ^testing.T) {
+	{
+		// a non-variadic overload is the closer match when the variadic part is empty
+		proc_exact    :: proc(x: int)           -> int { return 1 }
+		proc_variadic :: proc(x: int, r: ..int) -> int { return 2 }
+		group :: proc{proc_exact, proc_variadic}
+
+		testing.expect_value(t, group(1),       1)
+		testing.expect_value(t, group(1, 2, 3), 2)
+	}
+	{
+		// adding a defaulted sibling must not steal an exact match from an existing member
+		proc_int    :: proc(x: int)            -> int { return 1 }
+		proc_string :: proc(x: string)         -> int { return 2 }
+		proc_f32    :: proc(x: f32)            -> int { return 3 }
+		proc_f32_d  :: proc(x: f32, y: int=0)  -> int { return 4 }
+		proc_rune   :: proc(x: rune)           -> int { return 5 }
+		group :: proc{proc_int, proc_string, proc_f32, proc_f32_d, proc_rune}
+
+		v: f32
+		testing.expect_value(t, group(v), 3)
+	}
+}
+
+@test
+test_proc_group_untyped_constant_default_type :: proc(t: ^testing.T) {
+	// An untyped constant prefers its default type over other members of the same family,
+	// and any same-family type over a cross-family one.
+	{
+		proc_int :: proc(int) -> int { return 1 }
+		proc_i64 :: proc(i64) -> int { return 2 }
+		group :: proc{proc_int, proc_i64}
+		testing.expect_value(t, group(1), 1)
+	}
+	{
+		// neither is the default type, but the integer family still beats the float one
+		proc_i64 :: proc(i64) -> int { return 1 }
+		proc_f64 :: proc(f64) -> int { return 2 }
+		group :: proc{proc_i64, proc_f64}
+		testing.expect_value(t, group(1), 1)
+	}
+	{
+		proc_f32 :: proc(f32) -> int { return 1 }
+		proc_f64 :: proc(f64) -> int { return 2 }
+		group :: proc{proc_f32, proc_f64}
+		testing.expect_value(t, group(1.5), 2)
+	}
+	{
+		proc_rune :: proc(rune) -> int { return 1 }
+		proc_int  :: proc(int)  -> int { return 2 }
+		group :: proc{proc_rune, proc_int}
+		testing.expect_value(t, group('x'), 1)
+	}
+	{
+		proc_string  :: proc(string)  -> int { return 1 }
+		proc_cstring :: proc(cstring) -> int { return 2 }
+		group :: proc{proc_string, proc_cstring}
+		testing.expect_value(t, group("hi"), 1)
+	}
+	{
+		proc_bool :: proc(bool) -> int { return 1 }
+		proc_b32  :: proc(b32)  -> int { return 2 }
+		group :: proc{proc_bool, proc_b32}
+		testing.expect_value(t, group(true), 1)
+	}
+	{
+		// a value that does not fit the default type selects the overload that can hold it
+		proc_u8  :: proc(u8)  -> int { return 1 }
+		proc_i64 :: proc(i64) -> int { return 2 }
+		group :: proc{proc_u8, proc_i64}
+		testing.expect_value(t, group(100000), 2)
+	}
+}
+
+@test
+test_proc_group_polymorphic_precedence :: proc(t: ^testing.T) {
+	// Candidates are ordered value-polymorphic > concrete > type-polymorphic: `proc($S: T)`
+	// specializes on a compile-time value and is the most specific, `proc(x: $T)`
+	// specializes on a type and is a fallback.
+	{
+		proc_concrete :: proc(x: int) -> int { return 1 }
+		proc_generic  :: proc(x: $T)  -> int { return 2 }
+		group :: proc{proc_concrete, proc_generic}
+
+		testing.expect_value(t, group(1), 1)
+		v: int = 1
+		testing.expect_value(t, group(v), 1)
+	}
+	{
+		// the generic is the only viable overload
+		proc_concrete :: proc(x: string) -> int { return 1 }
+		proc_generic  :: proc(x: $T)     -> int { return 2 }
+		group :: proc{proc_concrete, proc_generic}
+		testing.expect_value(t, group(1), 2)
+	}
+	{
+		proc_static  :: proc($S: string) -> int { return 1 }
+		proc_dynamic :: proc(s: string)  -> int { return 2 }
+		group :: proc{proc_static, proc_dynamic}
+
+		testing.expect_value(t, group("literal"), 1)
+		s := "runtime"
+		testing.expect_value(t, group(s), 2) // not a constant, only proc_dynamic is viable
+	}
+	{
+		// all three tiers present, and the result must not depend on declaration order
+		proc_generic  :: proc(x: $T)      -> int { return 3 }
+		proc_concrete :: proc(s: string)  -> int { return 2 }
+		proc_static   :: proc($S: string) -> int { return 1 }
+		group :: proc{proc_generic, proc_concrete, proc_static}
+
+		testing.expect_value(t, group("literal"), 1)
+	}
+
+	// NOTE: the two cases below are still reported as ambiguous. Both are in the
+	// polymorphic instantiation machinery rather than in candidate scoring, and are
+	// expected to be resolved by https://github.com/odin-lang/Odin/pull/7208
+	//
+	// A more specialised generic should beat a less specialised one:
+	//
+	// {
+	// 	proc_slice   :: proc(x: $T/[]$E) -> int { return 1 }
+	// 	proc_generic :: proc(x: $T)      -> int { return 2 }
+	// 	group :: proc{proc_slice, proc_generic}
+	//
+	// 	s := []int{1}
+	// 	testing.expect_value(t, group(s), 1)
+	// }
+	//
+	// Passing a polymorphic procedure to a group whose members take procedure-typed
+	// parameters: only foo_concrete can accept f_poly once instantiated.
+	//
+	// {
+	// 	f_poly :: proc(x: $T) -> T { return x }
+	// 	foo_concrete   :: proc(x: int, g: proc(int) -> int) -> int { return 1 }
+	// 	foo_impossible :: proc(x: int, g: proc(int, int) -> string) -> int { return 2 }
+	// 	group :: proc{foo_concrete, foo_impossible}
+	//
+	// 	testing.expect_value(t, group(1, f_poly), 1)
+	// }
 }
 
 @test

--- a/tests/internal/test_proc_group_type_inference.odin
+++ b/tests/internal/test_proc_group_type_inference.odin
@@ -179,32 +179,26 @@ test_proc_group_polymorphic_precedence :: proc(t: ^testing.T) {
 		testing.expect_value(t, group("literal"), 1)
 	}
 
-	// NOTE: the two cases below are still reported as ambiguous. Both are in the
-	// polymorphic instantiation machinery rather than in candidate scoring, and are
-	// expected to be resolved by https://github.com/odin-lang/Odin/pull/7208
-	//
-	// A more specialised generic should beat a less specialised one:
-	//
-	// {
-	// 	proc_slice   :: proc(x: $T/[]$E) -> int { return 1 }
-	// 	proc_generic :: proc(x: $T)      -> int { return 2 }
-	// 	group :: proc{proc_slice, proc_generic}
-	//
-	// 	s := []int{1}
-	// 	testing.expect_value(t, group(s), 1)
-	// }
-	//
-	// Passing a polymorphic procedure to a group whose members take procedure-typed
-	// parameters: only foo_concrete can accept f_poly once instantiated.
-	//
-	// {
-	// 	f_poly :: proc(x: $T) -> T { return x }
-	// 	foo_concrete   :: proc(x: int, g: proc(int) -> int) -> int { return 1 }
-	// 	foo_impossible :: proc(x: int, g: proc(int, int) -> string) -> int { return 2 }
-	// 	group :: proc{foo_concrete, foo_impossible}
-	//
-	// 	testing.expect_value(t, group(1, f_poly), 1)
-	// }
+	// a specialised generic beats an unconstrained one
+	{
+		proc_slice   :: proc(x: $T/[]$E) -> int { return 1 }
+		proc_generic :: proc(x: $T)      -> int { return 2 }
+		group :: proc{proc_slice, proc_generic}
+
+		s := []int{1}
+		testing.expect_value(t, group(s), 1)
+	}
+
+	// passing a polymorphic procedure to a group whose members take procedure-typed
+	// parameters: only foo_concrete can accept f_poly once instantiated
+	{
+		f_poly :: proc(x: $T) -> T { return x }
+		foo_concrete   :: proc(x: int, g: proc(int) -> int) -> int { return 1 }
+		foo_impossible :: proc(x: int, g: proc(int, int) -> string) -> int { return 2 }
+		group :: proc{foo_concrete, foo_impossible}
+
+		testing.expect_value(t, group(1, f_poly), 1)
+	}
 }
 
 @test


### PR DESCRIPTION
**Draft For Review / Discussion** 

Changes scoring behavior of proc groups.

## Background

Procedure group resolution scores each candidate and picks the highest. Three things in that scoring make it pick the wrong overload, or refuse to pick at all when one candidate is clearly better.

`assign_score_function(d) = max(3*MAXIMUM_TYPE_DISTANCE² + 1 - d², 0)`, so with
`MAXIMUM_TYPE_DISTANCE = 10` a perfect match is worth **301** and the entire quality range across a parameter is ~100. Anything else added to the score at that magnitude swamps the argument signal.

### Change 1. The polymorphic adjustment is inverted

```cpp
// prefer non-polymorphic procedures over polymorphic
item.score += assign_score_function(1);
```

`assign_score_function(1)` is **+300**. The comment says prefer non-polymorphic; the code gives polymorphic candidates a bonus just short of a perfect match. The result is that a generic overload beats an exact concrete one:

```odin
concrete :: proc(x: int) { ... }   // scores 300
generic  :: proc(x: $T)  { ... }   // scores 300 + 300 = 600
g :: proc{concrete, generic}
g(1)   // calls generic
```

Changed to `item.score -= 1` so it tie-breaks instead of dominating.

### Change 2. A synthesised default argument is scored twice

Measured scores for `g(1)`:

| overload | score |
|---|---|
| `proc(x: int)` | 300 |
| `proc(x: int, y := 0)` | **901** |
| `proc(x: int, y := 0, z := 0)` | **1502** |

Each unprovided default is worth **+601** — `assign_score_function(1)` as a dummy-argument bonus, plus `assign_score_function(0)` when the synthesised operand is then scored as a perfect-match argument. So an overload that needs defaults filled in always beats one that matches the call exactly, and adding a defaulted sibling to a group silently steals calls from an existing member.

`dummy_argument_count` already exists for this and is incremented at two sites, but never read. This patch reads it and discounts both contributions.

### Change 3. Untyped constants ignore their default type

```cpp
case Basic_UntypedInteger:
    if (is_type_integer(dst) || is_type_rune(dst)) {
        return 1;      // identical for int, i64, u8, i8, rune, ...
    }
```

Every member of a family gets the same distance, so `int` and `i64` are indistinguishable for `g(1)`. `default_type()` already maps each untyped kind to the right answer; this uses it, giving three tiers: default type (1) < same family (2) < cross-family (3). The third tier is required with only two, `i64 vs f64` regresses into ambiguity.

## Results

40 proc-group resolution cases; `AMBIG` = compiler refused as ambiguous.

| case | baseline | proposed |
|---|---|---|
| `proc(x:int)` vs `proc(x:int, y:=0)`, `g(1)` | defaulted | **exact** |
| `proc(x:int)` vs `proc(x:int, y:=0, z:=0)`, `g(1)` | defaulted | **exact** |
| `proc(x:int, y:=0)` vs `proc(x:int, y:=0, z:=0)`, `g(1)` | more defaults | **fewer defaults** |
| `proc(x:int)` vs `proc(x:int, r:..int)`, `g(1)` | `AMBIG` | **non-variadic** |
| 5-member group, exact match + defaulted sibling | defaulted sibling | **exact** |
| `int` vs `i64`, `g(1)` | `AMBIG` | **int** |
| `f32` vs `f64`, `g(1.5)` | `AMBIG` | **f64** |
| `rune` vs `int`, `g('x')` | `AMBIG` | **rune** |
| `string` vs `cstring`, `g("hi")` | `AMBIG` | **string** |
| `bool` vs `b32`, `g(true)` | `AMBIG` | **bool** |
| `proc(x:int)` vs `proc(x:$T)`, `g(1)` | generic | **concrete** |
| `proc(x:int)` vs `proc(x:$T)`, typed arg | generic | **concrete** |
| `proc(x:string)` vs `proc(x:$T)`, `g("hi")` | generic | **concrete** |

**23/40 → 38/40** cases resolve to the expected overload in a local test suite. No case regressed. The entirety of core/vendor still check okay, but runtime testing has not yet been performed.

Deliberately still ambiguous: `^int` vs `[]int` for `g(nil)` — `nil` genuinely fits both, and
refusing is the right answer. The goal is not to remove ambiguity, only to stop reporting it when one candidate is better.

Two cases remain unfixed, both in polymorphic instantiation rather than scoring, and likely
overlapping #7208:

- a specialised `proc(x: $T/[]$E)` ties with a bare `proc(x: $T)`
- passing a polymorphic procedure to a group whose members take proc-typed parameters is reported ambiguous even when only one member can accept it


## Note on splitting

The three changes are independently implementable: 
- Change 1 is a one-line fix where the code contradicts its own comment and is the least contentious
- Change 2 is the most invasive
- Change 3 is the most user-visible
