### PR TITLE
vendor/sdl3: wasm foreign import library configurable

### DIFF
--- a/vendor/sdl3/sdl3__foreign.odin
+++ b/vendor/sdl3/sdl3__foreign.odin
@@ -1,6 +1,10 @@
 package sdl3
 
-when ODIN_OS == .Windows {
+SDL3_WASM_LIB :: #config(SDL3_WASM_LIB, "env.o")
+
+when ODIN_ARCH == .wasm32 || ODIN_ARCH == .wasm64p32 {
+	@(export) foreign import lib { SDL3_WASM_LIB }
+} else when ODIN_OS == .Windows {
 	@(export) foreign import lib { "SDL3.lib" }
 } else {
 	@(export) foreign import lib { "system:SDL3" }

--- a/vendor/sdl3/ttf/sdl3_ttf.odin
+++ b/vendor/sdl3/ttf/sdl3_ttf.odin
@@ -4,7 +4,11 @@ package sdl3_ttf
 import "core:c"
 import SDL "vendor:sdl3"
 
-when ODIN_OS == .Windows {
+SDL3_TTF_WASM_LIB :: #config(SDL3_TTF_WASM_LIB, "env.o")
+
+when ODIN_ARCH == .wasm32 || ODIN_ARCH == .wasm64p32 {
+	foreign import lib { SDL3_TTF_WASM_LIB }
+} else when ODIN_OS == .Windows {
 	foreign import lib "SDL3_ttf.lib"
 } else {
 	foreign import lib "system:SDL3_ttf"


### PR DESCRIPTION
Make sdl3 and sdl3_ttf usable with emscripten `--use-port=sdl3 --use-port=sdl3_ttf` flags by using a path ending with `.o` so the compiler doesn't concatenate the module name with the symbols, mirroring the configurable `RAYLIB_WASM_LIB` in vendor:raylib

Previous wasm behaviour is recoverable with `-define:SDL3_WASM_LIB=system:SDL3`, but it could only ever produce a module that fails to instantiate