### PR TITLE
Fix slice.simple_equal misbehaviour on empty slice with non-nil data

### DIFF
--- a/core/slice/slice.odin
+++ b/core/slice/slice.odin
@@ -357,6 +357,17 @@ simple_equal :: proc "contextless" (a, b: $T/[]$E) -> bool where intrinsics.type
 	if len(a) != len(b) {
 		return false
 	}
+	if len(a) == 0 {
+		// Empty slices are always equivalent to each other.
+		//
+		// This check is here in the event that a slice with a `data` of
+		// nil is compared against a slice with a non-nil `data` but a
+		// length of zero.
+		//
+		// In that case, `memory_compare` would return -1 or +1 because one
+		// of the pointers is nil.
+		return true
+	}
 	return runtime.memory_compare(raw_data(a), raw_data(b), len(a)*size_of(E)) == 0
 }
 


### PR DESCRIPTION
I was checking out what the difference between `slice.equal` and `slice.simple_equal` was in `core:slice` when I noticed this bug.

`slice.simple_equal` currently omits a zero-length check which `slice.equal` has, which is explained in the comments to be because `runtime.memory_compare` returns +1 or -1 when one of the pointers passed is nil and the other isn't even when the length of data to be compared is zero.

If this isn't in fact a bug in `slice.simple_equal`'s implementation it should probably be documented what the expected bahaviour is, since it diverges from `slice.equal`'s behaviour in a way that is non-obvious (at least to myself). And I think having two empty slices not be "equal" to each other is also quite a surprising result regardless.

Before this change, the following code:

```odin
package strconcat

import "core:fmt"
import "core:slice"

main :: proc() {
	a: [1]u8
	s1: []u8 = {}
	s2: []u8 = a[:0]

	fmt.printfln("s1={} len(s1)={} raw_data(s1)={}", s1, len(s1), raw_data(s1))
	fmt.printfln("s2={} len(s2)={} raw_data(s2)={}", s2, len(s2), raw_data(s2))
	fmt.printfln("equal(s1, s2):        {}", slice.equal(s1, s2))
	fmt.printfln("simple_equal(s1, s2): {}", slice.simple_equal(s1, s2))
}
```

Produced the following output on my machine:

```
s1=[] len(s1)=0 raw_data(s1)=<nil>
s2=[] len(s2)=0 raw_data(s2)=0x7FFFED64F74F
equal(s1, s2):        true
simple_equal(s1, s2): false
```

This commit fixes simple_equal's behaviour to match that of equal.