### PR TITLE
[core:sys/darwin] expand CoreFoundation bindings

### DIFF
--- a/core/sys/darwin/CoreFoundation/CFArray.odin
+++ b/core/sys/darwin/CoreFoundation/CFArray.odin
@@ -1,0 +1,35 @@
+package CoreFoundation
+
+foreign import CoreFoundation "system:CoreFoundation.framework"
+
+Array        :: distinct TypeRef
+MutableArray :: distinct TypeRef
+
+ArrayRetainCallBack          :: proc "c" (allocator: AllocatorRef, value: rawptr) -> rawptr
+ArrayReleaseCallBack         :: proc "c" (allocator: AllocatorRef, value: rawptr)
+ArrayCopyDescriptionCallBack :: proc "c" (value: rawptr) -> String
+ArrayEqualCallBack           :: proc "c" (value1, value2: rawptr) -> b8
+
+ArrayCallBacks :: struct {
+	version:         Index,
+	retain:          ArrayRetainCallBack,
+	release:         ArrayReleaseCallBack,
+	copyDescription: ArrayCopyDescriptionCallBack,
+	equal:           ArrayEqualCallBack,
+}
+
+@(default_calling_convention="c")
+foreign CoreFoundation {
+	kCFTypeArrayCallBacks: ArrayCallBacks
+}
+
+@(link_prefix="CF", default_calling_convention="c")
+foreign CoreFoundation {
+	ArrayGetTypeID :: proc() -> TypeID ---
+	ArrayCreate :: proc(allocator: AllocatorRef, values: [^]rawptr, numValues: Index, callBacks: ^ArrayCallBacks) -> Array ---
+	ArrayCreateMutable :: proc(allocator: AllocatorRef, capacity: Index, callBacks: ^ArrayCallBacks) -> MutableArray ---
+	ArrayGetCount :: proc(theArray: Array) -> Index ---
+	ArrayGetValueAtIndex :: proc(theArray: Array, idx: Index) -> rawptr ---
+	ArrayGetFirstIndexOfValue :: proc(theArray: Array, range: Range, value: rawptr) -> Index ---
+	ArrayAppendValue :: proc(theArray: MutableArray, value: rawptr) ---
+}

--- a/core/sys/darwin/CoreFoundation/CFAttributedString.odin
+++ b/core/sys/darwin/CoreFoundation/CFAttributedString.odin
@@ -1,0 +1,20 @@
+package CoreFoundation
+
+foreign import CoreFoundation "system:CoreFoundation.framework"
+
+AttributedString        :: distinct TypeRef
+MutableAttributedString :: distinct TypeRef
+
+@(link_prefix="CF", default_calling_convention="c")
+foreign CoreFoundation {
+	AttributedStringGetTypeID :: proc() -> TypeID ---
+	AttributedStringCreate :: proc(alloc: AllocatorRef, str: String, attributes: Dictionary) -> AttributedString ---
+	AttributedStringGetString :: proc(aStr: AttributedString) -> String ---
+	AttributedStringGetLength :: proc(aStr: AttributedString) -> Index ---
+
+	AttributedStringCreateMutable :: proc(alloc: AllocatorRef, maxLength: Index) -> MutableAttributedString ---
+	AttributedStringCreateMutableCopy :: proc(alloc: AllocatorRef, maxLength: Index, aStr: AttributedString) -> MutableAttributedString ---
+	AttributedStringReplaceString :: proc(aStr: MutableAttributedString, range: Range, replacement: String) ---
+	AttributedStringSetAttributes :: proc(aStr: MutableAttributedString, range: Range, replacement: Dictionary, clearOtherAttributes: b8) ---
+	AttributedStringSetAttribute :: proc(aStr: MutableAttributedString, range: Range, attrName: String, value: TypeRef) ---
+}

--- a/core/sys/darwin/CoreFoundation/CFBase.odin
+++ b/core/sys/darwin/CoreFoundation/CFBase.odin
@@ -2,11 +2,14 @@ package CoreFoundation
 
 foreign import CoreFoundation "system:CoreFoundation.framework"
 
