### PR TITLE
Reenables LLVMSetUnnamedAddress for global constants merging

### DIFF
--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -3274,7 +3274,7 @@ gb_internal bool lb_generate_code(lbGenerator *gen) {
 			LLVMValueRef g = LLVMAddGlobal(m->mod, internal_llvm_type, LB_TYPE_INFO_DATA_NAME);
 			LLVMSetInitializer(g, LLVMConstNull(internal_llvm_type));
 			LLVMSetLinkage(g, USE_SEPARATE_MODULES ? LLVMExternalLinkage : LLVMInternalLinkage);
-			// LLVMSetUnnamedAddress(g, LLVMGlobalUnnamedAddr);
+			LLVMSetUnnamedAddress(g, LLVMGlobalUnnamedAddr);
 			LLVMSetGlobalConstant(g, true);
 
 			lbValue value = {};

--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -364,7 +364,7 @@ gb_internal void lb_loop_end(lbProcedure *p, lbLoopData const &data) {
 
 gb_internal void lb_make_global_private_const(LLVMValueRef global_data) {
 	LLVMSetLinkage(global_data, LLVMLinkerPrivateLinkage);
-	// LLVMSetUnnamedAddress(global_data, LLVMGlobalUnnamedAddr);
+	LLVMSetUnnamedAddress(global_data, LLVMGlobalUnnamedAddr);
 	LLVMSetGlobalConstant(global_data, true);
 }
 gb_internal void lb_make_global_private_const(lbAddr const &addr) {
@@ -3786,7 +3786,7 @@ gb_internal lbValue lb_generate_global_array(lbModule *m, Type *elem_type, i64 c
 	g.type = alloc_type_pointer(t);
 	LLVMSetInitializer(g.value, LLVMConstNull(lb_type(m, t)));
 	LLVMSetLinkage(g.value, LLVMPrivateLinkage);
-	// LLVMSetUnnamedAddress(g.value, LLVMGlobalUnnamedAddr);
+	LLVMSetUnnamedAddress(g.value, LLVMGlobalUnnamedAddr);
 	string_map_set(&m->members, s, g);
 	return g;
 }


### PR DESCRIPTION
LLVMSetUnnamedAddress has been commented out in three places in https://github.com/odin-lang/Odin/commit/fd6d7d412dbf666bbd10eddc98b04e1af3ef9f81. It looks like that commit was dealing with package/module/file names and I guess the commenting was for debugging purposes (to pin what originates where, or sth), but somehow ended in the commit and never got reverted.

LLVMSetUnnamedAddress tells LLVM "hey, I don't care about the actual address of this, you can deduplicate this constant and keep a single copy for all of its instances", which happens at the [constmerge pass](https://llvm.org/docs/Passes.html#constmerge-merge-duplicate-global-constants). 

So I did a quick before/after test on examples/demo.odin  (Win10, LLVM 20.1):
| Opt Level    | Without| With   | Shaved off|
|--------------|-----------|-----------|-----------------------|
| -o:minimal | 1,192,960 | 1,192,448 | 512 bytes   |
| -o:size    | 722,944   | 707,584   | 15,360 bytes (−2.1%) |
| -o:speed   | 722,944   | 707,584   | 15,360 bytes (−2.1%) |

Not bad for uncommenting three lines. (Note that the constmerge pass doesn't run at -o:minimal.)

**Storytime**
The most important of the three commented LLVMSetUnnamedAddress calls is in lb_make_global_private_const, which is used for string literals, generated globals, caller locations, among other stuff.

"Must be constant strings folding", you might be thinking about the size reduction. Well, at least that's my first thought. So I open demo.odin and have a glance. It's source code is around 65KB and it is heavily commented. A quick scroll is enough to ensure anyone there certainly can't be 15KB of duplicated strings in there. "Hmm, maybe some internal strings then"? Only one way to tell! (multiple ways, really, but, hey, boring truth can never stand in the way of drama! :)

So, I build _before_ and _after_ (at -o:size) and have a look at the IR. Ctrl-F "private constant" gives me ~5100 results in _before_ and "private unnamed_addr constant" gives me ~60 more (_before_ still has one surviving call to LLVMSetUnnamedAddress). In _after_ I get zero "private constant", but "private unnamed_addr constant" shows ~4440 results. We have more than 700 constants deduplicated. I scroll around, looking for string constants, and there are string constants like type info, error messages, etc. But I don't see a single duplicated string constant in _before_. Which is when my amnesia lifts and I recall the Odin compiler deduplicates string data per module (look up in lb_find_or_add_entity_string_ptr for the curious), and at -o:size and above the program is built as a single module. "A-ha!" This only intensifies the mystery.

Digging around more, I notice a bunch of blocks like this (more than 250 similar lines actually):
```
@"ggv$main::control_flow$1" = private constant %..string { ptr @"csbs$$cc8", i64 1 }
@"ggv$main::control_flow$2" = private constant %..string { ptr @"csbs$$cc8", i64 1 }
@"ggv$main::control_flow$3" = private constant %..string { ptr @"csbs$$cc8", i64 1 }
@"ggv$main::control_flow$4" = private constant %..string { ptr @"csbs$$cc8", i64 1 }
@"ggv$main::control_flow$5" = private constant %..string { ptr @"csbs$$cc8", i64 1 }
```
And "csbs$$cc8" is :
```
@"csbs$$cc8" = private constant [2 x i8] c" \00", align 1
```
While the ggv* constants are used like this (again, ~250 similar lines)
```
call fastcc void @"fmt::println"(ptr nonnull %351, ptr nonnull @"ggv$main::control_flow$1", ptr nonnull %__.context_ptr)
call fastcc void @"fmt::println"(ptr nonnull %351, ptr nonnull @"ggv$main::control_flow$2", ptr nonnull %__.context_ptr)
call fastcc void @"fmt::println"(ptr nonnull %351, ptr nonnull @"ggv$main::control_flow$3", ptr nonnull %__.context_ptr)
```
And here is how [fmt::println](https://pkg.odin-lang.org/core/fmt/#println) signature looks like
```odin
println :: proc(args: ..any, sep: string = " ", flush: bool = true) -> int {…}
```
(These are all the necessary elements of the puzzle, so puzzle fans can stop reading here and ponder it themselves :)

"csbs" is the prefix the compiler stamps on the names of constant strings, and "ggv" is for global generated (value?), also stamped by the compiler.

So what happens is " " is the default separator for fmt::println and it's symbol data is kept in the "csbs$$cc8" constant (once; remember, the compiler deduplicates string data at -o:size due to building as a single module). But every time when it is passed to a fmt::println call a new string typed constant global is issued, which wraps the " " (+ null terminator) symbols in a string struct. These are the ggv* guys above, and each of these is 16 bytes (ptr + len). Now, because this is Windows, structs of more than 8 bytes need to be passed by address, which means there must be an actual string struct somewhere in memory to get the address of, and the compiler happens to use the ggv constant for this. In this case this amasses to more than 250 such constants and > 250 * 16 = 4000 bytes. 

Once the backend has the knowledge that the specific address (name) of these doesn't matter (which we tell it with LLVMSetUnnamedAddress), these all disappear. Here is how these look in _after_:
```
@"ggv$main::arbitrary_precision_mathematics.print_bigint-0$6" = private unnamed_addr constant %..string { ptr @"csbs$$cc8", i64 1 }
```
```
  call fastcc void @"fmt::println"(ptr nonnull %351, ptr nonnull @"ggv$main::arbitrary_precision_mathematics.print_bigint-0$6", ptr nonnull %__.context_ptr)
  call fastcc void @"fmt::println"(ptr nonnull %351, ptr nonnull @"ggv$main::arbitrary_precision_mathematics.print_bigint-0$6", ptr nonnull %__.context_ptr)
  call fastcc void @"fmt::println"(ptr nonnull %351, ptr nonnull @"ggv$main::arbitrary_precision_mathematics.print_bigint-0$6", ptr nonnull %__.context_ptr)
```
As you can see all the global constant string structs have been collapsed to a single one (which happens to be called "ggv$main::arbitrary_precision_mathematics.print_bigint-0$6" :)


So the huge part of the deduplicated constants is string structs passed to procedures. In particular, in addition to the " " separator in println, there are around 280 cases of bounds check error handling passing the filename of the file of the call. With bounds checks disabled in build settings the table looks like this:

| Opt Level        | Without| With   | Shaved off               |
|--------------|-----------|-----------|---------------------|
| -o:minimal | 1,123,328 | 1,122,816 | 512 bytes             |
| -o:size    | 705,536   | 698,368   | 7,168 bytes (−1.0%)    |
| -o:speed   | 706,048   | 698,880   | 7,168 bytes (−1.0%)    |

(And in my own odin project, which builds in release mode at -o:speed with no bounds checks, I get ~19kb savings.)


I also tried this on my Linux machine, which does pass 2x8b structs in registers when possible, courtesy of the System V ABI using 2 more registers than the Windows ABI. The string struct constants wouldn't generally be needed there, but I still get ~2000 bytes less in -o:minimal (unlike the windows linker, the ELF linker merges the actual duplicated string data; remember, multiple modules at o:minimal, so no compiler deduplication of strings) and ~1000 bytes less in -o:size (single module, the compiler dedups, so reduction comes from constmerge).