### PR TITLE
Fix a swizzle target in a multi-assignment reading an already-written source

### DIFF
--- a/src/llvm_backend_utility.cpp
+++ b/src/llvm_backend_utility.cpp
@@ -994,7 +994,7 @@ gb_internal lbAddr lb_find_or_generate_context_ptr(lbProcedure *p) {
 }
 
 gb_internal lbValue lb_address_from_load_or_generate_local(lbProcedure *p, lbValue value) {
-	if (LLVMIsALoadInst(value.value)) {
+	if (!p->in_multi_assignment && LLVMIsALoadInst(value.value)) {
 		lbValue res = {};
 		res.value = LLVMGetOperand(value.value, 0);
 		res.type = alloc_type_pointer(value.type);

--- a/tests/issues/run.bat
+++ b/tests/issues/run.bat
@@ -52,6 +52,7 @@ set COMMON=-define:ODIN_TEST_FANCY=false -file -vet -strict-style -ignore-unused
 clang -c ..\test_issue_sysv_abi.c -o test_issue_sysv_abi_c.o || exit /b
 ..\..\..\odin test ..\test_issue_sysv_abi.odin %COMMON%  || exit /b
 ..\..\..\odin build ..\test_issue_7073-1.odin %COMMON% 2>&1 | find /c "Error:" | findstr /x "2" || exit /b
+..\..\..\odin test ..\test_issue_swizzle_multi_assign.odin %COMMON%  || exit /b
 
 @echo off
 

--- a/tests/issues/run.sh
+++ b/tests/issues/run.sh
@@ -97,6 +97,7 @@ $ODIN build ../test_issue_7167.odin $COMMON
 $ODIN build ../test_issue_7188.odin $COMMON
 $ODIN check ../test_issue_7260.odin -no-entry-point $COMMON_CHECK
 $ODIN test ../test_issue_bool_to_be_conversion.odin $COMMON
+$ODIN test ../test_issue_swizzle_multi_assign.odin $COMMON
 
 $ODIN check ../test_issue_foreign_redeclaration.odin -no-entry-point $COMMON_CHECK
 if [[ $($ODIN check ../test_issue_foreign_redeclaration_mismatch.odin -no-entry-point $COMMON_CHECK 2>&1 >/dev/null | grep -c "Error:") -eq 1 ]]; then

--- a/tests/issues/test_issue_swizzle_multi_assign.odin
+++ b/tests/issues/test_issue_swizzle_multi_assign.odin
@@ -1,0 +1,80 @@
+package test_issues
+
+import "core:testing"
+
+// A multi-assignment reads every right-hand side before it stores into any target, which is what
+// makes `a, b = b, a` a swap. Storing into a swizzle reused the address the source was loaded from
+// instead of the value read at that point, so a source that named a target written earlier in the
+// same statement read back the new contents.
+
+@(test)
+swizzle_multi_assign_swap :: proc(t: ^testing.T) {
+	v := [4]f32{1, 2, 3, 4}
+	v.xy, v.zw = v.zw, v.xy
+	testing.expect_value(t, v, [4]f32{3, 4, 1, 2})
+
+	// the other order happened to be correct already
+	w := [4]f32{1, 2, 3, 4}
+	w.zw, w.xy = w.xy, w.zw
+	testing.expect_value(t, w, [4]f32{3, 4, 1, 2})
+
+	x := [4]f32{1, 2, 3, 4}
+	x.xy, x.wz = x.wz, x.xy
+	testing.expect_value(t, x, [4]f32{4, 3, 2, 1})
+}
+
+@(test)
+swizzle_multi_assign_element_types :: proc(t: ^testing.T) {
+	a := [4]i32{1, 2, 3, 4}
+	a.xy, a.zw = a.zw, a.xy
+	testing.expect_value(t, a, [4]i32{3, 4, 1, 2})
+
+	b := [4]f64{1, 2, 3, 4}
+	b.xy, b.zw = b.zw, b.xy
+	testing.expect_value(t, b, [4]f64{3, 4, 1, 2})
+
+	c := [4]u8{1, 2, 3, 4}
+	c.xy, c.zw = c.zw, c.xy
+	testing.expect_value(t, c, [4]u8{3, 4, 1, 2})
+}
+
+@(test)
+swizzle_multi_assign_through_pointer :: proc(t: ^testing.T) {
+	v := [4]f32{1, 2, 3, 4}
+	p := &v
+	p.xy, p.zw = p.zw, p.xy
+	testing.expect_value(t, v, [4]f32{3, 4, 1, 2})
+}
+
+@(test)
+swizzle_multi_assign_across_variables :: proc(t: ^testing.T) {
+	// the source names a different variable, which an earlier store still writes to
+	a := [4]f32{1, 2, 3, 4}
+	b := [4]f32{5, 6, 7, 8}
+	a.xy, b.xy = b.xy, a.xy
+	testing.expect_value(t, a, [4]f32{5, 6, 3, 4})
+	testing.expect_value(t, b, [4]f32{1, 2, 7, 8})
+}
+
+@(test)
+swizzle_multi_assign_three_targets :: proc(t: ^testing.T) {
+	v := [4]f32{1, 2, 3, 4}
+	v.xy, v.zw, v.x = v.zw, v.xy, v.w
+	testing.expect_value(t, v, [4]f32{4, 4, 1, 2})
+}
+
+@(test)
+swizzle_single_assign_unchanged :: proc(t: ^testing.T) {
+	// one target still reads every lane before it writes any of them
+	v := [4]f32{1, 2, 3, 4}
+	v.yzw = v.xyz
+	testing.expect_value(t, v, [4]f32{1, 1, 2, 3})
+
+	w := [4]f32{1, 2, 3, 4}
+	w.xy = w.zw
+	testing.expect_value(t, w, [4]f32{3, 4, 3, 4})
+
+	x := [4]f32{1, 2, 3, 4}
+	x.x, x.y = x.y, x.x
+	testing.expect_value(t, x, [4]f32{2, 1, 3, 4})
+}


### PR DESCRIPTION
In a multi-assignment, a swizzle target read its source value at *store* time rather than at *read* time, so a source naming a target written earlier in the same statement came back with the new contents.

```odin
v := [4]f32{1, 2, 3, 4}
v.xy, v.zw = v.zw, v.xy
// expected [3, 4, 1, 2]
// got      [3, 4, 3, 4]
```

The first store writes `v.xy = [3, 4]`. The second store then reads its source through a pointer into `v` itself, so `v.zw` is assigned the `[3, 4]` that was just written instead of the `[1, 2]` that was there when the right-hand sides were evaluated.

### Why

The three swizzle store paths in `lb_addr_store` (`lbAddr_Swizzle`, `lbAddr_SwizzleLarge`, `lbAddr_SwizzleSoa`) call `lb_address_from_load_or_generate_local` to get a pointer to the value being stored. That helper short-circuits when the value is a load: rather than copying into a fresh local it returns the load's own source pointer, and the store then reads memory that a preceding store in the same statement may have changed.

`lb_emit_store` already refuses that short-circuit inside a multi-assignment:

```cpp
// src/llvm_backend_general.cpp:1524
if (!p->in_multi_assignment && LLVMIsALoadInst(value.value)) {
```

`lb_address_from_load_or_generate_local` had no such guard, so the fix is the same test in the same place. `p->in_multi_assignment` is set in `lb_build_assignment` after every right-hand side has been evaluated and before the store loop runs, which is exactly the window where the aliasing matters.

Outside a multi-assignment nothing changes, so the existing copy elision is untouched.

### Scope of the bug

Reproduces on master with every element type tried (`f32`, `f64`, `i32`, `u8`, pointer), through a pointer to the array, across two distinct variables, and with three targets. It is not optimisation-dependent, all of `-o:none` through `-o:aggressive` are wrong the same way.

An exhaustive sweep of the 36 disjoint equal-length swizzle-pair swaps on `[4]f32` fails 2 cases on master and 0 after the fix. The two that fail are the ones whose *second* source is `.xy`, the prefix swizzle whose load can be addressed directly, which is why some orderings, such as `v.zw, v.xy = v.xy, v.zw`, happen to be correct on master already. The
test pins both orderings so the lucky one does not silently start failing.

Bit fields, `#soa` elements, struct fields, and matrix elements were checked on master and are not affected; they do not route their multi-assignment stores through this helper.
