### PR TITLE
Fix: `min(T) % -1` kills the process with SIGFPE, at every hardware width.

### DIFF
--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -322,6 +322,21 @@ gb_internal IntegerDivisionByZeroKind lb_check_for_integer_division_by_zero_beha
 }
 
 
+// LLVM has srem(min(Integer_Type), -1) as UB and it raises an FP exception on a hardware
+// divide, yet `x % -1` is 0 for every x; `x srem 1` is 0 too and cannot trap, so a runtime
+// -1 divisor can be swapped for 1. Vectorizable.
+gb_internal LLVMValueRef lb_srem_safe_divisor(lbProcedure *p, LLVMValueRef rhs) {
+	LLVMValueRef minus_one = LLVMConstAllOnes(LLVMTypeOf(rhs));
+	// build 1 as neg(-1), this folds for both scalars and vectors
+	LLVMValueRef one = LLVMBuildNeg(p->builder, minus_one, "");
+	if (LLVMIsAConstantInt(rhs)) {
+		return rhs == minus_one ? one : rhs;
+	}
+	LLVMValueRef is_minus_one = LLVMBuildICmp(p->builder, LLVMIntEQ, rhs, minus_one, "");
+	return LLVMBuildSelect(p->builder, is_minus_one, one, rhs, "");
+}
+
+
 // implements %% (the remainder/floored mod operator) on signed integers;
 // this is branchless and vectorizable, so it also covers vectors
 gb_internal LLVMValueRef lb_emit_signed_floor_mod(lbProcedure *p, LLVMValueRef lhs, LLVMValueRef rhs) {	
@@ -329,24 +344,11 @@ gb_internal LLVMValueRef lb_emit_signed_floor_mod(lbProcedure *p, LLVMValueRef l
 	// and works for arbitrary precision integers, but the add can wrap at finite precision
 
 	// the Odin spec mandates min(Integer_Type) %% -1 must be 0,
-	// but LLVM has srem(min(Integer_Type), -1) as UB and results in FP exception;
-	// since x %% -1 == 0 for every x, a constant rhs = -1 can fold,
-	// and a runtime -1 can be swapped with 1 (x srem 1 is 0 for every x, no exceptions)	
-	LLVMValueRef minus_one = LLVMConstAllOnes(LLVMTypeOf(rhs));
-	LLVMValueRef safe_rhs = rhs;
-	if (LLVMIsAConstantInt(rhs)) {
-		if (rhs == minus_one) {
-			return LLVMConstNull(LLVMTypeOf(rhs)); // the entire %% op folds to 0
-		}
-	} else {
-		// safe_rhs = (rhs == -1) ? 1 : rhs 
-		// vectorizable construction,
-		// build 1 as neg(-1), this folds for both scalars and vectors
-		LLVMValueRef one = LLVMBuildNeg(p->builder, minus_one, "");
-		LLVMValueRef is_minus_one = LLVMBuildICmp(p->builder, LLVMIntEQ, rhs, minus_one, "");
-		safe_rhs = LLVMBuildSelect(p->builder, is_minus_one, one, rhs, "");
+	// a constant rhs = -1 can fold the whole operation, a runtime one is handled by the swap
+	if (LLVMIsAConstantInt(rhs) && rhs == LLVMConstAllOnes(LLVMTypeOf(rhs))) {
+		return LLVMConstNull(LLVMTypeOf(rhs)); // the entire %% op folds to 0
 	}
-	LLVMValueRef r = LLVMBuildSRem(p->builder, lhs, safe_rhs, "");
+	LLVMValueRef r = LLVMBuildSRem(p->builder, lhs, lb_srem_safe_divisor(p, rhs), "");
 	// srem truncs to 0, so r needs a +rhs correction when the operands signs differ (and r != 0)
 	// so we implement
 	// r = lhs % rhs
@@ -498,9 +500,10 @@ gb_internal bool lb_try_direct_vector_arith(lbProcedure *p, TokenKind op, lbValu
 				}
 				break;
 			case Token_Mod:
-				{
-					auto *call = is_type_unsigned(integral_type) ? LLVMBuildURem : LLVMBuildSRem;
-					z = call(p->builder, x, y, "");
+				if (is_type_unsigned(integral_type)) {
+					z = LLVMBuildURem(p->builder, x, y, "");
+				} else {
+					z = LLVMBuildSRem(p->builder, x, lb_srem_safe_divisor(p, y), "");
 				}
 				break;
 			case Token_ModMod:
@@ -610,9 +613,10 @@ gb_internal bool lb_try_direct_vector_arith(lbProcedure *p, TokenKind op, lbValu
 				}
 				break;
 			case Token_Mod:
-				{
-					auto *call = is_type_unsigned(integral_type) ? LLVMBuildURem : LLVMBuildSRem;
-					z = call(p->builder, x, y, "");
+				if (is_type_unsigned(integral_type)) {
+					z = LLVMBuildURem(p->builder, x, y, "");
+				} else {
+					z = LLVMBuildSRem(p->builder, x, lb_srem_safe_divisor(p, y), "");
 				}
 				break;
 			case Token_ModMod:
@@ -1684,7 +1688,8 @@ gb_internal LLVMValueRef lb_integer_modulo(lbProcedure *p, LLVMValueRef lhs, LLV
 			if (is_unsigned) {
 				return LLVMBuildURem(p->builder, lhs, rhs, "");
 			} else {
-				return LLVMBuildSRem(p->builder, lhs, rhs, "");
+				// min(Integer_Type) % -1 is 0, matching the constant folder, and must not trap
+				return LLVMBuildSRem(p->builder, lhs, lb_srem_safe_divisor(p, rhs), "");
 			}
 		}
 	};

--- a/tests/internal/test_mod.odin
+++ b/tests/internal/test_mod.odin
@@ -1,0 +1,105 @@
+package test_internal
+
+import "core:testing"
+
+// % operator (truncated remainder)
+// remainder = x - y * trunc(x / y)
+
+@(private="file")
+trunc_mod :: proc(x, y: $T) -> T {
+	return x - y*(x/y)
+}
+
+// this seems to prevent folding at least at -o:minimal
+@(private="file")
+not_const :: #force_no_inline proc(v: $T) -> T { return v }
+
+@(test)
+mod_i8_exhaustive :: proc(t: ^testing.T) {
+	for i in -128..=127 {
+		for j in -128..=127 {
+			if j == 0 { continue }
+			// min(T) % -1 == 0 is tested in mod_exception,
+			// the trunc_mod reference itself would trap here
+			if i == -128 && j == -1 { continue }
+			x, y := i8(i), i8(j)
+			got := x % y
+			want := trunc_mod(x, y)
+			testing.expectf(t, got == want, "%v %% %v == %v, want %v", x, y, got, want)
+		}
+	}
+}
+
+@(test)
+mod_exception :: proc(t: ^testing.T) {
+	// min(T) % -1 is 0, which is what the constant folder answers
+	#assert(min(i8)   % i8(-1)   == 0)
+	#assert(min(i16)  % i16(-1)  == 0)
+	#assert(min(i32)  % i32(-1)  == 0)
+	#assert(min(i64)  % i64(-1)  == 0)
+	#assert(min(i128) % i128(-1) == 0)
+
+	check :: proc(t: ^testing.T, $T: typeid, loc := #caller_location) {
+		x, y := not_const(min(T)), not_const(T(-1))
+		testing.expectf(t, x % y == 0,  "min(%v) %% -1 (rt divisor) == %v, want 0", typeid_of(T), x % y, loc = loc)
+		testing.expectf(t, x % -1 == 0, "min(%v) %% -1 (const divisor) == %v, want 0", typeid_of(T), x % -1, loc = loc)
+	}
+	check(t, i8)
+	check(t, i16)
+	check(t, i32)
+	check(t, i64)
+	check(t, i128)
+}
+
+@(test)
+mod_exception_vec :: proc(t: ^testing.T) {
+	{
+		// [4]i32 emits `srem <4 x i32>`
+		x := not_const([4]i32{min(i32), 0, -7, 5})
+		y := not_const([4]i32{-1, -1, -1, -1})
+		testing.expect_value(t, x % y, [4]i32{0, 0, 0, 0})
+	}
+	{
+		// [16]i32 emits scalar `srem i32`, which is the other call site
+		x, y: [16]i32
+		for i in 0..<16 {
+			x[i] = i == 0 ? min(i32) : i32(i) - 8
+			y[i] = -1
+		}
+		testing.expect_value(t, not_const(x) % not_const(y), [16]i32{})
+	}
+}
+
+@(test)
+mod_assign :: proc(t: ^testing.T) {
+	// %= must agree with %
+	{
+		x := not_const(min(i32))
+		y := not_const(i32(-1))
+		x %= y
+		testing.expect_value(t, x, 0)
+	}
+	{
+		x := not_const(i64(-17))
+		y := not_const(i64(5))
+		x %= y
+		testing.expect_value(t, x, -17 % 5)
+	}
+}
+
+@(test)
+mod_unsigned_unchanged :: proc(t: ^testing.T) {
+	// the guard is signed-only; unsigned max is all-ones and must stay a real divisor
+	{
+		x, y := not_const(max(u32)), not_const(max(u32))
+		testing.expect_value(t, x % y, 0)
+	}
+	{
+		x, y := not_const(u32(7)), not_const(max(u32))
+		testing.expect_value(t, x % y, 7)
+	}
+	{
+		x, y := not_const(u8(200)), not_const(u8(255))
+		testing.expect_value(t, x % y, 200)
+	}
+}


### PR DESCRIPTION
`min(T) % -1` kills the process with SIGFPE, at every hardware width.

```odin
package main

import "core:fmt"
import "core:os"

@(optimization_mode="none")
opaque :: proc(v: i32) -> i32 { return v }

main :: proc() {
	n := opaque(i32(-i32(len(os.args))))   // -1, opaque to every pass
	fmt.println(min(i32) % n)
}
```

```
$ ./a.out
Floating point exception (core dumped)     exit 136
```

```
  i8    exit 136
  i16   exit 136
  i32   exit 136
  i64   exit 136
  i128  prints 0     <-- software divide, no hardware trap
```

`%` lowers to `srem`, LLVM treats `srem(min(T), -1)` as UB, and on x86 `idiv` raises #DE because the quotient `2^(n-1)` is not representable, even though only the remainder was asked for.

The constant folder answers `0` for the same expression, and `0` is the mathematically correct remainder:

```odin
#assert(min(i8)   % i8(-1)   == 0)   // passes
#assert(min(i32)  % i32(-1)  == 0)   // passes
#assert(min(i128) % i128(-1) == 0)   // passes
```

So the compiler contradicts itself, and the runtime side is the one that crashes. The divisor has to be opaque to reach codegen, which is why ordinary code does not hit it.

`/` is not the same case. The folder rejects it outright --

```
Error: Numeric value '2147483648' from 'min(i32) / i32(-1)' cannot be represented by 'i32'
```

Because the mathematical result really is out of range, so a runtime trap agrees with the compile-time verdict. This PR leaves `/` alone.

### Fix

[#7353](https://github.com/odin-lang/Odin/pull/7353) already solved this for `%%`: a runtime `-1` divisor is swapped for `1`, because `x srem 1` is `0` for every `x` and cannot trap. `%` needs the same swap and no correction term, so this lifts that guard into `lb_srem_safe_divisor` and calls it from every `srem` site.

There are three, and all three were reachable:

```
  lb_integer_modulo                   scalar  a % b
  lb_try_direct_vector_arith          [4]i32  % lowers to srem <4 x i32>
  the element-wise array path         [16]i32 % lowers to scalar srem i32
```

`lb_emit_signed_floor_mod` keeps its own early return, a constant `-1` folds the whole `%%` operation to `0`. Now shares the divisor swap instead of open-coding it.

### Codegen

Measured at `-o:speed`, x86-64, instruction counts:

```
                            before    after
  a % 16       const           7        7     unchanged
  a % 7        const          13       13     unchanged
  a % b        i32             9       12     cmp / mov / cmovne ahead of idiv
  a % b        u32             9        9     unchanged, guard is signed-only
  a %% b       i32            18       18     unchanged
  [4]i32 % b   vector         27       33
  a / b        i32             8        8     unchanged, `/` untouched
```

Nothing changes for a constant or unsigned divisor. A dynamic signed `%` pays three branchless instructions in front of an `idiv`, which is the same price `%%` already pays.
