### PR TITLE
amd64 asm: extend family emits mnemonic that doesnt exist

### DIFF
--- a/src/llvm_backend_asm.cpp
+++ b/src/llvm_backend_asm.cpp
@@ -185,6 +185,10 @@ struct lbAsmGenerate {
 	}
 
 	virtual char     instruction_size_suffix(AstAsmInstruction *instr) = 0;
+	// Some AT&T mnemonics encode BOTH operand widths and so cannot be spelled as a name plus one
+	// suffix: `movsx` from i8 to i32 is `movsbl`. Returns the complete mnemonic, or {} when the
+	// name-plus-suffix spelling is the right one
+	virtual String   instruction_att_mnemonic(AstAsmInstruction *instr) = 0;
 	virtual char     size_suffix_for_operand(Ast *op) = 0;
 	virtual gbString write_memory_operand(gbString asm_string, Slice<i32> const &op_number, AstAsmMemoryOperand *mem_op, u32 flags) = 0;
 	virtual lbValue  emit_call(lbProcedure *p, Array<lbValue> const &args) = 0;
@@ -220,6 +224,50 @@ struct lbAsmGenerate_amd64 : lbAsmGenerate {
 		return 0;
 	}
 
+
+	// The sign/zero-extend family is the only one whose two operands differ in width. Its AT&T
+	// mnemonic names both: `movsx` i8 -> i32 is `movsbl`, never `movsx` plus a suffix. `movsxd` is
+	// the same rule, movs + l + q
+	String instruction_att_mnemonic(AstAsmInstruction *instr) override {
+		bool sign_extend;
+		switch (instr->mnemonic) {
+		case Asm_amd64::M_MOVSX:
+		case Asm_amd64::M_MOVSXD:
+			sign_extend = true;
+			break;
+		case Asm_amd64::M_MOVZX:
+			sign_extend = false;
+			break;
+		default:
+			return {};
+		}
+
+		auto forms = g_asm_amd64.encoding_forms(instr->mnemonic);
+		if (instr->valid_form_index < 0 || instr->valid_form_index >= forms.count) {
+			return {};
+		}
+		auto const &form = forms[instr->valid_form_index];
+
+		// Intel operand order: dst first
+		i32 dst = g_asm_amd64.operand_type_bit_width(form.ops[0]);
+		i32 src = g_asm_amd64.operand_type_bit_width(form.ops[1]);
+
+		if (sign_extend) {
+			if (src ==  8 && dst == 16) { return str_lit("movsbw"); }
+			if (src ==  8 && dst == 32) { return str_lit("movsbl"); }
+			if (src ==  8 && dst == 64) { return str_lit("movsbq"); }
+			if (src == 16 && dst == 32) { return str_lit("movswl"); }
+			if (src == 16 && dst == 64) { return str_lit("movswq"); }
+			if (src == 32 && dst == 64) { return str_lit("movslq"); }
+		} else {
+			if (src ==  8 && dst == 16) { return str_lit("movzbw"); }
+			if (src ==  8 && dst == 32) { return str_lit("movzbl"); }
+			if (src ==  8 && dst == 64) { return str_lit("movzbq"); }
+			if (src == 16 && dst == 32) { return str_lit("movzwl"); }
+			if (src == 16 && dst == 64) { return str_lit("movzwq"); }
+		}
+		return {};
+	}
 
 	// Scan an instruction's operands for an annotated memory operand and return its
 	// size suffix, or 0 if none. The checker has already verified the annotation
