### PR TITLE
Fix compilation error when using the fixed-point write procedure and -vet-unused

### DIFF
--- a/core/math/fixed/fixed.odin
+++ b/core/math/fixed/fixed.odin
@@ -148,7 +148,7 @@ write :: proc(dst: []byte, x: $T/Fixed($Backing, $Fraction_Width)) -> string {
 		}
 	}
 
-	n := copy(dst, buf[:i])
+	copy(dst, buf[:i])
 	return string(dst[:i])
 }
 


### PR DESCRIPTION
### Issue
Using the `write` procedure, or the `to_string` procedure, in package `core:math/fixed` causes an "unused variable" compilation error when compiling with `-vet` (or `-vet-unused`).

### Minimal example
```odin
package main

import "core:fmt"
import fp "core:math/fixed"

main :: proc() {
	a: fp.Fixed16_16
	fp.init_from_f64(&a, 3.14159)

	a_str := fp.to_string(a)
	fmt.println(a_str)
}
```
Results in:
```
$ odin build -file -vet a.odin
/odin/core/math/fixed/fixed.odin(151:2) Error: 'n' declared but not used 
	n := copy(dst, buf[:i]) 
	^ 
```

After the simple fix this builds correctly and prints:
```
$ ./a 
3.1415863037109375
```

### Platforms
I can verify this happens on both Linux and Windows.