### PR TITLE
updated build_vendor script for windows and created one for linux

### DIFF
--- a/build_vendor.bat
+++ b/build_vendor.bat
@@ -22,3 +22,21 @@ if not exist "vendor\cgltf\lib\*.lib" (
 		call build.bat
 	popd
 )
+
+if not exist "vendor\commonmark\*.lib" (
+	pushd vendor\commonmark
+		call build.bat
+	popd
+)
+
+if not exist "vendor\box3d\lib\*.lib" (
+	pushd vendor\box3d\src
+		call build.bat
+	popd
+)
+
+if not exist "vendor\kb_text_shape\lib\*.lib" (
+	pushd vendor\kb_text_shape\src
+		call build.bat
+	popd
+)

--- a/build_vendor.sh
+++ b/build_vendor.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# build the .a files if they don't already exist
+
+if ! ls vendor/stb/lib/*.a >/dev/null 2>&1; then
+    pushd vendor/stb/src >/dev/null
+    ./build_stb.sh
+    popd >/dev/null
+fi
+
+if ! ls vendor/miniaudio/lib/*.a >/dev/null 2>&1; then
+    pushd vendor/miniaudio/src >/dev/null
+    ./build_miniaudio.sh
+    popd >/dev/null
+fi
+
+if ! ls vendor/cgltf/lib/*.a >/dev/null 2>&1; then
+    pushd vendor/cgltf/src >/dev/null
+    ./build_cgltf.sh
+    popd >/dev/null
+fi
+
+if ! ls vendor/box2d/*.a >/dev/null 2>&1; then
+    pushd vendor/box2d >/dev/null
+    ./build_box2d.sh
+    popd >/dev/null
+fi
+
+if ! ls vendor/box3d/lib/*.a >/dev/null 2>&1; then
+    pushd vendor/box3d/src >/dev/null
+    ./build.sh
+    popd >/dev/null
+fi
+
+if ! ls vendor/kb_text_shape/lib/*.a >/dev/null 2>&1; then
+    pushd vendor/kb_text_shape/src >/dev/null
+    ./build_unix.sh
+    popd >/dev/null
+fi


### PR DESCRIPTION
### Description
This PR adds `build_vendor.sh` script to automatically build the statically linked vendor libraries for macOS and Linux systems, and updates Windows `build_vendor.bat` to build all vendor libraries with a batch build file