### PR TITLE
checker: do not register map runtime dependencies under bedrock

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -8368,6 +8368,10 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 				gb_string_free(t);
 				return false;
 			}
+			if (build_context.bedrock) {
+				error(call, "'%.*s' is not available when using '-bedrock'", LIT(builtin_name));
+				return false;
+			}
 
 			add_map_key_type_dependencies(c, type);
 

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -319,6 +319,9 @@ gb_internal void error_operand_no_value(Operand *o) {
 }
 
 gb_internal void add_map_get_dependencies(CheckerContext *c) {
+	if (build_context.bedrock) {
+		return;
+	}
 	if (build_context.dynamic_map_calls) {
 		add_package_dependency(c, "runtime", "__dynamic_map_get");
 	} else {
@@ -328,6 +331,9 @@ gb_internal void add_map_get_dependencies(CheckerContext *c) {
 }
 
 gb_internal void add_map_set_dependencies(CheckerContext *c) {
+	if (build_context.bedrock) {
+		return;
+	}
 	init_core_source_code_location(c->checker);
 
 	if (t_map_set_proc == nullptr) {
@@ -344,6 +350,9 @@ gb_internal void add_map_set_dependencies(CheckerContext *c) {
 }
 
 gb_internal void add_map_reserve_dependencies(CheckerContext *c) {
+	if (build_context.bedrock) {
+		return;
+	}
 	init_core_source_code_location(c->checker);
 	add_package_dependency(c, "runtime", "__dynamic_map_reserve");
 }

--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -2993,6 +2993,11 @@ gb_internal void init_map_internal_types(Type *type) {
 }
 
 gb_internal void add_map_key_type_dependencies(CheckerContext *ctx, Type *key) {
+	if (build_context.bedrock) {
+		// the map runtime is declared '#+build !bedrock'
+		return;
+	}
+
 	key = core_type(key);
 
 	if (is_type_cstring(key)) {


### PR DESCRIPTION
Fixes map crash on bedrock

```
$ cat r.odin
package main
m: map[int]int
main :: proc() { _ = m }

$ odin check r.odin -file            # rc=0
$ odin check r.odin -file -bedrock
src/checker.cpp(960): Assertion Failure: `e != nullptr` default_hasher
This is a compiler error. Please report this.
Illegal instruction (core dumped)                     rc=132
```