### PR TITLE
Added a dedicated sort to core:sort with inline cmp for high performance

### DIFF
--- a/core/slice/sort.odin
+++ b/core/slice/sort.odin
@@ -98,35 +98,6 @@ sort_from_permutation_indices :: proc(data: $T/[]$E, indices: []int) {
 	}
 }
 
-sort_from_permutation_indices2 :: proc(data: $T/[]$E, indices: []int) {
-	assert(len(data) == len(indices))
-	if len(indices) <= 1 {
-		return
-	}
-
-	for i in 0..<len(indices) {
-		next_index := indices[i]
-
-		if next_index < 0 {
-			indices[i] *= -1
-			continue
-		}
-		
-		if next_index <= i {
-			continue
-		}
-
-		cur_index := i
-		for next_index != i {
-			indices[cur_index] *= -1
-			ptr_swap_non_overlapping(&data[cur_index], &data[next_index], size_of(E))
-			cur_index = next_index
-			next_index = indices[cur_index]
-		}
-		indices[i] *= -1
-	}
-}
-
 // sort sorts a slice and returns a slice of the original indices
 // This sort is not guaranteed to be stable
 sort_with_indices :: proc(data: $T/[]$E, allocator := context.allocator, loc := #caller_location) -> (indices: []int) where ORD(E) {

--- a/core/slice/sort.odin
+++ b/core/slice/sort.odin
@@ -98,6 +98,35 @@ sort_from_permutation_indices :: proc(data: $T/[]$E, indices: []int) {
 	}
 }
 
