### PR TITLE
matrix: enforce the element limit on multiplication and on overflowing dimensions

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -4268,8 +4268,22 @@ gb_internal void check_binary_matrix(CheckerContext *c, Token const &op, Operand
 						x->type = y->type;
 					}
 				} else {
+					// the result takes its rows from one operand and its columns from the other,
+					// so it can be larger than either. Each dimension is at least
+					// MATRIX_ELEMENT_COUNT_MIN, so testing them first keeps the product in range.
+					i64 row_count    = xt->Matrix.row_count;
+					i64 column_count = yt->Matrix.column_count;
+					if (row_count    > MATRIX_ELEMENT_COUNT_MAX ||
+					    column_count > MATRIX_ELEMENT_COUNT_MAX ||
+					    row_count*column_count > MATRIX_ELEMENT_COUNT_MAX) {
+						error(x->expr, "Matrix multiplication result exceeds the maximum matrix element count, got %lld, expected a maximum of %d", cast(long long)(row_count*column_count), MATRIX_ELEMENT_COUNT_MAX);
+						x->mode = Addressing_Invalid;
+						x->type = t_invalid;
+						return;
+					}
+
 					bool is_row_major = xt->Matrix.is_row_major && yt->Matrix.is_row_major;
-					x->type = alloc_type_matrix(xt->Matrix.elem, xt->Matrix.row_count, yt->Matrix.column_count, nullptr, nullptr, is_row_major);
+					x->type = alloc_type_matrix(xt->Matrix.elem, row_count, column_count, nullptr, nullptr, is_row_major);
 				}
 				goto matrix_success;
 			} else if (yt->kind == Type_Array) {

--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -3131,9 +3131,20 @@ gb_internal void check_matrix_type(CheckerContext *ctx, Type **type, Ast *node) 
 		}
 	}
 	
-	if ((generic_row == nullptr && generic_column == nullptr) && row_count*column_count > MATRIX_ELEMENT_COUNT_MAX) {
-		i64 element_count = row_count*column_count;
-		error(node, "Matrix types are limited to a maximum of %d elements, got %lld", MATRIX_ELEMENT_COUNT_MAX, cast(long long)element_count);
+	if (generic_row == nullptr && generic_column == nullptr) {
+		// row_count*column_count can overflow and wrap back under the limit, so test the
+		// dimensions first; each is at least MATRIX_ELEMENT_COUNT_MIN. Either one exceeding
+		// the maximum means the product does too
+		if (row_count > MATRIX_ELEMENT_COUNT_MAX || column_count > MATRIX_ELEMENT_COUNT_MAX ||
+		    row_count*column_count > MATRIX_ELEMENT_COUNT_MAX) {
+			// the element count is only printable when the multiply cannot overflow, which is
+			// exactly the case the dimension test above catches
+			if (row_count != 0 && column_count > I64_MAX/row_count) {
+				error(node, "Matrix types are limited to a maximum of %d elements, got %lld by %lld", MATRIX_ELEMENT_COUNT_MAX, cast(long long)row_count, cast(long long)column_count);
+			} else {
+				error(node, "Matrix types are limited to a maximum of %d elements, got %lld by %lld (%lld elements)", MATRIX_ELEMENT_COUNT_MAX, cast(long long)row_count, cast(long long)column_count, cast(long long)(row_count*column_count));
+			}
+		}
 	}
 
 


### PR DESCRIPTION
MATRIX_ELEMENT_COUNT_MAX is bypassable two ways:

1. Through *. The result takes its rows from one operand and its columns from the other, so it can be larger than either, the construction site never consulted the limit:
```odin
a: matrix[16,1]f32
b: matrix[1,16]f32
c := a * b            // matrix[16,16]f32 -- 256 elements, 1024 bytes
```

It compiles, runs, produces correct values, and can be multiplied again. Writing the same type is refused. `A * B` is the only growing construction site without a check.

2. Through overflow in the written-type guard. `row_count*column_count` was computed before the comparison, so a product that overflows i64 wraps back under the limit:
```odin
c: matrix[576460752303423489, 32]u8   // accepted; size_of and align_of both report 32
```

Both are fixed by testing the dimensions before multiplying. 

The written-type message now reports got `R by C (N elements)`.

Relates to #7300. Note that its two SIGFPE cases no longer reproduce on current master, but the silent wrap is fixed here.