### PR TITLE
a self-referential bit_field hangs the compiler

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -983,9 +983,12 @@ gb_internal Type *base_enum_type(Type *t) {
 }
 
 gb_internal Type *core_type(Type *t) {
-	for (;;) {
+	// each step strictly unwraps one layer; this only bounds a cycle
+	enum { CORE_TYPE_MAX_DEPTH = 1024 };
+
+	for (isize depth = 0; depth < CORE_TYPE_MAX_DEPTH; depth += 1) {
 		if (t == nullptr) {
-			break;
+			return t;
 		}
 
 		switch (t->kind) {
@@ -996,15 +999,21 @@ gb_internal Type *core_type(Type *t) {
 			t = t->Named.base;
 			continue;
 		case Type_Enum:
+			if (t == t->Enum.base_type) {
+				return t_invalid;
+			}
 			t = t->Enum.base_type;
 			continue;
 		case Type_BitField:
+			if (t == t->BitField.backing_type) {
+				return t_invalid;
+			}
 			t = t->BitField.backing_type;
 			continue;
 		}
-		break;
+		return t;
 	}
-	return t;
+	return t_invalid;
 }
 
 gb_internal void set_base_type(Type *t, Type *base) {
@@ -4442,6 +4451,9 @@ gb_internal i64 type_align_of_internal(Type *t, TypePath *path) {
 		return build_context.int_size;
 
 	case Type_BitField:
+		if (t == t->BitField.backing_type) {
+			return FAILURE_ALIGNMENT;
+		}
 		return type_align_of_internal(t->BitField.backing_type, path);
 
 	case Type_Tuple: {
@@ -4458,6 +4470,9 @@ gb_internal i64 type_align_of_internal(Type *t, TypePath *path) {
 	case Type_Map:
 		return build_context.ptr_size;
 	case Type_Enum:
+		if (t == t->Enum.base_type) {
+			return FAILURE_ALIGNMENT;
+		}
 		return type_align_of_internal(t->Enum.base_type, path);
 
 	case Type_Union: {
@@ -4757,6 +4772,9 @@ gb_internal i64 type_size_of_internal(Type *t, TypePath *path) {
 	} break;
 
 	case Type_Enum:
+		if (t == t->Enum.base_type) {
+			return FAILURE_SIZE;
+		}
 		return type_size_of_internal(t->Enum.base_type, path);
 
 	case Type_Union: {
@@ -4868,6 +4886,11 @@ gb_internal i64 type_size_of_internal(Type *t, TypePath *path) {
 	}
 
 	case Type_BitField:
+		// a self-referential backing type is an illegal cycle; this prevents the
+		// tail call below from spinning
+		if (t == t->BitField.backing_type) {
+			return FAILURE_SIZE;
+		}
 		return type_size_of_internal(t->BitField.backing_type, path);
 	}
 


### PR DESCRIPTION
```odin
package m
BF :: bit_field BF { a: u8 | 3 }
main :: proc() { x: BF; _ = x }
```

**Cause.** Three type walkers step through `Enum` and `BitField` without checking for self-reference, where the `Named` step beside them does:

```cpp
// core_type
case Type_Named:
	if (t == t->Named.base) { return t_invalid; }   // guarded
	t = t->Named.base; continue;
case Type_BitField:
	t = t->BitField.backing_type; continue;         // not guarded
```

**Fix.** Give the unguarded steps the guard the `Named` step has, in all three walkers, and bound `core_type`'s loop — it has no `TypePath` to fall back on, so a longer cycle through a named alias would still spin without it.

## Coverage

```
                                          before   after
BF :: bit_field BF { … }                  hang     Illegal type declaration cycle of `BF`
A :: bit_field B / B :: bit_field A       hang     Illegal type declaration cycle of `A`
A :: BF / BF :: bit_field A               hang     Backing type for a bit_field must be an integer…
BF :: bit_field [4]BF { … }               hang     Illegal type declaration cycle of `BF`
size_of, align_of, BF(0), typeid_of       hang     all diagnose
------------------------------------------------------------------------------------
E :: enum E { X }                         ok       unchanged (rejected: base must be an integer)
U :: u32 / BF :: bit_field U              ok       unchanged
bit_field u8 { e: E | 2 }                 ok       unchanged
```

The `Enum` guards are latent rather than reachable. An enum's base must be an integer, so a cyclic one is refused earlier. They are there because the step has the same shape.