+sort_from_permutation_indices2 :: proc(data: $T/[]$E, indices: []int) {
+	assert(len(data) == len(indices))
+	if len(indices) <= 1 {
+		return
+	}
+
+	for i in 0..<len(indices) {
+		next_index := indices[i]
+
+		if next_index < 0 {
+			indices[i] *= -1
+			continue
+		}
+		
+		if next_index <= i {
+			continue
+		}
+
+		cur_index := i
+		for next_index != i {
+			indices[cur_index] *= -1
+			ptr_swap_non_overlapping(&data[cur_index], &data[next_index], size_of(E))
+			cur_index = next_index
+			next_index = indices[cur_index]
+		}
+		indices[i] *= -1
+	}
+}
+
 // sort sorts a slice and returns a slice of the original indices
 // This sort is not guaranteed to be stable
 sort_with_indices :: proc(data: $T/[]$E, allocator := context.allocator, loc := #caller_location) -> (indices: []int) where ORD(E) {

--- a/core/sort/inlined_cmp.odin
+++ b/core/sort/inlined_cmp.odin
@@ -153,7 +153,7 @@ _quick_lumoto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 		depth := log2(len(arr)) / 5
 		pivot_index := median_3(arr, data, 0, len(arr) - 1, depth)
 
-		if last_piv != 0 && !LESS(arr[last_piv], arr[pivot_index], data) {
+		if last_piv == -1 && !LESS(arr[last_piv], arr[pivot_index], data) {
 			left := partition_lumoto_reverse(arr, data, pivot_index)
 			#must_tail loop(arr[left + 1:], data, 0)
 			return

--- a/core/sort/inlined_cmp.odin
+++ b/core/sort/inlined_cmp.odin
@@ -168,12 +168,12 @@ _quick_lumoto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 		right := len(arr) - left
 
 		if left < right {
-			loop(arr[:left], data, left)
+			loop(arr[:left], data, 0)
 			#must_tail loop(arr[left + 1:], data, -1)
 			return
 		} else {
 			loop(arr[left + 1:], data, -1)
-			#must_tail loop(arr[:left], data, left)
+			#must_tail loop(arr[:left], data, 0)
 			return
 		}
 	}

--- a/core/sort/inlined_cmp.odin
+++ b/core/sort/inlined_cmp.odin
@@ -38,8 +38,8 @@ sort_inlined_with_indices :: proc(arr: $T/[]$E, allocator := context.allocator) 
 			}
 
 			base_type :: intrinsics.type_core_type(E)
-			arr := transmute([]base_type)arr
-			_quick_lumoto(indices, &arr, proc(l, r: int, user_data: rawptr) -> bool {
+			base := transmute([]base_type)arr
+			_quick_lumoto(indices, &base, proc(l, r: int, user_data: rawptr) -> bool {
 				data := (^T)(user_data)
 				return data[l] < data[r]
 			})
@@ -148,37 +148,43 @@ _quick_lumoto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 	loop(arr, data, 0)
 	
 	loop :: proc(arr: T, data: rawptr, last_piv: int) #no_bounds_check {
-		if len(arr) <= 32 {
-			insertion_sort(arr, data)
-			return
-		}
-		
-		depth := log2(len(arr)) / 5
-		pivot_index := median_3(arr, data, 0, len(arr) - 1, depth)
+		arr := arr; last_piv := last_piv
 
-		if last_piv == -1 && !LESS(arr[last_piv], arr[pivot_index], data) {
-			left := partition_lumoto_reverse(arr, data, pivot_index)
-			#must_tail loop(arr[left + 1:], data, 0)
-			return
-		} 
+		for {
+			if len(arr) <= 32 {
+				insertion_sort(arr, data)
+				return
+			}
+			
+			depth := log2(len(arr)) / 5
+			pivot_index := median_3(arr, data, 0, len(arr) - 1, depth)
 
-		when size_of(E) > 80 {
-			left := prtition_hoare(arr, data, pivot_index)
-		} else {
-			left := partition_lumoto(arr, data, pivot_index)
-		}
-		
-		right := len(arr) - left
+			if last_piv == -1 && !LESS(arr[last_piv], arr[pivot_index], data) {
+				left := partition_lumoto_reverse(arr, data, pivot_index)
+				arr = arr[left + 1:]
+				last_piv = 0
+				continue
+			} 
 
-		if left < right {
-			loop(arr[:left], data, 0)
-			#must_tail loop(arr[left + 1:], data, -1)
-			return
-		} else {
-			loop(arr[left + 1:], data, -1)
-			#must_tail loop(arr[:left], data, 0)
-			return
+			when size_of(E) > 80 {
+				left := prtition_hoare(arr, data, pivot_index)
+			} else {
+				left := partition_lumoto(arr, data, pivot_index)
+			}
+			
+			right := len(arr) - left
+
+			if left < right {
+				loop(arr[:left], data, 0)
+				arr = arr[left + 1:]
+				last_piv = -1
+			} else {
+				loop(arr[left + 1:], data, -1)
+				arr = arr[:left]
+				last_piv = 0
+			}
 		}
+
 	}
 
 	log2 :: proc(n: int) -> (log: int) {

--- a/core/sort/inlined_cmp.odin
+++ b/core/sort/inlined_cmp.odin
@@ -99,11 +99,14 @@ sort_inlined_by_with_indices_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E
 				arr: T,
 				user_data: rawptr,
 			}
-			ctx := Context{arr, user_data}
+			arr := arr
+			ctx := &Context{arr, user_data}
 
-			_quick_lumoto(indices, &ctx, proc(l, r: int, user_data: rawptr) -> bool {
+			_quick_lumoto(indices, ctx, proc(l, r: int, user_data: rawptr) -> bool {
 				ctx := (^Context)(user_data)
-				return LESS(ctx.arr[l], ctx.arr[r], ctx.user_data)
+				left := ctx.arr[l]
+				right := ctx.arr[r]
+				return LESS(left , right, ctx.user_data)
 			})
 
 			slice.sort_from_permutation_indices(arr, indices)
@@ -150,7 +153,7 @@ _quick_lumoto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 		depth := log2(len(arr)) / 5
 		pivot_index := median_3(arr, data, 0, len(arr) - 1, depth)
 
-		if last_piv != 0 && arr[pivot_index] == arr[last_piv] {
+		if last_piv != 0 && !LESS(arr[last_piv], arr[pivot_index], data) {
 			left := partition_lumoto_reverse(arr, data, pivot_index)
 			#must_tail loop(arr[left + 1:], data, 0)
 			return

--- a/core/sort/inlined_cmp.odin
+++ b/core/sort/inlined_cmp.odin
@@ -1,11 +1,23 @@
 package sort
 
-import "core:slice"
 import "base:intrinsics"
 
-// WARNING: each call generates a new quicksort, only use in performance critical path
-//
-// This sort is not guaranteed to be stable
+Ordering :: enum {
+	Less = -1,
+	Equal = 0,
+	Greater = 1,
+}
+
+/*
+WARNING: each call generates a new quicksort, only use in performance critical path
+
+This sort is not guaranteed to be stable
+
+	example :: proc() {
+		arr := []int{3,2,1}
+		sort.sort_inlined(arr)
+	}
+*/
 sort_inlined :: proc(arr: $T/[]$E) where ORD(E) {
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
@@ -15,9 +27,20 @@ sort_inlined :: proc(arr: $T/[]$E) where ORD(E) {
 	}
 }
 
-// WARNING: each call generates a new quicksort, only use in performance critical path
-//
-// This sort is not guaranteed to be stable
+
+/*
+WARNING: each call generates a new quicksort, only use in performance critical path
+
+This sort is not guaranteed to be stable
+
+	example :: proc() {
+		Data :: struct { rand: int, data: int }
+		data_less :: proc(l, r: Data) -> bool { return l.rand < r.rand }
+		arr := make([]Data, 10)
+		// fill with data
+		sort.sort_inlined_by(arr, data_less)
+	}
+*/
 sort_inlined_by :: proc(arr: $T/[]$E, $LESS: proc(l, r: E) -> bool) {
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
@@ -26,9 +49,18 @@ sort_inlined_by :: proc(arr: $T/[]$E, $LESS: proc(l, r: E) -> bool) {
 	}
 }
 
-// WARNING: each call generates a new quicksort, only use in performance critical path
-//
-// This sort is not guaranteed to be stable
+/*
+WARNING: each call generates a new quicksort, only use in performance critical path
+
+This sort is not guaranteed to be stable
+
+	example :: proc() {
+		arr := []int{3,2,1}
+		indices := sort.sort_inlined_with_indices(arr)
+		// arr = {1,2,3}
+		defer delete(indices)
+	}
+*/
 sort_inlined_with_indices :: proc(arr: $T/[]$E, allocator := context.allocator) -> (indices: []int) where ORD(E) {
 	indices = make([]int, len(arr), allocator)
 	when size_of(E) != 0 {
@@ -49,9 +81,20 @@ sort_inlined_with_indices :: proc(arr: $T/[]$E, allocator := context.allocator) 
 	return indices
 }
 
-// WARNING: each call generates a new quicksort, only use in performance critical path
-//
-// This sort is not guaranteed to be stable
+/*
+WARNING: each call generates a new quicksort, only use in performance critical path
+
+This sort is not guaranteed to be stable
+
+	example :: proc() {
+		Data :: struct { rand: int, data: [10]int }
+		data_less :: proc(l, r: Data) -> bool { return l.rand < r.rand }
+		arr := make([]Data, 10)
+		// fill with data
+		sort.sort_inlined_by_with_indices(arr, data_less, context.temp_allocator)
+		free_all(context.temp_allocator)
+	}
+*/
 sort_inlined_by_with_indices :: proc(arr: $T/[]$E, $LESS: proc(l, r: E) -> bool, allocator := context.allocator) -> (indices: []int) {
 	indices = make([]int, len(arr), allocator)
 
@@ -72,9 +115,24 @@ sort_inlined_by_with_indices :: proc(arr: $T/[]$E, $LESS: proc(l, r: E) -> bool,
 	return indices
 }
 
-// WARNING: each call generates a new quicksort, only use in performance critical path
-//
-// This sort is not guaranteed to be stable
+/*
+WARNING: each call generates a new quicksort, only use in performance critical path
+
+This sort is not guaranteed to be stable
+
+	example :: proc() {
+		Data :: struct { rand: int, data: [10]int }
+		modulus := []int{5,4,6,7,3,2,1,8,9,0}
+		less_data_modulus :: proc(l, r: Data, mod: ^[]int)->bool{
+			left := l.rand %% 10
+			right := r.rand %% 10
+			return mod[left] < mod[right]
+		}
+		arr := make([]Data, 10)
+		// fill with data
+		sort.sort_inlined_by_with_data(data, less_data_modulus, &modulus)
+	}
+*/
 sort_inlined_by_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E, user_data: ^$D) -> bool, user_data: ^D) {
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
@@ -85,10 +143,26 @@ sort_inlined_by_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E, user_data: 
 	}
 }
 
-// WARNING: each call generates a new quicksort, only use in performance critical path
-//
-// This sort is not guaranteed to be stable
-sort_inlined_by_with_indices_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E, user_data: rawptr) -> bool, user_data: ^$D, allocator := context.allocator) -> (indices: []int) {
+/*
+WARNING: each call generates a new quicksort, only use in performance critical path
+
+This sort is not guaranteed to be stable
+
+	example :: proc() {
+		Data :: struct { rand: int, data: [10]int }
+		modulus := []int{5,4,6,7,3,2,1,8,9,0}
+		less_data_modulus :: proc(l, r: Data, mod: ^[]int)->bool{
+			left := l.rand %% 10
+			right := r.rand %% 10
+			return mod[left] < mod[right]
+		}
+		arr := make([]Data, 10)
+		// fill with data
+		indices := sort.sort_inlined_by_with_indices_with_data(data, less_data_modulus, &modulus)
+		defer delete(indices)
+	}
+*/
+sort_inlined_by_with_indices_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E, user_data: ^$D) -> bool, user_data: ^D, allocator := context.allocator) -> (indices: []int) {
 	indices = make([]int, len(arr), allocator)
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
@@ -103,8 +177,7 @@ sort_inlined_by_with_indices_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E
 			arr := arr
 			ctx := &Context{arr, user_data}
 
-			_quick_lomuto(indices, ctx, proc(l, r: int, user_data: rawptr) -> bool {
-				ctx := (^Context)(user_data)
+			_quick_lomuto(indices, ctx, proc(l, r: int, ctx: ^Context) -> bool {
 				return LESS(ctx.arr[l] , ctx.arr[r], ctx.user_data)
 			})
 
@@ -117,7 +190,7 @@ sort_inlined_by_with_indices_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E
 // WARNING: each call generates a new quicksort, only use in performance critical path
 //
 // This sort is not guaranteed to be stable
-sort_inlined_by_cmp :: proc(arr: $T/[]$E, $CMP: proc(l, r: E) -> slice.Ordering) {
+sort_inlined_by_cmp :: proc(arr: $T/[]$E, $CMP: proc(l, r: E) -> Ordering) {
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
 			_quick_lomuto(arr, rawptr(nil), proc(l, r: E, user_data: rawptr) -> bool { return CMP(l, r) == .Less })
@@ -128,7 +201,7 @@ sort_inlined_by_cmp :: proc(arr: $T/[]$E, $CMP: proc(l, r: E) -> slice.Ordering)
 // WARNING: each call generates a new quicksort, only use in performance critical path
 //
 // This sort is not guaranteed to be stable
-sort_inlined_by_cmp_with_data :: proc(arr: $T/[]$E, $CMP: proc(l, r: E, user_data: ^$D) -> slice.Ordering, user_data: ^D) {
+sort_inlined_by_cmp_with_data :: proc(arr: $T/[]$E, $CMP: proc(l, r: E, user_data: ^$D) -> Ordering, user_data: ^D) {
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
 			_quick_lomuto(arr, user_data, proc(l, r: E, user_data: ^D) -> bool {

--- a/core/sort/inlined_cmp.odin
+++ b/core/sort/inlined_cmp.odin
@@ -1,5 +1,7 @@
 package sort
 
+import "core:fmt"
+import "core:time"
 import "core:slice"
 import "base:intrinsics"
 
@@ -10,7 +12,7 @@ sort_inlined :: proc(arr: $T/[]$E) where ORD(E) {
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
 			base_type :: intrinsics.type_core_type(E)
-			_quick_lomuto(transmute([]base_type)arr, nil, proc(l, r: base_type, data: rawptr) -> bool { return l < r })
+			_quick_lomuto(transmute([]base_type)arr, rawptr(nil), proc(l, r: base_type, data: rawptr) -> bool { return l < r })
 		}
 	}
 }
@@ -21,7 +23,7 @@ sort_inlined :: proc(arr: $T/[]$E) where ORD(E) {
 sort_inlined_by :: proc(arr: $T/[]$E, $LESS: proc(l, r: E) -> bool) {
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
-			_quick_lomuto(arr, nil, proc(l, r: E, data: rawptr) -> bool { return LESS(l, r) })
+			_quick_lomuto(arr, rawptr(nil), proc(l, r: E, data: rawptr) -> bool { return LESS(l, r) })
 		}
 	}
 }
@@ -39,12 +41,11 @@ sort_inlined_with_indices :: proc(arr: $T/[]$E, allocator := context.allocator) 
 
 			base_type :: intrinsics.type_core_type(E)
 			base := transmute([]base_type)arr
-			_quick_lomuto(indices, &base, proc(l, r: int, user_data: rawptr) -> bool {
-				data := (^T)(user_data)
-				return data[l] < data[r]
+			_quick_lomuto(indices, &base, proc(l, r: int, user_data: ^T) -> bool {
+				return user_data[l] < user_data[r]
 			})
-
-			slice.sort_from_permutation_indices(arr, indices)
+			
+			sort_from_permutation_indices(arr, indices)
 		}
 	}
 	return indices
@@ -63,24 +64,24 @@ sort_inlined_by_with_indices :: proc(arr: $T/[]$E, $LESS: proc(l, r: E) -> bool,
 			}
 
 			arr := arr
-			_quick_lomuto(indices, &arr, proc(l, r: int, user_data: rawptr) -> bool {
-				data := (^T)(user_data)
-				return LESS(data[l], data[r])
+			_quick_lomuto(indices, &arr, proc(l, r: int, user_data: ^T) -> bool {
+				return LESS(user_data[l], user_data[r])
 			})
 
-			slice.sort_from_permutation_indices(arr, indices)
+			sort_from_permutation_indices(arr, indices)
 		}
 	}
 	return indices
 }
 
+
 // WARNING: each call generates a new quicksort, only use in performance critical path
 //
 // This sort is not guaranteed to be stable
-sort_inlined_by_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E, user_data: rawptr) -> bool, user_data: rawptr) {
+sort_inlined_by_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E, user_data: ^$D) -> bool, user_data: ^D) {
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
-			_quick_lomuto(arr, user_data, proc(l, r: E, user_data: rawptr) -> bool {
+			_quick_lomuto(arr, user_data, proc(l, r: E, user_data: ^D) -> bool {
 				return LESS(l, r, user_data)
 			})
 		}
@@ -112,7 +113,7 @@ sort_inlined_by_with_indices_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E
 				return LESS(left , right, ctx.user_data)
 			})
 
-			slice.sort_from_permutation_indices(arr, indices)
+			sort_from_permutation_indices(arr, indices)
 		}
 	}
 	return indices
@@ -124,7 +125,7 @@ sort_inlined_by_with_indices_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E
 sort_inlined_by_cmp :: proc(arr: $T/[]$E, $CMP: proc(l, r: E) -> slice.Ordering) {
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
-			_quick_lomuto(arr, nil, proc(l, r: E, user_data: rawptr) -> bool { return CMP(l, r) == .Less })
+			_quick_lomuto(arr, rawptr(nil), proc(l, r: E, user_data: rawptr) -> bool { return CMP(l, r) == .Less })
 		}
 	}
 }
@@ -132,22 +133,50 @@ sort_inlined_by_cmp :: proc(arr: $T/[]$E, $CMP: proc(l, r: E) -> slice.Ordering)
 // WARNING: each call generates a new quicksort, only use in performance critical path
 //
 // This sort is not guaranteed to be stable
-sort_inlined_by_cmp_with_data :: proc(arr: $T/[]$E, $CMP: proc(l, r: E, user_data: rawptr) -> slice.Ordering, user_data: rawptr) {
+sort_inlined_by_cmp_with_data :: proc(arr: $T/[]$E, $CMP: proc(l, r: E, user_data: ^$D) -> slice.Ordering, user_data: ^D) {
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
-			_quick_lomuto(arr, user_data, proc(l, r: E, user_data: rawptr) -> bool {
+			_quick_lomuto(arr, user_data, proc(l, r: E, user_data: ^D) -> bool {
 				return CMP(l, r, user_data) == .Less
 			})
 		}
 	}
 }
 
+sort_from_permutation_indices :: proc(data: $T/[]$E, indices: []int) {
+	assert(len(data) == len(indices))
+	if len(indices) <= 1 {
+		return
+	}
+
+	for i in 0..<len(indices) {
+		next_index := indices[i]
+
+		if next_index < 0 {
+			indices[i] *= -1
+			continue
+		}
+		
+		if next_index <= i {
+			continue
+		}
+
+		cur_index := i
+		for next_index != i {
+			indices[cur_index] *= -1
+			data[cur_index], data[next_index] = data[next_index], data[cur_index]
+			cur_index = next_index
+			next_index = indices[cur_index]
+		}
+		indices[i] *= -1
+	}
+}
 
 @private
-_quick_lomuto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
+_quick_lomuto :: proc(arr: $T/[]$E, data: $D, $LESS: $P) #no_bounds_check {
 	loop(arr, data, true)
 	
-	loop :: proc(arr: T, data: rawptr, leftmost: bool) #no_bounds_check {
+	loop :: proc(arr: T, data: D, leftmost: bool) #no_bounds_check {
 		arr := arr; leftmost := leftmost
 
 		for {
@@ -199,7 +228,7 @@ _quick_lomuto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 		return log
 	}
 
-	median_3 :: proc(arr: T, data: rawptr, start, end, depth: int) -> int #no_bounds_check {
+	median_3 :: proc(arr: T, data: D, start, end, depth: int) -> int #no_bounds_check {
 		if depth == 0 {
 			return start
 		}
@@ -219,7 +248,7 @@ _quick_lomuto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 		return swap[(int)(x == y) + (int)(y ~ z)]
 	}
 
-	insertion_sort :: proc(arr: T, data: rawptr) #no_bounds_check {
+	insertion_sort :: proc(arr: T, data: D) #no_bounds_check {
 		for i in 1..<len(arr) {
 			current := arr[i]
 			j := i
@@ -230,7 +259,7 @@ _quick_lomuto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 		}
 	}
 
