### PR TITLE
hoist if stmt in enumerated_array

### DIFF
--- a/src/llvm_backend_stmt.cpp
+++ b/src/llvm_backend_stmt.cpp
@@ -496,11 +496,12 @@ gb_internal void lb_build_range_indexed(lbProcedure *p, lbValue expr, Type *val_
 	case Type_EnumeratedArray: {
 		if (val_type != nullptr) {
 			val = lb_emit_load(p, lb_emit_array_ep(p, expr, idx));
-			// NOTE(bill): Override the idx value for the enumeration
-			Type *index_type = expr_type->EnumeratedArray.index;
-			if (compare_exact_values(Token_NotEq, *expr_type->EnumeratedArray.min_value, exact_value_u64(0))) {
-				idx = lb_emit_arith(p, Token_Add, idx, lb_const_value(m, index_type, *expr_type->EnumeratedArray.min_value), index_type);
-			}
+		}
+		// NOTE(bill): Override the idx value for the enumeration
+		// this does not depend on the value operand, which may be blank
+		Type *index_type = expr_type->EnumeratedArray.index;
+		if (compare_exact_values(Token_NotEq, *expr_type->EnumeratedArray.min_value, exact_value_u64(0))) {
+			idx = lb_emit_arith(p, Token_Add, idx, lb_const_value(m, index_type, *expr_type->EnumeratedArray.min_value), index_type);
 		}
 		break;
 	}


### PR DESCRIPTION
Iterating an enumerated array with a blank value operand binds the index variable to 0, 1, 2, … instead of the enum's own values:
```odin
E :: enum { Apple = 10, Banana = 11 }
t: [E]int
for v, e in t { fmt.print(int(e)) }   // 10 11   correct
for _, e in t { fmt.print(int(e)) }   // 0 1     wrong
```
fmt prints %!(BAD ENUM VALUE=0) and comparisons against enum constants fail, with no diagnostic. The same loop is right or wrong depending on whether its value operand is used.


Found by @mat888