### PR TITLE
core/sys/wasm/js: support shared WebAssembly memory in browser APIs

### DIFF
--- a/core/sys/wasm/js/odin.js
+++ b/core/sys/wasm/js/odin.js
@@ -19,6 +19,8 @@ class WasmMemoryInterface {
 		this.exports = null;
 		this.listenerMap = new Map();
 
+		this.isShared = false;
+
 		// Size (in bytes) of the integer type, should be 4 on `js_wasm32` and 8 on `js_wasm64p32`
 		this.intSize = 4;
 	}
@@ -29,6 +31,9 @@ class WasmMemoryInterface {
 
 	setMemory(memory) {
 		this.memory = memory;
+		// Avoid instanceof because memory may come from another realm.
+		this.isShared = typeof SharedArrayBuffer !== "undefined" && memory != null &&
+			Object.prototype.toString.call(memory.buffer) === "[object SharedArrayBuffer]";
 	}
 
 	setExports(exports) {
@@ -96,9 +101,16 @@ class WasmMemoryInterface {
 		return new Uint8Array(this.memory.buffer, ptr, Number(len));
 	}
 
+	loadBytesUnshared(ptr, len) {
+		const bytes = this.loadBytes(ptr, len);
+		if (this.isShared) {
+			return bytes.slice();
+		}
+		return bytes;
+	}
+
 	loadString(ptr, len) {
-		const bytes = this.loadBytes(ptr, Number(len));
-		return new TextDecoder().decode(bytes);
+		return new TextDecoder().decode(this.loadBytesUnshared(ptr, Number(len)));
 	}
 
 	loadCstring(ptr) {
@@ -1612,6 +1624,12 @@ function odinSetupDefaultImports(wasmMemoryInterface, consoleElement, memory) {
 
 			rand_bytes: (ptr, len) => {
 				const view = new Uint8Array(wasmMemoryInterface.memory.buffer, ptr, len)
+				if (wasmMemoryInterface.isShared) {
+					const tmp = new Uint8Array(len)
+					crypto.getRandomValues(tmp)
+					view.set(tmp)
+					return
+				}
 				crypto.getRandomValues(view)
 			},
 		},


### PR DESCRIPTION
## Problem

When Odin uses a shared `WebAssembly.Memory`, views into wasm memory are backed
by a `SharedArrayBuffer`.

The tested Chrome and Firefox versions reject these views in
`TextDecoder.decode`, causing `loadString` and `loadCstring` to throw a
`TypeError`. The Encoding Standard permits shared-backed input here, so the
copy is a compatibility workaround for current browser behavior.

`crypto.getRandomValues` also rejects shared-backed views, causing `rand_bytes`
to throw a `TypeError`. This rejection is expected because Web Crypto does not
allow shared-backed views for this API.

## Changes

- Detect shared WebAssembly memory once in `setMemory`.
- Copy shared-backed views to a temporary non-shared buffer before decoding
  strings with `TextDecoder`.
- Generate random bytes in a temporary non-shared buffer, then copy them into
  shared wasm memory.
- Keep the existing direct paths for non-shared memory, avoiding additional
  copies.

## Verification

- Verified with shared and non-shared WebAssembly memory.
- Tested in Chrome 149.0.7827.55 and Firefox 151.0 on a
  cross-origin-isolated page.
- Confirmed that Odin’s runtime limits each `getRandomValues` call to 65,536
  bytes, matching Web Crypto’s per-call limit.

This prepares the affected runtime paths for shared WebAssembly memory. It
does not itself add workers, synchronization, or multithreading support.
