### PR TITLE
Remove microarch:native from 3 Windows tests and tweak Win test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,19 +264,18 @@ jobs:
       - name: Wycheproof tests
         shell: cmd
         run: |
-          rem call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          rem odin test tests/core/crypto/wycheproof -vet -vet-tabs -strict-style -vet-style -vet-cast -warnings-as-errors -disallow-do -o:speed -microarch:native
-          echo Skipping Wycheproof on Windows because of CI flakiness that can't be replicated on real hardware
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          odin test tests/core/crypto/wycheproof -vet -vet-tabs -strict-style -vet-style -vet-cast -warnings-as-errors -disallow-do -o:speed
       - name: Noise Protocol Framework tests
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          odin test tests/core/crypto/noise -vet -vet-tabs -strict-style -vet-style -vet-cast -warnings-as-errors -disallow-do -o:speed -microarch:native
+          odin test tests/core/crypto/noise -vet -vet-tabs -strict-style -vet-style -vet-cast -warnings-as-errors -disallow-do -o:speed
       - name: X.509 limbo tests
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          odin test tests/core/crypto/x509_limbo -vet -vet-tabs -strict-style -vet-style -vet-cast -warnings-as-errors -disallow-do -o:speed -microarch:native
+          odin test tests/core/crypto/x509_limbo -vet -vet-tabs -strict-style -vet-style -vet-cast -warnings-as-errors -disallow-do -o:speed
       - name: Vendor library tests
         shell: cmd
         run: |

--- a/core/testing/signal_handler_windows.odin
+++ b/core/testing/signal_handler_windows.odin
@@ -48,7 +48,7 @@ when ODIN_ARCH == .i386 {
 
 @(private="file")
 stop_runner_callback :: proc "system" (ctrl_type: win32.DWORD) -> win32.BOOL  {
-	if ctrl_type == win32.CTRL_C_EVENT {
+	if ctrl_type == win32.CTRL_C_EVENT || ctrl_type == win32.CTRL_BREAK_EVENT || ctrl_type == win32.CTRL_CLOSE_EVENT {
 		prev := intrinsics.atomic_add(&stop_runner_flag, 1)
 
 		// If the flag was already set (if this is the second signal sent for example),
@@ -77,6 +77,12 @@ stop_test_callback :: proc "system" (info: ^win32.EXCEPTION_POINTERS) -> win32.L
 
 	context = runtime.default_context()
 	code := info.ExceptionRecord.ExceptionCode
+	if code < 0x8000_0000 {
+		// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/87fba13e-bf06-450e-83b1-9241dc81e781
+		// Ignore informational status codes
+		return win32.EXCEPTION_CONTINUE_SEARCH
+	}
+
 
 	if local_test_index == -1 {
 		// We're the test runner, and we ourselves have caught a signal from
@@ -210,4 +216,3 @@ _should_stop_test :: proc() -> (test_index: int, reason: Stop_Reason, ok: bool) 
 
 	return
 }
-


### PR DESCRIPTION
Following #7447, we suspect an issue on LLVM instruction set discovery on certain GitHub test runners, namely the AMD EPYC 9V74. This PR removes the microarch:native build flag from three tests that have seen intermittent failures.

Further research should investigate whether microarch flags like `x86-64-v3` or `x86-64-v2` also mitigate the issue.

The PR also adds some additional checks to the Windows test runner to maintain correctness in case of unexpected signals.