### PR TITLE
Fix compiler panic on a selector into `#branch_location`

### DIFF
--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -6546,6 +6546,11 @@ gb_internal lbAddr lb_build_addr_internal(lbProcedure *p, Ast *expr) {
 		return lb_build_addr_from_entity(p, e, expr);
 	case_end;
 
+	case_ast_node(bd, BasicDirective, expr);
+		lbValue ptr = lb_address_from_load_or_generate_local(p, lb_build_expr(p, expr));
+		return lb_addr(ptr);
+	case_end;
+
 	case_ast_node(se, SelectorExpr, expr);
 		Ast *sel_node = unparen_expr(se->selector);
 		if (sel_node->kind == Ast_Ident) {

--- a/tests/internal/test_branch_location.odin
+++ b/tests/internal/test_branch_location.odin
@@ -1,0 +1,26 @@
+package test_internal
+
+import "core:testing"
+
+@(private="file")
+returns_at :: proc(early: bool, got: ^i32) -> (expected: i32) {
+	defer got^ = #branch_location.line
+
+	if early {
+		return #line
+	}
+
+	return #line
+}
+
+// A selector on `#branch_location` reached `lb_build_addr`, which had no case for a directive
+@(test)
+branch_location_field_access :: proc(t: ^testing.T) {
+	got: i32
+
+	expected := returns_at(true, &got)
+	testing.expect_value(t, got, expected)
+
+	expected = returns_at(false, &got)
+	testing.expect_value(t, got, expected)
+}


### PR DESCRIPTION
Closes #7238.

`line := #branch_location.line` panicked with `Unexpected address expression`.

The neighboring forms are still caught by the checker rather than the backend: `&#branch_location` reports "Cannot take the pointer address", and using it outside a `defer` reports "may only be used within a 'defer' statement".
