### PR TITLE
vendor/box3d: add a fallback platform clock hook

### DIFF
--- a/vendor/box3d/src/src/timer.c
+++ b/vendor/box3d/src/src/timer.c
@@ -562,21 +562,38 @@ void b3JoinThread( b3Thread* t )
 
 #else
 
-uint64_t b3GetTicks( void )
+__attribute__( ( weak ) ) uint64_t b3PlatformTicks( void )
 {
 	return 0;
 }
 
+uint64_t b3GetTicks( void )
+{
+	return b3PlatformTicks();
+}
+
 float b3GetMilliseconds( uint64_t ticks )
 {
-	( (void)( ticks ) );
-	return 0.0f;
+	uint64_t ticksNow = b3PlatformTicks();
+	if ( ticksNow <= ticks )
+	{
+		return 0.0f;
+	}
+
+	return (float)( (double)( ticksNow - ticks ) * 0.001 );
 }
 
 float b3GetMillisecondsAndReset( uint64_t* ticks )
 {
-	( (void)( ticks ) );
-	return 0.0f;
+	uint64_t ticksNow = b3PlatformTicks();
+	uint64_t ticksThen = *ticks;
+	*ticks = ticksNow;
+	if ( ticksNow <= ticksThen )
+	{
+		return 0.0f;
+	}
+
+	return (float)( (double)( ticksNow - ticksThen ) * 0.001 );
 }
 
 void b3Yield( void )


### PR DESCRIPTION
## Summary

- let freestanding hosts override Box3D's generic timer with a monotonic microsecond clock
- preserve the existing zero-timing fallback when no host hook is supplied
- make elapsed/reset calculations handle non-advancing ticks safely

This is intentionally limited to the timer hook. Broader raw-WASM support belongs upstream in Box3D.

Related: erincatto/box3d#127

## Testing

- `./odin build vendor/box3d -target:js_wasm32 -build-mode:obj`