### PR TITLE
docs(core/sort): document all public procedures and Interface type

### DIFF
--- a/core/sort/sort.odin
+++ b/core/sort/sort.odin
@@ -7,6 +7,17 @@ import "base:intrinsics"
 _ :: intrinsics
 ORD :: intrinsics.type_is_ordered
 
+/*
+A generic interface describing a sequence of elements that can be sorted.
+
+It provides the operations the sorting procedures use to inspect and reorder
+the elements: `len` reports the number of elements, `less` compares two
+elements, and `swap` exchanges two elements. The underlying data lives in
+`collection`.
+
+Use `slice_interface` to obtain an `Interface` for a slice, or
+`reverse_interface` to wrap an `Interface` so that it is ordered in reverse.
+*/
 Interface :: struct {
 	len:  proc(it: Interface) -> int,
 	less: proc(it: Interface, i, j: int) -> bool,
@@ -14,8 +25,30 @@ Interface :: struct {
 	collection: rawptr,
 }
 
-// sort sorts an Interface
-// This sort is not guaranteed to be stable
+/*
+Sorts the elements of an `Interface` in place.
+
+This sort is not guaranteed to be stable.
+
+Inputs:
+- it: The `Interface` to sort.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	sort_example :: proc() {
+		data := []int{5, 2, 8, 1, 9}
+		sort.sort(sort.slice_interface(&data))
+		fmt.println(data)
+	}
+
+Output:
+
+	[1, 2, 5, 8, 9]
+
+*/
 sort :: proc(it: Interface) {
 	max_depth :: proc(n: int) -> int { // 2*ceil(log2(n+1))
 		depth: int
@@ -29,6 +62,38 @@ sort :: proc(it: Interface) {
 	_quick_sort(it, 0, n, max_depth(n))
 }
 
+/*
+Creates an `Interface` over the given slice of ordered elements, for use with
+the sorting procedures.
+
+The elements are compared with the `<` operator, so the resulting sort is in
+ascending order.
+
+Inputs:
+- s: A pointer to the slice to wrap.
+
+Returns:
+- An `Interface` that describes the elements of `s`.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	slice_interface_example :: proc() {
+		data := []int{3, 1, 2}
+		it := sort.slice_interface(&data)
+		fmt.println(sort.is_sorted(it))
+		sort.sort(it)
+		fmt.println(data)
+	}
+
+Output:
+
+	false
+	[1, 2, 3]
+
+*/
 slice_interface :: proc(s: ^$T/[]$E) -> Interface where ORD(E) {
 	return Interface{
 		collection = rawptr(s),
@@ -47,6 +112,33 @@ slice_interface :: proc(s: ^$T/[]$E) -> Interface where ORD(E) {
 	}
 }
 
+/*
+Wraps an `Interface` so that the ordering is reversed, making the sorting
+procedures sort the elements in descending order.
+
+Inputs:
+- it: A pointer to the `Interface` to reverse.
+
+Returns:
+- A new `Interface` that reverses the ordering of `it`.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	reverse_interface_example :: proc() {
+		data := []int{5, 2, 8}
+		s := sort.slice_interface(&data)
+		sort.sort(sort.reverse_interface(&s))
+		fmt.println(data)
+	}
+
+Output:
+
+	[8, 5, 2]
+
+*/
 reverse_interface :: proc(it: ^Interface) -> Interface {
 	return Interface{
 		collection = it,
@@ -66,11 +158,62 @@ reverse_interface :: proc(it: ^Interface) -> Interface {
 	}
 }
 
+/*
+Sorts the elements of an `Interface` in descending order, in place.
+
+This sort is not guaranteed to be stable.
+
+Inputs:
+- it: The `Interface` to sort.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	reverse_sort_example :: proc() {
+		data := []int{5, 2, 8, 1}
+		sort.reverse_sort(sort.slice_interface(&data))
+		fmt.println(data)
+	}
+
+Output:
+
+	[8, 5, 2, 1]
+
+*/
 reverse_sort :: proc(it: Interface) {
 	it := it
 	sort(reverse_interface(&it))
 }
 
+/*
+Reports whether the elements of an `Interface` are in ascending order.
+
+Inputs:
+- it: The `Interface` to check.
+
+Returns:
+- `true` if the elements are sorted in ascending order, `false` otherwise.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	is_sorted_example :: proc() {
+		a := []int{1, 2, 3}
+		b := []int{3, 1, 2}
+		fmt.println(sort.is_sorted(sort.slice_interface(&a)))
+		fmt.println(sort.is_sorted(sort.slice_interface(&b)))
+	}
+
+Output:
+
+	true
+	false
+
+*/
 is_sorted :: proc(it: Interface) -> bool {
 	n := it->len()
 	for i := n-1; i > 0; i -= 1 {
@@ -82,12 +225,64 @@ is_sorted :: proc(it: Interface) -> bool {
 }
 
 
+/*
+Swaps `n` elements beginning at index `a` with the `n` elements beginning at
+index `b`.
+
+Inputs:
+- it: The `Interface`.
+- a: Start index of the first range to swap.
+- b: Start index of the second range to swap.
+- n: The number of elements to swap.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	swap_range_example :: proc() {
+		data := []int{1, 2, 3, 4}
+		sort.swap_range(sort.slice_interface(&data), 0, 2, 2)
+		fmt.println(data)
+	}
+
+Output:
+
+	[3, 4, 1, 2]
+
+*/
 swap_range :: proc(it: Interface, a, b, n: int) {
 	for i in 0..<n {
 		it->swap(a+i, b+i)
 	}
 }
 
+/*
+Rotates the elements of an `Interface` in the range `[a, b)` so that the
+element at index `m` becomes the first element of the range.
+
+Inputs:
+- it: The `Interface`.
+- a: Start index of the range.
+- m: The index whose element becomes first after the rotation.
+- b: Exclusive end index of the range.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	rotate_example :: proc() {
+		data := []int{0, 1, 2, 3}
+		sort.rotate(sort.slice_interface(&data), 0, 2, 4)
+		fmt.println(data)
+	}
+
+Output:
+
+	[2, 3, 0, 1]
+
+*/
 rotate :: proc(it: Interface, a, m, b: int) {
 	i := m - a
 	j := b - m
@@ -260,6 +455,33 @@ _insertion_sort :: proc(it: Interface, a, b: int) {
 	}
 }
 
+/*
+Sorts a slice in place using bubble sort, ordered by the given comparator.
+
+The comparator `f` is called with two elements and must return a negative
+number if the first is less than the second, `0` if they are equal, and a
+positive number otherwise.
+
+Inputs:
+- array: The slice to sort.
+- f: The comparator used to order the elements.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	bubble_sort_proc_example :: proc() {
+		data := []int{5, 3, 8, 1}
+		sort.bubble_sort_proc(data, sort.compare_ints)
+		fmt.println(data)
+	}
+
+Output:
+
+	[1, 3, 5, 8]
+
+*/
 bubble_sort_proc :: proc(array: $A/[]$T, f: proc(T, T) -> int) {
 	assert(f != nil)
 	count := len(array)
@@ -288,6 +510,29 @@ bubble_sort_proc :: proc(array: $A/[]$T, f: proc(T, T) -> int) {
 	}
 }
 
+/*
+Sorts a slice of ordered elements in place using bubble sort, in ascending
+order.
+
+Inputs:
+- array: The slice to sort.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	bubble_sort_example :: proc() {
+		data := []int{5, 3, 8, 1}
+		sort.bubble_sort(data)
+		fmt.println(data)
+	}
+
+Output:
+
+	[1, 3, 5, 8]
+
+*/
 bubble_sort :: proc(array: $A/[]$T) where intrinsics.type_is_ordered(T) {
 	count := len(array)
 
@@ -315,6 +560,33 @@ bubble_sort :: proc(array: $A/[]$T) where intrinsics.type_is_ordered(T) {
 	}
 }
 
+/*
+Sorts a slice in place using quick sort, ordered by the given comparator.
+
+The comparator `f` is called with two elements and must return a negative
+number if the first is less than the second, `0` if they are equal, and a
+positive number otherwise.
+
+Inputs:
+- array: The slice to sort.
+- f: The comparator used to order the elements.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	quick_sort_proc_example :: proc() {
+		data := []int{5, 3, 8, 1}
+		sort.quick_sort_proc(data, sort.compare_ints)
+		fmt.println(data)
+	}
+
+Output:
+
+	[1, 3, 5, 8]
+
+*/
 quick_sort_proc :: proc(array: $A/[]$T, f: proc(T, T) -> int) {
 	assert(f != nil)
 	a := array
@@ -343,6 +615,29 @@ quick_sort_proc :: proc(array: $A/[]$T, f: proc(T, T) -> int) {
 	quick_sort_proc(a[i:n], f)
 }
 
+/*
+Sorts a slice of ordered elements in place using quick sort, in ascending
+order.
+
+Inputs:
+- array: The slice to sort.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	quick_sort_example :: proc() {
+		data := []int{5, 3, 8, 1}
+		sort.quick_sort(data)
+		fmt.println(data)
+	}
+
+Output:
+
+	[1, 3, 5, 8]
+
+*/
 quick_sort :: proc(array: $A/[]$T) where intrinsics.type_is_ordered(T) {
 	a := array
 	n := len(a)
@@ -378,6 +673,33 @@ _log2 :: proc(x: int) -> int {
 	return res
 }
 
+/*
+Sorts a slice in place using merge sort, ordered by the given comparator.
+
+The comparator `f` is called with two elements and must return a negative
+number if the first is less than the second, `0` if they are equal, and a
+positive number otherwise.
+
+Inputs:
+- array: The slice to sort.
+- f: The comparator used to order the elements.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	merge_sort_proc_example :: proc() {
+		data := []int{5, 3, 8, 1}
+		sort.merge_sort_proc(data, sort.compare_ints)
+		fmt.println(data)
+	}
+
+Output:
+
+	[1, 3, 5, 8]
+
+*/
 merge_sort_proc :: proc(array: $A/[]$T, f: proc(T, T) -> int) {
 	merge :: proc(a: A, start, mid, end: int, f: proc(T, T) -> int) {
 		s, m := start, mid
@@ -419,6 +741,29 @@ merge_sort_proc :: proc(array: $A/[]$T, f: proc(T, T) -> int) {
 	internal_sort(array, 0, len(array)-1, f)
 }
 
+/*
+Sorts a slice of ordered elements in place using merge sort, in ascending
+order.
+
+Inputs:
+- array: The slice to sort.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	merge_sort_example :: proc() {
+		data := []int{5, 3, 8, 1}
+		sort.merge_sort(data)
+		fmt.println(data)
+	}
+
+Output:
+
+	[1, 3, 5, 8]
+
+*/
 merge_sort :: proc(array: $A/[]$T) where intrinsics.type_is_ordered(T) {
 	merge :: proc(a: A, start, mid, end: int) {
 		s, m := start, mid
@@ -460,6 +805,33 @@ merge_sort :: proc(array: $A/[]$T) where intrinsics.type_is_ordered(T) {
 	internal_sort(array, 0, len(array)-1)
 }
 
+/*
+Sorts a slice in place using heap sort, ordered by the given comparator.
+
+The comparator `f` is called with two elements and must return a negative
+number if the first is less than the second, `0` if they are equal, and a
+positive number otherwise.
+
+Inputs:
+- array: The slice to sort.
+- f: The comparator used to order the elements.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	heap_sort_proc_example :: proc() {
+		data := []int{5, 3, 8, 1}
+		sort.heap_sort_proc(data, sort.compare_ints)
+		fmt.println(data)
+	}
+
+Output:
+
+	[1, 3, 5, 8]
+
+*/
 heap_sort_proc :: proc(array: $A/[]$T, f: proc(T, T) -> int) {
 	sift_proc :: proc(a: A, pi: int, n: int, f: proc(T, T) -> int) #no_bounds_check {
 		p := pi
@@ -494,6 +866,29 @@ heap_sort_proc :: proc(array: $A/[]$T, f: proc(T, T) -> int) {
 	}
 }
 
+/*
+Sorts a slice of ordered elements in place using heap sort, in ascending
+order.
+
+Inputs:
+- array: The slice to sort.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	heap_sort_example :: proc() {
+		data := []int{5, 3, 8, 1}
+		sort.heap_sort(data)
+		fmt.println(data)
+	}
+
+Output:
+
+	[1, 3, 5, 8]
+
+*/
 heap_sort :: proc(array: $A/[]$T) where intrinsics.type_is_ordered(T) {
 	sift :: proc(a: A, pi: int, n: int) #no_bounds_check {
 		p := pi
@@ -528,6 +923,32 @@ heap_sort :: proc(array: $A/[]$T) where intrinsics.type_is_ordered(T) {
 	}
 }
 
+/*
+Compares two booleans for ordering, where `false` is considered less than
+`true`.
+
+Returns:
+- A negative number if `a` is less than `b`, `0` if they are equal, and a
+  positive number otherwise.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	compare_bools_example :: proc() {
+		fmt.println(sort.compare_bools(false, true))
+		fmt.println(sort.compare_bools(true, true))
+		fmt.println(sort.compare_bools(true, false))
+	}
+
+Output:
+
+	-1
+	0
+	1
+
+*/
 compare_bools :: proc(a, b: bool) -> int {
 	switch {
 	case !a && b: return -1
@@ -537,6 +958,31 @@ compare_bools :: proc(a, b: bool) -> int {
 }
 
 
+/*
+Compares two `int` values for ordering.
+
+Returns:
+- A negative number if `a` is less than `b`, `0` if they are equal, and a
+  positive number otherwise.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	compare_ints_example :: proc() {
+		fmt.println(sort.compare_ints(1, 2))
+		fmt.println(sort.compare_ints(2, 2))
+		fmt.println(sort.compare_ints(3, 2))
+	}
+
+Output:
+
+	-1
+	0
+	1
+
+*/
 compare_ints :: proc(a, b: int) -> int {
 	switch delta := a - b; {
 	case delta < 0: return -1
@@ -545,6 +991,31 @@ compare_ints :: proc(a, b: int) -> int {
 	return 0
 }
 
+/*
+Compares two `uint` values for ordering.
+
+Returns:
+- A negative number if `a` is less than `b`, `0` if they are equal, and a
+  positive number otherwise.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	compare_uints_example :: proc() {
+		fmt.println(sort.compare_uints(1, 2))
+		fmt.println(sort.compare_uints(2, 2))
+		fmt.println(sort.compare_uints(3, 2))
+	}
+
+Output:
+
+	-1
+	0
+	1
+
+*/
 compare_uints :: proc(a, b: uint) -> int {
 	switch {
 	case a < b: return -1
@@ -553,6 +1024,31 @@ compare_uints :: proc(a, b: uint) -> int {
 	return 0
 }
 
+/*
+Compares two `u8` values for ordering.
+
+Returns:
+- A negative number if `a` is less than `b`, `0` if they are equal, and a
+  positive number otherwise.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	compare_u8s_example :: proc() {
+		fmt.println(sort.compare_u8s(1, 2))
+		fmt.println(sort.compare_u8s(2, 2))
+		fmt.println(sort.compare_u8s(3, 2))
+	}
+
+Output:
+
+	-1
+	0
+	1
+
+*/
 compare_u8s :: proc(a, b: u8) -> int {
 	switch {
 	case a < b: return -1
@@ -561,6 +1057,31 @@ compare_u8s :: proc(a, b: u8) -> int {
 	return 0
 }
 
+/*
+Compares two `u16` values for ordering.
+
+Returns:
+- A negative number if `a` is less than `b`, `0` if they are equal, and a
+  positive number otherwise.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	compare_u16s_example :: proc() {
+		fmt.println(sort.compare_u16s(1, 2))
+		fmt.println(sort.compare_u16s(2, 2))
+		fmt.println(sort.compare_u16s(3, 2))
+	}
+
+Output:
+
+	-1
+	0
+	1
+
+*/
 compare_u16s :: proc(a, b: u16) -> int {
 	switch {
 	case a < b: return -1
@@ -569,6 +1090,31 @@ compare_u16s :: proc(a, b: u16) -> int {
 	return 0
 }
 
+/*
+Compares two `u32` values for ordering.
+
+Returns:
+- A negative number if `a` is less than `b`, `0` if they are equal, and a
+  positive number otherwise.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	compare_u32s_example :: proc() {
+		fmt.println(sort.compare_u32s(1, 2))
+		fmt.println(sort.compare_u32s(2, 2))
+		fmt.println(sort.compare_u32s(3, 2))
+	}
+
+Output:
+
+	-1
+	0
+	1
+
+*/
 compare_u32s :: proc(a, b: u32) -> int {
 	switch {
 	case a < b: return -1
@@ -577,6 +1123,31 @@ compare_u32s :: proc(a, b: u32) -> int {
 	return 0
 }
 
+/*
+Compares two `u64` values for ordering.
+
+Returns:
+- A negative number if `a` is less than `b`, `0` if they are equal, and a
+  positive number otherwise.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	compare_u64s_example :: proc() {
+		fmt.println(sort.compare_u64s(1, 2))
+		fmt.println(sort.compare_u64s(2, 2))
+		fmt.println(sort.compare_u64s(3, 2))
+	}
+
+Output:
+
+	-1
+	0
+	1
+
+*/
 compare_u64s :: proc(a, b: u64) -> int {
 	switch {
 	case a < b: return -1
@@ -585,6 +1156,31 @@ compare_u64s :: proc(a, b: u64) -> int {
 	return 0
 }
 
+/*
+Compares two `i8` values for ordering.
+
+Returns:
+- A negative number if `a` is less than `b`, `0` if they are equal, and a
+  positive number otherwise.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	compare_i8s_example :: proc() {
+		fmt.println(sort.compare_i8s(-1, 2))
+		fmt.println(sort.compare_i8s(2, 2))
+		fmt.println(sort.compare_i8s(3, 2))
+	}
+
+Output:
+
+	-1
+	0
+	1
+
+*/
 compare_i8s :: proc(a, b: i8) -> int {
 	switch {
 	case a < b: return -1
@@ -593,6 +1189,31 @@ compare_i8s :: proc(a, b: i8) -> int {
 	return 0
 }
 
+/*
+Compares two `i16` values for ordering.
+
+Returns:
+- A negative number if `a` is less than `b`, `0` if they are equal, and a
+  positive number otherwise.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	compare_i16s_example :: proc() {
+		fmt.println(sort.compare_i16s(-1, 2))
+		fmt.println(sort.compare_i16s(2, 2))
+		fmt.println(sort.compare_i16s(3, 2))
+	}
+
+Output:
+
+	-1
+	0
+	1
+
+*/
 compare_i16s :: proc(a, b: i16) -> int {
 	switch {
 	case a < b: return -1
@@ -601,6 +1222,31 @@ compare_i16s :: proc(a, b: i16) -> int {
 	return 0
 }
 
+/*
+Compares two `i32` values for ordering.
+
+Returns:
+- A negative number if `a` is less than `b`, `0` if they are equal, and a
+  positive number otherwise.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	compare_i32s_example :: proc() {
+		fmt.println(sort.compare_i32s(-1, 2))
+		fmt.println(sort.compare_i32s(2, 2))
+		fmt.println(sort.compare_i32s(3, 2))
+	}
+
+Output:
+
+	-1
+	0
+	1
+
+*/
 compare_i32s :: proc(a, b: i32) -> int {
 	switch {
 	case a < b: return -1
@@ -609,6 +1255,31 @@ compare_i32s :: proc(a, b: i32) -> int {
 	return 0
 }
 
+/*
+Compares two `i64` values for ordering.
+
+Returns:
+- A negative number if `a` is less than `b`, `0` if they are equal, and a
+  positive number otherwise.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	compare_i64s_example :: proc() {
+		fmt.println(sort.compare_i64s(-1, 2))
+		fmt.println(sort.compare_i64s(2, 2))
+		fmt.println(sort.compare_i64s(3, 2))
+	}
+
+Output:
+
+	-1
+	0
+	1
+
+*/
 compare_i64s :: proc(a, b: i64) -> int {
 	switch {
 	case a < b: return -1
@@ -620,6 +1291,31 @@ compare_i64s :: proc(a, b: i64) -> int {
 
 
 
+/*
+Compares two `f32` values for ordering.
+
+Returns:
+- A negative number if `a` is less than `b`, `0` if they are equal, and a
+  positive number otherwise.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	compare_f32s_example :: proc() {
+		fmt.println(sort.compare_f32s(1.0, 2.0))
+		fmt.println(sort.compare_f32s(2.0, 2.0))
+		fmt.println(sort.compare_f32s(3.0, 2.0))
+	}
+
+Output:
+
+	-1
+	0
+	1
+
+*/
 compare_f32s :: proc(a, b: f32) -> int {
 	switch delta := a - b; {
 	case delta < 0: return -1
@@ -627,6 +1323,31 @@ compare_f32s :: proc(a, b: f32) -> int {
 	}
 	return 0
 }
+/*
+Compares two `f64` values for ordering.
+
+Returns:
+- A negative number if `a` is less than `b`, `0` if they are equal, and a
+  positive number otherwise.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	compare_f64s_example :: proc() {
+		fmt.println(sort.compare_f64s(1.0, 2.0))
+		fmt.println(sort.compare_f64s(2.0, 2.0))
+		fmt.println(sort.compare_f64s(3.0, 2.0))
+	}
+
+Output:
+
+	-1
+	0
+	1
+
+*/
 compare_f64s :: proc(a, b: f64) -> int {
 	switch delta := a - b; {
 	case delta < 0: return -1
@@ -634,6 +1355,31 @@ compare_f64s :: proc(a, b: f64) -> int {
 	}
 	return 0
 }
+/*
+Compares two strings lexicographically (byte-wise) for ordering.
+
+Returns:
+- A negative number if `a` is less than `b`, `0` if they are equal, and a
+  positive number otherwise.
+
+Example:
+
+	import "core:fmt"
+	import "core:sort"
+
+	compare_strings_example :: proc() {
+		fmt.println(sort.compare_strings("apple", "banana"))
+		fmt.println(sort.compare_strings("apple", "apple"))
+		fmt.println(sort.compare_strings("banana", "apple"))
+	}
+
+Output:
+
+	-1
+	0
+	1
+
+*/
 compare_strings :: proc(a, b: string) -> int {
 	x := transmute(mem.Raw_String)a
 	y := transmute(mem.Raw_String)b


### PR DESCRIPTION
## Summary

Implements part of https://github.com/odin-lang/Odin/issues/2358 by documenting the `core:sort` package.

Adds `core/strings`-style doc comments for the `Interface` type and all 29 public procedures in `core/sort/sort.odin`, including `Inputs:`/`Returns:` sections and runnable `Example:`/`Output:` blocks with exact expected output for every procedure.

The only change is documentation comments — no behavior or logic changes.

## Verification

- `tests/documentation/documentation_tester.odin` (the CI doc test) was run against an `all.odin-doc` built from a package importing the core packages: **Passes: 155, Fails: 0** · Examples verified. All 29 new `sort.*` examples were generated, compiled, run, and matched their `Output:` blocks exactly.
- `odin doc core/sort` renders every public procedure/type with its doc comment.
- No `-vet`/`-strict-style` issues (comments only; `core:sort` is a library with no entry point).

## AI assistance disclosure

This PR was drafted with the assistance of an AI coding agent (opencode). The documentation was written from a careful reading of the actual `core/sort` implementation, and every `Example:`/`Output:` block was verified by compiling and running against a built `odin` compiler, plus the official documentation tester. No code changes were made by the AI.

Refs #2358