### PR TITLE
fix FILE_NOTIFY_INFORMATION struct member casing

### DIFF
--- a/core/sys/windows/types.odin
+++ b/core/sys/windows/types.odin
@@ -2963,10 +2963,10 @@ FILE_END_OF_FILE_INFO :: struct {
 }
 
 FILE_NOTIFY_INFORMATION :: struct {
-	next_entry_offset: DWORD,
-	action:            DWORD,
-	file_name_length:  DWORD,
-	file_name:         [1]WCHAR,
+	NextEntryOffset: DWORD,
+	Action:          DWORD,
+	FileNameLength:  DWORD,
+	FileName:        [1]WCHAR,
 }
 
 REPARSE_DATA_BUFFER :: struct {


### PR DESCRIPTION
This updates `FILE_NOTIFY_INFORMATION` to match how the casing of everything else in [windows/types.odin](https://github.com/odin-lang/Odin/blob/master/core/sys/windows/types.odin#L2965) looks.