### PR TITLE
convert constants before narrowing to i64 in the remaining checker sites

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -5230,6 +5230,12 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 			operand->type = t_invalid;
 			return false;
 		}
+		convert_to_typed(c, &x, t_int);
+		if (x.mode == Addressing_Invalid) {
+			operand->mode = Addressing_Type;
+			operand->type = t_invalid;
+			return false;
+		}
 		i64 count = big_int_to_i64(&x.value.value_integer);
 
 		check_expr_or_type(c, &y, ce->args[1]);
@@ -7710,6 +7716,12 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 				return false;
 			}
 			
+			convert_to_typed(c, &x, t_int);
+			if (x.mode == Addressing_Invalid) {
+				operand->mode = Addressing_Type;
+				operand->type = t_invalid;
+				return false;
+			}
 			i64 index = big_int_to_i64(&x.value.value_integer);
 			if (index < 0 || index >= u->Union.variants.count) {
 				error(call, "Variant tag out of bounds index for '%.*s", LIT(builtin_name));

--- a/src/check_stmt.cpp
+++ b/src/check_stmt.cpp
@@ -954,14 +954,17 @@ gb_internal void check_unroll_range_stmt(CheckerContext *ctx, Ast *node, u32 mod
 			error(x.expr, "Expected a constant integer for #unroll, got '%s'", s);
 			gb_string_free(s);
 		} else {
-			ExactValue value = exact_value_to_integer(x.value);
-			i64 v = exact_value_to_i64(value);
-			if (v < 1) {
-				error(x.expr, "Expected a constant integer >= 1 for #unroll, got %lld", cast(long long)v);
-			} else {
-				unroll_count = v;
-				if (v > 1024) {
-					error(x.expr, "Too large of a value for #unroll, got %lld, expected <= 1024", cast(long long)v);
+			convert_to_typed(ctx, &x, t_int);
+			if (x.mode != Addressing_Invalid) {
+				ExactValue value = exact_value_to_integer(x.value);
+				i64 v = exact_value_to_i64(value);
+				if (v < 1) {
+					error(x.expr, "Expected a constant integer >= 1 for #unroll, got %lld", cast(long long)v);
+				} else {
+					unroll_count = v;
+					if (v > 1024) {
+						error(x.expr, "Too large of a value for #unroll, got %lld, expected <= 1024", cast(long long)v);
+					}
 				}
 			}
 

--- a/src/check_type.cpp
+++ b/src/check_type.cpp
@@ -1120,6 +1120,13 @@ gb_internal void check_bit_field_type(CheckerContext *ctx, Type *bit_field_type,
 			gb_string_free(s);
 		}
 
+		if (o.mode == Addressing_Constant) {
+			convert_to_typed(ctx, &o, t_int);
+			if (o.mode == Addressing_Invalid) {
+				o.value = exact_value_i64(1);
+			}
+		}
+
 		ExactValue bit_size = o.value;
 
 		if (bit_size.kind != ExactValue_Integer) {


### PR DESCRIPTION
#7295 fixed the `exact_value_to_i64` sites in check_builtin.cpp that narrowed a constant before range-checking it. Four sites were left: two in other files, and two reached through `big_int_to_i64` instead.

Run `convert_to_typed(.., t_int)` first, as #7295 does, so an out-of-range constant is rejected by the existing diagnostic rather than silently wrapping into an accepted value.
