### PR TITLE
Fixes -o:size

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -464,6 +464,15 @@ enum IntegerDivisionByZeroKind : u8 {
 	IntegerDivisionByZero_AllBits,
 };
 
+// values of BuildContext.optimization_level;
+// matches Odin_Optimization_Mode in checker.cpp
+enum OptimizationLevel : i32 {
+	OptimizationLevel_None       = -1,
+	OptimizationLevel_Minimal    =  0,
+	OptimizationLevel_Size       =  1,
+	OptimizationLevel_Speed      =  2,
+	OptimizationLevel_Aggressive =  3,
+};
 
 // This stores the information for the specify architecture of this build
 struct BuildContext {

--- a/src/llvm_backend.cpp
+++ b/src/llvm_backend.cpp
@@ -2438,6 +2438,7 @@ gb_internal WORKER_TASK_PROC(lb_llvm_function_pass_per_module) {
 			lbFunctionPassManagerKind pass_manager_kind = lbFunctionPassManager_default;
 			if (p->flags & lbProcedureFlag_WithoutMemcpyPass) {
 				pass_manager_kind = lbFunctionPassManager_default_without_memcpy;
+				lb_remove_attribute_from_proc(p->module, p->value, "optsize"); // incompatible with optnone
 				lb_add_attribute_to_proc(p->module, p->value, "optnone");
 				lb_add_attribute_to_proc(p->module, p->value, "noinline");
 			} else {

--- a/src/llvm_backend_general.cpp
+++ b/src/llvm_backend_general.cpp
@@ -3033,6 +3033,10 @@ gb_internal void lb_add_attribute_to_proc(lbModule *m, LLVMValueRef proc_value, 
 	LLVMAddAttributeAtIndex(proc_value, LLVMAttributeIndex_FunctionIndex, lb_create_enum_attribute(m->ctx, name, value));
 }
 
+gb_internal void lb_remove_attribute_from_proc(lbModule *m, LLVMValueRef proc_value, char const *name) {
+	LLVMRemoveEnumAttributeAtIndex(proc_value, LLVMAttributeIndex_FunctionIndex, LLVMGetEnumAttributeKindForName(name, gb_strlen(name)));
+}
+
 gb_internal bool lb_proc_has_attribute(lbModule *m, LLVMValueRef proc_value, char const *name) {
 	LLVMAttributeRef ref = LLVMGetEnumAttributeAtIndex(proc_value, LLVMAttributeIndex_FunctionIndex, LLVMGetEnumAttributeKindForName(name, gb_strlen(name)));
 	return ref != nullptr;

--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -213,6 +213,13 @@ gb_internal lbProcedure *lb_create_procedure(lbModule *m, Entity *entity, bool i
 	case ProcedureOptimizationMode_FavorSize:
 		lb_add_attribute_to_proc(m, p->value, "optsize");
 		break;
+	default:
+		// need optsize per proc for -o:size;
+		// (inliner, unroller, vectorizer, etc check it) 
+		if (build_context.optimization_level == OptimizationLevel_Size) {
+			lb_add_attribute_to_proc(m, p->value, "optsize");
+		}
+		break;
 	}
 
 	if (pt->Proc.enable_target_feature.len != 0) {


### PR DESCRIPTION
The -o:size optimization level currently doesn't work, it occasionally produces code bigger than o:speed.

This PR fixes it by adding the optsize attribute per procedure at this optimization level. Optsize is then consulted by most of the passes.

On Linux, x64, default target, -o:size, LLVM 22, compiling examples/demo.odin I get
| demo.odin      | code section   | .rodata | filesize   |
|---------------------------|--------:|--------:|--------:|
| before   | 331350 | 29248  | 540200 |
| after | 240342 | 26736  | 447832 |

or around 27% smaller code and around 17% smaller binary.


Note that one of the tests (union_in_aggregates in tests/internal/test_union_const.odin) segfaults at -o:size (Linux, x64, default target (SSE), LLVM 22) due to hitting one of the compiler's alignment bugs. On my pc the test is working by accident at o:speed, -o:minimal and -o:none (an align-1 alloca's (u in the test) field happens to land at alignment 16 (type alignment required and assumed for indirect args), which satisfies the movdqa instruction issued, but -o:size happens to change the stack layout and the same align-1alloca lands at alignment 8, causing the segfault). This bug is fixed in https://github.com/odin-lang/Odin/pull/7382 by copying underaligned indirect args to aligned temp before passing.