### PR TITLE
check_matrix_type_hint: require the element type and layout to match

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -4215,8 +4215,9 @@ gb_internal Type *check_matrix_type_hint(Type *matrix, Type *type_hint) {
 		} else if (xt->kind == Type_Matrix && th->kind == Type_Matrix) {
 			if (!are_types_identical(xt->Matrix.elem, th->Matrix.elem)) {
 				// ignore
-			} if (xt->Matrix.row_count == th->Matrix.row_count &&
-			      xt->Matrix.column_count == th->Matrix.column_count) {
+			} else if (xt->Matrix.row_count == th->Matrix.row_count &&
+			           xt->Matrix.column_count == th->Matrix.column_count &&
+			           xt->Matrix.is_row_major == th->Matrix.is_row_major) {
 				return type_hint;
 			}
 		} else if (xt->kind == Type_Matrix && th->kind == Type_Array) {


### PR DESCRIPTION
The element-mismatch branch is an empty `// ignore`, so control falls into the dimension test regardless and the hint is returned as the expression's type. 

A `matrix[2,2]i32` is accepted as `matrix[2,2]f32` and its bits reinterpreted (1 becomes 1e-45). With an f64 hint the same 16-byte value is typed as a 32-byte matrix, and the extra 16 bytes are whatever follows it. Affects transpose, `hadamard_product` and `outer_product`.

The dimension test also never compared layout, so a `#row_major` value could adopt a column-major hint: squaring a matrix whose [0,1] is 2 returned 9, having read [1,0]. `is_row_major` is now part of the comparison.

Found by @mat888