### PR TITLE
vendor/box3d: support WASM atomics builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -321,3 +321,4 @@ CMakeLists.txt
 sandbox/
 
 vendor/box3d/lib/box3d_wasm.o
+vendor/box3d/lib/box3d_wasm_threads.o

--- a/vendor/box3d/box3d.odin
+++ b/vendor/box3d/box3d.odin
@@ -10,8 +10,18 @@ ENABLE_VALIDATION :: false
 BOX3D_SHARED :: #config(BOX3D_SHARED, false)
 
 @(private)
+BOX3D_WASM_THREADS :: #config(BOX3D_WASM_THREADS, true)
+
+@(private)
+BOX3D_USE_WASM_THREADS ::
+	BOX3D_WASM_THREADS &&
+	(ODIN_ARCH == .wasm32 || ODIN_ARCH == .wasm64p32) &&
+	intrinsics.has_target_feature("atomics")
+
+@(private)
 LIB_PATH :: (
-	     "lib/box3d_wasm.o"           when ODIN_ARCH == .wasm32 || ODIN_ARCH == .wasm64p32
+	     "lib/box3d_wasm_threads.o"   when BOX3D_USE_WASM_THREADS
+	else "lib/box3d_wasm.o"           when ODIN_ARCH == .wasm32 || ODIN_ARCH == .wasm64p32
 	else "lib/linux-amd64/libbox3d.a" when ODIN_OS == .Linux && ODIN_ARCH == .amd64 && !BOX3D_SHARED
 	else "lib/linux-arm64/libbox3d.a" when ODIN_OS == .Linux && ODIN_ARCH == .arm64 && !BOX3D_SHARED
 	else "lib/darwin/libbox3d.a"      when ODIN_OS == .Darwin && (ODIN_ARCH == .amd64 || ODIN_ARCH == .arm64) && !BOX3D_SHARED

--- a/vendor/box3d/src/build.sh
+++ b/vendor/box3d/src/build.sh
@@ -90,24 +90,36 @@ Linux)
 	;;
 esac
 
-echo "Building Box3D for wasm32"
-mkdir -p build/wasm
-for src in src/*.c; do
-	obj="build/wasm/$(basename "${src%.c}.o")"
+build_wasm() {
+	name=$1
+	shift
+	build_dir="build/$name"
+	mkdir -p "$build_dir"
+	for src in src/*.c; do
+		obj="$build_dir/$(basename "${src%.c}.o")"
+		"$wasm_cc" -c -O3 -std=gnu17 --target=wasm32 \
+			--sysroot="$ODIN_ROOT/vendor/libc-shim" \
+			-Iinclude \
+			-include wasm_compat.h \
+			-DBOX3D_DISABLE_SIMD \
+			-DNDEBUG \
+			"$@" \
+			"$src" -o "$obj"
+	done
 	"$wasm_cc" -c -O3 -std=gnu17 --target=wasm32 \
 		--sysroot="$ODIN_ROOT/vendor/libc-shim" \
 		-Iinclude \
 		-include wasm_compat.h \
 		-DBOX3D_DISABLE_SIMD \
 		-DNDEBUG \
-		"$src" -o "$obj"
-done
-"$wasm_cc" -c -O3 -std=gnu17 --target=wasm32 \
-	--sysroot="$ODIN_ROOT/vendor/libc-shim" \
-	-Iinclude \
-	-include wasm_compat.h \
-	-DBOX3D_DISABLE_SIMD \
-	-DNDEBUG \
-	wasm_compat.c -o build/wasm/wasm_compat.o
-"$wasm_ld" -r -o ../lib/box3d_wasm.o build/wasm/*.o
-rm -rf build/wasm
+		"$@" \
+		wasm_compat.c -o "$build_dir/wasm_compat.o"
+	"$wasm_ld" -r -o "../lib/$name.o" "$build_dir"/*.o
+	rm -rf "$build_dir"
+}
+
+echo "Building Box3D for wasm32"
+build_wasm box3d_wasm
+
+echo "Building Box3D for wasm32 threads"
+build_wasm box3d_wasm_threads -matomics -mbulk-memory

--- a/vendor/box3d/src/src/timer.c
+++ b/vendor/box3d/src/src/timer.c
@@ -607,13 +607,21 @@ void b3Sleep( int milliseconds )
 
 typedef struct b3Mutex
 {
+#if defined( __wasm_atomics__ )
+	int state;
+#else
 	int dummy;
+#endif
 } b3Mutex;
 
 b3Mutex* b3CreateMutex( void )
 {
 	b3Mutex* m = b3Alloc( sizeof( b3Mutex ) );
+#if defined( __wasm_atomics__ )
+	__atomic_store_n( &m->state, 0, __ATOMIC_RELAXED );
+#else
 	m->dummy = 42;
+#endif
 	return m;
 }
 
@@ -625,12 +633,22 @@ void b3DestroyMutex( b3Mutex* m )
 
 void b3LockMutex( b3Mutex* m )
 {
+#if defined( __wasm_atomics__ )
+	while ( __atomic_exchange_n( &m->state, 1, __ATOMIC_ACQUIRE ) != 0 )
+	{
+	}
+#else
 	(void)m;
+#endif
 }
 
 void b3UnlockMutex( b3Mutex* m )
 {
+#if defined( __wasm_atomics__ )
+	__atomic_store_n( &m->state, 0, __ATOMIC_RELEASE );
+#else
 	(void)m;
+#endif
 }
 
 typedef struct b3Semaphore

--- a/vendor/box3d/src/src/timer.c
+++ b/vendor/box3d/src/src/timer.c
@@ -562,21 +562,38 @@ void b3JoinThread( b3Thread* t )
 
 #else
 
-uint64_t b3GetTicks( void )
+__attribute__( ( weak ) ) uint64_t b3PlatformTicks( void )
 {
 	return 0;
 }
 
+uint64_t b3GetTicks( void )
+{
+	return b3PlatformTicks();
+}
+
 float b3GetMilliseconds( uint64_t ticks )
 {
-	( (void)( ticks ) );
-	return 0.0f;
+	uint64_t ticksNow = b3PlatformTicks();
+	if ( ticksNow <= ticks )
+	{
+		return 0.0f;
+	}
+
+	return (float)( (double)( ticksNow - ticks ) * 0.001 );
 }
 
 float b3GetMillisecondsAndReset( uint64_t* ticks )
 {
-	( (void)( ticks ) );
-	return 0.0f;
+	uint64_t ticksNow = b3PlatformTicks();
+	uint64_t ticksThen = *ticks;
+	*ticks = ticksNow;
+	if ( ticksNow <= ticksThen )
+	{
+		return 0.0f;
+	}
+
+	return (float)( (double)( ticksNow - ticksThen ) * 0.001 );
 }
 
 void b3Yield( void )


### PR DESCRIPTION
## Summary

- build a second Box3D WASM object with atomics and bulk-memory enabled
- select the threaded object when Odin's target has the `atomics` feature
- use an acquire/release spin mutex on Box3D's generic branch when `__wasm_atomics__` is enabled

Depends on #7286. Broader raw-WASM support belongs upstream in Box3D.

Related: erincatto/box3d#127

## Testing

- built serial and atomics Box3D WASM objects with Homebrew LLVM
- built `vendor/box3d` for `js_wasm32` with and without `-target-features:atomics`