### PR TITLE
Sys/linux sigset dev wrappers

### DIFF
--- a/core/sys/linux/wrappers.odin
+++ b/core/sys/linux/wrappers.odin
@@ -51,7 +51,68 @@ WCOREDUMP :: #force_inline proc "contextless" (s: u32) -> bool {
 	return (cast(uint)sig - 1) / (8*size_of(uint))
 }
 
-// TODO: sigaddset etc
+/// Clear all signals from `set`.
+sigemptyset :: #force_inline proc "contextless" (set: ^Sig_Set) {
+	set^ = {}
+}
+
+/// Add every signal to `set`.
+sigfillset :: #force_inline proc "contextless" (set: ^Sig_Set) {
+	for &word in set {
+		word = max(uint)
+	}
+}
+
+/// Add `sig` to `set`.
+sigaddset :: #force_inline proc "contextless" (set: ^Sig_Set, sig: Signal) {
+	set[_sigword(sig)] |= _sigmask(sig)
+}
+
+/// Remove `sig` from `set`.
+sigdelset :: #force_inline proc "contextless" (set: ^Sig_Set, sig: Signal) {
+	set[_sigword(sig)] &~= _sigmask(sig)
+}
+
+/// Check whether `sig` is a member of `set`.
+sigismember :: #force_inline proc "contextless" (set: Sig_Set, sig: Signal) -> bool {
+	return set[_sigword(sig)] & _sigmask(sig) != 0
+}
+
+/// Store the union of `left` and `right` into `dest`.
+sigorset :: #force_inline proc "contextless" (dest: ^Sig_Set, left, right: Sig_Set) {
+	for i in 0 ..< _SIGSET_NWORDS {
+		dest[i] = left[i] | right[i]
+	}
+}
+
+/// Store the intersection of `left` and `right` into `dest`.
+sigandset :: #force_inline proc "contextless" (dest: ^Sig_Set, left, right: Sig_Set) {
+	for i in 0 ..< _SIGSET_NWORDS {
+		dest[i] = left[i] & right[i]
+	}
+}
+
+/// Extract the major device number from `dev`.
+major :: #force_inline proc "contextless" (dev: Dev) -> u32 {
+	d := u64(dev)
+	return u32((d & 0x00000000000fff00) >> 8) | u32((d & 0xfffff00000000000) >> 32)
+}
+
+/// Extract the minor device number from `dev`.
+minor :: #force_inline proc "contextless" (dev: Dev) -> u32 {
+	d := u64(dev)
+	return u32((d & 0x00000000000000ff) >> 0) | u32((d & 0x00000ffffff00000) >> 12)
+}
+
+/// Construct a `Dev` from a major and minor device number.
+makedev :: #force_inline proc "contextless" (maj: u32, min: u32) -> Dev {
+	d: u64
+	d |= u64(maj & 0x00000fff) << 8
+	d |= u64(maj & 0xfffff000) << 32
+	d |= u64(min & 0x000000ff) << 0
+	d |= u64(min & 0xffffff00) << 12
+	return Dev(d)
+}
 
 
 /*

--- a/core/sys/linux/wrappers.odin
+++ b/core/sys/linux/wrappers.odin
@@ -1,45 +1,45 @@
 #+build linux
 package linux
 
-/// Low 8 bits of the exit code
-/// Only retrieve the exit code if WIFEXITED(s) = true
+// Low 8 bits of the exit code
+// Only retrieve the exit code if WIFEXITED(s) = true
 WEXITSTATUS :: #force_inline proc "contextless" (s: u32) -> u32 {
 	return (s & 0xff00) >> 8
 }
 
-/// Termination signal
-/// Only retrieve the code if WIFSIGNALED(s) = true
+// Termination signal
+// Only retrieve the code if WIFSIGNALED(s) = true
 WTERMSIG :: #force_inline proc "contextless" (s: u32) -> u32 {
 	return s & 0x7f
 }
 
-/// The signal that stopped the child
-/// Only retrieve if WIFSTOPPED(s) = true
+// The signal that stopped the child
+// Only retrieve if WIFSTOPPED(s) = true
 WSTOPSIG :: #force_inline proc "contextless" (s: u32) -> u32 {
 	return WEXITSTATUS(s)
 }
 
-/// Check if the process terminated normally (via exit.2)
+// Check if the process terminated normally (via exit.2)
 WIFEXITED :: #force_inline proc "contextless" (s: u32) -> bool {
 	return WTERMSIG(s) == 0
 }
 
-/// Check if the process signaled
+// Check if the process signaled
 WIFSIGNALED :: #force_inline proc "contextless" (s: u32) -> bool {
 	return cast(i8)(((s) & 0x7f) + 1) >> 1 > 0
 }
 
-/// Check if the process has stopped
+// Check if the process has stopped
 WIFSTOPPED :: #force_inline proc "contextless" (s: u32) -> bool {
 	return (s & 0xff) == 0x7f
 }
 
-/// Check if the process is continued by the tracee
+// Check if the process is continued by the tracee
 WIFCONTINUED :: #force_inline proc "contextless" (s: u32) -> bool {
 	return s == 0xffff
 }
 
-/// Check if the process dumped core
+// Check if the process dumped core
 WCOREDUMP :: #force_inline proc "contextless" (s: u32) -> bool {
 	return s & 0x80 == 0x80
 }
@@ -51,60 +51,60 @@ WCOREDUMP :: #force_inline proc "contextless" (s: u32) -> bool {
 	return (cast(uint)sig - 1) / (8*size_of(uint))
 }
 
-/// Clear all signals from `set`.
+// Clear all signals from `set`.
 sigemptyset :: #force_inline proc "contextless" (set: ^Sig_Set) {
 	set^ = {}
 }
 
-/// Add every signal to `set`.
+// Add every signal to `set`.
 sigfillset :: #force_inline proc "contextless" (set: ^Sig_Set) {
 	for &word in set {
 		word = max(uint)
 	}
 }
 
-/// Add `sig` to `set`.
+// Add `sig` to `set`.
 sigaddset :: #force_inline proc "contextless" (set: ^Sig_Set, sig: Signal) {
 	set[_sigword(sig)] |= _sigmask(sig)
 }
 
-/// Remove `sig` from `set`.
+// Remove `sig` from `set`.
 sigdelset :: #force_inline proc "contextless" (set: ^Sig_Set, sig: Signal) {
 	set[_sigword(sig)] &~= _sigmask(sig)
 }
 
-/// Check whether `sig` is a member of `set`.
+// Check whether `sig` is a member of `set`.
 sigismember :: #force_inline proc "contextless" (set: Sig_Set, sig: Signal) -> bool {
 	return set[_sigword(sig)] & _sigmask(sig) != 0
 }
 
-/// Store the union of `left` and `right` into `dest`.
+// Store the union of `left` and `right` into `dest`.
 sigorset :: #force_inline proc "contextless" (dest: ^Sig_Set, left, right: Sig_Set) {
 	for i in 0 ..< _SIGSET_NWORDS {
 		dest[i] = left[i] | right[i]
 	}
 }
 
-/// Store the intersection of `left` and `right` into `dest`.
+// Store the intersection of `left` and `right` into `dest`.
 sigandset :: #force_inline proc "contextless" (dest: ^Sig_Set, left, right: Sig_Set) {
 	for i in 0 ..< _SIGSET_NWORDS {
 		dest[i] = left[i] & right[i]
 	}
 }
 
-/// Extract the major device number from `dev`.
+// Extract the major device number from `dev`.
 major :: #force_inline proc "contextless" (dev: Dev) -> u32 {
 	d := u64(dev)
 	return u32((d & 0x00000000000fff00) >> 8) | u32((d & 0xfffff00000000000) >> 32)
 }
 
-/// Extract the minor device number from `dev`.
+// Extract the minor device number from `dev`.
 minor :: #force_inline proc "contextless" (dev: Dev) -> u32 {
 	d := u64(dev)
 	return u32((d & 0x00000000000000ff) >> 0) | u32((d & 0x00000ffffff00000) >> 12)
 }
 
-/// Construct a `Dev` from a major and minor device number.
+// Construct a `Dev` from a major and minor device number.
 makedev :: #force_inline proc "contextless" (maj: u32, min: u32) -> Dev {
 	d: u64
 	d |= u64(maj & 0x00000fff) << 8
@@ -194,14 +194,14 @@ dirent_name :: proc "contextless" (dirent: ^Dirent) -> string #no_bounds_check {
 	return string(str[:str_size])
 }
 
-/// Constructor for the `futex_op` argument of a FUTEX_WAKE_OP call
+// Constructor for the `futex_op` argument of a FUTEX_WAKE_OP call
 futex_op :: proc "contextless" (arg_op: Futex_Arg_Op, cmp_op: Futex_Cmp_Op, op_arg: u32, cmp_arg: u32) -> u32 {
 	arg_op := cast(u32) arg_op
 	cmp_op := cast(u32) cmp_op
 	return (arg_op << 28) | (cmp_op << 24) | ((op_arg & 0xfff) << 12) | (cmp_arg & 0xfff)
 }
 
-/// Helper function for constructing the config for caches
+// Helper function for constructing the config for caches
 perf_cache_config :: #force_inline proc "contextless" (id: Perf_Hardware_Cache_Id,
 	op: Perf_Hardware_Cache_Op_Id,
 	res: Perf_Hardware_Cache_Result_Id) -> u64 {


### PR DESCRIPTION
Adds the missing sigset ops plus two related device-number helpers. Also fixes `///` comments showing a stray leading slash in generated docs.

Bit layout follows glibc's `bits/sysmacros.h`:
https://github.com/bminor/glibc/blob/master/bits/sysmacros.h