### PR TITLE
Fix compiler segfault on `distinct` of a type alias that cycles back

### DIFF
--- a/src/check_decl.cpp
+++ b/src/check_decl.cpp
@@ -473,7 +473,11 @@ gb_internal void check_type_decl(CheckerContext *ctx, Entity *e, Ast *init_expr,
 	check_type_path_pop(ctx);
 
 	Type *base = base_type(bt);
-	if (is_distinct && bt->kind == Type_Named && base->kind == Type_Enum) {
+	if (base == nullptr) {
+		// `bt` is a named type that is still being checked, e.g. a cycle back through a
+		// pointer or slice, so chain to it and let it resolve when it does.
+		base = bt;
+	} else if (is_distinct && bt->kind == Type_Named && base->kind == Type_Enum) {
 		base = clone_enum_type(ctx, base, named);
 	}
 	named->Named.base = base;

--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -4139,7 +4139,7 @@ gb_internal Type *check_type_expr(CheckerContext *ctx, Ast *e, Type *named_type)
 	}
 	#endif
 
-	if (type->kind == Type_Named && type->Named.base == nullptr || is_type_typed(type)) {
+	if (type->kind == Type_Named && base_type(type) == nullptr || is_type_typed(type)) {
 		add_type_and_value(ctx, e, Addressing_Type, type, empty_exact_value);
 	} else {
 		gbString name = type_to_string(type);


### PR DESCRIPTION
Fix compiler segfault on `distinct` of a type alias that cycles back

Closes #7254.

```odin
Foo      :: []Struct
Distinct :: distinct Foo
Struct   :: struct { foo: Foo, boom: Distinct }
```