-	unguarded_insertion_sort :: #force_inline proc(arr: T, data: rawptr) #no_bounds_check {
+	unguarded_insertion_sort :: #force_inline proc(arr: T, data: D) #no_bounds_check {
 		for i in 1..<len(arr) {
 			current := arr[i]
 			j := i
@@ -245,7 +274,7 @@ _quick_lomuto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 	// branchless partitioning
 	// [  <  |0|  >=  |  ?  ]
 	//	    left    right ->
-	partition_lomuto :: #force_inline proc(arr: T, data: rawptr, pivot_index: int) -> (left: int) #no_bounds_check {
+	partition_lomuto :: #force_inline proc(arr: T, data: D, pivot_index: int) -> (left: int) #no_bounds_check {
 		pivot := arr[pivot_index]
 		arr[pivot_index] = arr[0]
 
@@ -265,7 +294,7 @@ _quick_lomuto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 
 	// [  ?  |  <=  |0|  >  ]
 	//   <- left   right
-	partition_lomuto_reverse :: proc(arr: T, data: rawptr, pivot_index: int) -> (right: int) #no_bounds_check {
+	partition_lomuto_reverse :: proc(arr: T, data: D, pivot_index: int) -> (right: int) #no_bounds_check {
 		right = len(arr) - 1
 
 		pivot := arr[pivot_index]
@@ -288,7 +317,7 @@ _quick_lomuto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 	// only used for large types as it uses less data moves
 	// [  <  |0|   ?   |  >=  ]
 	//	 ->  left    right <-
-	partition_hoare :: proc(arr: T, data: rawptr, pivot_index: int) -> (left: int) #no_bounds_check {
+	partition_hoare :: proc(arr: T, data: D, pivot_index: int) -> (left: int) #no_bounds_check {
 		right := len(arr) - 1
 
 		pivot := arr[pivot_index]

--- a/core/sort/inlined_cmp.odin
+++ b/core/sort/inlined_cmp.odin
@@ -22,7 +22,9 @@ sort_inlined :: proc(arr: $T/[]$E) where ORD(E) {
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
 			base_type :: intrinsics.type_core_type(E)
-			_quick_lomuto(transmute([]base_type)arr, rawptr(nil), proc(l, r: base_type, data: rawptr) -> bool { return l < r })
+			_quick_lomuto(transmute([]base_type)arr, rawptr(nil), proc(l, r: base_type, data: rawptr) -> bool {
+				return l < r
+			})
 		}
 	}
 }
@@ -44,7 +46,9 @@ This sort is not guaranteed to be stable
 sort_inlined_by :: proc(arr: $T/[]$E, $LESS: proc(l, r: E) -> bool) {
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
-			_quick_lomuto(arr, rawptr(nil), proc(l, r: E, data: rawptr) -> bool { return LESS(l, r) })
+			_quick_lomuto(arr, rawptr(nil), proc(l, r: E, data: rawptr) -> bool {
+				return LESS(l, r)
+			})
 		}
 	}
 }
