### PR TITLE
Fixes f32 to 64-bit int/uint conversion

### DIFF
--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -2546,7 +2546,9 @@ gb_internal lbValue lb_emit_conv(lbProcedure *p, lbValue value, Type *t) {
 			lbValue res_i128 = lb_emit_runtime_call(p, call, args);
 			return lb_emit_conv(p, res_i128, t);
 		}
-		i64 sz = type_size_of(src);
+		// the intermediate int must be at least as wide as the dest,
+		// otherwise e.g. f32 -> u64 truncates through a 32-bit fptoui
+		i64 sz = gb_max(type_size_of(src), type_size_of(dst));
 
 		lbValue res = {};
 		res.type = t;


### PR DESCRIPTION
Conversion from f32 to larger int/uint types goes through 32-bit integers, so any float that won't fit in the 32-bit int gets mangled.

```odin
package main

import "core:fmt"
import "core:os"

f32_to_u64 :: #force_no_inline proc(f: f32) -> u64 { return u64(f) }
f32_to_i64 :: #force_no_inline proc(f: f32) -> i64 { return i64(f) }
f64_to_u64 :: #force_no_inline proc(f: f64) -> u64 { return u64(f) }
f64_to_i64 :: #force_no_inline proc(f: f64) -> i64 { return i64(f) }

main :: proc() {
	// 1e10, exactly representable in f32 and well above max(u32)
	f := f32(1e10) + f32(len(os.args))  // runtime dependent so it isnt't folded

	u := f32_to_u64(f)
	u_ref := f64_to_u64(f64(f))
	i := f32_to_i64(f)
	i_ref := f64_to_i64(f64(f))

	fmt.printfln("input f32: %.1f", f)
	fmt.printfln("u64(f): %d, must be: %d", u, u_ref)    // converts to 1410065408
	fmt.printfln("i64(f): %d, must be: %d", i, i_ref)       // converts to -2147483648
}
```

IR now (for f32_to_u64) :
```
    %1 = fptoui float %0 to i32
    %2 = zext i32 %1 to i64
```

IR after the fix:
`    %1 = fptoui float %0 to i64`

So this also doubles as optimization, cause we get rid of the redundant zext/sext. :)