### PR TITLE
Add non-allocating hex.decode_into_buffer

### DIFF
--- a/core/encoding/hex/hex.odin
+++ b/core/encoding/hex/hex.odin
@@ -95,12 +95,12 @@ Decodes a hex sequence into a byte slice
 *Allocates Using Provided Allocator*
 
 Inputs:
-- dst: The hex sequence decoded into bytes
 - src: The `[]byte` to be hex-decoded
 - allocator: (default: context.allocator)
 - loc: The caller location for debugging purposes (default: #caller_location)
 
 Returns:
+- dst: The hex sequence decoded into bytes
 - ok:  A bool, `true` if decoding succeeded, `false` otherwise
 */
 decode :: proc(src: []byte, allocator := context.allocator, loc := #caller_location) -> (dst: []byte, ok: bool) {
@@ -121,6 +121,40 @@ decode :: proc(src: []byte, allocator := context.allocator, loc := #caller_locat
 	}
 
 	return dst, true
+}
+
+/*
+Decodes a hex sequence into a byte slice
+
+Inputs:
+- src: The `[]byte` to be hex-decoded
+- buf: A buffer large enough to hold the decoded sequence
+
+Returns:
+- dst: The hex sequence decoded into bytes
+- ok:  A bool, `true` if decoding succeeded, `false` otherwise
+*/
+decode_into_buffer :: proc(src: []byte, buf: []byte) -> (dst: []byte, ok: bool) #optional_ok {
+	if len(src) % 2 == 1 {
+		return
+	}
+	dst_len := len(src) / 2
+	if len(buf) < dst_len {
+		return
+	}
+
+	#no_bounds_check for i, j := 0, 1; j < len(src); j += 2 {
+		p := src[j-1]
+		q := src[j]
+
+		a := hex_digit(p) or_return
+		b := hex_digit(q) or_return
+
+		buf[i] = (a << 4) | b
+		i += 1
+	}
+
+	return buf[:dst_len], true
 }
 
 /*

--- a/tests/core/encoding/hex/test_core_hex.odin
+++ b/tests/core/encoding/hex/test_core_hex.odin
@@ -48,6 +48,60 @@ hex_decode :: proc(t: ^testing.T) {
 }
 
 @(test)
+hex_decode_into_buffer :: proc(t: ^testing.T) {
+	for test in CASES {
+		buffer := make([]u8, len(test[1]) / 2)
+		defer delete(buffer)
+		decoded, ok := hex.decode_into_buffer(transmute([]byte)test[1], buffer)
+		testing.expect(t, ok, "decode_into_buffer: not ok")
+		testing.expectf(
+			t,
+			ok,
+			"decode: %q not ok",
+			test[1],
+		)
+		testing.expectf(
+			t,
+			string(decoded) == test[0],
+			"decode: %q -> %q (should be: %q)",
+			test[1],
+			string(decoded),
+			test[0],
+		)
+	}
+
+	// destination buffer is larger
+	for test in CASES {
+		buffer := make([]u8, len(test[1]) / 2 + 1)
+		defer delete(buffer)
+		decoded, ok := hex.decode_into_buffer(transmute([]byte)test[1], buffer)
+		testing.expect(t, ok, "decode_into_buffer: not ok")
+		testing.expectf(
+			t,
+			ok,
+			"decode: %q not ok",
+			test[1],
+		)
+		testing.expectf(
+			t,
+			string(decoded) == test[0],
+			"decode: %q -> %q (should be: %q)",
+			test[1],
+			string(decoded),
+			test[0],
+		)
+	}
+
+	// destination buffer is too small
+	for test in CASES {
+		buffer := make([]u8, len(test[1]) / 2 - 1)
+		defer delete(buffer)
+		_, ok := hex.decode_into_buffer(transmute([]byte)test[1], buffer)
+		testing.expect(t, !ok, "decode_into_buffer: should not be ok")
+	}
+}
+
+@(test)
 hex_decode_sequence :: proc(t: ^testing.T) {
 	b, ok := hex.decode_sequence("0x23")
 	testing.expect(t, ok, "decode_sequence: 0x23 not ok")


### PR DESCRIPTION
core:encoding/hex currently only provides an allocating decode() procedure. This PR adds a non-allocating version, using a buffer provided by the caller, along with a test which covers a destination buffer of the correct size, larger, and too small.

I'm also using `#optional_ok` for the new procedure -- I'm not sure Odin's standard yet about when to use this or not use this, so please let me know.

The documentation for the existing hex.decode() was slightly inaccurate in its description of parameters versus return values, so I fixed that as well.