@@ -63,6 +67,7 @@ This sort is not guaranteed to be stable
 */
 sort_inlined_with_indices :: proc(arr: $T/[]$E, allocator := context.allocator) -> (indices: []int) where ORD(E) {
 	indices = make([]int, len(arr), allocator)
+
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
 			for &index, i in indices{
@@ -71,8 +76,8 @@ sort_inlined_with_indices :: proc(arr: $T/[]$E, allocator := context.allocator) 
 
 			base_type :: intrinsics.type_core_type(E)
 			base := transmute([]base_type)arr
-			_quick_lomuto(indices, &base, proc(l, r: int, user_data: ^T) -> bool {
-				return user_data[l] < user_data[r]
+			_quick_lomuto(indices, base, proc(l, r: int, arr: []base_type) -> bool {
+				return arr[l] < arr[r]
 			})
 			
 			sort_from_permutation_indices(arr, indices)
@@ -104,9 +109,9 @@ sort_inlined_by_with_indices :: proc(arr: $T/[]$E, $LESS: proc(l, r: E) -> bool,
 				index = i
 			}
 
-			arr := arr
-			_quick_lomuto(indices, &arr, proc(l, r: int, user_data: ^T) -> bool {
-				return LESS(user_data[l], user_data[r])
+			// arr := arr
+			_quick_lomuto(indices, arr, proc(l, r: int, arr: T) -> bool {
+				return LESS(arr[l], arr[r])
 			})
 
 			sort_from_permutation_indices(arr, indices)
@@ -164,6 +169,7 @@ This sort is not guaranteed to be stable
 */
 sort_inlined_by_with_indices_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E, user_data: ^$D) -> bool, user_data: ^D, allocator := context.allocator) -> (indices: []int) {
 	indices = make([]int, len(arr), allocator)
+	
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
 			for &index, i in indices{
@@ -174,11 +180,10 @@ sort_inlined_by_with_indices_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E
 				arr: T,
 				user_data: ^D,
 			}
-			arr := arr
-			ctx := &Context{arr, user_data}
+			ctx := Context{arr, user_data}
 
-			_quick_lomuto(indices, ctx, proc(l, r: int, ctx: ^Context) -> bool {
-				return LESS(ctx.arr[l] , ctx.arr[r], ctx.user_data)
+			_quick_lomuto(indices, ctx, proc(l, r: int, ctx: Context) -> bool {
+				return LESS(ctx.arr[l], ctx.arr[r], ctx.user_data)
 			})
 
 			sort_from_permutation_indices(arr, indices)
@@ -193,7 +198,9 @@ sort_inlined_by_with_indices_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E
 sort_inlined_by_cmp :: proc(arr: $T/[]$E, $CMP: proc(l, r: E) -> Ordering) {
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
-			_quick_lomuto(arr, rawptr(nil), proc(l, r: E, user_data: rawptr) -> bool { return CMP(l, r) == .Less })
+			_quick_lomuto(arr, rawptr(nil), proc(l, r: E, user_data: rawptr) -> bool {
+				return CMP(l, r) == .Less
+			})
 		}
 	}
 }
@@ -289,7 +296,6 @@ _quick_lomuto :: proc(arr: $T/[]$E, data: $D, $LESS: $P) #no_bounds_check {
 				arr = arr[:left]
 			}
 		}
-
 	}
 
 	log2 :: proc(n: int) -> (log: int) {
@@ -330,7 +336,7 @@ _quick_lomuto :: proc(arr: $T/[]$E, data: $D, $LESS: $P) #no_bounds_check {
 		}
 	}
 
-	unguarded_insertion_sort :: #force_inline proc(arr: T, data: D) #no_bounds_check {
+	unguarded_insertion_sort :: proc(arr: T, data: D) #no_bounds_check {
 		for i in 1..<len(arr) {
 			current := arr[i]
 			j := i
@@ -344,7 +350,7 @@ _quick_lomuto :: proc(arr: $T/[]$E, data: $D, $LESS: $P) #no_bounds_check {
 	// branchless partitioning
 	// [  <  |0|  >=  |  ?  ]
 	//	    left    right ->
-	partition_lomuto :: #force_inline proc(arr: T, data: D, pivot_index: int) -> (left: int) #no_bounds_check {
+	partition_lomuto :: proc(arr: T, data: D, pivot_index: int) -> (left: int) #no_bounds_check {
 		pivot := arr[pivot_index]
 		arr[pivot_index] = arr[0]
 

--- a/core/sort/inlined_cmp.odin
+++ b/core/sort/inlined_cmp.odin
@@ -219,7 +219,7 @@ _quick_lomuto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 		return swap[(int)(x == y) + (int)(y ~ z)]
 	}
 
-	insertion_sort :: #force_inline proc(arr: T, data: rawptr) #no_bounds_check {
+	insertion_sort :: proc(arr: T, data: rawptr) #no_bounds_check {
 		for i in 1..<len(arr) {
 			current := arr[i]
 			j := i
@@ -286,8 +286,8 @@ _quick_lomuto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 	}
 
 	// only used for large types as it uses less data moves
-	// [  <=  |0|   ?   |  >  ]
-	//	  ->  left    right <-
+	// [  <  |0|   ?   |  >=  ]
+	//	 ->  left    right <-
 	partition_hoare :: proc(arr: T, data: rawptr, pivot_index: int) -> (left: int) #no_bounds_check {
 		right := len(arr) - 1
 

--- a/core/sort/inlined_cmp.odin
+++ b/core/sort/inlined_cmp.odin
@@ -10,7 +10,7 @@ sort_inlined :: proc(arr: $T/[]$E) where ORD(E) {
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
 			base_type :: intrinsics.type_core_type(E)
-			_quick_lumoto(transmute([]base_type)arr, nil, proc(l, r: base_type, data: rawptr) -> bool { return l < r })
+			_quick_lomuto(transmute([]base_type)arr, nil, proc(l, r: base_type, data: rawptr) -> bool { return l < r })
 		}
 	}
 }
@@ -21,7 +21,7 @@ sort_inlined :: proc(arr: $T/[]$E) where ORD(E) {
 sort_inlined_by :: proc(arr: $T/[]$E, $LESS: proc(l, r: E) -> bool) {
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
-			_quick_lumoto(arr, nil, proc(l, r: E, data: rawptr) -> bool { return LESS(l, r) })
+			_quick_lomuto(arr, nil, proc(l, r: E, data: rawptr) -> bool { return LESS(l, r) })
 		}
 	}
 }
@@ -39,7 +39,7 @@ sort_inlined_with_indices :: proc(arr: $T/[]$E, allocator := context.allocator) 
 
 			base_type :: intrinsics.type_core_type(E)
 			base := transmute([]base_type)arr