-TypeID      :: distinct uint
-OptionFlags :: distinct uint
-HashCode    :: distinct uint
-Index       :: distinct int
-TypeRef     :: distinct rawptr
+TypeID       :: distinct uint
+OptionFlags  :: distinct uint
+HashCode     :: distinct uint
+Index        :: distinct int
+TypeRef      :: distinct rawptr
+AllocatorRef :: distinct rawptr
+
+Null :: distinct TypeRef
 
 Range :: struct {
 	location: Index,
@@ -14,8 +17,16 @@ Range :: struct {
 }
 
 foreign CoreFoundation {
+	kCFNull: Null
+
+	CFRetain :: proc(cf: TypeRef) -> TypeRef ---
+
 	// Releases a Core Foundation object.
 	CFRelease :: proc(cf: TypeRef) ---
+
+	CFGetTypeID :: proc(cf: TypeRef) -> TypeID ---
+	CFEqual :: proc(cf1, cf2: TypeRef) -> b8 ---
+	CFNullGetTypeID :: proc() -> TypeID ---
 }
 
 // Releases a Core Foundation object.

--- a/core/sys/darwin/CoreFoundation/CFData.odin
+++ b/core/sys/darwin/CoreFoundation/CFData.odin
@@ -1,0 +1,15 @@
+package CoreFoundation
+
+foreign import CoreFoundation "system:CoreFoundation.framework"
+
+Data        :: distinct TypeRef
+MutableData :: distinct TypeRef
+
+@(link_prefix="CF", default_calling_convention="c")
+foreign CoreFoundation {
+	DataGetTypeID :: proc() -> TypeID ---
+	DataCreate :: proc(allocator: AllocatorRef, bytes: [^]u8, length: Index) -> Data ---
+	DataCreateMutable :: proc(allocator: AllocatorRef, capacity: Index) -> MutableData ---
+	DataGetLength :: proc(theData: Data) -> Index ---
+	DataGetBytePtr :: proc(theData: Data) -> [^]u8 ---
+}

--- a/core/sys/darwin/CoreFoundation/CFDictionary.odin
+++ b/core/sys/darwin/CoreFoundation/CFDictionary.odin
@@ -1,0 +1,48 @@
+package CoreFoundation
+
+foreign import CoreFoundation "system:CoreFoundation.framework"
+
+Dictionary        :: distinct TypeRef
+MutableDictionary :: distinct TypeRef
+
+DictionaryRetainCallBack          :: proc "c" (allocator: AllocatorRef, value: rawptr) -> rawptr
+DictionaryReleaseCallBack         :: proc "c" (allocator: AllocatorRef, value: rawptr)
+DictionaryCopyDescriptionCallBack :: proc "c" (value: rawptr) -> String
+DictionaryEqualCallBack           :: proc "c" (value1, value2: rawptr) -> b8
+DictionaryHashCallBack            :: proc "c" (value: rawptr) -> HashCode
+
+DictionaryKeyCallBacks :: struct {
+	version:         Index,
+	retain:          DictionaryRetainCallBack,
+	release:         DictionaryReleaseCallBack,
+	copyDescription: DictionaryCopyDescriptionCallBack,
+	equal:           DictionaryEqualCallBack,
+	hash:            DictionaryHashCallBack,
+}
+
+DictionaryValueCallBacks :: struct {
+	version:         Index,
+	retain:          DictionaryRetainCallBack,
+	release:         DictionaryReleaseCallBack,
+	copyDescription: DictionaryCopyDescriptionCallBack,
+	equal:           DictionaryEqualCallBack,
+}
+
+@(default_calling_convention="c")
+foreign CoreFoundation {
+	kCFTypeDictionaryKeyCallBacks: DictionaryKeyCallBacks
+	kCFTypeDictionaryValueCallBacks: DictionaryValueCallBacks
+}
+
+@(link_prefix="CF", default_calling_convention="c")
+foreign CoreFoundation {
+	DictionaryGetTypeID :: proc() -> TypeID ---
+	DictionaryCreate :: proc(allocator: AllocatorRef, keys, values: [^]rawptr, numValues: Index, keyCallBacks: ^DictionaryKeyCallBacks, valueCallBacks: ^DictionaryValueCallBacks) -> Dictionary ---
+	DictionaryCreateMutable :: proc(allocator: AllocatorRef, capacity: Index, keyCallBacks: ^DictionaryKeyCallBacks, valueCallBacks: ^DictionaryValueCallBacks) -> MutableDictionary ---
+	DictionaryGetCount :: proc(theDict: Dictionary) -> Index ---
+	DictionaryContainsKey :: proc(theDict: Dictionary, key: rawptr) -> b8 ---
+	DictionaryGetValue :: proc(theDict: Dictionary, key: rawptr) -> rawptr ---
+	DictionaryGetKeysAndValues :: proc(theDict: Dictionary, keys, values: [^]rawptr) ---
+	DictionarySetValue :: proc(theDict: MutableDictionary, key, value: rawptr) ---
+	DictionaryRemoveValue :: proc(theDict: MutableDictionary, key: rawptr) ---
+}

--- a/core/sys/darwin/CoreFoundation/CFLocale.odin
+++ b/core/sys/darwin/CoreFoundation/CFLocale.odin
@@ -1,0 +1,11 @@
+package CoreFoundation
+
+foreign import CoreFoundation "system:CoreFoundation.framework"
+
+Locale :: distinct TypeRef
+
+@(link_prefix="CF", default_calling_convention="c")
+foreign CoreFoundation {
+	LocaleGetTypeID :: proc() -> TypeID ---
+	LocaleCopyCurrent :: proc() -> Locale ---
+}

--- a/core/sys/darwin/CoreFoundation/CFNumber.odin
+++ b/core/sys/darwin/CoreFoundation/CFNumber.odin
@@ -1,0 +1,42 @@
+package CoreFoundation
+
+foreign import CoreFoundation "system:CoreFoundation.framework"
+
+Boolean :: distinct TypeRef
+Number  :: distinct TypeRef
+
+NumberType :: enum Index {
+	SInt8     = 1,
+	SInt16    = 2,
+	SInt32    = 3,
+	SInt64    = 4,
+	Float32   = 5,
+	Float64   = 6,
+	Char      = 7,
+	Short     = 8,
+	Int       = 9,
+	Long      = 10,
+	LongLong  = 11,
+	Float     = 12,
+	Double    = 13,
+	CFIndex   = 14,
+	NSInteger = 15,
+	CGFloat   = 16,
+	Max       = 16,
+}
+
+@(default_calling_convention="c")
+foreign CoreFoundation {
+	kCFBooleanTrue:  Boolean
+	kCFBooleanFalse: Boolean
+}
+
+@(link_prefix="CF", default_calling_convention="c")
+foreign CoreFoundation {
+	BooleanGetTypeID :: proc() -> TypeID ---
+	BooleanGetValue :: proc(boolean: Boolean) -> b8 ---
+	NumberGetTypeID :: proc() -> TypeID ---
+	NumberCreate :: proc(allocator: AllocatorRef, theType: NumberType, valuePtr: rawptr) -> Number ---
+	NumberGetType :: proc(number: Number) -> NumberType ---
+	NumberGetValue :: proc(number: Number, theType: NumberType, valuePtr: rawptr) -> b8 ---
+}

--- a/core/sys/darwin/CoreFoundation/CFString.odin
+++ b/core/sys/darwin/CoreFoundation/CFString.odin
@@ -161,6 +161,10 @@ StringEncodings :: enum Index {
 
 @(link_prefix="CF", default_calling_convention="c")
 foreign CoreFoundation {
+	StringGetTypeID :: proc() -> TypeID ---
+	StringCreateWithBytes :: proc(alloc: AllocatorRef, bytes: [^]u8, numBytes: Index, encoding: StringEncoding, isExternalRepresentation: b8) -> String ---
+	StringCreateWithCString :: proc(alloc: AllocatorRef, cStr: cstring, encoding: StringEncoding) -> String ---
+
 	// Copies the character contents of a string to a local C string buffer after converting the characters to a given encoding.
 	StringGetCString :: proc(theString: String, buffer: [^]byte, bufferSize: Index, encoding: StringEncoding) -> b8 ---
 

--- a/core/sys/darwin/CoreFoundation/CFStringTokenizer.odin
+++ b/core/sys/darwin/CoreFoundation/CFStringTokenizer.odin
@@ -1,0 +1,33 @@
+package CoreFoundation
+
+foreign import CoreFoundation "system:CoreFoundation.framework"
+
+StringTokenizer          :: distinct TypeRef
+StringTokenizerTokenType :: distinct OptionFlags
+
+StringTokenizerTokenNone                    :: StringTokenizerTokenType(0)
+StringTokenizerTokenNormal                  :: StringTokenizerTokenType(1 << 0)
+StringTokenizerTokenHasSubTokensMask        :: StringTokenizerTokenType(1 << 1)
+StringTokenizerTokenHasDerivedSubTokensMask :: StringTokenizerTokenType(1 << 2)
+StringTokenizerTokenHasHasNumbersMask       :: StringTokenizerTokenType(1 << 3)
+StringTokenizerTokenHasNonLettersMask       :: StringTokenizerTokenType(1 << 4)
+StringTokenizerTokenIsCJWordMask            :: StringTokenizerTokenType(1 << 5)
+
+StringTokenizerUnit :: enum OptionFlags {
+	Word                        = 0,
+	Sentence                    = 1,
+	Paragraph                   = 2,
+	LineBreak                   = 3,
+	WordBoundary                = 4,
+	AttributeLatinTranscription = 1 << 16,
+	AttributeLanguage           = 1 << 17,
+}
+
+@(link_prefix="CF", default_calling_convention="c")
+foreign CoreFoundation {
+	StringTokenizerGetTypeID :: proc() -> TypeID ---
+	StringTokenizerCreate :: proc(alloc: AllocatorRef, string: String, range: Range, options: OptionFlags, locale: Locale) -> StringTokenizer ---
+	StringTokenizerGoToTokenAtIndex :: proc(tokenizer: StringTokenizer, index: Index) -> StringTokenizerTokenType ---
+	StringTokenizerAdvanceToNextToken :: proc(tokenizer: StringTokenizer) -> StringTokenizerTokenType ---
+	StringTokenizerGetCurrentTokenRange :: proc(tokenizer: StringTokenizer) -> Range ---
+}


### PR DESCRIPTION
## Summary

- add CoreFoundation bindings for arrays, dictionaries, data, numbers, booleans, null, locales, attributed strings, and string tokenization
- add missing base ownership, type inspection, equality, and string creation APIs
- use typed collection callbacks and Apple ABI-compatible Boolean and CFNumber types

## Testing

- `odin check core/sys/darwin/CoreFoundation -no-entry-point -vet-style -vet-semicolon -warnings-as-errors`
- compiled and ran a macOS smoke test covering string, data, number, array, dictionary, attributed string, locale, and tokenizer APIs
