### PR TITLE
core/odin/tokenizer: fix broken double-checked lock in `init`

### DIFF
--- a/core/odin/tokenizer/tokenizer.odin
+++ b/core/odin/tokenizer/tokenizer.odin
@@ -109,8 +109,10 @@ init :: proc(t: ^Tokenizer, src: string, path: string, err: Error_Handler = defa
 
 	if !intrinsics.atomic_load(&_global_keyword_lut_initialized) {
 		_global_keyword_spin_lock()
-		ok := keyword_lut_init(&global_keyword_lut)
-		intrinsics.atomic_store(&_global_keyword_lut_initialized, ok)
+		if !intrinsics.atomic_load(&_global_keyword_lut_initialized) {
+			ok := keyword_lut_init(&global_keyword_lut)
+			intrinsics.atomic_store(&_global_keyword_lut_initialized, ok)
+		}
 		_global_keyword_spin_unlock()
 	}
 


### PR DESCRIPTION
# `core:odin/tokenizer`: fix broken double-checked lock in `init`

`init` never re-checks `_global_keyword_lut_initialized` after taking the spinlock, so two threads can both see it as `false` and both enter. The second one to get the lock runs `keyword_lut_init` on the already-populated `global_keyword_lut`, and `assert(entry.kind == .Invalid, name)` fires on the first keyword:

```
core/odin/tokenizer/tokenizer.odin(85:3) runtime assertion: import
```

The memory orderings were already fine; only the missing re-check was wrong.

## Repro

Fails 100/100 before the fix, 0/100 after. The gate is needed because the window is only as wide as `keyword_lut_init` itself, just spawning threads in a loop hardly ever hits it (0/200 for me), since each thread finishes initializing before the next one starts.

```odin
package main

import "base:intrinsics"
import "core:fmt"
import "core:odin/tokenizer"
import "core:thread"

N :: 16

ready: int  // atomic
go:    bool // atomic

worker :: proc(t: ^thread.Thread) {
	intrinsics.atomic_add(&ready, 1)
	for !intrinsics.atomic_load(&go) {
		intrinsics.cpu_relax()
	}
	tok: tokenizer.Tokenizer
	tokenizer.init(&tok, "package p\n", "p.odin")
}

main :: proc() {
	threads: [N]^thread.Thread
	for &t in threads {
		t = thread.create(worker)
		thread.start(t)
	}
	for intrinsics.atomic_load(&ready) < N {
		intrinsics.cpu_relax()
	}
	intrinsics.atomic_store(&go, true)
	for t in threads {
		thread.join(t)
	}
	fmt.println("ok")
}
```

Found by parsing a project's source files concurrently, one file per worker thread, via `parser.parse_file` (which wraps `tokenizer.init`). Any thread pool that releases its workers at once will trip it.

## Notes

No regression test added: `tests/core/odin` already initializes the LUT in `test_parse_demo` before any race test in that process could run, and resetting the global flag would break the other tests running in parallel.

Verified on Windows 11 amd64. `odin test tests/core/odin -all-packages` passes with the CI flag set.
