### PR TITLE
check_builtin: don't clear the operand value on the simd success path

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -1968,7 +1968,7 @@ gb_internal bool check_builtin_simd_operation(CheckerContext *c, Operand *operan
 			for (unsigned i = 0; i < 4; i++) {
 				if (!is_type_integer(x[i].type) || x[i].mode != Addressing_Constant) {
 					gbString xs = type_to_string(x[i].type);
-					error(x[i].expr, "'%.*s' expected a constant integer", LIT(builtin_name), xs);
+					error(x[i].expr, "'%.*s' expected a constant integer, got '%s'", LIT(builtin_name), xs);
 					gb_string_free(xs);
 					return false;
 				}
@@ -2872,8 +2872,8 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 		if (!ok) {
 			operand->type = t_invalid;
 			operand->mode = Addressing_Value;
+			operand->value = {};
 		}
-		operand->value = {};
 		operand->expr = call;
 		return ok;
 	}


### PR DESCRIPTION
Fixes the following repro:

```odin
package repro

import "base:intrinsics"

// _MM_SHUFFLE(3,2,1,0) is (3<<6)|(2<<4)|(1<<2)|0 == 228.
V :: intrinsics.simd_x86__MM_SHUFFLE(3, 2, 1, 0)

f :: proc() {
	v: [V]u8
	#assert(len(v) == 0)      // HOLDS. The value was wiped; 228 fails.
}
```
