### PR TITLE
struct layout: apply #max_field_align

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -4496,8 +4496,7 @@ gb_internal i64 type_align_of_internal(Type *t, TypePath *path) {
 		if (t->Struct.custom_min_field_align > 0) {
 			max = gb_max(max, t->Struct.custom_min_field_align);
 		}
-		if (t->Struct.custom_max_field_align != 0 &&
-		    t->Struct.custom_max_field_align > t->Struct.custom_min_field_align) {
+		if (t->Struct.custom_max_field_align != 0) {
 			max = gb_min(max, t->Struct.custom_max_field_align);
 		}
 		return max;
@@ -4567,7 +4566,7 @@ gb_internal i64 *type_set_offsets_of(Slice<Entity *> const &fields, bool is_pack
 			} else {
 				Type *t = fields[i]->type;
 				i64 align = gb_max(type_align_of_internal(t, &path), min_field_align);
-				if (max_field_align > min_field_align) {
+				if (max_field_align != 0) {
 					align = gb_min(align, max_field_align);
 				}
 				i64 size  = gb_max(type_size_of_internal(t, &path), 0);


### PR DESCRIPTION
Fixes #7281

Both layout sites guard the cap with a strict > against the minimum field alignment:

```cpp
if (max_field_align > min_field_align) {          // type_set_offsets_of
if (t->Struct.custom_max_field_align != 0 &&
    t->Struct.custom_max_field_align > t->Struct.custom_min_field_align) {   
```
`// type_align_of_internal 0` already means "unset" at both, so the second clause only excludes the case where the two are equal, which includes the default minimum, making #max_field_align(1) a no-op in every struct.

The two sites disagree. `type_set_offsets_of` normalizes the minimum to 1 first, so 1 > 1 fails and offsets are not capped; type_align_of_internal sees the un-normalized 0, so 1 > 0 holds and the alignment is capped. 

check_type.cpp separately validates min <= max and swaps them if not, so the strict comparison is not carrying that check.

Two things #7281 does not state, worth carrying over: the > appears at two sites that disagree, and the default minimum makes #max_field_align(1) a no-op everywhere.