### PR TITLE
Fixes float to 128-bit int/uint conversion

### DIFF
--- a/base/runtime/LICENSE-compiler-rt.txt
+++ b/base/runtime/LICENSE-compiler-rt.txt
@@ -1,0 +1,313 @@
+The below LLVM license applies to `runtime.fixuint` and `runtime.fixint`.
+
+==============================================================================
+The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:
+==============================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+---- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+
+==============================================================================
+Software from third parties included in the LLVM Project:
+==============================================================================
+The LLVM Project contains third party software which is under different license
+terms. All such code will be identified clearly using at least one of two
+mechanisms:
+1) It will be in a separate directory tree with its own `LICENSE.txt` or
+   `LICENSE` file at the top containing the specific license and restrictions
+   which apply to that software, or
+2) It will contain specific license and restriction terms at the top of every
+   file.
+
+==============================================================================
+Legacy LLVM License (https://llvm.org/docs/DeveloperPolicy.html#legacy):
+==============================================================================
+
+The compiler_rt library is dual licensed under both the University of Illinois
+"BSD-Like" license and the MIT license.  As a user of this code you may choose
+to use it under either license.  As a contributor, you agree to allow your code
+to be used under both.
+
+Full text of the relevant licenses is included below.
+
+==============================================================================
+
+University of Illinois/NCSA
+Open Source License
+
+Copyright (c) 2009-2019 by the contributors listed in CREDITS.TXT
+
+All rights reserved.
+
+Developed by:
+
+    LLVM Team
+
+    University of Illinois at Urbana-Champaign
+
+    http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimers in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the names of the LLVM Team, University of Illinois at
+      Urbana-Champaign, nor the names of its contributors may be used to
+      endorse or promote products derived from this Software without specific
+      prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.
+
+==============================================================================
+
+Copyright (c) 2009-2015 by the contributors listed in CREDITS.TXT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/base/runtime/internal_i128.odin
+++ b/base/runtime/internal_i128.odin
@@ -133,7 +133,7 @@ fixuint :: proc "contextless" ($U: typeid, a: f64) -> U where intrinsics.type_is
 // decompose the f64 into significand and exponent, shift the significand into place,
 // saturate out of range values
 @(private="file")
-fixint :: proc "contextless" ($T: typeid, a: f64) -> T where intrinsics.type_is_integer(T) && !intrinsics.type_is_unsigned(T) {
+fixint :: proc "contextless" ($T: typeid, a: f64) -> T where intrinsics.type_is_integer(T), !intrinsics.type_is_unsigned(T) {
 	BITS             :: 8 * size_of(T)
 	SIGNIFICAND_BITS :: 52
 	EXPONENT_BIAS    :: 1023

--- a/base/runtime/internal_i128.odin
+++ b/base/runtime/internal_i128.odin
@@ -92,9 +92,11 @@ floattidf_unsigned :: proc "c" (a: u128) -> f64 {
 
 
 // f64 -> unsigned integer conversion (truncating toward zero)
-// port of clang/compiler-rt's fp_fixuint_impl.inc;
 // decompose the f64 into significand and exponent, shift the significand into place,
 // saturate out of range values
+//
+// Uses parts of compiler-rt's [fp_fixuint_impl.inc](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/builtins/fp_fixuint_impl.inc), licensed under the [Apache License v2.0 with LLVM Exceptions](https://github.com/llvm/llvm-project/blob/main/compiler-rt/LICENSE.TXT).
+// For a copy of the license, see `LICENSE-compiler-rt.txt`.
 @(private="file")
 fixuint :: proc "contextless" ($U: typeid, a: f64) -> U where intrinsics.type_is_unsigned(U) {
 	BITS             :: 8 * size_of(U)
@@ -129,9 +131,11 @@ fixuint :: proc "contextless" ($U: typeid, a: f64) -> U where intrinsics.type_is
 }
 
 // f64 -> signed integer conversion (truncating toward zero)
-// port of clang/compiler-rt's fp_fixint_impl.inc;
 // decompose the f64 into significand and exponent, shift the significand into place,
 // saturate out of range values
+//
+// Uses parts of compiler-rt's [fp_fixuint_impl.inc](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/builtins/fp_fixuint_impl.inc), licensed under the [Apache License v2.0 with LLVM Exceptions](https://github.com/llvm/llvm-project/blob/main/compiler-rt/LICENSE.TXT).
+// For a copy of the license, see `LICENSE-compiler-rt.txt`.
 @(private="file")
 fixint :: proc "contextless" ($T: typeid, a: f64) -> T where intrinsics.type_is_integer(T), !intrinsics.type_is_unsigned(T) {
 	BITS             :: 8 * size_of(T)
@@ -257,4 +261,3 @@ divti3 :: proc "c" (a, b: i128) -> i128 {
 
 	return i128((udivmodti4(u128(an), u128(bn), nil) ~ u_s_a) - u_s_a) // negate if negative
 }
-

--- a/base/runtime/internal_i128.odin
+++ b/base/runtime/internal_i128.odin
@@ -91,22 +91,107 @@ floattidf_unsigned :: proc "c" (a: u128) -> f64 {
 }
 
 
+// f64 -> unsigned integer conversion (truncating toward zero)
+// port of clang/compiler-rt's fp_fixuint_impl.inc;
+// decompose the f64 into significand and exponent, shift the significand into place,
+// saturate out of range values
+@(private="file")
+fixuint :: proc "contextless" ($U: typeid, a: f64) -> U where intrinsics.type_is_unsigned(U) {
+	BITS             :: 8 * size_of(U)
+	SIGNIFICAND_BITS :: 52
+	EXPONENT_BIAS    :: 1023
+
+	IMPLICIT_BIT     :: (u64(1) << SIGNIFICAND_BITS)
+	SIGNIFICAND_MASK :: (IMPLICIT_BIT - 1)
+
+	// Break a into sign, exponent, significand parts.
+	a_rep := transmute(u64)a
+	negative := (a_rep >> 63) != 0
+	exponent := i32((a_rep >> SIGNIFICAND_BITS) & 0x7ff) - EXPONENT_BIAS
+	significand := (a_rep & SIGNIFICAND_MASK) | IMPLICIT_BIT
+
+	// If either the value or the exponent is negative, the result is zero.
+	if negative || exponent < 0 {
+		return 0
+	}
+
+	// If the value is too large for the integer type, saturate.
+	if exponent >= BITS {
+		return max(U)
+	}
+
+	// If 0 <= exponent < SIGNIFICAND_BITS, right shift to get the result.
+	// Otherwise, shift left.
+	if exponent < SIGNIFICAND_BITS {
+		return U(significand >> u32(SIGNIFICAND_BITS - exponent))
+	}
+	return U(significand) << u32(exponent - SIGNIFICAND_BITS)
+}
+
+// f64 -> signed integer conversion (truncating toward zero)
+// port of clang/compiler-rt's fp_fixint_impl.inc;
+// decompose the f64 into significand and exponent, shift the significand into place,
+// saturate out of range values
+@(private="file")
+fixint :: proc "contextless" ($T: typeid, a: f64) -> T where intrinsics.type_is_integer(T) && !intrinsics.type_is_unsigned(T) {
+	BITS             :: 8 * size_of(T)
+	SIGNIFICAND_BITS :: 52
+	EXPONENT_BIAS    :: 1023
+
+	IMPLICIT_BIT     :: (u64(1) << SIGNIFICAND_BITS)
+	SIGNIFICAND_MASK :: (IMPLICIT_BIT - 1)
+
+	// Break a into sign, exponent, significand parts.
+	a_rep := transmute(u64)a
+	negative := (a_rep >> 63) != 0
+	exponent := i32((a_rep >> SIGNIFICAND_BITS) & 0x7ff) - EXPONENT_BIAS
+	significand := (a_rep & SIGNIFICAND_MASK) | IMPLICIT_BIT
+
+	// If exponent is negative, the result is zero.
+	if exponent < 0 {
+		return 0
+	}
+
+	// If the value is too large for the integer type, saturate;
+	// (the only exactly representable value with exponent BITS-1 is min(T))
+	// this deviates from clang/compiler-rt (it instead wraps from BITS-1 to BITS,
+	// that is, f64(1 << 127) would wrap to min(i128) (for T=i128)),
+	// while this saturates consistently
+	if exponent >= BITS - 1 {
+		return min(T) if negative else max(T)
+	}
+
+	// If 0 <= exponent < SIGNIFICAND_BITS, right shift to get the result.
+	// Otherwise, shift left. After saturation the magnitude is below
+	// 1 << (BITS-1), so it fits in T and negation can't overflow
+	r: T
+	if exponent < SIGNIFICAND_BITS {
+		r = T(significand >> u32(SIGNIFICAND_BITS - exponent))
+	} else {
+		r = T(significand) << u32(exponent - SIGNIFICAND_BITS)
+	}
+	return -r if negative else r
+}
 
 @(link_name="__fixunsdfti", linkage=RUNTIME_LINKAGE, require=RUNTIME_REQUIRE)
-fixunsdfti :: #force_no_inline proc "c" (a: f64) -> u128 {
-	// TODO(bill): implement `fixunsdfti` correctly
-	x := u64(a)
-	return u128(x)
+fixunsdfti :: proc "c" (a: f64) -> u128 {
+	return fixuint(u128, a)
 }
 
 @(link_name="__fixunsdfdi", linkage=RUNTIME_LINKAGE, require=RUNTIME_REQUIRE)
-fixunsdfdi :: #force_no_inline proc "c" (a: f64) -> i128 {
-	// TODO(bill): implement `fixunsdfdi` correctly
-	x := i64(a)
-	return i128(x)
+fixunsdfdi :: proc "c" (a: f64) -> u64 {
+	return fixuint(u64, a)
 }
 
+@(link_name="__fixdfti", linkage=RUNTIME_LINKAGE, require=RUNTIME_REQUIRE)
+fixdfti :: proc "c" (a: f64) -> i128 {
+	return fixint(i128, a)
+}
 
+@(link_name="__fixdfdi", linkage=RUNTIME_LINKAGE, require=RUNTIME_REQUIRE)
+fixdfdi :: proc "c" (a: f64) -> i64 {
+	return fixint(i64, a)
+}
 
 
 @(link_name="__umodti3", linkage=RUNTIME_LINKAGE, require=RUNTIME_REQUIRE)
@@ -171,47 +256,5 @@ divti3 :: proc "c" (a, b: i128) -> i128 {
 	u_s_a := u128(s_a)
 
 	return i128((udivmodti4(u128(an), u128(bn), nil) ~ u_s_a) - u_s_a) // negate if negative
-}
-
-
-@(link_name="__fixdfti", linkage=RUNTIME_LINKAGE, require=RUNTIME_REQUIRE)
-fixdfti :: proc "c" (a: u64) -> i128 {
-	significandBits :: 52
-	typeWidth       :: (size_of(u64)*8)
-	exponentBits    :: (typeWidth - significandBits - 1)
-	maxExponent     :: ((1 << exponentBits) - 1)
-	exponentBias    :: (maxExponent >> 1)
-
-	implicitBit     :: (u64(1) << significandBits)
-	significandMask :: (implicitBit - 1)
-	signBit         :: (u64(1) << (significandBits + exponentBits))
-	absMask         :: (signBit - 1)
-	exponentMask    :: (absMask ~ significandMask)
-
-	// Break a into sign, exponent, significand
-	aRep := a
-	aAbs := aRep & absMask
-	sign := i128(-1 if aRep & signBit != 0 else 1)
-	exponent := u64((aAbs >> significandBits) - exponentBias)
-	significand := u64((aAbs & significandMask) | implicitBit)
-
-	// If exponent is negative, the result is zero.
-	if exponent < 0 {
-		return 0
-	}
-
-	// If the value is too large for the integer type, saturate.
-	if exponent >= size_of(i128) * 8 {
-		return max(i128) if sign == 1 else min(i128)
-	}
-
-	// If 0 <= exponent < significandBits, right shift to get the result.
-	// Otherwise, shift left.
-	if exponent < significandBits {
-		return sign * i128(significand >> (significandBits - exponent))
-	} else {
-		return sign * (i128(significand) << (exponent - significandBits))
-	}
-
 }
 

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -3982,7 +3982,7 @@ gb_internal void check_cast(CheckerContext *c, Operand *x, Type *type, bool forb
 				add_package_dependency(c, "runtime", "floattidf",          REQUIRE);
 			} else if (is_type_integer_128bit(dst) && is_type_float(src)) {
 				add_package_dependency(c, "runtime", "fixunsdfti",         REQUIRE);
-				add_package_dependency(c, "runtime", "fixunsdfdi",         REQUIRE);
+				add_package_dependency(c, "runtime", "fixdfti",            REQUIRE);
 			} else if (src == t_f16 && is_type_float(dst)) {
 				add_package_dependency(c, "runtime", "gnu_h2f_ieee",       REQUIRE);
 				add_package_dependency(c, "runtime", "extendhfsf2",        REQUIRE);

--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -2538,8 +2538,8 @@ gb_internal lbValue lb_emit_conv(lbProcedure *p, lbValue value, Type *t) {
 			TEMPORARY_ALLOCATOR_GUARD();
 
 			auto args = array_make<lbValue>(temporary_allocator(), 1);
-			args[0] = value;
-			char const *call = "fixunsdfdi";
+			args[0] = lb_emit_conv(p, value, t_f64);
+			char const *call = "fixdfti";
 			if (is_type_unsigned(dst)) {
 				call = "fixunsdfti";
 			}

--- a/tests/internal/test_128_float_conversion.odin
+++ b/tests/internal/test_128_float_conversion.odin
@@ -1,0 +1,48 @@
+package test_internal
+
+import "core:testing"
+
+// #force_no_inline so conversions are not folded;
+// they must go through the runtime __fixunsdfti/__fixdfti
+@(private="file") f64_to_u128 :: #force_no_inline proc(f: f64) -> u128 { return u128(f) }
+@(private="file") f64_to_i128 :: #force_no_inline proc(f: f64) -> i128 { return i128(f) }
+@(private="file") f32_to_u128 :: #force_no_inline proc(f: f32) -> u128 { return u128(f) }
+@(private="file") f32_to_i128 :: #force_no_inline proc(f: f32) -> i128 { return i128(f) }
+
+@test
+test_f64_to_u128 :: proc(t: ^testing.T) {
+	testing.expect_value(t, f64_to_u128(2.75), 2) // trunc toward 0
+	testing.expect_value(t, f64_to_u128(0.75), 0) // < 1
+	testing.expect_value(t, f64_to_u128(-3.5), 0) // negative to 0
+	testing.expect_value(t, f64_to_u128(f64(1 << 51)), u128(1) << 51) // significand shifts right
+	testing.expect_value(t, f64_to_u128(f64(1 << 52)), u128(1) << 52) // no shift
+	testing.expect_value(t, f64_to_u128(f64(1 << 53)), u128(1) << 53) // significand shifts left
+	testing.expect_value(t, f64_to_u128(1e19), 10_000_000_000_000_000_000)
+	testing.expect_value(t, f64_to_u128(f64(1 << 80)), u128(1) << 80) // > max(u64)
+	testing.expect_value(t, f64_to_u128(2 * f64(1 << 127)), max(u128)) // out of range saturates, implementation specific
+}
+
+@test
+test_f64_to_i128 :: proc(t: ^testing.T) {
+	testing.expect_value(t, f64_to_i128(-2.75), -2) // trunc toward 0
+	testing.expect_value(t, f64_to_i128(-0.75), 0)  // |f| < 1
+	testing.expect_value(t, f64_to_i128(1e19), 10_000_000_000_000_000_000) // > max(i64)
+	testing.expect_value(t, f64_to_i128(f64(-(1 << 80))), -(i128(1) << 80))
+	testing.expect_value(t, f64_to_i128(f64(1 << 126)), i128(1) << 126)
+	testing.expect_value(t, f64_to_i128(f64(min(i128))), min(i128)) // exact
+	// out of range saturates, implementation specific
+	testing.expect_value(t, f64_to_i128(f64(1 << 127)), max(i128))
+	testing.expect_value(t, f64_to_i128(2 * f64(1 << 127)), max(i128))
+}
+
+@test
+test_f32_to_u128 :: proc(t: ^testing.T) {
+	testing.expect_value(t, f32_to_u128(2.75), 2) // trunc toward 0
+	testing.expect_value(t, f32_to_u128(f32(1 << 80)), u128(1) << 80) // > max(u64)
+}
+
+@test
+test_f32_to_i128 :: proc(t: ^testing.T) {
+	testing.expect_value(t, f32_to_i128(-2.75), -2) // trunc toward 0
+	testing.expect_value(t, f32_to_i128(f32(-(1 << 80))), -(i128(1) << 80))
+}


### PR DESCRIPTION
As a followup of https://github.com/odin-lang/Odin/pull/7319, conversion to 128-bit integers also doesn't work, but apparently this was known (Bill's TODOs in internal_i128.odin)

```odin
package main

import "core:fmt"
import "core:os"

f64_to_u128 :: #force_no_inline proc(f: f64) -> u128 { return u128(f) }
f64_to_i128 :: #force_no_inline proc(f: f64) -> i128 { return i128(f) }
f32_to_u128 :: #force_no_inline proc(f: f32) -> u128 { return u128(f) }

main :: proc() {
	a64 := f64(len(os.args)) // prevent folding, 1.0 at runtime, not representable after addition below
	a32 := f32(len(os.args)) //

	f := f64(1 << 80) + a64  // 2^80, exact in f64, > max(u64)
	g := 1e19 + a64          // 10^19, exact in f64; > max(i64)
	h := f32(1 << 80) + a32  // 2^80, exact in f32

	fmt.printfln("u128(f64 2^80): %d, must be %d", f64_to_u128(f), u128(1) << 80)
	fmt.printfln("i128(f64 -2^80): %d, must be %d", f64_to_i128(-f), -(i128(1) << 80))
	fmt.printfln("i128(f64 1e19): %d, must be %d", f64_to_i128(g), i128(10_000_000_000_000_000_000))
	fmt.printfln("u128(f32 2^80): %d, must be %d", f32_to_u128(h), u128(1) << 80)
}
```

This implements the TODOs with direct port from clang (compiler-rt) [here](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/builtins/fp_fixuint_impl.inc) and [here](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/builtins/fp_fixint_impl.inc), with a small deviation in out of range behavior for signed conversion. I believe this one is more predictable, cause it saturates consistently, while clang's initially wraps on the first overflown bit, and just then saturates from the next bit ownwards.

Also adds a test.