### PR TITLE
[llvm_backend] fix duplicated name for temporary `.ll` files

### DIFF
--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -2694,10 +2694,9 @@ gb_internal void lb_llvm_module_passes_and_verification(lbGenerator *gen, bool d
 }
 
 gb_internal String lb_filepath_ll_for_module(lbModule *m) {
-	String path = concatenate3_strings(permanent_allocator(),
+	String path = concatenate_strings(permanent_allocator(),
 		build_context.build_paths[BuildPath_Output].basename,
-		STR_LIT("/"),
-		build_context.build_paths[BuildPath_Output].name
+		STR_LIT("/")
 	);
 
 	GB_ASSERT(m->module_name != nullptr);


### PR DESCRIPTION
For the past two releases, temporary `.ll` files have had "duplicate" names occur in certain cases — i.e. if the command `odin build . -keep-temp-files -out:build/foo` were run, filenames akin to `<name><name>-main.ll` would be produced as an intermediate. This can be seen in the case of Compiler Explorer which has had the LLVM IR view broken for the last two months.

In my testing, this change produces the same intermediate and final artifacts but fixes the name duplication.

EDIT:
I should note that my removal of the build path name from the output *doesn't* remove any information since the `module_name` it is then populated with is set in the module worker:
```cpp
String name = build_context.build_paths[BuildPath_Output].name;
gbString module_name = gb_string_make(heap_allocator(), "");
module_name = gb_string_append_length(module_name, name.text, name.len);
```
and uses the same path