### PR TITLE
check_stmt: reject a built-in procedure assigned to

### DIFF
--- a/src/check_stmt.cpp
+++ b/src/check_stmt.cpp
@@ -444,6 +444,19 @@ gb_internal Type *check_assignment_variable(CheckerContext *ctx, Operand *lhs, O
 			      expr_str,
 			      LIT(context_name));
 			rhs->mode = Addressing_Invalid;
+			return nullptr;
+		}
+		case Addressing_Builtin: {
+			// a builtin is not a value
+			gbString expr_str = expr_to_string(rhs->expr);
+			defer (gb_string_free(expr_str));
+
+			error(rhs->expr,
+			      "Cannot assign built-in procedure '%s' in %.*s",
+			      expr_str,
+			      LIT(context_name));
+			rhs->mode = Addressing_Invalid;
+			return nullptr;
 		}
 		case Addressing_Invalid:
 			return nullptr;


### PR DESCRIPTION
Naming a builtin without calling it passes the checker and crashes the backend:

```odin
package t
import "base:intrinsics"
main :: proc() {
	_ = intrinsics.count_ones
}
```
```
$ odin check .     (no output, exit 0)
$ odin build .     src/llvm_backend_general.cpp(2173): Assertion Failure: `type != t_invalid`
```
