### PR TITLE
core/bytes: optimize `index_any` with a byte bitset

### DIFF
--- a/core/bytes/bytes.odin
+++ b/core/bytes/bytes.odin
@@ -709,13 +709,20 @@ index_any :: proc(s, chars: []byte) -> int {
 	if chars == nil {
 		return -1
 	}
+	if len(chars) == 1 {
+		return index_byte(s, chars[0])
+	}
 
-	// TODO(bill): Optimize
+	// NOTE: Same technique as strings.Ascii_Set, duplicated here since
+	// core:strings imports core:bytes and not the other way around.
+	set: [8]u32
+	for c in chars {
+		set[c >> 5] |= 1 << (u32(c) & 31)
+	}
+
 	for r, i in s {
-		for c in chars {
-			if r == c {
-				return i
-			}
+		if set[r >> 5] & (1 << (u32(r) & 31)) != 0 {
+			return i
 		}
 	}
 	return -1


### PR DESCRIPTION
`bytes.index_any` used a naive nested loop (`O(len(s) × len(chars))`). Replaced with the same technique `core:strings` already uses for `Ascii_Set`, reimplemented here since `core:strings` imports `core:bytes` and not the other way around.

### Benchmark

vs. the old implementation, needle at the end of `s` (worst case). Machine: Intel Core i5-8265U @ 1.60GHz, Linux x86_64.

| s size | len(chars)=3 | len(chars)=32 |
|---|---|---|
| 128 | 2.5x | 8.7x |
| 1024 | 2.7x | 11.9x |
| 4096 | 2.7x | 12.5x |
| 1MB | 2.3x | 11.1x |