### PR TITLE
Fix `odin doc -doc-format` aborting on any package that imports another package

### DIFF
--- a/src/docs_writer.cpp
+++ b/src/docs_writer.cpp
@@ -265,8 +265,12 @@ gb_internal OdinDocPosition odin_doc_token_pos_cast(OdinDocWriter *w, TokenPos c
 		AstFile *file = global_files[pos.file_id];
 		if (file != nullptr) {
 			OdinDocFileIndex *file_index_found = map_get(&w->file_cache, file);
-			GB_ASSERT(file_index_found != nullptr);
-			file_index = *file_index_found;
+			// NOTE: a documented entity may hold a position in a file belonging to an
+			// imported package. Such files are only in file_cache when -all-packages is
+			// used, so fall back to the reserved "no file" index.
+			if (file_index_found != nullptr) {
+				file_index = *file_index_found;
+			}
 		}
 	}
 


### PR DESCRIPTION
`odin doc <pkg> -doc-format` aborts on essentially every real package:

```
$ odin doc core/c/libc -doc-format
src/docs_writer.cpp(268): Assertion Failure: `file_index_found != nullptr`
This is a compiler error. Please report this.
Illegal instruction (core dumped)      # rc 132
```

Also reproduces on `core/strings` and `core/fmt`. Text-mode `odin doc` is unaffected.

## Cause

`odin_doc_write_docs` collects only `Package_Init` and `is_extra` packages unless `-all-packages` is given, and `w->file_cache` is populated solely from those packages' files (`:1166`). But a documented entity can hold a `TokenPos` in a file belonging to an *imported* package, so the lookup misses and the assert fires.

The two guards immediately above it already handle the same class of situation by leaving `file_index` at 0:

```cpp
OdinDocFileIndex file_index = 0;
if (pos.file_id != 0) {                 // guard 1 -> falls back to 0
	AstFile *file = global_files[pos.file_id];
	if (file != nullptr) {              // guard 2 -> falls back to 0
		OdinDocFileIndex *file_index_found = map_get(&w->file_cache, file);
		GB_ASSERT(file_index_found != nullptr);   // :268 -- third case, asserts
		file_index = *file_index_found;
	}
}
```

Index 0 is the format's reserved sentinel, per `core/odin/doc-format/doc_format.odin`:

```odin
// NOTE: These arrays reserve the zero element as a sentinel value
files:    Array(File),
```

## Before / after

| command | before | after |
|---|---|---|
| trivial pkg, no imports | ok | ok |
| `core/c/libc -doc-format` | **abort rc=132** | ok |
| `core/strings -doc-format` | **abort rc=132** | ok |
| `core/fmt -doc-format` | **abort rc=132** | ok |
| `core/c/libc -doc-format -all-packages` | ok | ok |
| `core/c/libc` (text mode) | ok | ok |
