### PR TITLE
add regression test for #7336

### DIFF
--- a/tests/issues/run.bat
+++ b/tests/issues/run.bat
@@ -44,6 +44,7 @@ set COMMON=-define:ODIN_TEST_FANCY=false -file -vet -strict-style -ignore-unused
 ..\..\..\odin check ..\test_issue_7012.odin -no-entry-point %COMMON% || exit /b
 ..\..\..\odin check ..\test_issue_7260.odin -no-entry-point %COMMON% || exit /b
 ..\..\..\odin test ..\test_issue_bool_comparison_truthiness.odin %COMMON%  || exit /b
+..\..\..\odin check ..\test_issue_7336.odin -no-entry-point %COMMON% || exit /b
 ..\..\..\odin check ..\test_issue_ellipsis_type_call.odin -no-entry-point %COMMON% 2>&1 | find /c "Error:" | findstr /x "10" || exit /b
 ..\..\..\odin check ..\test_issue_foreign_redeclaration.odin -no-entry-point %COMMON% || exit /b
 ..\..\..\odin check ..\test_issue_foreign_redeclaration_mismatch.odin -no-entry-point %COMMON% 2>&1 | find /c "Error:" | findstr /x "1" || exit /b

--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -93,6 +93,7 @@ $ODIN check ../test_issue_7012.odin -no-entry-point $COMMON_CHECK
 $ODIN build ../test_issue_7037.odin $COMMON -o:none
 $ODIN check ../test_issue_7429.odin $COMMON_CHECK
 $ODIN test ../test_issue_7356.odin $COMMON
+$ODIN test ../test_issue_7336.odin $COMMON
 $ODIN build ../test_issue_7167.odin $COMMON
 $ODIN build ../test_issue_7188.odin $COMMON
 $ODIN check ../test_issue_7260.odin -no-entry-point $COMMON_CHECK

--- a/tests/issues/test_issue_7336.odin
+++ b/tests/issues/test_issue_7336.odin
@@ -1,0 +1,20 @@
+// Tests issue #7336 https://github.com/odin-lang/Odin/issues/7336
+package test_issues
+
+import "core:testing"
+
+S :: struct {
+	a: [dynamic; 1]matrix[4, 4]f32,
+	b: matrix[4, 4]f32,
+}
+
+@(test)
+test_offset :: proc(t: ^testing.T) {
+	s := new(S)
+	defer free(s)
+
+	// 4*4 f32 + dynamic len == 72
+	expect: uintptr = 4 * 4 * 4 + size_of(int)
+	testing.expect(t, offset_of(S, b) == expect)
+	testing.expect(t, uintptr(rawptr(&s.b)) - uintptr(rawptr(s)) == expect)
+}


### PR DESCRIPTION
I was investigating another open bug that referred to problems with `offset_of`, #7336, and discovered that it had been fixed. The large merge #7327 seems to have addressed the issue. I've added a regression test to catch the specific misalignment cited in the issue.

Closes #7336.
Fixed by #7327.