-			_quick_lumoto(indices, &base, proc(l, r: int, user_data: rawptr) -> bool {
+			_quick_lomuto(indices, &base, proc(l, r: int, user_data: rawptr) -> bool {
 				data := (^T)(user_data)
 				return data[l] < data[r]
 			})
@@ -63,7 +63,7 @@ sort_inlined_by_with_indices :: proc(arr: $T/[]$E, $LESS: proc(l, r: E) -> bool,
 			}
 
 			arr := arr
-			_quick_lumoto(indices, &arr, proc(l, r: int, user_data: rawptr) -> bool {
+			_quick_lomuto(indices, &arr, proc(l, r: int, user_data: rawptr) -> bool {
 				data := (^T)(user_data)
 				return LESS(data[l], data[r])
 			})
@@ -80,7 +80,7 @@ sort_inlined_by_with_indices :: proc(arr: $T/[]$E, $LESS: proc(l, r: E) -> bool,
 sort_inlined_by_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E, user_data: rawptr) -> bool, user_data: rawptr) {
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
-			_quick_lumoto(arr, user_data, proc(l, r: E, user_data: rawptr) -> bool {
+			_quick_lomuto(arr, user_data, proc(l, r: E, user_data: rawptr) -> bool {
 				return LESS(l, r, user_data)
 			})
 		}
@@ -105,7 +105,7 @@ sort_inlined_by_with_indices_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E
 			arr := arr
 			ctx := &Context{arr, user_data}
 
-			_quick_lumoto(indices, ctx, proc(l, r: int, user_data: rawptr) -> bool {
+			_quick_lomuto(indices, ctx, proc(l, r: int, user_data: rawptr) -> bool {
 				ctx := (^Context)(user_data)
 				left := ctx.arr[l]
 				right := ctx.arr[r]
@@ -124,7 +124,7 @@ sort_inlined_by_with_indices_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E
 sort_inlined_by_cmp :: proc(arr: $T/[]$E, $CMP: proc(l, r: E) -> slice.Ordering) {
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
-			_quick_lumoto(arr, nil, proc(l, r: E, user_data: rawptr) -> bool { return CMP(l, r) == .Less })
+			_quick_lomuto(arr, nil, proc(l, r: E, user_data: rawptr) -> bool { return CMP(l, r) == .Less })
 		}
 	}
 }
@@ -135,7 +135,7 @@ sort_inlined_by_cmp :: proc(arr: $T/[]$E, $CMP: proc(l, r: E) -> slice.Ordering)
 sort_inlined_by_cmp_with_data :: proc(arr: $T/[]$E, $CMP: proc(l, r: E, user_data: rawptr) -> slice.Ordering, user_data: rawptr) {
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
-			_quick_lumoto(arr, user_data, proc(l, r: E, user_data: rawptr) -> bool {
+			_quick_lomuto(arr, user_data, proc(l, r: E, user_data: rawptr) -> bool {
 				return CMP(l, r, user_data) == .Less
 			})
 		}
@@ -144,44 +144,49 @@ sort_inlined_by_cmp_with_data :: proc(arr: $T/[]$E, $CMP: proc(l, r: E, user_dat
 
 
 @private
-_quick_lumoto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
-	loop(arr, data, 0)
+_quick_lomuto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
+	loop(arr, data, true)
 	
-	loop :: proc(arr: T, data: rawptr, last_piv: int) #no_bounds_check {
-		arr := arr; last_piv := last_piv
+	loop :: proc(arr: T, data: rawptr, leftmost: bool) #no_bounds_check {
+		arr := arr; leftmost := leftmost
 
 		for {
 			if len(arr) <= 32 {
-				insertion_sort(arr, data)
+				if leftmost {
+					insertion_sort(arr, data)
+				} else {
+					unguarded_insertion_sort(arr, data)
+				}
 				return
 			}
 			
-			depth := log2(len(arr)) / 5
-			pivot_index := median_3(arr, data, 0, len(arr) - 1, depth)
+			median_3_depth := log2(len(arr)) / 5
+			pivot_index := median_3(arr, data, 0, len(arr) - 1, median_3_depth)
 
-			if last_piv == -1 && !LESS(arr[last_piv], arr[pivot_index], data) {
-				left := partition_lumoto_reverse(arr, data, pivot_index)
-				arr = arr[left + 1:]
-				last_piv = 0
-				continue
+			if !leftmost {
+				if !LESS(arr[-1], arr[pivot_index], data) {
+					left := partition_lomuto_reverse(arr, data, pivot_index)
+					arr = arr[left + 1:]
+					leftmost = false
+					continue					
+				}
 			} 
 
 			when size_of(E) > 80 {
-				left := prtition_hoare(arr, data, pivot_index)
+				left := partition_hoare(arr, data, pivot_index)
 			} else {
-				left := partition_lumoto(arr, data, pivot_index)
+				left := partition_lomuto(arr, data, pivot_index)
 			}
 			
 			right := len(arr) - left
 
 			if left < right {
-				loop(arr[:left], data, 0)
+				loop(arr[:left], data, leftmost)
 				arr = arr[left + 1:]
-				last_piv = -1
+				leftmost = false
 			} else {
-				loop(arr[left + 1:], data, -1)
+				loop(arr[left + 1:], data, false)
 				arr = arr[:left]
-				last_piv = 0
 			}
 		}
 
@@ -225,11 +230,22 @@ _quick_lumoto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 		}
 	}
 
+	unguarded_insertion_sort :: #force_inline proc(arr: T, data: rawptr) #no_bounds_check {
+		for i in 1..<len(arr) {
+			current := arr[i]
+			j := i
+			for ; LESS(current, arr[j - 1], data); j -= 1 {
+				arr[j] = arr[j - 1]
+			}
+			arr[j] = current
+		}
+	}
+
 
 	// branchless partitioning
 	// [  <  |0|  >=  |  ?  ]
 	//	    left    right ->
-	partition_lumoto :: #force_inline proc(arr: T, data: rawptr, pivot_index: int) -> (left: int) #no_bounds_check {
+	partition_lomuto :: #force_inline proc(arr: T, data: rawptr, pivot_index: int) -> (left: int) #no_bounds_check {
 		pivot := arr[pivot_index]
 		arr[pivot_index] = arr[0]
 
@@ -249,7 +265,7 @@ _quick_lumoto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 
 	// [  ?  |  <=  |0|  >  ]
 	//   <- left   right
-	partition_lumoto_reverse :: proc(arr: T, data: rawptr, pivot_index: int) -> (right: int) #no_bounds_check {
+	partition_lomuto_reverse :: proc(arr: T, data: rawptr, pivot_index: int) -> (right: int) #no_bounds_check {
 		right = len(arr) - 1
 
 		pivot := arr[pivot_index]
@@ -272,7 +288,7 @@ _quick_lumoto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 	// only used for large types as it uses less data moves
 	// [  <=  |0|   ?   |  >  ]
 	//	  ->  left    right <-
-	prtition_hoare :: proc(arr: T, data: rawptr, pivot_index: int) -> (left: int) #no_bounds_check {
+	partition_hoare :: proc(arr: T, data: rawptr, pivot_index: int) -> (left: int) #no_bounds_check {
 		right := len(arr) - 1
 
 		pivot := arr[pivot_index]

--- a/core/sort/inlined_cmp.odin
+++ b/core/sort/inlined_cmp.odin
@@ -72,7 +72,6 @@ sort_inlined_by_with_indices :: proc(arr: $T/[]$E, $LESS: proc(l, r: E) -> bool,
 	return indices
 }
 
-
 // WARNING: each call generates a new quicksort, only use in performance critical path
 //
 // This sort is not guaranteed to be stable
@@ -89,7 +88,7 @@ sort_inlined_by_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E, user_data: 
 // WARNING: each call generates a new quicksort, only use in performance critical path
 //
 // This sort is not guaranteed to be stable
-sort_inlined_by_with_indices_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E, user_data: rawptr) -> bool, user_data: rawptr, allocator := context.allocator) -> (indices: []int) {
+sort_inlined_by_with_indices_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E, user_data: rawptr) -> bool, user_data: ^$D, allocator := context.allocator) -> (indices: []int) {
 	indices = make([]int, len(arr), allocator)
 	when size_of(E) != 0 {
 		if len(arr) > 1 {
@@ -99,16 +98,14 @@ sort_inlined_by_with_indices_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E
 			
 			Context :: struct {
 				arr: T,
-				user_data: rawptr,
+				user_data: ^D,
 			}
 			arr := arr
 			ctx := &Context{arr, user_data}
 
 			_quick_lomuto(indices, ctx, proc(l, r: int, user_data: rawptr) -> bool {
 				ctx := (^Context)(user_data)
-				left := ctx.arr[l]
-				right := ctx.arr[r]
-				return LESS(left , right, ctx.user_data)
+				return LESS(ctx.arr[l] , ctx.arr[r], ctx.user_data)
 			})
 
 			sort_from_permutation_indices(arr, indices)
@@ -163,7 +160,9 @@ sort_from_permutation_indices :: proc(data: $T/[]$E, indices: []int) {
 		cur_index := i
 		for next_index != i {
 			indices[cur_index] *= -1
+
 			data[cur_index], data[next_index] = data[next_index], data[cur_index]
+			
 			cur_index = next_index
 			next_index = indices[cur_index]
 		}

--- a/core/sort/inlined_cmp.odin
+++ b/core/sort/inlined_cmp.odin
@@ -1,0 +1,289 @@
+package sort
+
+import "core:slice"
+import "base:intrinsics"
+
+
+// This sort is not guaranteed to be stable
+sort_inlined :: proc(arr: $T/[]$E) where ORD(E) {
+	when size_of(E) != 0 {
+		if len(arr) > 1 {
+			base_type :: intrinsics.type_core_type(E)
+			_quick_lumoto(transmute([]base_type)arr, nil, proc(l, r: base_type, data: rawptr) -> bool { return l < r })
+		}
+	}
+}
+
+// WARNING: each call generates a new quicksort, only use in performance critical path
+//
+// This sort is not guaranteed to be stable
+sort_inlined_by :: proc(arr: $T/[]$E, $LESS: proc(l, r: E) -> bool) {
+	when size_of(E) != 0 {
+		if len(arr) > 1 {
+			_quick_lumoto(arr, nil, proc(l, r: E, data: rawptr) -> bool { return LESS(l, r) })
+		}
+	}
+}
+
+// This sort is not guaranteed to be stable
+sort_inlined_with_indices :: proc(arr: $T/[]$E, allocator := context.allocator) -> (indices: []int) where ORD(E) {
+	indices = make([]int, len(arr), allocator)
+	when size_of(E) != 0 {
+		if len(arr) > 1 {
+			for &index, i in indices{
+				index = i
+			}
+
+			base_type :: intrinsics.type_core_type(E)
+			arr := transmute([]base_type)arr
+			_quick_lumoto(indices, &arr, proc(l, r: int, user_data: rawptr) -> bool {
+				data := (^T)(user_data)
+				return data[l] < data[r]
+			})
+
+			slice.sort_from_permutation_indices(arr, indices)
+		}
+	}
+	return indices
+}
+
+// WARNING: each call generates a new quicksort, only use in performance critical path
+//
+// This sort is not guaranteed to be stable
+sort_inlined_by_with_indices :: proc(arr: $T/[]$E, $LESS: proc(l, r: E) -> bool, allocator := context.allocator) -> (indices: []int) {
+	indices = make([]int, len(arr), allocator)
+
+	when size_of(E) != 0 {
+		if len(arr) > 1 {
+			for &index, i in indices{
+				index = i
+			}
+
+			arr := arr
+			_quick_lumoto(indices, &arr, proc(l, r: int, user_data: rawptr) -> bool {
+				data := (^T)(user_data)
+				return LESS(data[l], data[r])
+			})
+
+			slice.sort_from_permutation_indices(arr, indices)
+		}
+	}
+	return indices
+}
+
+// WARNING: each call generates a new quicksort, only use in performance critical path
+//
+// This sort is not guaranteed to be stable
+sort_inlined_by_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E, user_data: rawptr) -> bool, user_data: rawptr) {
+	when size_of(E) != 0 {
+		if len(arr) > 1 {
+			_quick_lumoto(arr, user_data, proc(l, r: E, user_data: rawptr) -> bool {
+				return LESS(l, r, user_data)
+			})
+		}
+	}
+}
+
+// WARNING: each call generates a new quicksort, only use in performance critical path
+//
+// This sort is not guaranteed to be stable
+sort_inlined_by_with_indices_with_data :: proc(arr: $T/[]$E, $LESS: proc(l, r: E, user_data: rawptr) -> bool, user_data: rawptr, allocator := context.allocator) -> (indices: []int) {
+	indices = make([]int, len(arr), allocator)
+	when size_of(E) != 0 {
+		if len(arr) > 1 {
+			for &index, i in indices{
+				index = i
+			}
+			
+			Context :: struct {
+				arr: T,
+				user_data: rawptr,
+			}
+			ctx := Context{arr, user_data}
+
+			_quick_lumoto(indices, &ctx, proc(l, r: int, user_data: rawptr) -> bool {
+				ctx := (^Context)(user_data)
+				return LESS(ctx.arr[l], ctx.arr[r], ctx.user_data)
+			})
+
+			slice.sort_from_permutation_indices(arr, indices)
+		}
+	}
+	return indices
+}
+
+// WARNING: each call generates a new quicksort, only use in performance critical path
+//
+// This sort is not guaranteed to be stable
+sort_inlined_by_cmp :: proc(arr: $T/[]$E, $CMP: proc(l, r: E) -> slice.Ordering) {
+	when size_of(E) != 0 {
+		if len(arr) > 1 {
+			_quick_lumoto(arr, nil, proc(l, r: E, user_data: rawptr) -> bool { return CMP(l, r) == .Less })
+		}
+	}
+}
+
+// WARNING: each call generates a new quicksort, only use in performance critical path
+//
+// This sort is not guaranteed to be stable
+sort_inlined_by_cmp_with_data :: proc(arr: $T/[]$E, $CMP: proc(l, r: E, user_data: rawptr) -> slice.Ordering, user_data: rawptr) {
+	when size_of(E) != 0 {
+		if len(arr) > 1 {
+			_quick_lumoto(arr, user_data, proc(l, r: E, user_data: rawptr) -> bool {
+				return CMP(l, r, user_data) == .Less
+			})
+		}
+	}
+}
+
+
+@private
+_quick_lumoto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
+	loop(arr, data, 0)
+	
+	loop :: proc(arr: T, data: rawptr, last_piv: int) #no_bounds_check {
+		if len(arr) <= 32 {
+			insertion_sort(arr, data)
+			return
+		}
+		
+		depth := log2(len(arr)) / 5
+		pivot_index := median_3(arr, data, 0, len(arr) - 1, depth)
+
+		if last_piv != 0 && arr[pivot_index] == arr[last_piv] {
+			left := partition_lumoto_reverse(arr, data, pivot_index)
+			#must_tail loop(arr[left + 1:], data, 0)
+			return
+		} 
+
+		when size_of(T) > 80 {
+			left := prtition_hoare(arr, data, pivot_index)
+		} else {
+			left := partition_lumoto(arr, data, pivot_index)
+		}
+		
+		right := len(arr) - left
+
+		if left < right {
+			loop(arr[:left], data, left)
+			#must_tail loop(arr[left + 1:], data, -1)
+			return
+		} else {
+			loop(arr[left + 1:], data, -1)
+			#must_tail loop(arr[:left], data, left)
+			return
+		}
+	}
+
+	log2 :: proc(n: int) -> (log: int) {
+		for n := n; n > 0; n >>= 1 {
+			log += 1
+		}
+		return
+	}
+
+	median_3 :: proc(arr: T, data: rawptr, start, end, depth: int) -> int #no_bounds_check {
+		if depth == 0 {
+			return start
+		}
+
+		div := (end - start) / 3
+
+		swap := [3]int{
+			median_3(arr, data, start, start + div, depth - 1),
+			median_3(arr, data, start + div, start + div * 2, depth - 1),
+			median_3(arr, data, start + div * 2, end, depth - 1),
+		}
+		
+		x := LESS(arr[swap[0]], arr[swap[1]], data)
+		y := LESS(arr[swap[0]], arr[swap[2]], data)
+		z := LESS(arr[swap[1]], arr[swap[2]], data)
+
+		return swap[(int)(x == y) + (int)(y ~ z)]
+	}
+
+	insertion_sort :: #force_inline proc(arr: T, data: rawptr) #no_bounds_check {
+		for i in 1..<len(arr) {
+			current := arr[i]
+			j := i
+			for ; j > 0 && LESS(current, arr[j - 1], data); j -= 1 {
+				arr[j] = arr[j - 1]
+			}
+			arr[j] = current
+		}
+	}
+
+
+	// branchless partitioning
+	// [  <  |0|  >=  |  ?  ]
+	//	    left    right ->
+	partition_lumoto :: #force_inline proc(arr: T, data: rawptr, pivot_index: int) -> (left: int) #no_bounds_check {
+		pivot := arr[pivot_index]
+		arr[pivot_index] = arr[0]
+
+		j := 0
+		#unroll(8) for _ in arr[:len(arr) - 1] {
+			arr[j] = arr[left]
+			j += 1
+			arr[left] = arr[j]
+			left += cast(int)LESS(arr[left], pivot, data)
+		}
+
+		arr[j] = arr[left]
+		arr[left] = pivot
+
+		return
+	}
+
+	// [  ?  |  <=  |0|  >  ]
+	//   <- left   right
+	partition_lumoto_reverse :: proc(arr: T, data: rawptr, pivot_index: int) -> (right: int) #no_bounds_check {
+		right = len(arr) - 1
+
+		pivot := arr[pivot_index]
+		arr[pivot_index] = arr[right]
+
+		j := right
+		for j >= 1 {
+			arr[j] = arr[right]
+			j -= 1
+			arr[right] = arr[j]
+			right -= cast(int)LESS(pivot, arr[right], data)
+		}
+
+		arr[j] = arr[right]
+		arr[right] = pivot
+
+		return
+	}
+
+	// only used for large types as it uses less data moves
+	// [  <=  |0|   ?   |  >  ]
+	//	  ->  left    right <-
+	prtition_hoare :: proc(arr: T, data: rawptr, pivot_index: int) -> (left: int) #no_bounds_check {
+		right := len(arr) - 1
+
+		pivot := arr[pivot_index]
+		arr[pivot_index] = arr[0]
+
+		for {
+			for !LESS(arr[right], pivot, data) && left < right { right -= 1 }
+			if left >= right {
+				arr[left] = pivot
+				return left 
+			}
+			arr[left] = arr[right]
+			left += 1
+
+			for LESS(arr[left], pivot, data) && left < right { left += 1 }
+			if left >= right {
+				arr[right] = pivot
+				left = right
+				return  
+			}
+			arr[right] = arr[left]
+			right -= 1
+		}
+	}
+}
+

