### PR TITLE
improved stable sort | from insertion_sort to merge_rotate

### DIFF
--- a/core/slice/sort_private.odin
+++ b/core/slice/sort_private.odin
@@ -15,7 +15,7 @@ Sort_Kind :: enum {
 
 _stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) where (ORD(E) && KIND == .Ordered) || (KIND != .Ordered) #no_bounds_check {
 	less :: #force_inline proc(a, b: E, call: P) -> bool {
-		when KIND == .Ordered {
+	when KIND == .Ordered {
 			return a < b
 		} else when KIND == .Less {
 			return call(a, b)
@@ -29,21 +29,21 @@ _stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) where (O
 	merge_rotate(data, call)
 
 	insertion_sort :: proc(data: T, call: P){
-        for i in 1..<len(data) {
-            j := i
-            temp := data[j]
-            for ; j > 0 && less(temp, data[j - 1], call); j -= 1 {
-                data[j] = data[j - 1]
-            }
-            data[j] = temp
-        }
-    }
+		for i in 1..<len(data) {
+			j := i
+			temp := data[j]
+			for ; j > 0 && less(temp, data[j - 1], call); j -= 1 {
+				data[j] = data[j - 1]
+			}
+			data[j] = temp
+		}
+	}
 
 	merge_rotate :: proc(data: T, call: P){
-        if len(data) <= 200 {
-            insertion_sort(data, call)
-            return
-        }
+		if len(data) <= 200 {
+			insertion_sort(data, call)
+			return
+		}
 
 		mid := len(data) / 2
 		merge_rotate(data[:mid], call)
@@ -51,7 +51,7 @@ _stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) where (O
 
 		merge(data, mid, len(data) - mid, call)
 	}
-    
+
 	bin_search_left :: proc(data:T, value: E, call: P) -> int{
 		from := 0
 		len := len(data)
@@ -75,10 +75,10 @@ _stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) where (O
 		len := len(data)
 
 		for len > 0 {
-			half := len / 2
-			mid := from + half
+		half := len / 2
+		mid := from + half
 
-			if less(value, data[mid], call){
+		if less(value, data[mid], call){
 				len = half
 			} else {
 				from = mid + 1
@@ -90,32 +90,32 @@ _stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) where (O
 
 	merge :: proc(data: T, left, right: int, call: P) {
 		if left == 0 || right == 0 {
-            return
-        }
+			return
+		}
 
 		if left + right == 2 {
 			if less(data[1],data[0], call) {
-                data[1], data[0] = data[0], data[1]
-            }
+				data[1], data[0] = data[0], data[1]
+			}
 			return
 		} 
 
 		first_cut, second_cut : int
 		left2, right2 : int
 		if left > right {
-			left2 = left / 2
-			first_cut = left2
+				left2 = left / 2
+				first_cut = left2
 
-			second_cut = left + bin_search_left(data[left:], data[first_cut], call)
-			right2 = second_cut - left
-		} else {
-			right2 = right / 2
-			second_cut = left + right2
+				second_cut = left + bin_search_left(data[left:], data[first_cut], call)
+				right2 = second_cut - left
+			} else {
+				right2 = right / 2
+				second_cut = left + right2
 
-			first_cut = bin_search_right(data[:left], data[second_cut], call)
-			left2 = first_cut
+				first_cut = bin_search_right(data[:left], data[second_cut], call)
+				left2 = first_cut
 		}
-		
+
 		rotate_left(data[first_cut:second_cut], left - first_cut)
 		new_mid := first_cut + right2
 

--- a/core/slice/sort_private.odin
+++ b/core/slice/sort_private.odin
@@ -104,17 +104,17 @@ _stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) where (O
 		left2, right2: int
 
 		if left > right {
-				left2 = left / 2
-				first_cut = left2
+			left2 = left / 2
+			first_cut = left2
 
-				second_cut = left + bin_search_left(data[left:], data[first_cut], call)
-				right2 = second_cut - left
-			} else {
-				right2 = right / 2
-				second_cut = left + right2
+			second_cut = left + bin_search_left(data[left:], data[first_cut], call)
+			right2 = second_cut - left
+		} else {
+			right2 = right / 2
+			second_cut = left + right2
 
-				first_cut = bin_search_right(data[:left], data[second_cut], call)
-				left2 = first_cut
+			first_cut = bin_search_right(data[:left], data[second_cut], call)
+			left2 = first_cut
 		}
 
 		rotate_left(data[first_cut:second_cut], left - first_cut)

--- a/core/slice/sort_private.odin
+++ b/core/slice/sort_private.odin
@@ -40,7 +40,7 @@ _stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) where (O
     }
 
 	merge_rotate :: proc(data: T, call: P){
-        if len(data) <= 64 {
+        if len(data) <= 200 {
             insertion_sort(data, call)
             return
         }

--- a/core/slice/sort_private.odin
+++ b/core/slice/sort_private.odin
@@ -15,7 +15,7 @@ Sort_Kind :: enum {
 
 _stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) where (ORD(E) && KIND == .Ordered) || (KIND != .Ordered) #no_bounds_check {
 	less :: #force_inline proc(a, b: E, call: P) -> bool {
-	when KIND == .Ordered {
+		when KIND == .Ordered {
 			return a < b
 		} else when KIND == .Less {
 			return call(a, b)
@@ -28,7 +28,7 @@ _stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) where (O
 
 	merge_rotate(data, call)
 
-	insertion_sort :: proc(data: T, call: P){
+	insertion_sort :: proc(data: T, call: P) {
 		for i in 1..<len(data) {
 			j := i
 			temp := data[j]
@@ -39,7 +39,7 @@ _stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) where (O
 		}
 	}
 
-	merge_rotate :: proc(data: T, call: P){
+	merge_rotate :: proc(data: T, call: P) {
 		if len(data) <= 200 {
 			insertion_sort(data, call)
 			return
@@ -52,39 +52,39 @@ _stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) where (O
 		merge(data, mid, len(data) - mid, call)
 	}
 
-	bin_search_left :: proc(data:T, value: E, call: P) -> int{
-		from := 0
-		len := len(data)
+	bin_search_left :: proc(data: T, value: E, call: P) -> (from: int) {
+		n := len(data)
 
-		for len > 0 {
-			half := len / 2
+		for n > 0 {
+			half := n / 2
 			mid := from + half
 
-			if less(data[mid], value, call){
+			if less(data[mid], value, call) {
 				from = mid + 1
-				len -= half + 1
+				n -= half + 1
 			} else {
-				len = half
+				n = half
 			}
 		}
+
 		return from
 	}
 
-	bin_search_right :: proc(data: T, value: E, call: P) -> int {
-		from := 0
-		len := len(data)
+	bin_search_right :: proc(data: T, value: E, call: P) -> (from: int) {
+		n := len(data)
 
-		for len > 0 {
-		half := len / 2
+		for n > 0 {
+		half := n / 2
 		mid := from + half
 
-		if less(value, data[mid], call){
-				len = half
+		if less(value, data[mid], call) {
+				n = half
 			} else {
 				from = mid + 1
-				len -= half + 1
+				n -= half + 1
 			}
 		}
+
 		return from
 	}
 
@@ -94,14 +94,15 @@ _stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) where (O
 		}
 
 		if left + right == 2 {
-			if less(data[1],data[0], call) {
+			if less(data[1], data[0], call) {
 				data[1], data[0] = data[0], data[1]
 			}
 			return
 		} 
 
-		first_cut, second_cut : int
-		left2, right2 : int
+		first_cut, second_cut: int
+		left2, right2: int
+
 		if left > right {
 				left2 = left / 2
 				first_cut = left2
@@ -119,8 +120,8 @@ _stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) where (O
 		rotate_left(data[first_cut:second_cut], left - first_cut)
 		new_mid := first_cut + right2
 
-		merge(data[:new_mid], left2,      right2,       call)
-		merge(data[new_mid:], left-left2, right-right2, call)
+		merge(data[:new_mid], left2       , right2        , call)
+		merge(data[new_mid:], left - left2, right - right2, call)
 	}
 }
 

--- a/core/slice/sort_private.odin
+++ b/core/slice/sort_private.odin
@@ -13,7 +13,7 @@ Sort_Kind :: enum {
 	Cmp,
 }
 
-_stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) {
+_stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) where (ORD(E) && KIND == .Ordered) || (KIND != .Ordered) #no_bounds_check {
 	less :: #force_inline proc(a, b: E, call: P) -> bool {
 		when KIND == .Ordered {
 			return a < b

--- a/core/slice/sort_private.odin
+++ b/core/slice/sort_private.odin
@@ -74,10 +74,10 @@ _stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) where (O
 		n := len(data)
 
 		for n > 0 {
-		half := n / 2
-		mid := from + half
+			half := n / 2
+			mid := from + half
 
-		if less(value, data[mid], call) {
+			if less(value, data[mid], call) {
 				n = half
 			} else {
 				from = mid + 1

--- a/core/slice/sort_private.odin
+++ b/core/slice/sort_private.odin
@@ -116,7 +116,7 @@ _stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) {
 			left2 = first_cut
 		}
 		
-		slice.rotate_left(data[first_cut:second_cut], left - first_cut)
+		rotate_left(data[first_cut:second_cut], left - first_cut)
 		new_mid := first_cut + right2
 
 		merge(data[:new_mid], left2,      right2,       call)

--- a/core/slice/sort_private.odin
+++ b/core/slice/sort_private.odin
@@ -13,7 +13,7 @@ Sort_Kind :: enum {
 	Cmp,
 }
 
-_stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) where (ORD(E) && KIND == .Ordered) || (KIND != .Ordered) #no_bounds_check {
+_stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) {
 	less :: #force_inline proc(a, b: E, call: P) -> bool {
 		when KIND == .Ordered {
 			return a < b
@@ -25,14 +25,102 @@ _stable_sort_general :: proc(data: $T/[]$E, call: $P, $KIND: Sort_Kind) where (O
 			#panic("unhandled Sort_Kind")
 		}
 	}
-	
-	// insertion sort
-	// TODO(bill): use a different algorithm as insertion sort is O(n^2)
-	n := len(data)
-	for i in 1..<n {
-		for j := i; j > 0 && less(data[j], data[j-1], call); j -= 1 {
-			swap(data, j, j-1)
+
+	merge_rotate(data, call)
+
+	insertion_sort :: proc(data: T, call: P){
+        for i in 1..<len(data) {
+            j := i
+            temp := data[j]
+            for ; j > 0 && less(temp, data[j - 1], call); j -= 1 {
+                data[j] = data[j - 1]
+            }
+            data[j] = temp
+        }
+    }
+
+	merge_rotate :: proc(data: T, call: P){
+        if len(data) <= 64 {
+            insertion_sort(data, call)
+            return
+        }
+
+		mid := len(data) / 2
+		merge_rotate(data[:mid], call)
+		merge_rotate(data[mid:], call)
+
+		merge(data, mid, len(data) - mid, call)
+	}
+    
+	bin_search_left :: proc(data:T, value: E, call: P) -> int{
+		from := 0
+		len := len(data)
+
+		for len > 0 {
+			half := len / 2
+			mid := from + half
+
+			if less(data[mid], value, call){
+				from = mid + 1
+				len -= half + 1
+			} else {
+				len = half
+			}
 		}
+		return from
+	}
+
+	bin_search_right :: proc(data: T, value: E, call: P) -> int {
+		from := 0
+		len := len(data)
+
+		for len > 0 {
+			half := len / 2
+			mid := from + half
+
+			if less(value, data[mid], call){
+				len = half
+			} else {
+				from = mid + 1
+				len -= half + 1
+			}
+		}
+		return from
+	}
+
+	merge :: proc(data: T, left, right: int, call: P) {
+		if left == 0 || right == 0 {
+            return
+        }
+
+		if left + right == 2 {
+			if less(data[1],data[0], call) {
+                data[1], data[0] = data[0], data[1]
+            }
+			return
+		} 
+
+		first_cut, second_cut : int
+		left2, right2 : int
+		if left > right {
+			left2 = left / 2
+			first_cut = left2
+
+			second_cut = left + bin_search_left(data[left:], data[first_cut], call)
+			right2 = second_cut - left
+		} else {
+			right2 = right / 2
+			second_cut = left + right2
+
+			first_cut = bin_search_right(data[:left], data[second_cut], call)
+			left2 = first_cut
+		}
+		
+		slice.rotate_left(data[first_cut:second_cut], left - first_cut)
+		new_mid := first_cut + right2
+
+		merge(data[:new_mid], left2,      right2,       call)
+		merge(data[new_mid:], left-left2, right-right2, call)
 	}
 }
 

--- a/tests/core/slice/test_core_slice.odin
+++ b/tests/core/slice/test_core_slice.odin
@@ -141,6 +141,51 @@ test_sort_by_indices :: proc(t: ^testing.T) {
 }
 
 @test
+test_sort_stability :: proc(t: ^testing.T) {
+	// Test sizes are all prime.
+	test_sizes :: []int{7, 13, 347, 1031, 10111, 100003}
+    Data :: struct {
+        rand: int,
+        index: int,
+    }
+
+	for test_size in test_sizes {
+		rand.reset(t.seed)
+
+		vals  := make([]Data, test_size)
+		defer {
+			delete(vals)
+		}
+
+		// Set up test values
+		for _, i in vals {
+			vals[i].rand = rand.int_max(10)
+			vals[i].index = i
+		}
+
+		// Sort
+		slice.stable_sort_by(vals, proc(l, r: Data) -> bool {return l.rand < r.rand})
+
+		// Verify sorted test values
+		rand.reset(t.seed)
+
+        for i in 1..<len(vals) {
+            if vals[i - 1].rand < vals[i].rand {
+                continue
+            }
+            if vals[i - 1].rand > vals[i].rand {
+	            testing.expect(t, false, "Expected slice to be sorted")
+            }
+            if vals[i - 1].index > vals[i].index {
+	            testing.expect(t, false, "Expected slice to be stable")
+            }
+        }
+
+	}
+}
+
+
+@test
 test_binary_search :: proc(t: ^testing.T) {
 	index: int
 	found: bool

--- a/tests/core/slice/test_core_slice.odin
+++ b/tests/core/slice/test_core_slice.odin
@@ -169,17 +169,21 @@ test_sort_stability :: proc(t: ^testing.T) {
 		// Verify sorted test values
 		rand.reset(t.seed)
 
+        sum := vals[0].index
         for i in 1..<len(vals) {
-            if vals[i - 1].rand < vals[i].rand {
-                continue
-            }
-            if vals[i - 1].rand > vals[i].rand {
+            sum += vals[i].index
+            if vals[i-1].rand > vals[i].rand {
 	            testing.expect(t, false, "Expected slice to be sorted")
             }
-            if vals[i - 1].index > vals[i].index {
+            if vals[i-1].rand < vals[i].rand {
+                continue
+            }
+            if vals[i-1].index > vals[i].index {
 	            testing.expect(t, false, "Expected slice to be stable")
             }
         }
+
+        testing.expect(t, sum == test_size * (test_size - 1) / 2, "Expected slice to have all indecies")
 
 	}
 }

--- a/tests/core/slice/test_core_slice.odin
+++ b/tests/core/slice/test_core_slice.odin
@@ -153,14 +153,11 @@ test_sort_stability :: proc(t: ^testing.T) {
 		rand.reset(t.seed)
 
 		vals  := make([]Data, test_size)
-		defer {
-			delete(vals)
-		}
+		defer delete(vals)
 
 		// Set up test values
-		for _, i in vals {
-			vals[i].rand = rand.int_max(10)
-			vals[i].index = i
+		for &val, i in vals {
+			val = {rand.int_max(10), i}
 		}
 
 		// Sort
@@ -172,13 +169,13 @@ test_sort_stability :: proc(t: ^testing.T) {
 		sum := vals[0].index
 		for i in 1..<len(vals) {
 			sum += vals[i].index
-			if vals[i-1].rand > vals[i].rand {
+			if vals[i - 1].rand > vals[i].rand {
 				testing.expect(t, false, "Expected slice to be sorted")
 			}
-			if vals[i-1].rand < vals[i].rand {
+			if vals[i - 1].rand < vals[i].rand {
 				continue
 			}
-			if vals[i-1].index > vals[i].index {
+			if vals[i - 1].index > vals[i].index {
 				testing.expect(t, false, "Expected slice to be stable")
 			}
 		}

--- a/tests/core/slice/test_core_slice.odin
+++ b/tests/core/slice/test_core_slice.odin
@@ -144,10 +144,10 @@ test_sort_by_indices :: proc(t: ^testing.T) {
 test_sort_stability :: proc(t: ^testing.T) {
 	// Test sizes are all prime.
 	test_sizes :: []int{7, 13, 347, 1031, 10111, 100003}
-    Data :: struct {
-        rand: int,
-        index: int,
-    }
+	Data :: struct {
+		rand: int,
+		index: int,
+	}
 
 	for test_size in test_sizes {
 		rand.reset(t.seed)
@@ -169,21 +169,21 @@ test_sort_stability :: proc(t: ^testing.T) {
 		// Verify sorted test values
 		rand.reset(t.seed)
 
-        sum := vals[0].index
-        for i in 1..<len(vals) {
-            sum += vals[i].index
-            if vals[i-1].rand > vals[i].rand {
-	            testing.expect(t, false, "Expected slice to be sorted")
-            }
-            if vals[i-1].rand < vals[i].rand {
-                continue
-            }
-            if vals[i-1].index > vals[i].index {
-	            testing.expect(t, false, "Expected slice to be stable")
-            }
-        }
+		sum := vals[0].index
+		for i in 1..<len(vals) {
+			sum += vals[i].index
+			if vals[i-1].rand > vals[i].rand {
+				testing.expect(t, false, "Expected slice to be sorted")
+			}
+			if vals[i-1].rand < vals[i].rand {
+				continue
+			}
+			if vals[i-1].index > vals[i].index {
+				testing.expect(t, false, "Expected slice to be stable")
+			}
+		}
 
-        testing.expect(t, sum == test_size * (test_size - 1) / 2, "Expected slice to have all indecies")
+		testing.expect(t, sum == test_size * (test_size - 1) / 2, "Expected slice to have all indecies")
 
 	}
 }


### PR DESCRIPTION
this is an update to #6768
im a noob with git and that was on my master branch, so i accidently closed it

old implementation
---
insertion sort, n² algoritm, in-place

new implementation
---
merge_rotate, n * logn * logn, in-place

Memory_footprint
---
the temp variable in insertion_sort is the only stack allocation
```
insertion_sort :: proc(data: T, call: P){
      for i in 1..<len(data) {
          j := i
          temp := data[j]
          for ; j > 0 && less(temp, data[j - 1], call); j -= 1 {
              data[j] = data[j - 1]
          }
          data[j] = temp
      }
  }
  ```
if that is too much insertion sort could be changed back to the old way, that does a swap with buffer on big types, but would be much slower

```
n := len(data)
for i in 1..<n {
  for j := i; j > 0 && less(data[j], data[j-1], call); j -= 1 {
	  swap(data, j, j-1)
  }
}
```

other stack allocation is the recursion, but we always half the bigger part, so max depth is bounded by log2(n) * 2
  

Benchmarks
---
https://github.com/TheRadischen/odin-utils/blob/main/sort/new_stable_sort/test.odin
all times are measured in intrinsics.read_cycle_counter() / len(input)

```
16 bytes vs slice.sort_by
iterations: 10000 size: 10    new.stable_sort_by: 22 slice.sort_by: 70    diff:  3
iterations: 1000 size: 100    new.stable_sort_by: 105 slice.sort_by: 219    diff:  2
iterations: 100 size: 1000    new.stable_sort_by: 312 slice.sort_by: 362    diff:  1
iterations: 10 size: 10000    new.stable_sort_by: 572 slice.sort_by: 484    diff:  0
iterations: 2 size: 100000    new.stable_sort_by: 1110 slice.sort_by: 933    diff:  0

160 bytes vs slice.sort_by
iterations: 10000 size: 10    new.stable_sort_by: 18 slice.sort_by: 84    diff:  4
iterations: 1000 size: 100    new.stable_sort_by: 110 slice.sort_by: 279    diff:  2
iterations: 100 size: 1000    new.stable_sort_by: 364 slice.sort_by: 479    diff:  1
iterations: 10 size: 10000    new.stable_sort_by: 698 slice.sort_by: 658    diff:  0
iterations: 2 size: 100000    new.stable_sort_by: 1443 slice.sort_by: 1062    diff:  0

16 bytes vs old stable sort
iterations: 100 size: 10    new.stable_sort_by: 28 old.stable_sort_by: 14    diff:  0
iterations: 10 size: 100    new.stable_sort_by: 115 old.stable_sort_by: 193    diff:  1
iterations: 2 size: 1000    new.stable_sort_by: 323 old.stable_sort_by: 2043    diff:  6
iterations: 2 size: 10000    new.stable_sort_by: 566 old.stable_sort_by: 22795    diff:  40
```
