### PR TITLE
fixed negative read bug in core:image/jpeg

### DIFF
--- a/core/image/jpeg/jpeg.odin
+++ b/core/image/jpeg/jpeg.odin
@@ -247,7 +247,7 @@ load_from_context :: proc(ctx: ^$C, options := Options{}, allocator := context.a
 			if slice.equal(ident[:], image.JFIF_Magic[:]) {
 				if length != 14 {
 					// Malformed APP0. Skip it
-					compress.read_slice(ctx, length - len(ident) - 1) or_return
+					compress.read_slice(ctx, max(0, length - len(ident) - 1)) or_return
 					continue
 				}
 


### PR DESCRIPTION
the APP0 branch lets idents potentially go outside the declared length,  that's fine normally but then in the JFIF path there's `compress.read_slice(ctx, length - len(ident) - 1)` which attempts to recover from a malformed APP0 by skipping the rest of the length but which will skip a negative amount the ident when't past declared length

`compress.read_slice_from_memory` handles reads less than the remaining size (and hence all negative reads) in a `#no_bounds_check` block, so when it does `z.input_data = z.input_daa[size:]` the negative size makes `z.input_data` point outside of valid memory