### PR TITLE
Fix canonical names for types in procedure literals

### DIFF
--- a/src/name_canonicalization.cpp
+++ b/src/name_canonicalization.cpp
@@ -675,6 +675,17 @@ gb_internal void write_canonical_entity_name(TypeWriter *w, Entity *e) {
 			}
 
 			goto write_base_name;
+		} else if (s->decl_info != nullptr && s->decl_info->proc_lit != nullptr) {
+			Ast *proc_lit = s->decl_info->proc_lit;
+			String file_name = filename_without_directory(proc_lit->file()->fullpath);
+			type_writer_append(w, e->pkg->name.text, e->pkg->name.len);
+			type_writer_append_fmt(w, CANONICAL_NAME_SEPARATOR CANONICAL_ANON_PREFIX "_%.*s:%d" CANONICAL_NAME_SEPARATOR,
+			                       LIT(file_name), ast_token(proc_lit).pos.offset);
+			if (e->scope->index > 0) {
+				write_scope_index_suffix = true;
+			}
+
+			goto write_base_name;
 		} else if ((s->flags & ScopeFlag_File) && s->file != nullptr) {
 			String file_name = filename_without_directory(s->file->fullpath);
 			type_writer_append(w, e->pkg->name.text, e->pkg->name.len);

--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -91,6 +91,7 @@ $ODIN check ../test_issue_6979.odin -no-entry-point $COMMON_CHECK
 $ODIN test ../test_issue_7008.odin $COMMON
 $ODIN check ../test_issue_7012.odin -no-entry-point $COMMON_CHECK
 $ODIN build ../test_issue_7037.odin $COMMON -o:none
+$ODIN check ../test_issue_7429.odin $COMMON_CHECK
 $ODIN test ../test_issue_7356.odin $COMMON
 $ODIN build ../test_issue_7167.odin $COMMON
 $ODIN build ../test_issue_7188.odin $COMMON

--- a/tests/issues/test_issue_7429.odin
+++ b/tests/issues/test_issue_7429.odin
@@ -1,0 +1,15 @@
+// Tests issue #7429: local distinct types in procedure literal values must have
+// unique canonical names.
+// https://github.com/odin-lang/Odin/issues/7429
+package test_issues
+
+main :: proc() {
+	_ = proc() {
+		Foo :: distinct string
+		_ = typeid_of(Foo)
+	}
+	_ = proc() {
+		Foo :: distinct string
+		_ = typeid_of(Foo)
+	}
+}


### PR DESCRIPTION
Closes #7429 

Since anonymous procedure literals don’t have checker entities, local types were falling back to just the type name for canonicalization. That meant identically named types in different literals could get the same canonical hash and panic the checker.

I have now included the procedure literal’s package, filename, and source offset in the canonical prefix so those types stay distinct.