### PR TITLE
riscv64: fix ABI classification for padded, over-aligned, and pointer-bearing structs

### DIFF
--- a/src/llvm_abi.cpp
+++ b/src/llvm_abi.cpp
@@ -1766,10 +1766,12 @@ namespace lbAbiRiscv64 {
 		// compatibility for struct declarations.
 		// The flattened form is for the floating-point rules, which are about the MEMBERS; the
 		// integer fallback below is about the OBJECT, so `size` stays the size of the original.
+		// The rules are stated over the members alone, so the aggregate's size does not gate
+		// them: over-alignment grows a struct without changing any member type.
 		LLVMTypeRef  fp_type = type;
 		LLVMTypeKind fp_kind = kind;
 		i64          fp_size = size;
-		if (kind == LLVMStructTypeKind && size <= gb_max(2*xlen, 2*flen)) {
+		if (kind == LLVMStructTypeKind) {
 			Array<LLVMTypeRef> fields = array_make<LLVMTypeRef>(temporary_allocator(), 0, LLVMCountStructElementTypes(type));
 			flatten(m, &fields, type, false);
 
@@ -1785,6 +1787,11 @@ namespace lbAbiRiscv64 {
 
 		if (is_float(fp_type) && fp_size <= flen && *fprs_left >= 1) {
 			*fprs_left -= 1;
+			if (fp_type != orig_type) {
+				// A struct that flattened to a single float has to be coerced to that float;
+				// handing back the original sends an over-aligned one to integer registers.
+				return lb_arg_type_direct(orig_type, fp_type, nullptr, nullptr);
+			}
 			return non_struct(c, orig_type);
 		}
 

--- a/src/llvm_abi.cpp
+++ b/src/llvm_abi.cpp
@@ -1738,6 +1738,13 @@ namespace lbAbiRiscv64 {
 		}
 	}
 
+	// The psABI's rule is "one floating-point real and one integer (or bitfield)", and a pointer
+	// is not an integer. `is_register` admits pointers and keeps that meaning for its other
+	// callers, so the floating-point arms need their own predicate.
+	gb_internal bool is_int_member(LLVMTypeRef type) {
+		return LLVMGetTypeKind(type) == LLVMIntegerTypeKind && lb_sizeof(type) > 0;
+	}
+
 	gb_internal lbArgType compute_arg_type(lbModule *m, LLVMTypeRef type, int *gprs_left, int *fprs_left, Type *odin_type) {
 		LLVMContextRef c = m->ctx;
 
@@ -1808,13 +1815,13 @@ namespace lbAbiRiscv64 {
 					return lb_arg_type_direct(orig_type, fp_type, nullptr, nullptr);
 				}
 
-				if (is_float(ty1) && is_register(ty2) && ty1s <= flen && ty2s <= xlen && *fprs_left >= 1 && *gprs_left >= 1) {
+				if (is_float(ty1) && is_int_member(ty2) && ty1s <= flen && ty2s <= xlen && *fprs_left >= 1 && *gprs_left >= 1) {
 					*fprs_left -= 1;
 					*gprs_left -= 1;
 					return lb_arg_type_direct(orig_type, fp_type, nullptr, nullptr);
 				}
 
-				if (is_register(ty1) && is_float(ty2) && ty1s <= xlen && ty2s <= flen && *gprs_left >= 1 && *fprs_left >= 1) {
+				if (is_int_member(ty1) && is_float(ty2) && ty1s <= xlen && ty2s <= flen && *gprs_left >= 1 && *fprs_left >= 1) {
 					*fprs_left -= 1;
 					*gprs_left -= 1;
 					return lb_arg_type_direct(orig_type, fp_type, nullptr, nullptr);

--- a/src/llvm_abi.cpp
+++ b/src/llvm_abi.cpp
@@ -1764,49 +1764,53 @@ namespace lbAbiRiscv64 {
 		// Flatten down the type so it is easier to check all the ABI conditions.
 		// Note that we also need to remove all implicit padding fields Odin adds so we keep ABI
 		// compatibility for struct declarations.
+		// The flattened form is for the floating-point rules, which are about the MEMBERS; the
+		// integer fallback below is about the OBJECT, so `size` stays the size of the original.
+		LLVMTypeRef  fp_type = type;
+		LLVMTypeKind fp_kind = kind;
+		i64          fp_size = size;
 		if (kind == LLVMStructTypeKind && size <= gb_max(2*xlen, 2*flen)) {
 			Array<LLVMTypeRef> fields = array_make<LLVMTypeRef>(temporary_allocator(), 0, LLVMCountStructElementTypes(type));
 			flatten(m, &fields, type, false);
 
 			if (fields.count == 1) {
-				type = fields[0];
+				fp_type = fields[0];
 			} else {
-				type = LLVMStructTypeInContext(c, fields.data, cast(unsigned)fields.count, false);
+				fp_type = LLVMStructTypeInContext(c, fields.data, cast(unsigned)fields.count, false);
 			}
 
-			kind = LLVMGetTypeKind(type);
-			size = lb_sizeof(type);
-			GB_ASSERT_MSG(size == lb_sizeof(orig_type), "flattened: %s of size %d, original: %s of size %d", LLVMPrintTypeToString(type), size, LLVMPrintTypeToString(orig_type), lb_sizeof(orig_type));
+			fp_kind = LLVMGetTypeKind(fp_type);
+			fp_size = lb_sizeof(fp_type);
 		}
 
-		if (is_float(type) && size <= flen && *fprs_left >= 1) {
+		if (is_float(fp_type) && fp_size <= flen && *fprs_left >= 1) {
 			*fprs_left -= 1;
 			return non_struct(c, orig_type);
 		}
 
-		if (kind == LLVMStructTypeKind && size <= 2*flen) {
-			unsigned elem_count = LLVMCountStructElementTypes(type);
+		if (fp_kind == LLVMStructTypeKind && fp_size <= 2*flen) {
+			unsigned elem_count = LLVMCountStructElementTypes(fp_type);
 			if (elem_count == 2) {
-				LLVMTypeRef ty1 = LLVMStructGetTypeAtIndex(type, 0);
+				LLVMTypeRef ty1 = LLVMStructGetTypeAtIndex(fp_type, 0);
 				i64 ty1s = lb_sizeof(ty1);
-				LLVMTypeRef ty2 = LLVMStructGetTypeAtIndex(type, 1);
+				LLVMTypeRef ty2 = LLVMStructGetTypeAtIndex(fp_type, 1);
 				i64 ty2s = lb_sizeof(ty2);
 
 				if (is_float(ty1) && is_float(ty2) && ty1s <= flen && ty2s <= flen && *fprs_left >= 2) {
 					*fprs_left -= 2;
-					return lb_arg_type_direct(orig_type, type, nullptr, nullptr);
+					return lb_arg_type_direct(orig_type, fp_type, nullptr, nullptr);
 				}
 
 				if (is_float(ty1) && is_register(ty2) && ty1s <= flen && ty2s <= xlen && *fprs_left >= 1 && *gprs_left >= 1) {
 					*fprs_left -= 1;
 					*gprs_left -= 1;
-					return lb_arg_type_direct(orig_type, type, nullptr, nullptr);
+					return lb_arg_type_direct(orig_type, fp_type, nullptr, nullptr);
 				}
 
 				if (is_register(ty1) && is_float(ty2) && ty1s <= xlen && ty2s <= flen && *gprs_left >= 1 && *fprs_left >= 1) {
 					*fprs_left -= 1;
 					*gprs_left -= 1;
-					return lb_arg_type_direct(orig_type, type, nullptr, nullptr);
+					return lb_arg_type_direct(orig_type, fp_type, nullptr, nullptr);
 				}
 			}
 		}


### PR DESCRIPTION
odin build -target:linux_riscv64 fails an internal assertion for any struct whose members don't tile it exactly:

```odin
package p
S :: struct #align(16) { a: i8, b: i8 }
@(export) f :: proc "c" (s: S) {}
```
```
src/llvm_abi.cpp(1779): Assertion Failure: `size == lb_sizeof(orig_type)`
  flattened: { i8, i8 } of size 2,
  original:  %"p::S" = type { i8, i8, [14 x i8] } of size 16
```
linux_amd64 and linux_arm64 compile the same file. Trailing padding, inter-field padding and over-alignment all trip it.

Odin materializes padding as an explicit member, and `flatten(..., with_padding = false)` discards it, so `size == lb_sizeof(orig_type)` holds only for a type with no padding. size was doing two jobs, as the floating-point rules are about the struct's members while the integer fallback below them is about the object. The flattened form gets its own variables and size stays the original.

That crash hid two further divergences from clang, fixed in the following commits:

The flatten was gated on `size <= max(2*xlen, 2*flen)`, but the psABI states the FP rules over a struct's members alone. Over-alignment grows a struct without changing any member, so `struct #align(32){a, b: f32}` went indirect where clang passes (float, float). A struct that flattens to a single float also has to be coerced to that float.
The "one float and one integer" arm tested its second member with is_register, which returns true for LLVMPointerTypeKind, so `struct{f32, rawptr}` was passed as (fa0, a0). clang 22.1.8 and gcc 15.1.0 both pass it in two integer registers.

Verified by linking an Odin caller against a clang-compiled riscv64 callee and running it under qemu-riscv64. Each fix has a probe that goes red when that fix alone is reverted: the size split, the single-float coercion (in return position, where Odin emits %"p::B" against clang's float), and the pointer predicate.

Every edit is inside `lbAbiRiscv64`, other arch untouched