### PR TITLE
Fix justified printing of `0` producing all spaces.

### DIFF
--- a/core/fmt/fmt.odin
+++ b/core/fmt/fmt.odin
@@ -1102,7 +1102,13 @@ _fmt_int :: proc(fi: ^Info, u: u64, base: int, is_signed: bool, bit_size: int, d
 	if fi.prec_set {
 		prec = fi.prec
 		if prec == 0 && u == 0 {
-			fmt_write_padding(fi, fi.width)
+			if fi.minus {
+				io.write_byte(fi.writer, '0', &fi.n)
+				fmt_write_padding(fi, fi.width - 1)
+			} else {
+				fmt_write_padding(fi, fi.width - 1)
+				io.write_byte(fi.writer, '0', &fi.n)
+			}
 			return
 		}
 	} else if fi.zero && fi.width_set {

--- a/tests/core/fmt/test_core_fmt.odin
+++ b/tests/core/fmt/test_core_fmt.odin
@@ -402,7 +402,8 @@ test_fmt_left_justified_padding :: proc(t: ^testing.T) {
 	check(t, "3.0e+02   ",     "%-10.1e", 300.0)
 	check(t, "3.000000e+00  ", "%-14e",   3.0)
 	check(t, "1tib    ",       "%-8.0m",  mem.Terabyte)
-	check(t, "     ",          "%-5.0d",  0)
+	check(t, "0    ",          "%-5.0d",  0)
+	check(t, "0    ",          "%-5d",    0)
 	check(t, "ab   ",          "%-5s",    "ab")
 	check(t, "true ",          "%-5t",    true)
 	check(t, "42   ",          "%- 5d",   42)
@@ -415,6 +416,12 @@ test_fmt_left_justified_padding :: proc(t: ^testing.T) {
 	check(t, "-00042", "%6d",   -42)
 	check(t, "01tib",  "%5.0m", mem.Terabyte)
 	check(t, "   ab",  "%5s",   "ab")
+	check(t, "    0",  "% 5.0d", 0)
+	check(t, "    0",  "% 5d",   0)
+	check(t, "00000",  "%5.0d",  0)
+	check(t, "00000",  "%5d",    0)
+	check(t, "   42",  "% 5.0d", 42)
+	check(t, "   42",  "{: 5d}", 42)
 }
 
 @(private)


### PR DESCRIPTION
Addendum to #7461.

Replaces:
```odin
package main

@(require) import "core:fmt"

main :: proc() {
	fmt.printfln("<-- |%-5.0d|", 0) // <-- |     |
	fmt.printfln("<-- |%-5d|",   0) // <-- |0    |
	fmt.printfln("--> |% 5.0d|", 0) // --> |     |
	fmt.printfln("--> |% 5d|",   0) // --> |    0|
}
```
With:
```odin
package main

@(require) import "core:fmt"

main :: proc() {
	fmt.printfln("<-- |%-5.0d|", 0) // <-- |0    |
	fmt.printfln("<-- |%-5d|",   0) // <-- |0    |
	fmt.printfln("--> |% 5.0d|", 0) // --> |    0|
	fmt.printfln("--> |% 5d|",   0) // --> |    0|
}
```