### PR TITLE
fix eol diagnostic

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -432,8 +432,10 @@ gb_internal isize show_error_on_line(TokenPos const &pos, TokenPos end) {
 		window_close_bytes = line_length_bytes;
 	}
 
-	for (i32 i = error_start_index_graphemes; i > 0; i -= 1) {
-		if (graphemes[i].byte_index == window_open_bytes) {
+	// counts the graphemes before the error. It must not read the one at it: an error at the
+	// end of a line indexes one past the last grapheme
+	for (i32 i = error_start_index_graphemes-1; i >= 0; i -= 1) {
+		if (graphemes[i].byte_index < window_open_bytes) {
 			break;
 		}
 		squiggle_padding += graphemes[i].width;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -113,6 +113,12 @@ gb_internal gbString get_file_line_as_string(TokenPos const &pos, i32 *offset_) 
 	if (len < offset) {
 		return nullptr;
 	}
+
+	// a column past the first cannot belong to a line the offset has already left
+	if (offset > 0 && pos.column > 1 && start[offset-1] == '\n') {
+		offset -= 1;
+	}
+
 	u8 *pos_offset = start+offset;
 
 	u8 *line_start = pos_offset;


### PR DESCRIPTION
Two bugs, the second only reachable once the first is fixed.

**1. A diagnostic positioned at EOL renders the *following* line.** `get_file_line_as_string` picks the line from `pos.offset`, while the printed `(line:column)` comes from `pos.line`/`pos.column`. For a token that ends a line those disagree: `offset` has already advanced one past the newline, so every downstream computation runs on the next line. The existing guard handles an offset landing *on* a newline, not one past it.

```odin
package eol
A :: 0h123
B :: A
```
```
a.odin(2:11) Syntax Error: Invalid hexadecimal float, expected 4, 8, or 16 digits, got 3
	B :: A          <- line 3, caret at its column 1; the offending text is never shown
	^
```

The fix trusts `line`/`column`, which are the fields actually printed: a column past the first cannot belong to a line the offset has already left.

**2. The caret was placed by an out-of-bounds read.** With the correct line rendered, the error sits at EOL. `error_start_index_graphemes == line_length_graphemes`, the padding loop started at exactly that index, one past the last grapheme. The value read there compared equal to `window_open_bytes` and broke the loop immediately, putting the caret at column 1.

Rewriting it to count the graphemes *before* the error also corrects a latent off-by-one: it summed widths `1..E` rather than `0..E-1`, which differ by `width[E] - width[0]`. 