@@ -508,6 +556,10 @@ struct lbAsmGenerate_amd64 : lbAsmGenerate {
 			case_ast_node(instr, AsmInstruction, instr_);
 				asm_string = gb_string_appendc(asm_string, "\t");
 				String name = instr->name->Ident.token.string;
+				String att = this->instruction_att_mnemonic(instr);
+				if (att.len != 0) {
+					name = att;
+				}
 				asm_string = gb_string_append_length(asm_string, name.text, name.len);
 
 				// If a memory operand carries an explicit size annotation ([p]:u8) and
@@ -515,8 +567,10 @@ struct lbAsmGenerate_amd64 : lbAsmGenerate {
 				// encoded as a mnemonic suffix (crc32 -> crc32b). The checker has already
 				// verified the annotation agrees with the matched form, so an emitted
 				// suffix can never conflict with a register operand's implied width.
-				if (char suffix = this->instruction_size_suffix(instr)) {
-					asm_string = gb_string_append_length(asm_string, &suffix, 1);
+				if (att.len == 0) {
+					if (char suffix = this->instruction_size_suffix(instr)) {
+						asm_string = gb_string_append_length(asm_string, &suffix, 1);
+					}
 				}
 
 				asm_string = gb_string_appendc(asm_string, " ");

--- a/tests/internal/test_asm_extend.odin
+++ b/tests/internal/test_asm_extend.odin
@@ -1,0 +1,40 @@
+package test_internal
+
+import "core:testing"
+
+// The sign/zero-extend family is the only one whose two operands differ in width, so its AT&T
+// mnemonic names both -- `movsx` from i8 to i32 is `movsbl`. Emitting the name plus a single width
+// suffix produced `movsxl`, which no assembler has, so none of these forms could be built
+@(test)
+asm_extend_mnemonics :: proc(t: ^testing.T) {
+	when ODIN_ARCH == .amd64 {
+		sx_8_16  :: asm(a: i8)  -> (r: i16) { movsx r, a; }
+		sx_8_32  :: asm(a: i8)  -> (r: i32) { movsx r, a; }
+		sx_8_64  :: asm(a: i8)  -> (r: i64) { movsx r, a; }
+		sx_16_32 :: asm(a: i16) -> (r: i32) { movsx r, a; }
+		sx_16_64 :: asm(a: i16) -> (r: i64) { movsx r, a; }
+		zx_8_16  :: asm(a: u8)  -> (r: u16) { movzx r, a; }
+		zx_8_32  :: asm(a: u8)  -> (r: u32) { movzx r, a; }
+		zx_8_64  :: asm(a: u8)  -> (r: u64) { movzx r, a; }
+		zx_16_32 :: asm(a: u16) -> (r: u32) { movzx r, a; }
+		zx_16_64 :: asm(a: u16) -> (r: u64) { movzx r, a; }
+		sxd      :: asm(a: i32) -> (r: i64) { movsxd r, a; }
+
+		testing.expect_value(t, sx_8_16(-1),        i16(-1))
+		testing.expect_value(t, sx_8_32(-1),        i32(-1))
+		testing.expect_value(t, sx_8_64(-1),        i64(-1))
+		testing.expect_value(t, sx_16_32(-300),     i32(-300))
+		testing.expect_value(t, sx_16_64(-300),     i64(-300))
+		testing.expect_value(t, sxd(-123456),       i64(-123456))
+
+		testing.expect_value(t, zx_8_16(0xFF),      u16(255))
+		testing.expect_value(t, zx_8_32(0xFF),      u32(255))
+		testing.expect_value(t, zx_8_64(0xFF),      u64(255))
+		testing.expect_value(t, zx_16_32(0xFFFF),   u32(65535))
+		testing.expect_value(t, zx_16_64(0xFFFF),   u64(65535))
+
+		// positive values too, so a mnemonic that merely truncates cannot pass
+		testing.expect_value(t, sx_8_32(127),       i32(127))
+		testing.expect_value(t, zx_8_32(1),         u32(1))
+	}
+}

--- a/tests/internal/test_asm_extend.odin
+++ b/tests/internal/test_asm_extend.odin
@@ -1,3 +1,4 @@
+#+build amd64
 package test_internal
 
 import "core:testing"
@@ -7,34 +8,32 @@ import "core:testing"
 // suffix produced `movsxl`, which no assembler has, so none of these forms could be built
 @(test)
 asm_extend_mnemonics :: proc(t: ^testing.T) {
-	when ODIN_ARCH == .amd64 {
-		sx_8_16  :: asm(a: i8)  -> (r: i16) { movsx r, a; }
-		sx_8_32  :: asm(a: i8)  -> (r: i32) { movsx r, a; }
-		sx_8_64  :: asm(a: i8)  -> (r: i64) { movsx r, a; }
-		sx_16_32 :: asm(a: i16) -> (r: i32) { movsx r, a; }
-		sx_16_64 :: asm(a: i16) -> (r: i64) { movsx r, a; }
-		zx_8_16  :: asm(a: u8)  -> (r: u16) { movzx r, a; }
-		zx_8_32  :: asm(a: u8)  -> (r: u32) { movzx r, a; }
-		zx_8_64  :: asm(a: u8)  -> (r: u64) { movzx r, a; }
-		zx_16_32 :: asm(a: u16) -> (r: u32) { movzx r, a; }
-		zx_16_64 :: asm(a: u16) -> (r: u64) { movzx r, a; }
-		sxd      :: asm(a: i32) -> (r: i64) { movsxd r, a; }
+	sx_8_16  :: asm(a: i8)  -> (r: i16) { movsx r, a; }
+	sx_8_32  :: asm(a: i8)  -> (r: i32) { movsx r, a; }
+	sx_8_64  :: asm(a: i8)  -> (r: i64) { movsx r, a; }
+	sx_16_32 :: asm(a: i16) -> (r: i32) { movsx r, a; }
+	sx_16_64 :: asm(a: i16) -> (r: i64) { movsx r, a; }
+	zx_8_16  :: asm(a: u8)  -> (r: u16) { movzx r, a; }
+	zx_8_32  :: asm(a: u8)  -> (r: u32) { movzx r, a; }
+	zx_8_64  :: asm(a: u8)  -> (r: u64) { movzx r, a; }
+	zx_16_32 :: asm(a: u16) -> (r: u32) { movzx r, a; }
+	zx_16_64 :: asm(a: u16) -> (r: u64) { movzx r, a; }
+	sxd      :: asm(a: i32) -> (r: i64) { movsxd r, a; }
 
-		testing.expect_value(t, sx_8_16(-1),        i16(-1))
-		testing.expect_value(t, sx_8_32(-1),        i32(-1))
-		testing.expect_value(t, sx_8_64(-1),        i64(-1))
-		testing.expect_value(t, sx_16_32(-300),     i32(-300))
-		testing.expect_value(t, sx_16_64(-300),     i64(-300))
-		testing.expect_value(t, sxd(-123456),       i64(-123456))
+	testing.expect_value(t, sx_8_16(-1),        i16(-1))
+	testing.expect_value(t, sx_8_32(-1),        i32(-1))
+	testing.expect_value(t, sx_8_64(-1),        i64(-1))
+	testing.expect_value(t, sx_16_32(-300),     i32(-300))
+	testing.expect_value(t, sx_16_64(-300),     i64(-300))
+	testing.expect_value(t, sxd(-123456),       i64(-123456))
 
-		testing.expect_value(t, zx_8_16(0xFF),      u16(255))
-		testing.expect_value(t, zx_8_32(0xFF),      u32(255))
-		testing.expect_value(t, zx_8_64(0xFF),      u64(255))
-		testing.expect_value(t, zx_16_32(0xFFFF),   u32(65535))
-		testing.expect_value(t, zx_16_64(0xFFFF),   u64(65535))
+	testing.expect_value(t, zx_8_16(0xFF),      u16(255))
+	testing.expect_value(t, zx_8_32(0xFF),      u32(255))
+	testing.expect_value(t, zx_8_64(0xFF),      u64(255))
+	testing.expect_value(t, zx_16_32(0xFFFF),   u32(65535))
+	testing.expect_value(t, zx_16_64(0xFFFF),   u64(65535))
 
-		// positive values too, so a mnemonic that merely truncates cannot pass
-		testing.expect_value(t, sx_8_32(127),       i32(127))
-		testing.expect_value(t, zx_8_32(1),         u32(1))
-	}
+	// positive values too, so a mnemonic that merely truncates cannot pass
+	testing.expect_value(t, sx_8_32(127),       i32(127))
+	testing.expect_value(t, zx_8_32(1),         u32(1))
 }


### PR DESCRIPTION
`movsx`, `movzx` and `movsxd` cannot be used at all, 11 of 11 valid forms fail.

```odin
package main
t :: asm(a: i8) -> (r: i32) { movsx r, a; }    // movsbl
main :: proc() { _ = t(1) }
```
```
error: <inline asm>:1:3: invalid instruction mnemonic 'movsxl'
                movsxl %al, %eax
```

`movsxl` is not an x86 instruction. The AT&T mnemonic is `movsbl`, sign-extend *byte* to *long*; this family is spelled with **both** widths.

**Cause.** `instruction_size_suffix` derives one AT&T suffix by taking the widest operand:

```cpp
width = gb_max(width, w);   // llvm_backend_asm.cpp:270
```

That is right for every mnemonic whose operands share a width, which is all of them but these three. The extend family exists *because* its operands differ, so collapsing to a maximum discards exactly what the mnemonic needs: `movsx` + the destination's `l` gives `movsxl`, where the assembler wants source and destination.

`movsxd` failed a step earlier, it has a single encoding form, so the `forms.count <= 1` early return gave it no suffix at all and the Intel-only spelling reached an AT&T assembler unchanged.

**Fix.** A `char` return cannot express a two-width mnemonic, so `instruction_att_mnemonic` returns the complete one for these three and `{}` for everything else, and the suffix append is gated on it. Nothing else changes shape.


Ordinary mnemonics were spot-checked to confirm the general path is untouched (`mov`, `neg`, `shl`, `bsf` all lower and execute correctly).
