### PR TITLE
Fix default linker timing label on non-Windows platforms

### DIFF
--- a/src/linker.cpp
+++ b/src/linker.cpp
@@ -155,7 +155,7 @@ try_cross_linking:;
 		String section_name = str_lit("msvc-link");
 		bool is_windows = build_context.metrics.os == TargetOs_windows;
 	#else
-		String section_name = str_lit("lld-link");
+		String section_name = str_lit("ld-link");
 		bool is_windows = false;
 	#endif
 


### PR DESCRIPTION
Fixes #7074

It was just a wrong variable name in `linker.cpp`.

After rebuild I run this:

```
./odin build examples/demo -show-timings -show-system-calls
```

Which produces a correct output.

```
Total Time                         -   357.085 ms - 100.00%
initialization                     -     1.478 ms -   0.41%
parse files                        -    21.195 ms -   5.93%
type check                         -    72.804 ms -  20.38%
LLVM API Code Gen (   61 modules ) -   182.629 ms -  51.14%
ld-link                            -    78.970 ms -  22.11%
```