### PR TITLE
normalize bool cmp

### DIFF
--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -3860,6 +3860,24 @@ gb_internal lbValue lb_emit_comp(lbProcedure *p, TokenKind op_kind, lbValue left
 			rhs = lb_emit_byte_swap(p, {rhs, pt}, pt).value;
 		}
 
+		if (is_type_boolean(a) && is_type_boolean(b) && (op_kind == Token_CmpEq || op_kind == Token_NotEq)) {
+			// anything not 0 is true, which is what control flow already tests for
+			bool lhs_is_const = LLVMIsAConstantInt(lhs) != nullptr;
+			bool rhs_is_const = LLVMIsAConstantInt(rhs) != nullptr;
+			if (lhs_is_const != rhs_is_const) {
+				// against a literal, the truthiness test is the whole comparison
+				LLVMValueRef v = rhs_is_const ? lhs : rhs;
+				LLVMValueRef c = rhs_is_const ? rhs : lhs;
+				bool is_true = LLVMConstIntGetZExtValue(c) != 0;
+				pred = ((op_kind == Token_CmpEq) == is_true) ? LLVMIntNE : LLVMIntEQ;
+				lhs = v;
+				rhs = LLVMConstNull(LLVMTypeOf(v));
+			} else {
+				lhs = LLVMBuildICmp(p->builder, LLVMIntNE, lhs, LLVMConstNull(LLVMTypeOf(lhs)), "");
+				rhs = LLVMBuildICmp(p->builder, LLVMIntNE, rhs, LLVMConstNull(LLVMTypeOf(rhs)), "");
+			}
+		}
+
 		res.value = LLVMBuildICmp(p->builder, pred, lhs, rhs, "");
 	} else if (is_type_float(a)) {
 		LLVMRealPredicate pred = {};

--- a/tests/issues/run.bat
+++ b/tests/issues/run.bat
@@ -43,6 +43,7 @@ set COMMON=-define:ODIN_TEST_FANCY=false -file -vet -strict-style -ignore-unused
 ..\..\..\odin test ..\test_issue_7008.odin %COMMON%  || exit /b
 ..\..\..\odin check ..\test_issue_7012.odin -no-entry-point %COMMON% || exit /b
 ..\..\..\odin check ..\test_issue_7260.odin -no-entry-point %COMMON% || exit /b
+..\..\..\odin test ..\test_issue_bool_comparison_truthiness.odin %COMMON%  || exit /b
 ..\..\..\odin check ..\test_issue_ellipsis_type_call.odin -no-entry-point %COMMON% 2>&1 | find /c "Error:" | findstr /x "10" || exit /b
 ..\..\..\odin check ..\test_issue_foreign_redeclaration.odin -no-entry-point %COMMON% || exit /b
 ..\..\..\odin check ..\test_issue_foreign_redeclaration_mismatch.odin -no-entry-point %COMMON% 2>&1 | find /c "Error:" | findstr /x "1" || exit /b

--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -95,6 +95,7 @@ $ODIN test ../test_issue_7356.odin $COMMON
 $ODIN build ../test_issue_7167.odin $COMMON
 $ODIN build ../test_issue_7188.odin $COMMON
 $ODIN check ../test_issue_7260.odin -no-entry-point $COMMON_CHECK
+$ODIN test ../test_issue_bool_comparison_truthiness.odin $COMMON
 
 $ODIN check ../test_issue_foreign_redeclaration.odin -no-entry-point $COMMON_CHECK
 if [[ $($ODIN check ../test_issue_foreign_redeclaration_mismatch.odin -no-entry-point $COMMON_CHECK 2>&1 >/dev/null | grep -c "Error:") -eq 1 ]]; then

--- a/tests/issues/test_issue_bool_comparison_truthiness.odin
+++ b/tests/issues/test_issue_bool_comparison_truthiness.odin
@@ -1,0 +1,57 @@
+package test_issues
+
+import "core:testing"
+
+// A boolean is true when its payload is non-zero, which is what `if`, `!` and `&&` test for.
+// `==`, `!=` and `switch` compared the payload against 1 instead, so a boolean decoded from
+// bytes -- transmuted, read through a pointer, or returned by a foreign procedure -- was true
+// under `if` yet matched neither arm of its own switch.
+
+@(test)
+bool_comparison_uses_truthiness :: proc(t: ^testing.T) {
+	two: u8 = 2
+	one: u8 = 1
+	nil_: u8 = 0
+
+	b := transmute(bool)two
+	c := transmute(bool)one
+	f := transmute(bool)nil_
+
+	testing.expect(t, b, "a non-zero payload is true")
+
+	testing.expect_value(t, b == true,  true)
+	testing.expect_value(t, b != true,  false)
+	testing.expect_value(t, b == false, false)
+	testing.expect_value(t, b != false, true)
+
+	// both operands are normalised, not just the literal one
+	testing.expect_value(t, b == c, true)
+	testing.expect_value(t, b != c, false)
+	testing.expect_value(t, b == f, false)
+	testing.expect_value(t, b != f, true)
+
+	arm := 2
+	switch b {
+	case true:  arm = 1
+	case false: arm = 0
+	}
+	testing.expect_value(t, arm, 1)
+
+	// the wider boolean types share the path
+	two16: u16 = 2
+	two32: u32 = 2
+	two64: u64 = 2
+	testing.expect_value(t, transmute(b8)two    == true, true)
+	testing.expect_value(t, transmute(b16)two16 == true, true)
+	testing.expect_value(t, transmute(b32)two32 == true, true)
+	testing.expect_value(t, transmute(b64)two64 == true, true)
+
+	// the normal 0/1 payloads keep behaving
+	yes := true
+	no  := false
+	testing.expect_value(t, yes == true,  true)
+	testing.expect_value(t, yes == false, false)
+	testing.expect_value(t, no  == false, true)
+	testing.expect_value(t, yes == no,    false)
+	testing.expect_value(t, yes != no,    true)
+}


### PR DESCRIPTION
The rule is that anything not `0` is true. The backend implements it on the control-flow paths and not on the comparison path.

`lb_emit_comp` groups `is_type_boolean` with integers, pointers, enums and procedures, and emits `icmp` on the raw values. Control flow is lowered elsewhere and tests for non-zero. Emitted at `-o:none`, before any LLVM pass:

```
  if b               icmp ne i8 %0, 0      non-zero test
  !b                 icmp eq i8 %0, 0      non-zero test
  b && c             icmp ne i8 %0, 0      non-zero test
  b ? x : y          icmp ne i8 %0, 0      non-zero test
  b == true          icmp eq i8 %0, 1      <-- payload
  b != true          icmp ne i8 %0, 1      <-- payload
  b == c             icmp eq i8 %0, %1     <-- payload against payload
  switch b           icmp eq 1 / icmp eq 0 <-- payload
```

Nothing normalizes a `bool` on load, so a payload other than 0 or 1 arrives whenever a boolean is decoded rather than computed: `transmute`, a pointer cast over bytes from a file or a socket, a foreign procedure returning a C `_Bool` or an `int`-shaped flag, or a `bit_field` boolean field wider than one bit.

```odin
package main
import "core:fmt"

main :: proc() {
	bytes := [1]u8{2}
	b := (^bool)(&bytes[0])^

	sw := "neither"
	switch b {
	case true:  sw = "true"
	case false: sw = "false"
	}
	fmt.printf("if=%v ==true=%v ==false=%v switch=%v\n", b ? true : false, b == true, b == false, sw)
}
```

```
if=true ==true=false ==false=false switch=neither
```

A two-valued type falls through its own exhaustive case analysis and reaches the code after the `switch`. Identical under `-o:none`, `-o:minimal`, `-o:size` and `-o:speed`, and on `b8`, `b16`, `b32` and `b64` as well as `bool`, so it is neither an unoptimised-build artefact nor specific to `i8`.

Two booleans compare their payloads against each other, so two values that are both true can compare unequal:

```odin
b := (^bool)(&two[0])^   // payload 2
c := (^bool)(&one[0])^   // payload 1
b == c                   // false, both are true
```

### Fix

Normalise both operands with `icmp ne 0` before the comparison, so `==`, `!=` and `switch` ask the same question `if` does. `trunc i8 %b to i1` is the other reading of "convert to an i1 first", but it takes the low bit -- `2` would become `false` -- which contradicts the rule and would force `if b` to change too. `icmp ne 0` is already the convention in the same file.

When one operand is a literal, the truthiness test *is* the comparison, so that case picks the predicate instead of emitting a second `icmp`.

### Codegen

Measured at `-o:speed`, x86-64:

```
                     before          after
  b == true          3 insns         3 insns    cmp $1 becomes test
  b == false         3 insns         3 insns    unchanged
  switch b           8 insns         4 insns    the cmp $1 chain collapses
  b == c             3 insns         5 insns    two extra branchless insns
  b != c             3 insns         5 insns    two extra branchless insns
```

At `-o:none` every literal comparison emits exactly one `icmp`, the same count as before. Only a boolean-against-boolean comparison grows, and that is the case that was wrong.