### PR TITLE
intrinsics.type_integer_to_unsigned(rune) returns f16

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -6995,6 +6995,13 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 				return false;
 			}
 
+			if (bt->Basic.kind == Basic_rune) {
+				gbString t = type_to_string(operand->type);
+				error(operand->expr, "Type %s does not have an unsigned integer mapping for '%.*s'", t, LIT(builtin_name));
+				gb_string_free(t);
+				return false;
+			}
+
 			Type *u_type = &basic_types[bt->Basic.kind + 1];
 
 			operand->type = u_type;

--- a/tests/internal/test_intrinsics_integer_to.odin
+++ b/tests/internal/test_intrinsics_integer_to.odin
@@ -12,6 +12,18 @@ example_usage :: proc(#any_int x: int) -> intrinsics.type_integer_to_unsigned(ty
 
 @test
 test_intrinsic_integer_to :: proc(t: ^testing.T) {
+	testing.expect_value(t, typeid_of(intrinsics.type_integer_to_unsigned(i8)), typeid_of(u8))
+	testing.expect_value(t, typeid_of(intrinsics.type_integer_to_unsigned(i16)), typeid_of(u16))
+	testing.expect_value(t, typeid_of(intrinsics.type_integer_to_unsigned(i32)), typeid_of(u32))
+	testing.expect_value(t, typeid_of(intrinsics.type_integer_to_unsigned(i64)), typeid_of(u64))
+	testing.expect_value(t, typeid_of(intrinsics.type_integer_to_unsigned(i128)), typeid_of(u128))
+
+	testing.expect_value(t, typeid_of(intrinsics.type_integer_to_signed(u8)), typeid_of(i8))
+	testing.expect_value(t, typeid_of(intrinsics.type_integer_to_signed(u16)), typeid_of(i16))
+	testing.expect_value(t, typeid_of(intrinsics.type_integer_to_signed(u32)), typeid_of(i32))
+	testing.expect_value(t, typeid_of(intrinsics.type_integer_to_signed(u64)), typeid_of(i64))
+	testing.expect_value(t, typeid_of(intrinsics.type_integer_to_signed(u128)), typeid_of(i128))
+
 	testing.expect_value(t, typeid_of(intrinsics.type_integer_to_unsigned(i16le)), typeid_of(u16le))
 	testing.expect_value(t, typeid_of(intrinsics.type_integer_to_unsigned(i32le)), typeid_of(u32le))
 	testing.expect_value(t, typeid_of(intrinsics.type_integer_to_unsigned(i64le)), typeid_of(u64le))


### PR DESCRIPTION
Fixes the following repro:
```odin
package a
import "base:intrinsics"

U :: intrinsics.type_integer_to_unsigned(rune)

#assert(U == f16)          // passes
#assert(size_of(U) == 2)   // passes
```