--- a/core/sort/inlined_cmp.odin
+++ b/core/sort/inlined_cmp.odin
@@ -185,7 +185,7 @@ _quick_lumoto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 		for n := n; n > 0; n >>= 1 {
 			log += 1
 		}
-		return
+		return log
 	}
 
 	median_3 :: proc(arr: T, data: rawptr, start, end, depth: int) -> int #no_bounds_check {
@@ -238,7 +238,7 @@ _quick_lumoto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 		arr[j] = arr[left]
 		arr[left] = pivot
 
-		return
+		return left
 	}
 
 	// [  ?  |  <=  |0|  >  ]
@@ -260,7 +260,7 @@ _quick_lumoto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 		arr[j] = arr[right]
 		arr[right] = pivot
 
-		return
+		return right
 	}
 
 	// only used for large types as it uses less data moves
@@ -285,7 +285,7 @@ _quick_lumoto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 			if left >= right {
 				arr[right] = pivot
 				left = right
-				return  
+				return left
 			}
 			arr[right] = arr[left]
 			right -= 1

--- a/core/sort/inlined_cmp.odin
+++ b/core/sort/inlined_cmp.odin
@@ -1,7 +1,5 @@
 package sort
 
-import "core:fmt"
-import "core:time"
 import "core:slice"
 import "base:intrinsics"
 
