### PR TITLE
thread_pool: an exiting worker must not leave  published

### DIFF
--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -252,7 +252,14 @@ gb_internal THREAD_PROC(thread_pool_thread_proc) {
 
 		// if we've done all our work, and there's nothing to steal, go to sleep
 		pool->tasks_available.store(Someone_Waiting);
-		if (!pool->running) { break; }
+		if (!pool->running) {
+			// do not leave the word published on the way out: a worker still on its way to
+			// futex_wait would sleep on it, and the destroyer does not broadcast again once it
+			// has committed to its first join
+			pool->tasks_available.store(Nobody_Waiting);
+			futex_broadcast(&pool->tasks_available);
+			break;
+		}
 		futex_wait(&pool->tasks_available, Someone_Waiting);
 
 		main_loop_continue:;


### PR DESCRIPTION
The compiler finishes all work, writes correct output, and then hangs forever in its own teardown. Observed at ~0.1% of concurrent runs.

Every capture looks the same: main thread stuck in the shutdown `defer`, every worker asleep on the same futex with the same expected value:

```
#4  thread_join_and_destroy (t=0x7fa5e17ff438)      at src/threading.cpp:671
#5  thread_pool_destroy (pool=<global_thread_pool>) at src/thread_pool.cpp:74
#6  main::$_4::operator()                           at src/main.cpp:4311

#1  futex_wait (addr=<global_thread_pool+36>, val=1) at src/threading.cpp:743
#2  thread_pool_thread_proc                          at src/thread_pool.cpp:256
```

`+36` is `tasks_available`, and `val=1` is the crux: the word really was `Someone_Waiting` when they slept. No checker frames appear in any dump, so the compile is long done.

**Mechanism.** The worker publishes *before* it checks whether to exit:

```c
A:  pool->tasks_available.store(Someone_Waiting);          // 253
B:  if (!pool->running) { break; }                         // 254
C:  futex_wait(&pool->tasks_available, Someone_Waiting);   // 255
```

and the destroyer's broadcast for thread N+1 sits behind the join for thread N:

```c
D:  pool->running.store(false);
    for_array_off(i, 1, pool->threads) {
E:      pool->tasks_available.store(Nobody_Waiting);
F:      futex_broadcast(&t->pool->tasks_available);
G:      thread_join_and_destroy(t);                        // blocks; E and F never run again
    }
```

```
 t_1   A: store 1
 t_1   B: running == true            (D has not happened yet)
 ---   D, E: store 0, F: broadcast   (t_1 is not asleep yet, so it misses it)
 ---   G: join(t_1)                  blocks forever
 t_2   A: store 1                    an exiting worker republishes
 t_2   B: running == false, breaks
 t_1   C: futex_wait(addr, 1) -> the word IS 1, so it sleeps. Nothing will clear it.
```

The capture confirmed the destroyer never got past its **first** join: the `t=` pointer in its frame is the same pointer as the lowest worker's `thread=` argument, so exactly one `store`/`broadcast` pair was ever issued.

**Fix.** Don't let a worker leave the word dirty:

```c
pool->tasks_available.store(Someone_Waiting);
if (!pool->running) {
    pool->tasks_available.store(Nobody_Waiting);
    futex_broadcast(&pool->tasks_available);
    break;
}
futex_wait(&pool->tasks_available, Someone_Waiting);
```

Both orderings are safe with no timing argument. Cleared *before* the stranded worker reaches its wait: the value compare fails and it returns immediately. Cleared *after* it is asleep: the accompanying broadcast wakes it. Either way it loops, re-reads `running == false`, and exits. Since every worker that publishes also clears on its way out, the last one to leave always leaves a 0 and a broadcast behind it.

## Reproduction

Deterministic, by staging the documented interleaving with two temporary delays. One worker held before **A** so it republishes after the destroyer's store, another held between **B** and **C** so it sleeps after that republish:

```
instrumented, without the fix    8/8 wedged, then 12/12 wedged
instrumented, with the fix      16/16 clean, then 24/24 clean
clean build, natural rate      200/200 clean (and 400/400 on the previous base)
```