### PR TITLE
Fixes non_zero_append_elem_fixed_capacity_string

### DIFF
--- a/base/runtime/core_builtin.odin
+++ b/base/runtime/core_builtin.odin
@@ -921,7 +921,7 @@ non_zero_append_elem_string :: proc(#no_alias array: ^$T/[dynamic]$E/u8, arg: $A
 // Note: Prefer using the procedure group `non_zero_append`.
 @builtin
 non_zero_append_elem_fixed_capacity_string :: proc "contextless" (array: ^$T/[dynamic; $N]$E/u8, arg: $A/string) -> (num_appended: int) {
-	return append_fixed_capacity_elem(array, transmute([]byte)arg)
+	return append_fixed_capacity_elems(array, ..transmute([]E)arg)
 }
 
 


### PR DESCRIPTION
Fixes non_zero_append_elem_fixed_capacity_string / non_zero_append of string bytes to a fixed capacity dynamic array.

```odin
package main

import "core:fmt"

main :: proc() {
	buf: [dynamic; 16]u8
	n := non_zero_append(&buf, "sup")   // 
	fmt.printfln("buf=%q len=%v", string(buf[:]), len(buf))
}
```

```
Error: Cannot assign value 'transmute([]E)arg' of type '[]u8' to 'u8' in a procedure argument 
        return append_fixed_capacity_elems(array, transmute([]E)arg) 
```