@@ -143,6 +141,7 @@ sort_inlined_by_cmp_with_data :: proc(arr: $T/[]$E, $CMP: proc(l, r: E, user_dat
 	}
 }
 
+@private
 sort_from_permutation_indices :: proc(data: $T/[]$E, indices: []int) {
 	assert(len(data) == len(indices))
 	if len(indices) <= 1 {
@@ -270,7 +269,6 @@ _quick_lomuto :: proc(arr: $T/[]$E, data: $D, $LESS: $P) #no_bounds_check {
 		}
 	}
 
-
 	// branchless partitioning
 	// [  <  |0|  >=  |  ?  ]
 	//	    left    right ->
@@ -279,7 +277,7 @@ _quick_lomuto :: proc(arr: $T/[]$E, data: $D, $LESS: $P) #no_bounds_check {
 		arr[pivot_index] = arr[0]
 
 		j := 0
-		#unroll(8) for _ in arr[:len(arr) - 1] {
+		for _ in arr[:len(arr) - 1] {
 			arr[j] = arr[left]
 			j += 1
 			arr[left] = arr[j]

--- a/core/sort/inlined_cmp.odin
+++ b/core/sort/inlined_cmp.odin
@@ -109,7 +109,6 @@ sort_inlined_by_with_indices :: proc(arr: $T/[]$E, $LESS: proc(l, r: E) -> bool,
 				index = i
 			}
 
-			// arr := arr
 			_quick_lomuto(indices, arr, proc(l, r: int, arr: T) -> bool {
 				return LESS(arr[l], arr[r])
 			})
@@ -238,14 +237,18 @@ sort_from_permutation_indices :: proc(data: $T/[]$E, indices: []int) {
 		}
 
 		cur_index := i
+		temp := data[cur_index]
+
 		for next_index != i {
 			indices[cur_index] *= -1
 
-			data[cur_index], data[next_index] = data[next_index], data[cur_index]
+			data[cur_index] = data[next_index]
 			
 			cur_index = next_index
 			next_index = indices[cur_index]
 		}
+		
+		data[cur_index] = temp
 		indices[i] *= -1
 	}
 }

--- a/core/sort/inlined_cmp.odin
+++ b/core/sort/inlined_cmp.odin
@@ -3,7 +3,8 @@ package sort
 import "core:slice"
 import "base:intrinsics"
 
