### PR TITLE
Fixed typo in raylib.odin

### DIFF
--- a/core/math/rand/rand.odin
+++ b/core/math/rand/rand.odin
@@ -561,7 +561,7 @@ uint_max :: proc(n: uint, gen := context.random_generator) -> (val: uint) {
 Generates a random unsigned 32 bit value in the range `[lo, hi)` using the provided random number generator. If no generator is provided the global random number generator will be used.
 
 Inputs:
-- lo: The lower bound of the generated number, this value is inclusice
+- lo: The lower bound of the generated number, this value is inclusive
 - hi: The upper bound of the generated number, this value is exclusive
 
 Returns:

--- a/vendor/raylib/raylib.odin
+++ b/vendor/raylib/raylib.odin
@@ -663,7 +663,7 @@ MouseButton :: enum c.int {
 	MIDDLE  = 2,                      // Mouse button middle (pressed wheel)
 	SIDE    = 3,                      // Mouse button side (advanced mouse device)
 	EXTRA   = 4,                      // Mouse button extra (advanced mouse device)
-	FORWARD = 5,                      // Mouse button fordward (advanced mouse device)
+	FORWARD = 5,                      // Mouse button forward (advanced mouse device)
 	BACK    = 6,                      // Mouse button back (advanced mouse device)
 }
 


### PR DESCRIPTION
Fixed typo on line 666 (!?) from "fordward" to "forward"