### PR TITLE
Fix unparenthesized attributes missing end position in its AST node

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -1110,6 +1110,7 @@ parse_attribute :: proc(p: ^Parser, tok: tokenizer.Token, open_kind, close_kind:
 	open, close: tokenizer.Token
 
 	if p.curr_tok.kind == .Ident {
+		close = p.curr_tok
 		elem := parse_ident(p)
 		append(&elems, elem)
 	} else {


### PR DESCRIPTION
Attribute AST nodes miss the end location when expressed in the 'naked' form, where a single expression is used without being surrounded with parenthesis.

e.g.
`@private FOO :: 1`
