### PR TITLE
backend: a union nested inside a union panicked with "unfound variant"

### DIFF
--- a/src/llvm_backend_const.cpp
+++ b/src/llvm_backend_const.cpp
@@ -791,6 +791,33 @@ gb_internal lbValue lb_const_value_bit_field(lbModule *m, Type *type, Ast *value
 }
 
 
+// The variant a scalar constant belongs to, when the value's kind names exactly one of them. Only
+// used where the expression is no longer available, eg nested unions, that the payload
+// lb_const_value builds from the value alone. Ambiguity is left to the caller
+gb_internal Type *lb_union_variant_from_value_kind(Type *bt, ExactValue const &value) {
+	GB_ASSERT(bt->kind == Type_Union);
+
+	Type *found = nullptr;
+	for (Type *vt : bt->Union.variants) {
+		bool matches = false;
+		switch (value.kind) {
+		case ExactValue_Integer:    matches = is_type_integer(vt);    break;
+		case ExactValue_Float:      matches = is_type_float(vt);      break;
+		case ExactValue_Bool:       matches = is_type_boolean(vt);    break;
+		case ExactValue_String:     matches = is_type_string(vt);     break;
+		case ExactValue_Complex:    matches = is_type_complex(vt);    break;
+		case ExactValue_Quaternion: matches = is_type_quaternion(vt); break;
+		}
+		if (matches) {
+			if (found != nullptr) {
+				return nullptr; // more than one candidate: do not guess
+			}
+			found = vt;
+		}
+	}
+	return found;
+}
+
 gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, Type *value_type, lbConstContext cc) {
 	if (cc.allow_local) {
 		cc.is_rodata = false;
@@ -906,6 +933,11 @@ gb_internal lbValue lb_const_value(lbModule *m, Type *type, ExactValue value, Ty
 
 				} else if (value.kind == ExactValue_Invalid) {
 					return lb_const_nil(m, original_type);
+				}
+
+				if (Type *variant = lb_union_variant_from_value_kind(bt, value)) {
+					value_type = variant;
+					break;
 				}
 
 				GB_PANIC("(value.kind=%s) %s vs %s",

--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -4468,7 +4468,15 @@ gb_internal Type *lb_build_expr_original_const_type(Ast *expr) {
 	if (is_type_union(type)) {
 		if (expr->kind == Ast_CallExpr) {
 			if (expr->CallExpr.proc->tav.mode == Addressing_Type) {
-				Type *res = lb_build_expr_original_const_type(expr->CallExpr.args[0]);
+				Ast *arg = unparen_expr(expr->CallExpr.args[0]);
+				// Peel one conversion at a time: the argument's own type is the answer as soon as it
+				// is a variant of this union. Peeling further would walk through a variant that is
+				// itself a union, and look for that union's variant in this one
+				Type *arg_type = type_of_expr(arg);
+				if (arg_type != nullptr && union_is_variant_of(type, arg_type)) {
+					return arg_type;
+				}
+				Type *res = lb_build_expr_original_const_type(arg);
 				return res;
 			}
 		} else if (expr->kind == Ast_Ident || expr->kind == Ast_SelectorExpr) {

--- a/tests/internal/test_union_const.odin
+++ b/tests/internal/test_union_const.odin
@@ -52,3 +52,32 @@ union_constant_as_a_global_initializer :: proc(t: ^testing.T) {
 	if v, ok := G.(int);     testing.expect(t, ok, "global lost its variant")        { testing.expect_value(t, v, 3) }
 	if v, ok := GS.(string); testing.expect(t, ok, "string global lost its variant") { testing.expect_value(t, v, "hello") }
 }
+
+// A union nested inside a union: peeling `Outer(Wrapper(int(42)))` all the way to `int` looked for
+// `int` among Outer's variants and panicked with "unfound variant". The peel stops at the level that
+// is a variant of the union being built, and the inner level is resolved from the value where the
+// variant is unambiguous
+@(test)
+union_constant_nested_in_a_union :: proc(t: ^testing.T) {
+	Base  :: union { int, f32 }
+	WA    :: distinct Base
+	WB    :: distinct Base
+	Outer :: union { WA, WB }
+
+	CI :: Outer(WA(int(42)))
+	CF :: Outer(WB(f32(1.5)))
+
+	ci := CI
+	cf := CF
+
+	if wa, ok := ci.(WA); testing.expect(t, ok, "outer variant lost") {
+		if v, ok2 := Base(wa).(int); testing.expect(t, ok2, "inner variant lost") {
+			testing.expect_value(t, v, 42)
+		}
+	}
+	if wb, ok := cf.(WB); testing.expect(t, ok, "outer variant lost (f32)") {
+		if v, ok2 := Base(wb).(f32); testing.expect(t, ok2, "inner variant lost (f32)") {
+			testing.expect_value(t, v, f32(1.5))
+		}
+	}
+}


### PR DESCRIPTION
```odin
package main

Base_Union :: union { int, f32 }
Wrapper_A  :: distinct Base_Union
Wrapper_B  :: distinct Base_Union
Outer_Union :: union { Wrapper_A, Wrapper_B }

main :: proc() {
	_ = Outer_Union(Wrapper_A(int(42)))
}
```
```
src/types.cpp(3541): Panic: unfound variant -> union {Wrapper_A, Wrapper_B} int
```

Closes  #6895.

**Two defects stacked**, which is why the panic named a type that appears nowhere in the outer union.

**1. The peel over-shot.** `lb_build_expr_original_const_type` recursed for as long as the type was a union, so it stripped `Outer_Union(Wrapper_A(int(42)))` all the way down to `int`. The backend then looked for `int` among `Outer_Union`'s variants and panicked.

It now stops at the level that is a variant of the union being built:

```cpp
Type *arg_type = type_of_expr(arg);
if (arg_type != nullptr && union_is_variant_of(type, arg_type)) {
	return arg_type;
}
```

This is pre-existing before #7396.

**2. The inner union then hit the old panic.** With `Wrapper_A` correctly chosen, `lb_const_value`
builds its payload from the value alone, and at that depth the expression is gone, so a scalar whose type is the union has nothing left to peel.

For that case only, the variant is resolved from the value's kind, **and only when exactly one variant matches**:

```
nested, unambiguous inner    Outer(WA(int(7)))   -> 7
nested, ambiguous inner      O(W(i16(3)))        -> still panics, no guess
direct, ambiguous            W(i16(300))         -> 300, via the expression (#7396's path)
```
