### PR TITLE
i386: return aggregates through the hidden pointer on System V targets

### DIFF
--- a/src/llvm_abi.cpp
+++ b/src/llvm_abi.cpp
@@ -450,12 +450,21 @@ namespace lbAbi386 {
 		if (!return_is_defined) {
 			return lb_arg_type_direct(LLVMVoidTypeInContext(c));
 		} else if (lb_is_type_kind(return_type, LLVMStructTypeKind) || lb_is_type_kind(return_type, LLVMArrayTypeKind)) {
+			// Only some i386 targets return a small aggregate in EDX:EAX. The Intel386 System V
+			// psABI returns every structure and union through the hidden pointer, with no size
+			// threshold; Windows and the BSDs return one of eight bytes or fewer in registers.
+			bool small_in_registers = build_context.metrics.os == TargetOs_windows ||
+			                          build_context.metrics.os == TargetOs_freebsd ||
+			                          build_context.metrics.os == TargetOs_openbsd;
+
 			i64 sz = lb_sizeof(return_type);
-			switch (sz) {
-			case 1: return lb_arg_type_direct(return_type, LLVMIntTypeInContext(c,  8), nullptr, nullptr);
-			case 2: return lb_arg_type_direct(return_type, LLVMIntTypeInContext(c, 16), nullptr, nullptr);
-			case 4: return lb_arg_type_direct(return_type, LLVMIntTypeInContext(c, 32), nullptr, nullptr);
-			case 8: return lb_arg_type_direct(return_type, LLVMIntTypeInContext(c, 64), nullptr, nullptr);
+			if (small_in_registers) {
+				switch (sz) {
+				case 1: return lb_arg_type_direct(return_type, LLVMIntTypeInContext(c,  8), nullptr, nullptr);
+				case 2: return lb_arg_type_direct(return_type, LLVMIntTypeInContext(c, 16), nullptr, nullptr);
+				case 4: return lb_arg_type_direct(return_type, LLVMIntTypeInContext(c, 32), nullptr, nullptr);
+				case 8: return lb_arg_type_direct(return_type, LLVMIntTypeInContext(c, 64), nullptr, nullptr);
+				}
 			}
 
 			LB_ABI_MODIFY_RETURN_IF_TUPLE_MACRO();


### PR DESCRIPTION
`lbAbi386::compute_return_type` returned any struct of 1, 2, 4 or 8 bytes in EDX:EAX on every i386 target. 

The Intel386 System V psABI returns every structure and union through a hidden pointer, with no size threshold, so on linux_i386 a proc "c" returning a small struct is incompatible with C. The C callee treats whatever sits at 4(%esp) as the result address and stores through it:

```odin
package p
S8 :: struct { a, b: i32 }
foreign { c_mk :: proc "c" () -> S8 --- }
```
```
Odin  declares: declare i64 @c_mk()
clang defines : define dso_local void @c_mk(ptr sret(%struct.S8))

exit=139 (SIGSEGV)
```
Windows and the BSDs do return small aggregates in registers, linux does not


| | struct{i8,i8}	| struct{i32,i32} | 	struct{i32,i32,i32}|
|-|-|-|-|
| linux_i386	|sret | 	sret |	sret |
| windows_i386 |	i16 |	i64 |	sret |
| freebsd_i386	| i16 |	i64	| sret |

All three match clang for the same C types. windows_i386 and freebsd_i386 emit byte-identical IR before and after this change.

Verified by linking an Odin caller against a clang-compiled i386 callee and running it under qemu-i386, along with Odin multi-returns up to -> (S8, S8).