### PR TITLE
i386: correct System V aggregate alignment and byval stack slots

### DIFF
--- a/src/llvm_abi.cpp
+++ b/src/llvm_abi.cpp
@@ -34,8 +34,11 @@ gb_internal lbArgType lb_arg_type_indirect(LLVMTypeRef type, LLVMAttributeRef at
 }
 
 gb_internal lbArgType lb_arg_type_indirect_byval(LLVMContextRef c, LLVMTypeRef type) {
-	i64 alignment = lb_alignof(type);
-	alignment = gb_max(alignment, 8);
+	// the outgoing stack slot, which i386 never over-aligns, not even for an over-aligned struct
+	i64 alignment = build_context.ptr_size;
+	if (build_context.metrics.arch != TargetArch_i386) {
+		alignment = gb_max(alignment, lb_alignof(type));
+	}
 
 	LLVMAttributeRef byval_attr = lb_create_enum_attribute_with_type(c, "byval", type);
 	LLVMAttributeRef align_attr = lb_create_enum_attribute(c, "align", alignment);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -4539,7 +4539,13 @@ gb_internal i64 type_align_of_internal(Type *t, TypePath *path) {
 
 	// NOTE(bill): Things that are bigger than build_context.ptr_size, are actually comprised of smaller types
 	// TODO(bill): Is this correct for 128-bit types (integers)?
-	return gb_clamp(next_pow2(type_size_of_internal(t, path)), 1, build_context.max_align);
+	i64 max_align = build_context.max_align;
+	if (build_context.metrics.arch == TargetArch_i386 &&
+	    build_context.metrics.os != TargetOs_windows) {
+		// the i386 System V psABI aligns every scalar to at most 4, unlike Windows
+		max_align = gb_min(max_align, 4);
+	}
+	return gb_clamp(next_pow2(type_size_of_internal(t, path)), 1, max_align);
 }
 
 gb_internal i64 *type_set_offsets_of(Slice<Entity *> const &fields, bool is_packed, bool is_raw_union, i64 min_field_align, i64 max_field_align) {


### PR DESCRIPTION
i386 emits `byval ... align 8` for every aggregate argument. That is the amd64 stack slot; i386's is 4, and the over-aligned slot gets four bytes of padding in front of it, shifting the aggregate and every argument after it.

Second commit: 64 bit scalar alignment on i386 System V

`align_of(i64)` and `align_of(f64)` were 8 on every i386 target. The i386 System V
psABI says 4; Windows says 8. 


