### PR TITLE
Use enum value init expression instead of numeric value in doc format

### DIFF
--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -1009,6 +1009,7 @@ gb_internal void check_enum_type(CheckerContext *ctx, Type *enum_type, Type *nam
 		e->Constant.flags |= entity_flags;
 		e->Constant.docs = docs;
 		e->Constant.comment = comment;
+		e->Constant.init_expr = init;
 
 		auto interned = entity_interned_name(e);
 

--- a/src/docs_writer.cpp
+++ b/src/docs_writer.cpp
@@ -890,6 +890,9 @@ gb_internal OdinDocEntityIndex odin_doc_add_entity(OdinDocWriter *w, Entity *e) 
 		}
 		break;
 	case Entity_Constant:
+		if (init_expr == nullptr) {
+			init_expr = e->Constant.init_expr;
+		}
 		field_group_index = e->Constant.field_group_index;
 		break;
 	case Entity_Procedure:

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -205,6 +205,7 @@ struct Entity {
 			i32 field_group_index;
 			CommentGroup *docs;
 			CommentGroup *comment;
+			Ast *init_expr; // only used for enum values
 		} Constant;
 		struct {
 			Ast *type_expr; // only used for some variables within procedure bodies


### PR DESCRIPTION
before enum value docs were generated from the numeric value, which is not always ideal:
<img width="371" height="237" alt="image" src="https://github.com/user-attachments/assets/82dbe1a4-71d4-4ad8-83bd-e871da6d7554" />
