### PR TITLE
c_vararg: fix c_va_start guard and c_va_arg format mismatch

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -769,12 +769,12 @@ gb_internal bool check_builtin_c_procedure(CheckerContext *c, Operand *operand, 
 		Operand args = {};
 		check_expr(c, &args, ce->args[1]);
 		c->allow_c_vararg_param = false;
-		if (list.mode == Addressing_Invalid) {
+		if (args.mode == Addressing_Invalid) {
 			return false;
 		}
 		Entity *e = entity_of_node(args.expr);
 		if (e == nullptr || (e->flags & EntityFlag_CVarArg) == 0) {
-			error(list.expr, "'%.*s' expected a `#c_vararg` parameter", LIT(builtin_name));
+			error(args.expr, "'%.*s' expected a `#c_vararg` parameter", LIT(builtin_name));
 		}
 
 		operand->mode = Addressing_NoValue;
@@ -857,7 +857,7 @@ gb_internal bool check_builtin_c_procedure(CheckerContext *c, Operand *operand, 
 
 		Type *type = check_type(c, ce->args[1]);
 		if (type == nullptr || type == t_invalid) {
-			error(ce->args[1], "'%.*s' expected a type as the second parameter to intrinsics.%.*s", LIT(builtin_name));
+			error(ce->args[1], "'%.*s' expected a type as the second parameter", LIT(builtin_name));
 			return false;
 		}
 


### PR DESCRIPTION
1. `c_va_start` checked `ce->args[1]` into `args`, then tested `list.mode`. The guard could never fire, and the `#c_vararg` diagnostic was anchored on the first argument instead of the correct one.

2. `c_va_arg`'s type error had two `%.*s` verbs and one `LIT()`. The second verb read past the varargs list. 
