### PR TITLE
 types: make the three endianness predicates partition

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -2091,10 +2091,11 @@ gb_internal bool is_type_endian_big(Type *t) {
 		return build_context.endian_kind == TargetEndian_Big;
 	} else if (t->kind == Type_BitSet) {
 		return is_type_endian_big(bit_set_to_int(t));
-	} else if (t->kind == Type_Pointer) {
+	} else if (t->kind == Type_Pointer || t->kind == Type_MultiPointer) {
 		return is_type_endian_big(&basic_types[Basic_uintptr]);
 	}
-	return build_context.endian_kind == TargetEndian_Big;
+	// a type with no endianness is neither little nor big
+	return false;
 }
 gb_internal bool is_type_endian_little(Type *t) {
 	t = core_type(t);
@@ -2108,10 +2109,11 @@ gb_internal bool is_type_endian_little(Type *t) {
 		return build_context.endian_kind == TargetEndian_Little;
 	} else if (t->kind == Type_BitSet) {
 		return is_type_endian_little(bit_set_to_int(t));
-	} else if (t->kind == Type_Pointer) {
+	} else if (t->kind == Type_Pointer || t->kind == Type_MultiPointer) {
 		return is_type_endian_little(&basic_types[Basic_uintptr]);
 	}
-	return build_context.endian_kind == TargetEndian_Little;
+	// a type with no endianness is neither little nor big
+	return false;
 }
 
 gb_internal bool is_type_endian_platform(Type *t) {
@@ -2121,7 +2123,7 @@ gb_internal bool is_type_endian_platform(Type *t) {
 		return (t->Basic.flags & (BasicFlag_EndianLittle|BasicFlag_EndianBig)) == 0;
 	} else if (t->kind == Type_BitSet) {
 		return is_type_endian_platform(bit_set_to_int(t));
-	} else if (t->kind == Type_Pointer) {
+	} else if (t->kind == Type_Pointer || t->kind == Type_MultiPointer) {
 		return is_type_endian_platform(&basic_types[Basic_uintptr]);
 	}
 	return false;
@@ -2179,6 +2181,10 @@ gb_internal bool is_type_dereferenceable(Type *t) {
 
 
 gb_internal bool is_type_different_to_arch_endianness(Type *t) {
+	// a type with no endianness never needs swapping
+	if (!is_type_endian_specific(t)) {
+		return false;
+	}
 	switch (build_context.endian_kind) {
 	case TargetEndian_Little:
 		return !is_type_endian_little(t);


### PR DESCRIPTION
type_is_endian_little, _big and _platform should partition. I *think* the intrinsic should only care when its actually endian, so `int` says no. if that is not true, this PR needs reworked.

```odin
#assert(intrinsics.type_is_endian_little(struct{a: int}))    // passes
#assert(!intrinsics.type_is_endian_platform(struct{a: int})) // also passes
```

Together those assert that a struct carries an explicit little-endian marker. Structs have no endianness at all.
```
                              little   big     platform
  int / bool / f32 / ^int      true    false   true       coherent
  u32le                        true    false   false      coherent
  u32be                        false   true    false      coherent
  ---------------------------------------------------------------
  struct / [N]T / []T / proc()
  map / #simd / matrix / [^]T  true    false   FALSE      contradiction
```

is_type_endian_little and _big fall through to build_context.endian_kind for anything that is not Type_Basic, Type_BitSet or Type_Pointer, while _platform falls through to false. For a basic type the two agree because the basic branch decides both. 


No behavior change outside the three intrinsics