### PR TITLE
`core:net`: use explicitly passed allocators

### DIFF
--- a/core/net/dns.odin
+++ b/core/net/dns.odin
@@ -620,7 +620,8 @@ validate_hostname :: proc(hostname: string) -> (ok: bool) {
 	return true
 }
 
-parse_record :: proc(packet: []u8, cur_off: ^int, filter: DNS_Record_Type = nil) -> (record: DNS_Record, ok: bool) {
+parse_record :: proc(packet: []u8, cur_off: ^int, filter: DNS_Record_Type = nil, allocator := context.allocator) -> (record: DNS_Record, ok: bool) {
+	context.allocator = allocator
 	record_buf := packet[cur_off^:]
 
 	srv_record_name, hn_sz := decode_hostname(packet, cur_off^, context.temp_allocator) or_return

--- a/core/net/url.odin
+++ b/core/net/url.odin
@@ -42,12 +42,12 @@ split_url :: proc(url: string, allocator := context.allocator) -> (scheme, host,
 		query_str := s[i+1:]
 		s = s[:i]
 		if query_str != "" {
-			queries_parts := strings.split(query_str, "&")
-			defer delete(queries_parts)
+			queries_parts := strings.split(query_str, "&", allocator)
+			defer delete(queries_parts, allocator)
 			queries = make(map[string]string, len(queries_parts), allocator)
 			for q in queries_parts {
-				parts := strings.split(q, "=")
-				defer delete(parts)
+				parts := strings.split(q, "=", allocator)
+				defer delete(parts, allocator)
 				switch len(parts) {
 				case 1:  queries[parts[0]] = ""        // NOTE(tetra): Query not set to anything, was but present.
 				case 2:  queries[parts[0]] = parts[1]  // NOTE(tetra): Query set to something.

--- a/core/net/url.odin
+++ b/core/net/url.odin
@@ -44,16 +44,13 @@ split_url :: proc(url: string, allocator := context.allocator) -> (scheme, host,
 		if query_str != "" {
 			queries = make(map[string]string, allocator)
 			for query in strings.split_iterator(&query_str, "&") {
-				i = strings.index_byte(query, '=')
-				if i == -1 {
-					queries[query] = ""
-				} else {
-					value := query[i+1:]
-					if strings.index_byte(value, '=') != -1 {
-						continue // incorrect format
-					}
-					queries[query] = value // may not be set to anything, e.g. ?x=
+				query := query
+				key := strings.split_by_byte_iterator(&query, '=') or_continue
+				value, _ := strings.split_by_byte_iterator(&query, '=') // may be empty
+				if strings.index_byte(query, '=') != -1 {
+					continue // additional =, weird x=y=z format
 				}
+				queries[key] = value
 			}
 		}
 	}

--- a/core/net/url.odin
+++ b/core/net/url.odin
@@ -31,27 +31,28 @@ split_url :: proc(url: string, allocator := context.allocator) -> (scheme, host,
 		s = s[i+3:]
 	}
 
-	i = strings.index(s, "#")
+	i = strings.index_byte(s, '#')
 	if i != -1 {
 		fragment = s[i+1:]
 		s = s[:i]
 	}
 
-	i = strings.index(s, "?")
+	i = strings.index_byte(s, '?')
 	if i != -1 {
 		query_str := s[i+1:]
 		s = s[:i]
 		if query_str != "" {
-			queries_parts := strings.split(query_str, "&", allocator)
-			defer delete(queries_parts, allocator)
-			queries = make(map[string]string, len(queries_parts), allocator)
-			for q in queries_parts {
-				parts := strings.split(q, "=", allocator)
-				defer delete(parts, allocator)
-				switch len(parts) {
-				case 1:  queries[parts[0]] = ""        // NOTE(tetra): Query not set to anything, was but present.
-				case 2:  queries[parts[0]] = parts[1]  // NOTE(tetra): Query set to something.
-				case:    break
+			queries = make(map[string]string, allocator)
+			for query in strings.split_iterator(&query_str, "&") {
+				i = strings.index_byte(query, '=')
+				if i == -1 {
+					queries[query] = ""
+				} else {
+					value := query[i+1:]
+					if strings.index_byte(value, '=') != -1 {
+						continue // incorrect format
+					}
+					queries[query] = value // may not be set to anything, e.g. ?x=
 				}
 			}
 		}


### PR DESCRIPTION
Procedures were explicitly using the context.allocator, now allows passing in an allocator, and actually uses it
Fixes #7453 