### PR TITLE
core:sys/darwin/Foundation: Skip Cocoa import on iOS

### DIFF
--- a/core/sys/darwin/Foundation/objc.odin
+++ b/core/sys/darwin/Foundation/objc.odin
@@ -1,8 +1,10 @@
 package objc_Foundation
 
 foreign import "system:Foundation.framework"
-// NOTE: Most of our bindings are reliant on Cocoa (everything under appkit) so just unconditionally import it
-@(require) foreign import "system:Cocoa.framework"
+when !ODIN_PLATFORM_SUBTARGET_IOS {
+	// Most macOS bindings rely on Cocoa through AppKit.
+	@(require) foreign import "system:Cocoa.framework"
+}
 
 import "base:intrinsics"
 import "core:c"


### PR DESCRIPTION
## Summary

- Require `Cocoa.framework` only for macOS Darwin targets.
- Keep `Foundation.framework` available on iPhone and iPhone Simulator targets.

## Problem

`core:sys/darwin/Foundation` imports `Cocoa.framework` unconditionally. Cocoa is
a macOS umbrella framework and is absent from the iOS SDKs. Linking any iOS
executable that imports Foundation therefore fails with:

```text
ld: framework 'Cocoa' not found
```

## Validation

- Reproduced the linker failure with a minimal Foundation import and stock core.
- Built the same program for iPhone Simulator and iPhone with the patched core.
- Checked `core/sys/darwin/Foundation` with `-no-entry-point`.
- Built a macOS AppKit application and verified that it still links Cocoa.
- Built an iPhone Simulator UIKit application and verified that it does not link Cocoa.
