### PR TITLE
Fix segfault comparing two foreign declarations of the same symbol

### DIFF
--- a/src/check_decl.cpp
+++ b/src/check_decl.cpp
@@ -881,10 +881,10 @@ gb_internal bool signature_parameter_similar_enough(Type *x, Type *y) {
 		    	if (x_base->Struct.is_raw_union) {
 		    		return true;
 		    	}
-		    	if (x->Struct.fields.count == y->Struct.fields.count) {
-		    		for (isize i = 0; i < x->Struct.fields.count; i++) {
-		    			Entity *a = x->Struct.fields[i];
-		    			Entity *b = y->Struct.fields[i];
+		    	if (x_base->Struct.fields.count == y_base->Struct.fields.count) {
+		    		for (isize i = 0; i < x_base->Struct.fields.count; i++) {
+		    			Entity *a = x_base->Struct.fields[i];
+		    			Entity *b = y_base->Struct.fields[i];
 		    			bool similar = signature_parameter_similar_enough(a->type, b->type);
 		    			if (!similar) {
 		    				// NOTE(bill): If the fields are not similar enough, then stop.

--- a/tests/issues/run.bat
+++ b/tests/issues/run.bat
@@ -42,6 +42,8 @@ set COMMON=-define:ODIN_TEST_FANCY=false -file -vet -strict-style -ignore-unused
 ..\..\..\odin check ..\test_issue_6979.odin -no-entry-point %COMMON%  || exit /b
 ..\..\..\odin check ..\test_issue_7012.odin -no-entry-point %COMMON% || exit /b
 ..\..\..\odin check ..\test_issue_7260.odin -no-entry-point %COMMON% || exit /b
+..\..\..\odin check ..\test_issue_foreign_redeclaration.odin -no-entry-point %COMMON% || exit /b
+..\..\..\odin check ..\test_issue_foreign_redeclaration_mismatch.odin -no-entry-point %COMMON% 2>&1 | find /c "Error:" | findstr /x "1" || exit /b
 ..\..\..\odin build ..\test_issue_7037.odin %COMMON% -o:none  || exit /b
 ..\..\..\odin build ..\test_issue_7188.odin %COMMON%  || exit /b
 clang -c ..\test_issue_sysv_abi.c -o test_issue_sysv_abi_c.o || exit /b

--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -94,6 +94,13 @@ $ODIN test ../test_issue_7356.odin $COMMON
 $ODIN build ../test_issue_7167.odin $COMMON
 $ODIN build ../test_issue_7188.odin $COMMON
 $ODIN check ../test_issue_7260.odin -no-entry-point $COMMON_CHECK
+$ODIN check ../test_issue_foreign_redeclaration.odin -no-entry-point $COMMON_CHECK
+if [[ $($ODIN check ../test_issue_foreign_redeclaration_mismatch.odin -no-entry-point $COMMON_CHECK 2>&1 >/dev/null | grep -c "Error:") -eq 1 ]]; then
+	echo "SUCCESSFUL 1/1"
+else
+	echo "SUCCESSFUL 0/1"
+	exit 1
+fi
 
 if [[ $($ODIN build ../test_issue_7108.odin $COMMON 2>&1 >/dev/null | grep -c "Error:") -eq 2 ]]; then
 	echo "SUCCESSFUL 1/1"

--- a/tests/issues/test_issue_foreign_redeclaration.odin
+++ b/tests/issues/test_issue_foreign_redeclaration.odin
@@ -1,24 +1,8 @@
-// The field comparison that guards this had been reading a type's name as its field list, so
-// signatures this different were accepted whenever the two names differed in length
+// Two declarations of the same foreign symbol whose parameters reach a named struct through a
+// slice or a field read the wrong member of the type union and segfaulted the compiler
 package test_issues
 
 foreign import lib "this_library_does_not_exist"
-
-Ints :: struct { a: i32, b: i32 }
-Floats :: struct { c: f32, d: f32 }
-
-@(default_calling_convention="c")
-foreign lib {
-	@(link_name="mismatched") mismatched_1 :: proc(x: []Ints) ---
-}
-
-@(default_calling_convention="c")
-foreign lib {
-	@(link_name="mismatched") mismatched_2 :: proc(x: []Floats) ---
-}
-
-// Two declarations of the same foreign symbol whose parameters reach a named struct through a
-// slice or a field read the wrong member of the type union and segfaulted the compiler
 
 Inner :: struct { a: i32, b: i32 }
 Other :: struct { c: i32, d: i32 }

--- a/tests/issues/test_issue_foreign_redeclaration.odin
+++ b/tests/issues/test_issue_foreign_redeclaration.odin
@@ -1,0 +1,39 @@
+// The field comparison that guards this had been reading a type's name as its field list, so
+// signatures this different were accepted whenever the two names differed in length
+package test_issues
+
+foreign import lib "this_library_does_not_exist"
+
+Ints :: struct { a: i32, b: i32 }
+Floats :: struct { c: f32, d: f32 }
+
+@(default_calling_convention="c")
+foreign lib {
+	@(link_name="mismatched") mismatched_1 :: proc(x: []Ints) ---
+}
+
+@(default_calling_convention="c")
+foreign lib {
+	@(link_name="mismatched") mismatched_2 :: proc(x: []Floats) ---
+}
+
+// Two declarations of the same foreign symbol whose parameters reach a named struct through a
+// slice or a field read the wrong member of the type union and segfaulted the compiler
+
+Inner :: struct { a: i32, b: i32 }
+Other :: struct { c: i32, d: i32 }
+
+Wrap1 :: struct { f: Inner }
+Wrap2 :: struct { f: Other }
+
+@(default_calling_convention="c")
+foreign lib {
+	@(link_name="via_slice") slice_1 :: proc(x: []Inner) ---
+	@(link_name="via_field") field_1 :: proc(x: Wrap1) ---
+}
+
+@(default_calling_convention="c")
+foreign lib {
+	@(link_name="via_slice") slice_2 :: proc(x: []Other) ---
+	@(link_name="via_field") field_2 :: proc(x: Wrap2) ---
+}

--- a/tests/issues/test_issue_foreign_redeclaration_mismatch.odin
+++ b/tests/issues/test_issue_foreign_redeclaration_mismatch.odin
@@ -1,0 +1,18 @@
+// The field comparison that guards this had been reading a type's name as its field list, so
+// signatures this different were accepted whenever the two names differed in length
+package test_issues
+
+foreign import lib "this_library_does_not_exist"
+
+Ints :: struct { a: i32, b: i32 }
+Floats :: struct { c: f32, d: f32 }
+
+@(default_calling_convention="c")
+foreign lib {
+	@(link_name="mismatched") mismatched_1 :: proc(x: []Ints) ---
+}
+
+@(default_calling_convention="c")
+foreign lib {
+	@(link_name="mismatched") mismatched_2 :: proc(x: []Floats) ---
+}


### PR DESCRIPTION
`signature_parameter_similar_enough` reads the wrong member of the type union. The struct block computes `x_base`/`y_base` and uses them for seven lines, then asks `x->Struct.fields` on what may still be a `Type_Named`. `Slice<Entity *>` and `String` are both a pointer followed by an `isize`, so under that misread `fields.count` is `name.len` and `fields.data` is `name.text`.

```odin
foreign import lib "system:c"

Inner :: struct { a: i32, b: i32 }
Other :: struct { c: i32, d: i32 }

@(default_calling_convention="c")
foreign lib { @(link_name="zz") q1 :: proc(x: []Inner) --- }
@(default_calling_convention="c")
foreign lib { @(link_name="zz") q2 :: proc(x: []Other) --- }
```

`odin check` on that segfaults: the two names are the same length, so the field loop runs and dereferences characters of the name as Entity *. Rename Other to Otherx and the counts differ, the loop is skipped, and the two signatures are accepted.
