### PR TITLE
i386: pass aggregate arguments by value on the stack

### DIFF
--- a/src/llvm_abi.cpp
+++ b/src/llvm_abi.cpp
@@ -437,7 +437,9 @@ namespace lbAbi386 {
 				if (sz == 0) {
 					args[i] = lb_arg_type_ignore(t);
 				} else {
-					args[i] = lb_arg_type_indirect(t, nullptr);
+					// Aggregates are pushed onto the stack by value, not passed as a pointer
+					// to a caller-owned copy. This is the rule for both i386 targets.
+					args[i] = lb_arg_type_indirect_byval(c, t);
 				}
 			} else {
 				args[i] = non_struct(c, t, false);


### PR DESCRIPTION
Fixes #5608

`lbAbi386::compute_arg_types` passed every struct and array argument as `lb_arg_type_indirect`. The i386 System V ABI pushes aggregates onto the stack by value, so the callee read the caller's four-byte pointer as the first bytes of the aggregate.

```
Odin  : declare i32 @c_s8(ptr)
clang : define dso_local i32 @c_s8(i32 %0, i32 %1)
```

#5608 describes this as a failure to flatten "sufficiently small structs", which understates it, it is every aggregate at every size, arrays included. Verified across 3, 8 and 16-byte structs and a [4]i32 by linking an Odin caller against a clang-compiled i386 callee and running it under qemu-i386; before the change the first case already returns the wrong value.

The argument rule is the same on windows_i386 and linux_i386, so one fix serves both targets.