### PR TITLE
check_expr: range-check a constant passed to an `#any_int` parameter

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -6917,7 +6917,12 @@ gb_internal CallArgumentError check_call_arguments_internal(CheckerContext *c, A
 			bool ok = false;
 			if (e && (e->flags & EntityFlag_AnyInt)) {
 				if (o->mode != Addressing_Type && is_type_integer(param_type) && (is_type_integer(o->type) || is_type_enum(o->type))) {
-					ok = check_is_castable_to(c, o, param_type);
+					if (o->mode == Addressing_Constant) {
+						// constants have to fit the parameter
+						ok = check_representable_as_constant(c, o->value, param_type, &o->value);
+					} else {
+						ok = check_is_castable_to(c, o, param_type);
+					}
 				}
 			}
 			if (!allow_array_programming && check_is_assignable_to_with_score(c, o, param_type, nullptr, param_is_variadic, !allow_array_programming)) {


### PR DESCRIPTION
Closes #5377

`#any_int` accepted an untyped constant without checking that it fits the parameter. Above the range that asserts in the backend; below zero it wraps silently.

```odin
p :: proc(#any_int x: u8) { _ = x }
main :: proc() { p(256) }
```
```
src/llvm_backend_const.cpp(526): Assertion Failure: `sz >= max_count` max_count: 2, sz: 1, written: 0, type u8
This is a compiler error. Please report this.
```

and the same omission below zero, which does not crash:

```odin
p :: proc(#any_int x: u8) { fmt.printf("u8 <- %v\n", x) }
q :: proc(#any_int x: i8) { fmt.printf("i8 <- %v\n", x) }
main :: proc() { p(-1); p(-256); q(-129) }
```
```
u8 <- 255
u8 <- 0
i8 <- 127        <- a negative constant arriving positive in a signed parameter
```

**RUNTIME NOTE:** I observed that at runtime it truncates the value, it seems wise to put runtime bounds check in place, but wanted to verify first.