### PR TITLE
Fix out of bounds for zero arg `#load_directory`

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -2244,7 +2244,10 @@ gb_internal LoadDirectiveResult check_load_directory_directive(CheckerContext *c
 	String name = bd->name.string;
 	GB_ASSERT(name == "load_directory");
 
-	if (ce->args.count != 1) {
+	if (ce->args.count == 0) {
+		error(ce->close, "'#%.*s' expects 1 argument, got 0", LIT(name));
+		return LoadDirective_Error;
+	} else if (ce->args.count != 1) {
 		error(ce->args[0], "'#%.*s' expects 1 argument, got %td", LIT(name), ce->args.count);
 		return LoadDirective_Error;
 	}


### PR DESCRIPTION
Fixes #7299

Properly emits an error now

```go
package main

main :: proc() {
	w :=  #load_directory()
}
```

```cmd
> odin run main.odin -file
/home/cluster2/Projects/odin/OdinDebug/main.odin(4:24) Error: '#load_directory' expects 1 argument, got 0
	w :=  #load_directory()
	                      ^

```