### PR TITLE
Make redeclaration diagnostics stable under threading

### DIFF
--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -2050,18 +2050,26 @@ gb_internal bool redeclaration_error(String name, Entity *prev, Entity *found) {
 			// NOTE(bill): Error should have been handled already
 			return false;
 		}
+		// NOTE: the insertion order is a race between the files of a package, so anchor on the
+		// lower position to keep the diagnostic stable
+		TokenPos lo = prev->token.pos;
+		TokenPos hi = pos;
+		if (hi < lo) {
+			lo = pos;
+			hi = prev->token.pos;
+		}
 		if (found->flags & EntityFlag_Result) {
-			error(prev->token,
+			error(lo,
 			      "Direct shadowing of the named return value '%.*s' in this scope\n"
 			      "\tat %s",
 			      LIT(name),
-			      token_pos_to_string(pos));
+			      token_pos_to_string(hi));
 		} else {
-			error(prev->token,
+			error(lo,
 			      "Redeclaration of '%.*s' in this scope\n"
 			      "\tat %s",
 			      LIT(name),
-			      token_pos_to_string(pos));
+			      token_pos_to_string(hi));
 		}
 	}
 	return false;

--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -2050,26 +2050,26 @@ gb_internal bool redeclaration_error(String name, Entity *prev, Entity *found) {
 			// NOTE(bill): Error should have been handled already
 			return false;
 		}
-		// NOTE: the insertion order is a race between the files of a package, so anchor on the
-		// lower position to keep the diagnostic stable
-		TokenPos lo = prev->token.pos;
-		TokenPos hi = pos;
-		if (hi < lo) {
-			lo = pos;
-			hi = prev->token.pos;
+		// NOTE: the insertion order is a race between the files of a package, so order the pair by
+		// position; the later declaration stays the anchor, as it is the one being reported
+		TokenPos first = prev->token.pos;
+		TokenPos second = pos;
+		if (second < first) {
+			first = pos;
+			second = prev->token.pos;
 		}
 		if (found->flags & EntityFlag_Result) {
-			error(lo,
+			error(second,
 			      "Direct shadowing of the named return value '%.*s' in this scope\n"
 			      "\tat %s",
 			      LIT(name),
-			      token_pos_to_string(hi));
+			      token_pos_to_string(first));
 		} else {
-			error(lo,
+			error(second,
 			      "Redeclaration of '%.*s' in this scope\n"
 			      "\tat %s",
 			      LIT(name),
-			      token_pos_to_string(hi));
+			      token_pos_to_string(first));
 		}
 	}
 	return false;


### PR DESCRIPTION
The insertion order is a race between the files of a package, so order the pair by position; the later declaration stays the anchor, as it is the one being reported.

Note: Doesn't resolve full determinism when N>2. That would require collection ordering to be deterministic as well. 
