### PR TITLE
core/odin: fold ternary-opeartor keyword special-casing into is_operator

### DIFF
--- a/core/odin/parser/parser.odin
+++ b/core/odin/parser/parser.odin
@@ -180,14 +180,14 @@ parse_file :: proc(p: ^Parser, file: ^ast.File) -> bool {
 		error(p, t.pos, "Expected a package declaration at the start of the file")
 		return false
 	}
-	
+
 	p.file.pkg_token = expect_token(p, .Package)
-	
+
 	if ippt, ok := invalid_pre_package_token.?; ok {
 		error(p, ippt.pos, "Expected only comments or lines starting with '#+' before the package declaration")
 		return false
 	}
-	
+
 	pkg_name := expect_token_after(p, .Ident, "package")
 	if pkg_name.kind == .Ident {
 		switch name := pkg_name.text; {
@@ -417,14 +417,9 @@ expect_token_after :: proc(p: ^Parser, kind: tokenizer.Token_Kind, msg: string) 
 
 expect_operator :: proc(p: ^Parser) -> tokenizer.Token {
 	prev := p.curr_tok
-	#partial switch prev.kind {
-	case .If, .When, .Or_Else:
-		// okay
-	case:
-		if !tokenizer.is_operator(prev.kind) {
-			g := tokenizer.token_to_string(prev)
-			error(p, prev.pos, "expected an operator, got '%s'", g)
-		}
+	if !tokenizer.is_operator(prev.kind) {
+		g := tokenizer.token_to_string(prev)
+		error(p, prev.pos, "expected an operator, got '%s'", g)
 	}
 	advance_token(p)
 	return prev
@@ -470,7 +465,7 @@ expect_closing_token_of_field_list :: proc(p: ^Parser, closing_kind: tokenizer.T
 			advance_token(p)
 		}
 		return p.curr_tok
-	} 
+	}
 
 	return expect_closing
 }
@@ -848,7 +843,7 @@ parse_if_stmt :: proc(p: ^Parser) -> ^ast.If_Stmt {
 			else_stmt = ast.new(ast.Bad_Stmt, p.curr_tok.pos, end_pos(p.curr_tok))
 		}
 	}
-	
+
 	end: tokenizer.Pos
 	if body != nil {
 		end = body.end
@@ -2996,7 +2991,7 @@ parse_operand :: proc(p: ^Parser, lhs: bool) -> ^ast.Expr {
 		bst.underlying = underlying
 		bst.close = close.pos
 		return bst
-		
+
 	case .Matrix:
 		tok := expect_token(p, .Matrix)
 		expect_token(p, .Open_Bracket)
@@ -3012,7 +3007,7 @@ parse_operand :: proc(p: ^Parser, lhs: bool) -> ^ast.Expr {
 		mt.column_count = column_count
 		mt.elem = elem
 		return mt
-	
+
 	case .Bit_Field:
 		tok := expect_token(p, .Bit_Field)
 
@@ -3565,7 +3560,7 @@ parse_unary_expr :: proc(p: ^Parser, lhs: bool) -> ^ast.Expr {
 	     .Mul_Mul:
 		op := advance_token(p)
 		expr := parse_unary_expr(p, lhs)
-		
+
 		ue := ast.new(ast.Unary_Expr, op.pos, expr)
 		ue.op   = op
 		ue.expr = expr

--- a/core/odin/tokenizer/token.odin
+++ b/core/odin/tokenizer/token.odin
@@ -331,7 +331,7 @@ is_operator :: proc(kind: Token_Kind) -> bool {
 		return true
 	case .In, .Not_In:
 		return true
-	case .If:
+	case .If, .When, .Or_Else:
 		return true
 	}
 	return false


### PR DESCRIPTION
I was reading through the parser logic because I am working on a toy lang and I wanted to learn some patterns, and I observed that `expect_operator` was checking if the token is an operator, and the tokenizer method was a fallback which also checked for `.If`. Made the change locally, the tests are passing