### PR TITLE
fix bitfield intrinsic

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1446,11 +1446,13 @@ gb_internal bool is_type_ordered(Type *t) {
 	return false;
 }
 gb_internal bool is_type_ordered_numeric(Type *t) {
-	t = core_type(t);
+	t = base_type(t);
 	if (t == nullptr) { return false; }
 	switch (t->kind) {
 	case Type_Basic:
 		return (t->Basic.flags & BasicFlag_OrderedNumeric) != 0;
+	case Type_Enum:
+		return is_type_ordered_numeric(t->Enum.base_type);
 	}
 	return false;
 }


### PR DESCRIPTION
`is_type_ordered_numeric` used `core_type`, which unwraps a `bit_field` to its backing integer, while `is_type_numeric` uses `base_type` and stops at the `bit_field`. 

The fix treats a bit_field as the aggregate it is, so it consistently does _not_ report as numeric.

Before this change both of these pass:

```odin
BF :: bit_field u32 { a: u8 | 3 }
#assert( intrinsics.type_is_ordered_numeric(BF))
#assert(!intrinsics.type_is_numeric(BF))
```

base_type alone would have regressed enums, since core_type also unwraps Type_Enum. The added branch keeps that behaviour and mirrors is_type_numeric, which carries the same branch.

Ordering is unaffected: x < y on a bit_field still compiles and type_is_comparable is unchanged. 