### PR TITLE
fix byte swap on untyped int-like untyped types

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -5770,6 +5770,14 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 				error(x.expr, "Invalid type passed to '%.*s', got %s", LIT(builtin_name), xts);
 				gb_string_free(xts);
 			}
+			// An untyped constant is integer-like, so it reaches the size check below, and
+			// `type_size_of` asserts on a type that has no size. 
+			// no-op on typed types
+			convert_to_typed(c, &x, default_type(x.type));
+			if (x.mode == Addressing_Invalid) {
+				return false;
+			}
+
 			i64 sz = type_size_of(x.type);
 			if (sz < 2) {
 				gbString xts = type_to_string(x.type);


### PR DESCRIPTION
Fixes #5715

An untyped constant is integer-like, so it passes the kind check and reaches `type_size_of(x.type)`, which asserts that its argument is typed. odin check aborts.

```odin
v := intrinsics.byte_swap(0x1234)

src/types.cpp(4299): Assertion Failure: `is_type_typed(t)` untyped integer
```