### PR TITLE
Remove the `os.Error == 0` compatibility hack

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -5060,8 +5060,12 @@ gb_internal void convert_untyped_error(CheckerContext *c, Operand *operand, Type
 	gbString from_type_str = type_to_string(operand->type);
 	char const *extra_text = "";
 
-	if (operand->mode == Addressing_Constant) {
-		if (big_int_is_zero(&operand->value.value_integer)) {
+	if (operand->mode == Addressing_Constant && type_has_nil(target_type)) {
+		bool is_zero_int_or_float =
+			(operand->value.kind == ExactValue_Integer || operand->value.kind == ExactValue_Float) &&
+			is_exact_value_zero(operand->value);
+
+		if (is_zero_int_or_float) {
 			if (make_string_c(expr_str) != "nil") { // HACK NOTE(bill): Just in case
 				// NOTE(bill): Doesn't matter what the type is as it's still zero in the union
 				extra_text = " - Did you want 'nil'?";
@@ -5275,27 +5279,6 @@ gb_internal void convert_to_typed(CheckerContext *c, Operand *operand, Type *tar
 		
 
 	case Type_Union:
-		// IMPORTANT NOTE HACK(bill): This is just to allow for comparisons against `0` with the `os.Error` type
-		// as a kind of transition period
-		if (!build_context.strict_style &&
-		    operand->mode == Addressing_Constant &&
-		    target_type->kind == Type_Named &&
-		    (c->pkg == nullptr || c->pkg->name != "os") &&
-		    target_type->Named.name == "Error") {
-			Entity *e = target_type->Named.type_name;
-			if (e->pkg && e->pkg->name == "os") {
-				if (is_exact_value_zero(operand->value) &&
-				    (operand->value.kind == ExactValue_Integer ||
-				     operand->value.kind == ExactValue_Float)) {
-					operand->mode = Addressing_Value;
-					// target_type = t_untyped_nil;
-				     	operand->value = empty_exact_value;
-					update_untyped_expr_value(c, operand->expr, operand->value);
-					break;
-				}
-			}
-		}
-		// "fallthrough"
 		if (!is_operand_nil(*operand) && !is_operand_uninit(*operand)) {
 			TEMPORARY_ALLOCATOR_GUARD();
 
@@ -5371,7 +5354,6 @@ gb_internal void convert_to_typed(CheckerContext *c, Operand *operand, Type *tar
 			} else if (!is_type_untyped_nil(operand->type) || !type_has_nil(target_type)) {
 				ERROR_BLOCK();
 
-				operand->mode = Addressing_Invalid;
 				convert_untyped_error(c, operand, target_type, true);
 				if (count > 0) {
 					error_line("'%s' is a union which only accepts the following types:\n", type_str);


### PR DESCRIPTION
This issue popped up due to this compiler crash: https://github.com/DanielGavin/ols/pull/1637 -- The `os.Error == 0` checks started to crash the compiler.

- Removed `os.Error == 0` compatibility hack. I think the transition period has been quite a while now.
- Changed the `big_int_is_zero` check in `convert_untyped_error` so that it checks if it is int or float, plus a zero check. This makes it not read a float as an integer.
- Restored the `did you mean nil?` diagnostic if one actually tries to do an `os.Error == 0` comparison. The `operand->mode = Addressing_Invalid;` assignment that happend before `convert_untyped_error` is removed.

Regarding the last point, that assignment happens in a lot of other places, before `convert_untyped_error` runs. This can supress other such diagnostics. Should I remove all of them? `convert_untyped_error` sets it to `operand->mode = Addressing_Invalid;` anyways.
