### PR TITLE
big_int: a base prefix with only digit separators has no digits

### DIFF
--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -218,6 +218,7 @@ gb_internal void big_int_from_string(BigInt *dst, String const &s, bool *success
 	defer (big_int_dealloc(&digit));
 
 	isize i = 0;
+	isize digit_count = 0;
 	for (; i < len; i++) {
 		Rune r = cast(Rune)text[i];
 
@@ -241,11 +242,18 @@ gb_internal void big_int_from_string(BigInt *dst, String const &s, bool *success
 				*success = false;
 			}
 			break;
+		} else {
+			digit_count += 1;
 		}
 
 		big_int_from_u64(&digit, v);
 		big_int_mul_eq(dst, &b);
 		big_int_add_eq(dst, &digit);
+	}
+	if (digit_count == 0) {
+		// a base prefix with only digit separators after it, `0x_`, has no digits at all
+		*success = false;
+		return;
 	}
 	if (i < len && (text[i] == 'e' || text[i] == 'E')) {
 		i += 1;


### PR DESCRIPTION
`0x_` is `0`. as are `0b_`, `0o_`, `0z_`, `0d_`:

```odin
X :: 0x_
main :: proc() { fmt.println(X, 0x_FF) }   // 0 255
```

Moved to the number parser per @gingerBill's review, using @Kelimion's diff: `big_int_from_string` skips separators without counting them, so a body that is entirely separators consumes cleanly and reports success with the value still zero. It now reports failure when it saw no digits, and the existing `Invalid integer literal` diagnostic covers it.

The hexadecimal float path already counts digits, which is what made the integer paths' omission visible in the first place.
