### PR TITLE
Fix -no-crt on windows

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -2630,12 +2630,13 @@ gb_internal bool init_build_paths(String init_filename) {
 
 	if (build_context.no_crt && !build_context.no_thread_local) {
 		switch (build_context.metrics.os) {
+		case TargetOs_windows:
 		case TargetOs_linux:
 		case TargetOs_darwin:
 		case TargetOs_freebsd:
 		case TargetOs_openbsd:
 		case TargetOs_netbsd:
-			gb_printf_err("-no-crt on Unix systems requires the -no-thread-local flag to also be present, because the TLS is inaccessible without CRT\n");
+			gb_printf_err("-no-crt requires the -no-thread-local flag to also be present, because the TLS is inaccessible without CRT\n");
 			no_crt_checks_failed = true;
 		}
 	}


### PR DESCRIPTION
### Problem

When using `-no-crt` on windows without `-no-thread-local` my apps crash
I'm not sure if forcing people to use -no-thread-local is the correct fix but I want to save other peoples time by adding this error

### Reproduction

```odin
package main

import "core:fmt"

main :: proc() {
	fmt.println("Hello, World!")
}
```

```cmd
> odin run . -no-crt
Hello, World!
> echo %ERRORLEVEL%
-1073741819
```
### System Information

- **OS**: Windows 11 x86_64 (`Microsoft Windows NT 10.0.26200.0`)
- **Odin Version**: `dev-2026-08:2439aaf18`

Edit: #6140 seems to have the similar issue (we are both using vulkan) 