### PR TITLE
Remove `inline` and `no_inline` keywords from `core:odin`

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -1383,15 +1383,8 @@ parse_unrolled_for_loop :: proc(p: ^Parser, inline_tok: tokenizer.Token) -> ^ast
 
 parse_stmt :: proc(p: ^Parser) -> ^ast.Stmt {
 	#partial switch p.curr_tok.kind {
-	case .Inline:
-		if peek_token_kind(p, .For) {
-			inline_tok := expect_token(p, .Inline)
-			return parse_unrolled_for_loop(p, inline_tok)
-		}
-		fallthrough
 	// Operands
-	case .No_Inline,
-	     .Context, // Also allows for 'context = '
+	case .Context, // Also allows for 'context = '
 	     .Proc,
 	     .Ident,
 	     .Integer, .Float, .Imag,
@@ -2310,10 +2303,6 @@ parse_inlining_or_tailing_operand :: proc(p: ^Parser, lhs: bool, tok: tokenizer.
 	pi := ast.Proc_Inlining.None
 	pt := ast.Proc_Tailing.None
 	#partial switch tok.kind {
-	case .Inline:
-		pi = .Inline
-	case .No_Inline:
-		pi = .No_Inline
 	case .Ident:
 		switch tok.text {
 		case "force_inline":
@@ -2540,10 +2529,6 @@ parse_operand :: proc(p: ^Parser, lhs: bool) -> ^ast.Expr {
 			te.expr = expr
 			return te
 		}
-
-	case .Inline, .No_Inline:
-		tok := advance_token(p)
-		return parse_inlining_or_tailing_operand(p, lhs, tok)
 
 	case .Proc:
 		tok := expect_token(p, .Proc)

--- a/core/odin/tokenizer/token.odin
+++ b/core/odin/tokenizer/token.odin
@@ -154,8 +154,6 @@ Token_Kind :: enum u32 {
 		Or_Break,    // or_break
 		Or_Continue, // or_continue
 		Asm,         // asm
-		Inline,      // inline
-		No_Inline,   // no_inline
 		Matrix,      // matrix
 	B_Keyword_End,
 
@@ -291,8 +289,6 @@ tokens := [Token_Kind.COUNT]string {
 	"or_break",
 	"or_continue",
 	"asm",
-	"inline",
-	"no_inline",
 	"matrix",
 	"",
 }


### PR DESCRIPTION
Odin uses `#force_inline` and `#force_no_inline` directives, not keywords.
The cpp parser does not define them as keywords: https://github.com/odin-lang/Odin/blob/a75be8e9a5e8a36fae4d4634fc7b28bdbca36093/src/tokenizer.cpp#L86-L126
Nor does the grammar spec: https://odin-lang.org/spec/grammar/#keywords

I've discovered this while looking at spall's source code, which uses `inline` as an enum variant name, which breaks ols but not odin compiler: https://github.com/colrdavidson/spall-native/blob/main/src/dwarf.odin#L144