### PR TITLE
Return false for identical specialization types

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -7370,7 +7370,11 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 
 			operand->mode = Addressing_Constant;
 			operand->type = t_untyped_bool;
-			operand->value = exact_value_bool(check_type_specialization_to(c, s, t, false, false));
+			bool is_specialization = false;
+			if (!are_types_identical(s, t)) {
+				is_specialization = check_type_specialization_to(c, s, t, false, false);
+			}
+			operand->value = exact_value_bool(is_specialization);
 
 		}
 		break;

--- a/tests/issues/run.bat
+++ b/tests/issues/run.bat
@@ -41,6 +41,7 @@ set COMMON=-define:ODIN_TEST_FANCY=false -file -vet -strict-style -ignore-unused
 ..\..\..\odin test ..\test_issue_6753.odin %COMMON%  || exit /b
 ..\..\..\odin check ..\test_issue_6874.odin %COMMON% 2>&1 | find /c "Error:" | findstr /x "1" || exit /b
 ..\..\..\odin check ..\test_issue_6979.odin -no-entry-point %COMMON%  || exit /b
+..\..\..\odin check ..\test_issue_7012.odin -no-entry-point %COMMON% || exit /b
 ..\..\..\odin build ..\test_issue_7037.odin %COMMON% -o:none  || exit /b
 ..\..\..\odin build ..\test_issue_7188.odin %COMMON%  || exit /b
 ..\..\..\odin build ..\test_issue_7073-1.odin %COMMON% 2>&1 | find /c "Error:" | findstr /x "2" || exit /b

--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -89,6 +89,7 @@ else
 	exit 1
 fi
 $ODIN check ../test_issue_6979.odin -no-entry-point $COMMON_CHECK
+$ODIN check ../test_issue_7012.odin -no-entry-point $COMMON_CHECK
 $ODIN build ../test_issue_7037.odin $COMMON -o:none
 $ODIN build ../test_issue_7167.odin $COMMON
 $ODIN build ../test_issue_7188.odin $COMMON

--- a/tests/issues/test_issue_7012.odin
+++ b/tests/issues/test_issue_7012.odin
@@ -1,0 +1,13 @@
+// Tests issue https://github.com/odin-lang/Odin/issues/7012
+package test_issues
+
+import "base:intrinsics"
+
+Foo :: struct($T: typeid) {
+	x: T,
+}
+
+#assert(intrinsics.type_is_specialization_of(Foo(int), Foo))
+#assert(!intrinsics.type_is_specialization_of(Foo, Foo))
+#assert(!intrinsics.type_is_specialization_of(Foo(int), Foo(int)))
+#assert(!intrinsics.type_is_specialization_of(i32, Foo))


### PR DESCRIPTION
Fixes #7012.

`intrinsics.type_is_specialization_of` now returns `false` when both arguments are identical types.

The specialization compatibility check remains unchanged. An explicit identity check is performed before calling it.

The test is registered in both the Unix and Windows issue test runners.

The focused regression test passes:
```sh
./odin check tests/issues/test_issue_7012.odin \
    -file \
    -no-entry-point \
    -vet \
    -strict-style \
    -ignore-unused-defineables
```

The new test also passes as part of tests/issues/run.sh. The full local suite later fails on an unrelated AddressSanitizer linker error in test_issue_5640 on macOS ARM64. Not sure what to with this...

Also, if this is approved and merged there is consecutive ticket about docs https://github.com/odin-lang/pkg.odin-lang.org/issues/74...I could even squeeze it this PR if possible.