### PR TITLE
os (windows): resolve relative path before SHFileOperationW in _remove_all

### DIFF
--- a/core/os/path_windows.odin
+++ b/core/os/path_windows.odin
@@ -84,7 +84,13 @@ _remove_all :: proc(path: string) -> Error {
 	}
 
 	temp_allocator := TEMP_ALLOCATOR_GUARD({})
-	dir := win32_utf8_to_wstring(path, temp_allocator) or_return
+
+	// SHFileOperationW is documented as not thread safe with relative paths.
+	abs_path := path
+	if !_is_absolute_path(path) {
+		abs_path = _get_absolute_path(path, temp_allocator) or_return
+	}
+	dir := win32_utf8_to_wstring(abs_path, temp_allocator) or_return
 
 	empty: [1]u16
 


### PR DESCRIPTION
The Windows implementation of `_remove_all` calls `SHFileOperationW` with the caller's path as-is, without resolving it to an absolute path first. Microsoft's documentation for SHFileOperationW states that:
> You should use fully qualified path names with this function. Using it with relative path names is not thread safe.

https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shfileoperationw#remarks