### PR TITLE
Fix percent encoding for bytes < 0x10

### DIFF
--- a/core/net/url.odin
+++ b/core/net/url.odin
@@ -19,7 +19,6 @@ package net
 */
 
 import "core:strings"
-import "core:strconv"
 import "core:unicode/utf8"
 import "core:encoding/hex"
 

--- a/core/net/url.odin
+++ b/core/net/url.odin
@@ -114,6 +114,8 @@ join_url :: proc(scheme, host, path: string, queries: map[string]string, fragmen
 }
 
 percent_encode :: proc(s: string, allocator := context.allocator) -> string {
+	HEX_DIGITS_UPPER := "0123456789ABCDEF" // NOTE(michtesar): RFC 3986 §2.1
+
 	b := strings.builder_make(allocator)
 	strings.builder_grow(&b, len(s) + 16) // NOTE(tetra): A reasonable number to allow for the number of things we need to escape.
 
@@ -124,10 +126,9 @@ percent_encode :: proc(s: string, allocator := context.allocator) -> string {
 		case:
 			bytes, n := utf8.encode_rune(ch)
 			for byte in bytes[:n] {
-				buf: [2]u8 = ---
-				t := strconv.write_int(buf[:], i64(byte), 16)
-				strings.write_rune(&b, '%')
-				strings.write_string(&b, t)
+				strings.write_byte(&b, '%')
+				strings.write_byte(&b, HEX_DIGITS_UPPER[byte >> 4])
+				strings.write_byte(&b, HEX_DIGITS_UPPER[byte & 0xF])
 			}
 		}
 	}

--- a/tests/core/net/test_core_net.odin
+++ b/tests/core/net/test_core_net.odin
@@ -304,7 +304,7 @@ client_sends_server_data :: proc(t: ^testing.T) {
 		r.length, r.err = net.recv_tcp(client, r.data[:])
 		return
 	}
-
+	
 	thread_data := [2]Thread_Data{}
 
 	wg: sync.Wait_Group
@@ -313,7 +313,7 @@ client_sends_server_data :: proc(t: ^testing.T) {
 	thread_data[0].t = t
 	thread_data[0].wg = &wg
 	thread_data[0].tid = thread.create_and_start_with_data(&thread_data[0], tcp_server, context)
-
+	
 	sync.wait_group_wait(&wg)
 	sync.wait_group_add(&wg, 2)
 

--- a/tests/core/net/test_core_net.odin
+++ b/tests/core/net/test_core_net.odin
@@ -304,7 +304,7 @@ client_sends_server_data :: proc(t: ^testing.T) {
 		r.length, r.err = net.recv_tcp(client, r.data[:])
 		return
 	}
-	
+
 	thread_data := [2]Thread_Data{}
 
 	wg: sync.Wait_Group
@@ -313,7 +313,7 @@ client_sends_server_data :: proc(t: ^testing.T) {
 	thread_data[0].t = t
 	thread_data[0].wg = &wg
 	thread_data[0].tid = thread.create_and_start_with_data(&thread_data[0], tcp_server, context)
-	
+
 	sync.wait_group_wait(&wg)
 	sync.wait_group_add(&wg, 2)
 
@@ -522,6 +522,31 @@ join_url_test :: proc(t: ^testing.T) {
 			pass |= url == test_url
 		}
 		testing.expectf(t, pass, "Expected `net.join_url` to return one of %s, got %s", test.url, url)
+	}
+}
+
+@test
+percent_encode_test :: proc(t: ^testing.T) {
+	test_cases := []struct{input, expected: string} {
+		// Bytes < 0x10 must be zero-padded to two hex digits
+		{"\n",   "%0A"},
+		{"\t",   "%09"},
+		{"\r",   "%0D"},
+		{"a\nb", "a%0Ab"},
+		{"\x00", "%00"},
+
+		// Bytes >= 0x10
+		{" ",    "%20"},
+		{"😃",   "%F0%9F%98%83"},
+
+		// Unreserved characters pass through unescaped
+		{"AZaz09-_.~", "AZaz09-_.~"},
+	}
+
+	for test in test_cases {
+		encoded := net.percent_encode(test.input)
+		defer delete(encoded)
+		testing.expectf(t, encoded == test.expected, "Expected `net.percent_encode(%q)` to return %q, got %q", test.input, test.expected, encoded)
 	}
 }
 

--- a/tests/core/net/test_core_net.odin
+++ b/tests/core/net/test_core_net.odin
@@ -547,6 +547,11 @@ percent_encode_test :: proc(t: ^testing.T) {
 		encoded := net.percent_encode(test.input)
 		defer delete(encoded)
 		testing.expectf(t, encoded == test.expected, "Expected `net.percent_encode(%q)` to return %q, got %q", test.input, test.expected, encoded)
+
+		decoded, ok := net.percent_decode(encoded)
+		defer delete(decoded)
+		testing.expectf(t, ok, "Expected `net.percent_decode(%q)` to succeed", encoded)
+		testing.expectf(t, decoded == test.input, "Expected percent-encoding roundtrip for %q, got %q", test.input, decoded)
 	}
 }
 


### PR DESCRIPTION
Fixes #7109

`percent_encode` used `strconv.write_int` to format each escaped byte, which writes the shortest representation. Bytes below 0x10 therefore produced a single hex digit, e.g. '\n' -> "%a" instead of "%0A".

Regression test added to tests/core/net covering cases of < 0x10, >= 0x10 and unreserved characters.