### PR TITLE
type_is_comparable: false for an unspecialized polymorphic record

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -2824,6 +2824,10 @@ gb_internal bool is_type_comparable(Type *t) {
 		if (t->Struct.soa_kind != StructSoa_None) {
 			return false;
 		}
+		// an unspecialized polymorphic record has no values to compare
+		if (is_type_polymorphic_record_unspecialized(t)) {
+			return false;
+		}
 		if (t->Struct.is_raw_union) {
 			return is_type_simple_compare(t);
 		}


### PR DESCRIPTION
```odin
Poly :: struct($T: typeid) { x: T }
#assert(intrinsics.type_is_comparable(Poly))   // passes
```

Makes uninnstantiated types rejected for comparable.