### PR TITLE
Added UnregisterHotKey to user32.odin

### DIFF
--- a/core/sys/windows/user32.odin
+++ b/core/sys/windows/user32.odin
@@ -34,6 +34,7 @@ foreign user32 {
 	UnregisterClassW :: proc(lpClassName: LPCWSTR, hInstance: HINSTANCE) -> BOOL ---
 
 	RegisterHotKey :: proc(hnwd: HWND, id: c_int, fsModifiers: UINT, vk: UINT) -> BOOL ---
+	UnregisterHotKey :: proc(hnwd: HWND, id: c_int) -> BOOL ---
 
 	CreateWindowExW :: proc(
 		dwExStyle:             DWORD,


### PR DESCRIPTION
[RegisterHotKey](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-registerhotkey) was already there, but [UnregisterHotKey](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-unregisterhotkey) was missing. A simple 1 line fix