### PR TITLE
Fix constant `transmute` from unsigned to signed wrapping one value too many

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -4082,7 +4082,7 @@ gb_internal bool check_transmute(CheckerContext *c, Ast *node, Operand *o, Type 
 				big_int_shl_eq(&umax, &sz_in_bits);
 
 				if (is_type_unsigned(src_t) && !is_type_unsigned(dst_t)) {
-					if (big_int_cmp(&v, &smax) >= 0) {
+					if (big_int_cmp(&v, &smax) > 0) {
 						big_int_sub_eq(&v, &umax);
 					}
 				} else if (!is_type_unsigned(src_t) && is_type_unsigned(dst_t)) {


### PR DESCRIPTION
Note: Suffers same underlying printing issue solved by #7243 

Repro:
```odin
package p
#assert(transmute(i32)u32(0x7FFFFFFE) == 2147483646)  // holds
#assert(transmute(i32)u32(0x7FFFFFFF) == 2147483647)  // FAILS
#assert(transmute(i32)u32(0x80000000) == -2147483648) // holds
```

The stored value is `(2^31 - 1) - 2^32 = -2147483649`, below `min(i32)`. On current master this holds, which should not be possible for a value of type `i32`:

```odin
#assert(transmute(i32)u32(0x7FFFFFFF) < min(i32))     // holds -- before the fix
```

Exactly one value per width is affected — `2^(bits-1) - 1` — with both neighbours correct:

| width | affected input | `0x..7E`-side | `0x..80`-side |
|---|---|---|---|
| `u8 -> i8` | `0x7F` | ok | ok |
| `u16 -> i16` | `0x7FFF` | ok | ok |
| `u32 -> i32` | `0x7FFFFFFF` | ok | ok |
| `u64 -> i64` | `0x7FFFFFFFFFFFFFFF` | ok | ok |

Also reachable through `bit_set` with a signed backing type, e.g. `transmute(bit_set[E; i32])u32(0x7FFFFFFF)`.
