### PR TITLE
Fix compiler segfault on a bare `..` in a type position call

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -8309,6 +8309,10 @@ gb_internal CallArgumentError check_polymorphic_record_type(CheckerContext *c, O
 
 	bool named_fields = false;
 	{
+		if (ce->ellipsis.pos.line != 0) {
+			error(ce->ellipsis, "Invalid use of '..' in a polymorphic type call");
+		}
+
 		// NOTE(bill, 2019-10-26): Allow a cycle in the parameters but not in the fields themselves
 		auto prev_type_path = c->type_path;
 
@@ -8345,11 +8349,6 @@ gb_internal CallArgumentError check_polymorphic_record_type(CheckerContext *c, O
 
 				}
 				check_expr_or_type(c, &operands[i], fv->value);
-			}
-
-			bool vari_expand = (ce->ellipsis.pos.line != 0);
-			if (vari_expand) {
-				error(ce->ellipsis, "Invalid use of '..' in a polymorphic type call'");
 			}
 
 		} else {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -3660,7 +3660,10 @@ gb_internal Ast *parse_call_expr(AstFile *f, Ast *operand) {
 		} else if (seen_ellipsis) {
 			syntax_error(arg, "Positional arguments are not allowed after '..'");
 		}
-		array_add(&args, arg);
+		if (arg != nullptr) {
+			// `parse_atom_expr` returns nothing when `allow_type` is set and there is no operand
+			array_add(&args, arg);
+		}
 
 		if (ellipsis.pos.line != 0) {
 			seen_ellipsis = true;

--- a/tests/issues/run.bat
+++ b/tests/issues/run.bat
@@ -42,6 +42,7 @@ set COMMON=-define:ODIN_TEST_FANCY=false -file -vet -strict-style -ignore-unused
 ..\..\..\odin check ..\test_issue_6979.odin -no-entry-point %COMMON%  || exit /b
 ..\..\..\odin check ..\test_issue_7012.odin -no-entry-point %COMMON% || exit /b
 ..\..\..\odin check ..\test_issue_7260.odin -no-entry-point %COMMON% || exit /b
+..\..\..\odin check ..\test_issue_ellipsis_type_call.odin -no-entry-point %COMMON% 2>&1 | find /c "Error:" | findstr /x "10" || exit /b
 ..\..\..\odin build ..\test_issue_7037.odin %COMMON% -o:none  || exit /b
 ..\..\..\odin build ..\test_issue_7188.odin %COMMON%  || exit /b
 clang -c ..\test_issue_sysv_abi.c -o test_issue_sysv_abi_c.o || exit /b

--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -95,6 +95,13 @@ $ODIN build ../test_issue_7167.odin $COMMON
 $ODIN build ../test_issue_7188.odin $COMMON
 $ODIN check ../test_issue_7260.odin -no-entry-point $COMMON_CHECK
 
+if [[ $($ODIN check ../test_issue_ellipsis_type_call.odin -no-entry-point $COMMON_CHECK 2>&1 >/dev/null | grep -c "Error:") -eq 10 ]]; then
+	echo "SUCCESSFUL 1/1"
+else
+	echo "SUCCESSFUL 0/1"
+	exit 1
+fi
+
 if [[ $($ODIN build ../test_issue_7108.odin $COMMON 2>&1 >/dev/null | grep -c "Error:") -eq 2 ]]; then
 	echo "SUCCESSFUL 1/1"
 else

--- a/tests/issues/test_issue_ellipsis_type_call.odin
+++ b/tests/issues/test_issue_ellipsis_type_call.odin
@@ -1,0 +1,45 @@
+// Tests that a bare `..` in a type position call is rejected rather than left as a
+// null argument for the checker to walk off of.
+package test_issues
+
+Foo :: struct($T: typeid) {
+	x: T,
+}
+
+S :: struct {
+	a: int,
+}
+
+bare :: proc() {
+	v: Foo(..)
+	_ = v
+}
+
+named_then_bare :: proc() {
+	v: Foo(T = int, ..)
+	_ = v
+}
+
+bare_then_named :: proc() {
+	v: Foo(.., T = int)
+	_ = v
+}
+
+positional_then_bare :: proc() {
+	v: Foo(int, ..)
+	_ = v
+}
+
+conversion_to_struct :: proc() {
+	v: S(..)
+	_ = v
+}
+
+conversion_to_builtin :: proc() {
+	v: int(..)
+	_ = v
+}
+
+result_type :: proc() -> Foo(..) {
+	return {}
+}


### PR DESCRIPTION
`parse_atom_expr` returns `nullptr` when it cannot produce an operand while `f->allow_type` is set, emitting no diagnostic and no `Ast_BadExpr`. `parse_call_expr` then appended that null straight into `ce->args`, and the checker dereferences those elements unguarded, so any bare `..` inside a type position call crashed the compiler:

```odin
Foo :: struct($T: typeid) { x: T }
S   :: struct { a: int }

f :: proc()            { v: Foo(..);          _ = v }
g :: proc()            { v: Foo(T = int, ..); _ = v }
h :: proc()            { v: Foo(.., T = int); _ = v }
i :: proc()            { v: S(..);            _ = v }
j :: proc()            { v: int(..);          _ = v }
k :: proc() -> Foo(..) { return {} }
```