-
+// WARNING: each call generates a new quicksort, only use in performance critical path
+//
 // This sort is not guaranteed to be stable
 sort_inlined :: proc(arr: $T/[]$E) where ORD(E) {
 	when size_of(E) != 0 {
@@ -25,6 +26,8 @@ sort_inlined_by :: proc(arr: $T/[]$E, $LESS: proc(l, r: E) -> bool) {
 	}
 }
 
+// WARNING: each call generates a new quicksort, only use in performance critical path
+//
 // This sort is not guaranteed to be stable
 sort_inlined_with_indices :: proc(arr: $T/[]$E, allocator := context.allocator) -> (indices: []int) where ORD(E) {
 	indices = make([]int, len(arr), allocator)
@@ -159,7 +162,7 @@ _quick_lumoto :: proc(arr: $T/[]$E, data: rawptr, $LESS: $P) {
 			return
 		} 
 
-		when size_of(T) > 80 {
+		when size_of(E) > 80 {
 			left := prtition_hoare(arr, data, pivot_index)
 		} else {
 			left := partition_lumoto(arr, data, pivot_index)

--- a/tests/core/slice/test_sort_inlined.odin
+++ b/tests/core/slice/test_sort_inlined.odin
@@ -122,8 +122,7 @@ test_sort_inlined_by_with_indices_with_data :: proc(t: ^testing.T) {
 
 	indecies := sort.sort_inlined_by_with_indices_with_data(
 		arr,
-		proc(l, r: i32, user_data: rawptr) -> bool {
-			modulus := (^[]i32)(user_data)
+		proc(l, r: i32, modulus: ^[]i32) -> bool {
 			return modulus[l %% 10] < modulus[r %% 10]
 		},
 		&modulus,
@@ -151,7 +150,7 @@ test_sort_inlined_by_cmp :: proc(t: ^testing.T) {
 
 	sort.sort_inlined_by_cmp(
 		arr,
-		proc(l, r: f32) -> slice.Ordering {
+		proc(l, r: f32) -> sort.Ordering {
 			if l < r  {return .Less}
 			if l > r {return .Greater}
 			return .Equal
@@ -177,7 +176,7 @@ test_sort_inlined_by_cmp_with_data :: proc(t: ^testing.T) {
 
 	sort.sort_inlined_by_cmp_with_data(
 		arr,
-		proc(l, r: int, modulus: ^[]int) -> slice.Ordering {
+		proc(l, r: int, modulus: ^[]int) -> sort.Ordering {
 			if modulus[l %% 10] < modulus[r %% 10] {
 				return .Less
 			}

--- a/tests/core/slice/test_sort_inlined.odin
+++ b/tests/core/slice/test_sort_inlined.odin
@@ -93,8 +93,7 @@ test_sort_inlined_by_with_data :: proc(t: ^testing.T) {
 
 	sort.sort_inlined_by_with_data(
 		arr,
-		proc(l, r: i32, user_data: rawptr) -> bool {
-			modulus := (^[]i32)(user_data)
+		proc(l, r: i32, modulus: ^[]i32) -> bool {
 			return modulus[l %% 10] < modulus[r %% 10]
 		},
 		&modulus,
@@ -178,8 +177,7 @@ test_sort_inlined_by_cmp_with_data :: proc(t: ^testing.T) {
 
 	sort.sort_inlined_by_cmp_with_data(
 		arr,
-		proc(l, r: int, user_data: rawptr) -> slice.Ordering {
-			modulus := (^[]int)(user_data)
+		proc(l, r: int, modulus: ^[]int) -> slice.Ordering {
 			if modulus[l %% 10] < modulus[r %% 10] {
 				return .Less
 			}

--- a/tests/core/slice/test_sort_inlined.odin
+++ b/tests/core/slice/test_sort_inlined.odin
@@ -153,8 +153,8 @@ test_sort_inlined_by_cmp :: proc(t: ^testing.T) {
 	sort.sort_inlined_by_cmp(
 		arr,
 		proc(l, r: f32) -> slice.Ordering {
-			if l < r do return .Less
-			if l > r do return .Greater
+			if l < r  {return .Less}
+			if l > r {return .Greater}
 			return .Equal
 		},
 	)

--- a/tests/core/slice/test_sort_inlined.odin
+++ b/tests/core/slice/test_sort_inlined.odin
@@ -1,0 +1,201 @@
+package test_core_slice
+
+import "core:math/rand"
+import "core:slice"
+import "core:testing"
+import "core:sort"
+
+@(test)
+test_sort_inlined :: proc(t: ^testing.T) {
+	rand.reset(t.seed)
+	id :: distinct i32
+	arr := make([]id, 1_000)
+	defer delete(arr)
+
+	for &a in arr {
+		a = cast(id)rand.int_max(1_000)
+	}
+
+	sort.sort_inlined(arr)
+
+	testing.expect(t, slice.is_sorted(arr), "expected sort_inlined to sort")
+}
+
+@(test)
+test_sort_inlined_by :: proc(t: ^testing.T) {
+	rand.reset(t.seed)
+	arr := make([][5]i32, 1_000)
+	defer delete(arr)
+	
+	for &a in arr {
+		a[0] = cast(i32)rand.int_max(1_000)
+	}
+
+	sort.sort_inlined_by(arr, proc(l, r: [5]i32) -> bool {
+		return l[0] > r[0]
+	})
+
+	testing.expect(t, slice.is_sorted_by(arr, proc(l, r: [5]i32) -> bool {
+		return l[0] > r[0]
+	}), "expected sort_inlined_by to sort")
+}
+
+@(test)
+test_sort_inlined_with_indices :: proc(t: ^testing.T) {
+	rand.reset(t.seed)
+	arr := make([]i32, 1_000)
+	defer delete(arr)
+
+	for &a in arr {
+		a = cast(i32)rand.int_max(1_000)
+	}
+
+	indices := sort.sort_inlined_with_indices(arr)
+	defer delete(indices)
+
+	testing.expect(t, slice.is_sorted(arr), "expected sort_inlined_with_indices to sort")
+}
+
+@(test)
+test_sort_inlined_by_with_indices :: proc(t: ^testing.T) {
+	rand.reset(t.seed)
+	arr := make([]i32, 1_000)
+	defer delete(arr)
+
+	for &a in arr {
+		a = cast(i32)rand.int_max(1_000)
+	}
+
+	indices := sort.sort_inlined_by_with_indices(
+		arr,
+		proc(l, r: i32) -> bool {
+			return l > r
+		},
+	)
+	defer delete(indices)
+
+	testing.expect(t, slice.is_sorted_by(arr, proc(l, r: i32) -> bool {
+		return l > r
+	}), "expected sort_inlined_by_with_indices to sort")
+}
+
+@(test)
+test_sort_inlined_by_with_data :: proc(t: ^testing.T) {
+	rand.reset(t.seed)
+	arr := make([]i32, 1_000)
+	defer delete(arr)
+
+	for &a in arr {
+		a = cast(i32)rand.int_max(1_000)
+	}
+
+	modulus := []i32{1,2,5,0,4,3,9,8,7,6}
+
+	sort.sort_inlined_by_with_data(
+		arr,
+		proc(l, r: i32, user_data: rawptr) -> bool {
+			modulus := (^[]i32)(user_data)
+			return modulus[l %% 10] < modulus[r %% 10]
+		},
+		&modulus,
+	)
+
+	sorted := true
+	for i in 1..<len(arr) {
+		if modulus[arr[i - 1] %% 10] > modulus[arr[i] %% 10] {
+			sorted = false
+		}
+	}
+	testing.expect(t, sorted, "expected sort_inlined_by_with_data to sort")
+}
+
+@(test)
+test_sort_inlined_by_with_indices_with_data :: proc(t: ^testing.T) {
+	rand.reset(t.seed)
+	arr := make([]i32, 1_000)
+	defer delete(arr)
+
+	for &a in arr {
+		a = cast(i32)rand.int_max(1_000)
+	}
+
+	modulus := []i32{1,2,5,0,4,3,9,8,7,6}
+
+	indecies := sort.sort_inlined_by_with_indices_with_data(
+		arr,
+		proc(l, r: i32, user_data: rawptr) -> bool {
+			modulus := (^[]i32)(user_data)
+			return modulus[l %% 10] < modulus[r %% 10]
+		},
+		&modulus,
+	)
+	defer delete(indecies)
+
+	sorted := true
+	for i in 1..<len(arr) {
+		if modulus[arr[i - 1] %% 10] > modulus[arr[i] %% 10] {
+			sorted = false
+		}
+	}
+	testing.expect(t, sorted, "expected sort_inlined_by_with_indices_with_data to sort")
+}
+
+@(test)
+test_sort_inlined_by_cmp :: proc(t: ^testing.T) {
+	rand.reset(t.seed)
+	arr := make([]f32, 1_000)
+	defer delete(arr)
+
+	for &a in arr {
+		a = rand.float32()
+	}
+
+	sort.sort_inlined_by_cmp(
+		arr,
+		proc(l, r: f32) -> slice.Ordering {
+			if l < r do return .Less
+			if l > r do return .Greater
+			return .Equal
+		},
+	)
+
+	testing.expect(t, slice.is_sorted_by(arr, proc(l, r: f32) -> bool {
+		return l < r
+	}), "expected sort_inlined_by_cmp to sort")
+}
+
+@(test)
+test_sort_inlined_by_cmp_with_data :: proc(t: ^testing.T) {
+	rand.reset(t.seed)
+	arr := make([]int, 1_000)
+	defer delete(arr)
+
+	for &a in arr {
+		a = rand.int_max(1_000)
+	}
+
+	modulus := []int{1,2,5,0,4,3,9,8,7,6}
+
+	sort.sort_inlined_by_cmp_with_data(
+		arr,
+		proc(l, r: int, user_data: rawptr) -> slice.Ordering {
+			modulus := (^[]int)(user_data)
+			if modulus[l %% 10] < modulus[r %% 10] {
+				return .Less
+			}
+			if modulus[l %% 10] > modulus[r %% 10] {
+				return .Greater
+			}
+			return .Equal
+		},
+		&modulus,
+	)
+
+	sorted := true
+	for i in 1..<len(arr) {
+		if modulus[arr[i - 1] %% 10] > modulus[arr[i] %% 10] {
+			sorted = false
+		}
+	}
+	testing.expect(t, sorted, "expected sort_inlined_by_cmp_with_data to sort")
+}

--- a/tests/core/slice/test_sort_inlined.odin
+++ b/tests/core/slice/test_sort_inlined.odin
@@ -24,18 +24,18 @@ test_sort_inlined :: proc(t: ^testing.T) {
 @(test)
 test_sort_inlined_by :: proc(t: ^testing.T) {
 	rand.reset(t.seed)
-	arr := make([][5]i32, 1_000)
+	arr := make([][25]i32, 1_000)
 	defer delete(arr)
 	
 	for &a in arr {
 		a[0] = cast(i32)rand.int_max(1_000)
 	}
 
-	sort.sort_inlined_by(arr, proc(l, r: [5]i32) -> bool {
+	sort.sort_inlined_by(arr, proc(l, r: [25]i32) -> bool {
 		return l[0] > r[0]
 	})
 
-	testing.expect(t, slice.is_sorted_by(arr, proc(l, r: [5]i32) -> bool {
+	testing.expect(t, slice.is_sorted_by(arr, proc(l, r: [25]i32) -> bool {
 		return l[0] > r[0]
 	}), "expected sort_inlined_by to sort")
 }


### PR DESCRIPTION
Motivation
---

slice.sort is versatile, but slow. #7423 doesnt change that either
a dedicated sort for when performance matters would be usefull
#6739 tried to start that, but that went nowhere. this implementation is ~2x faster


Implementation
---
branchless quicksort + insertion sort

uses median3 rekursively to find the pivot
partitioning is with gapped lumoto for small types and hoare for types > 80 byte
unrolled recursion into bigger partition to keep stack usage low
everything is in-place exept temp variables

main improvements can be found with the smallsort, but there is not much that can be done without using extra memory

because it uses a compile time comparison proc, it generates a new function each time it is called with any change, so i added a warning to each proc.
the name is explicit about what it does: sort_inlined to inicate that the comparison proc gets inlined for more performance, but also more code gen
// WARNING: each call generates a new quicksort, only use in performance critical path

Written with simplicity in mind
Should i add more documentation?

API
---
`sort_inlined`
`sort_inlined_by`
`sort_inlined_with_indices`
`sort_inlined_by_with_indices`
`sort_inlined_by_with_data`
`sort_inlined_by_with_indices_with_data`
`sort_inlined_by_cmp`
`sort_inlined_by_cmp_with_data`

Benchmarks
---
Within 20% of optimized sorts like [ipnsort](https://github.com/Voultapher/sort-research-rs/blob/main/writeup/ipnsort_introduction/text.md) but significantly simpler and smaller

Bench code: https://github.com/TheRadischen/tests/blob/main/inline/test_inline.odin

```
test_highly_ordered(100_000 int)
size 100000   inline_sort:  1.6698ms _smoothsort:  4.6019ms 2.7559587974607735

test_many_similar(100_000 int)
size 100000   inline_sort:  282.2µs _smoothsort:  18.0055ms 63.80403968816442

test_random(100_000 int)
size 100000   inline_sort:  1.7465ms _smoothsort:  22.4256ms 12.840309189808188

test_slice_with_data_indecies_100_000
size 100000   inline_sort:  8.2521ms _smoothsort:  47.415ms 5.745810157414477

slice.big(100_00 1600 byte )
size 10000   inline_sort:  2.4425ms _smoothsort:  15.9196ms 6.517748208802456

sort_with_indecies(int)
size 10   inline_sort:  36 _smoothsort:  88     diff:    2.4444444444444446
size 100   inline_sort:  45 _smoothsort:  203     diff:    4.441048034934497
size 1000   inline_sort:  62 _smoothsort:  317     diff:    5.112254744290769
size 10000   inline_sort:  96 _smoothsort:  439     diff:    4.579292540234432
size 100000   inline_sort:  192 _smoothsort:  682     diff:    3.549356169599221

sort_by_with_indecies([10]int)
size 10   inline_sort:  38 _smoothsort:  106     diff:    2.789473684210526
size 100   inline_sort:  53 _smoothsort:  292     diff:    5.524528301886792
size 1000   inline_sort:  73 _smoothsort:  495     diff:    6.767276700355095
size 10000   inline_sort:  116 _smoothsort:  726     diff:    6.249204793590207
size 100000   inline_sort:  358 _smoothsort:  1532     diff:    4.278196987274467

test_random(int)
size 10   inline_sort:  20 _smoothsort:  92     diff:    4.6
size 100   inline_sort:  23 _smoothsort:  178     diff:    7.747826086956522
size 1000   inline_sort:  28 _smoothsort:  284     diff:    10.102982954545455
size 10000   inline_sort:  32 _smoothsort:  371     diff:    11.44681507060492
size 100000   inline_sort:  35 _smoothsort:  771     diff:    21.929470360539074 // sometimes you get hickups
size 1000000   inline_sort:  43 _smoothsort:  713     diff:    16.5538420141869
```