### PR TITLE
fix incorrect offset_of and size_of for unions with cyclic pointers

### DIFF
--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -2770,26 +2770,17 @@ gb_internal LLVMTypeRef lb_type_internal(lbModule *m, Type *type) {
 			if (is_type_union_maybe_pointer(type)) {
 				LLVMTypeRef variant = lb_type(m, type->Union.variants[0]);
 				array_add(&fields, variant);
-			} else if (type->Union.variants.count == 1) {
-				LLVMTypeRef block_type = lb_type(m, type->Union.variants[0]);
-
-				LLVMTypeRef tag_type = lb_type(m, union_tag_type(type));
-				array_add(&fields, block_type);
-				array_add(&fields, tag_type);
-				i64 used_size = lb_sizeof(block_type) + lb_sizeof(tag_type);
-				i64 padding = size - used_size;
-				if (padding > 0) {
-					LLVMTypeRef padding_type = lb_type_padding_filler(m, padding, align);
-					array_add(&fields, padding_type);
-				}
-				is_packed = true;
 			} else {
 				LLVMTypeRef block_type = lb_type_internal_union_block_type(m, type);
 
 				LLVMTypeRef tag_type = lb_type(m, union_tag_type(type));
 				array_add(&fields, block_type);
 				array_add(&fields, tag_type);
-				i64 used_size = lb_sizeof(block_type) + lb_sizeof(tag_type);
+				i64 block_size = lb_sizeof(block_type);
+				if (block_size == 0) {
+					block_size = type_size_of(type->Union.variants[0]);
+				}
+				i64 used_size = block_size + lb_sizeof(tag_type);
 				i64 padding = size - used_size;
 				if (padding > 0) {
 					LLVMTypeRef padding_type = lb_type_padding_filler(m, padding, align);

--- a/tests/issues/run.bat
+++ b/tests/issues/run.bat
@@ -40,6 +40,7 @@ set COMMON=-define:ODIN_TEST_FANCY=false -file -vet -strict-style -ignore-unused
 ..\..\..\odin test ..\test_issue_6753.odin %COMMON%  || exit /b
 ..\..\..\odin check ..\test_issue_6874.odin %COMMON% 2>&1 | find /c "Error:" | findstr /x "1" || exit /b
 ..\..\..\odin check ..\test_issue_6979.odin -no-entry-point %COMMON%  || exit /b
+..\..\..\odin test ..\test_issue_7008.odin %COMMON%  || exit /b
 ..\..\..\odin check ..\test_issue_7012.odin -no-entry-point %COMMON% || exit /b
 ..\..\..\odin build ..\test_issue_7037.odin %COMMON% -o:none  || exit /b
 ..\..\..\odin build ..\test_issue_7188.odin %COMMON%  || exit /b

--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -88,6 +88,7 @@ else
 	exit 1
 fi
 $ODIN check ../test_issue_6979.odin -no-entry-point $COMMON_CHECK
+$ODIN test ../test_issue_7008.odin $COMMON
 $ODIN check ../test_issue_7012.odin -no-entry-point $COMMON_CHECK
 $ODIN build ../test_issue_7037.odin $COMMON -o:none
 $ODIN test ../test_issue_7356.odin $COMMON

--- a/tests/issues/test_issue_7008.odin
+++ b/tests/issues/test_issue_7008.odin
@@ -1,0 +1,27 @@
+// Tests issue #7008 https://github.com/odin-lang/Odin/issues/7008
+package test_issues
+
+import "core:testing"
+import "core:slice"
+
+Bar :: struct {
+	p: ^Foo,
+}
+
+Maybe_Bar :: union {
+	Bar,
+}
+
+Foo :: struct {
+	bar: Maybe_Bar,
+	value: byte,
+}
+
+@(test)
+test_offset_of_is_correct :: proc(t: ^testing.T) {
+	foo: Foo
+	foo.value = 42
+
+	bytes := slice.bytes_from_ptr(&foo, size_of(Foo))
+	testing.expect_value(t, bytes[offset_of(foo.value)], 42)
+}


### PR DESCRIPTION
Fixes #7008

This was an interesting couple of hours, and gave me a chance to learn a bit of the compiler internals. I found that `lb_sizeof` will return 0 for the size of a variant block when the type is a struct that contains a pointer to a *forward* type, for reasons I don't fully understand. I can guess that it's simply a void type at that stage of the pipeline because of the forward reference. Here's a simple example:

```
Bar :: struct
{
	a: ^Foo,
}

Maybe_Bar :: union {
	Bar,
}

Foo :: struct {
	a: Maybe_Bar,
	b: string,
}
```

When `lb_type_internal_union_block_type` builds up the LLVM struct type for Maybe_Bar, it incorrectly calculates that additional padding is required, because it thinks the size of the union is 0 (before adding the size of the tag). If Bar.a were declared as `^int`, OR if the declaration of Foo is move BEFORE Bar, the code returns the correct non-zero size.

My proposed fix is to detect the 0 size condition, and fall back to using `type_size_of` on the first variant of the union.

While working with the code, I noticed that the special branch for the single variant case was duplicated code. The call to `lb_type_internal_union_block_type` at the top of the branch delegates to `lb_type` immediately, making the general branch identical to the single-variant branch. So I removed the latter.

Note that the fix must be applied in the general branch. For example, adding:

```
Baz :: struct {

}

Maybe_Bar :: union {
	Bar,
	Baz,
}
```

triggers the same 0-size bug, so it needs to be handled in the general case.

Oh, I forgot to mention: I verified the extra padding before the fix, and the correct padding afterwards, by looking at `-build-mode:llvm`. I ran the ABI tests locally, but I'm not exactly sure how to make a test for this. I'm happy to work on adding a test if I could get some guidance on it.