### PR TITLE
improved slice.sort_from_permutation_indices

### DIFF
--- a/core/slice/sort.odin
+++ b/core/slice/sort.odin
@@ -88,13 +88,31 @@ sort_from_permutation_indices :: proc(data: $T/[]$E, indices: []int) {
 	}
 
 	for i in 0..<len(indices) {
-		index_to_swap := indices[i]
+		next_index := indices[i]
 
-		for index_to_swap < i {
-			index_to_swap = indices[index_to_swap]
+		if next_index < 0 {
+			indices[i] *= -1
+			continue
+		}
+		
+		if next_index <= i {
+			continue
 		}
 
-		ptr_swap_non_overlapping(&data[i], &data[index_to_swap], size_of(E))
+		cur_index := i
+		temp := data[cur_index]
+
+		for next_index != i {
+			indices[cur_index] *= -1
+
+			data[cur_index] = data[next_index]
+			
+			cur_index = next_index
+			next_index = indices[cur_index]
+		}
+		
+		data[cur_index] = temp
+		indices[i] *= -1
 	}
 }
 


### PR DESCRIPTION
Old Implementation
---
follows the chain of indices each iteration until a new index is hit, effectivly doing the same thing multiple times.
performs 2x more data moves than neccessary

New Implementation 
---
immediatly moves the data into place following the indices chain, by using a temp variable
then skips indices it has allready visited by swapping their sign
the indices array is unchanged at the end


Benchmark
---
https://github.com/TheRadischen/odin-utils/blob/main/sort/test/new_permutaiton/test.odin on new branch
2 - 8x speed improvement for not much more complicated logic

```
Size: 10
new perm on 80 byte 100ns
old perm on 80 byte 200ns
new perm on 8 byte 100ns
old perm on 8 byte 200ns

Size: 100
new perm on 80 byte 400ns
old perm on 80 byte 1.3µs
new perm on 8 byte 400ns
old perm on 8 byte 1.4µs

Size: 1000
new perm on 80 byte 2.1µs
old perm on 80 byte 13.1µs
new perm on 8 byte 2.8µs
old perm on 8 byte 14µs

Size: 10000
new perm on 80 byte 56.3µs
old perm on 80 byte 242µs
new perm on 8 byte 110.3µs
old perm on 8 byte 338.8µs

Size: 100000
new perm on 80 byte 1.5164ms
old perm on 80 byte 6.6669ms
new perm on 8 byte 2.0299ms
old perm on 8 byte 7.1748ms

Size: 1000000
new perm on 80 byte 89.2422ms
old perm on 80 byte 739.469ms
new perm on 8 byte 86.1281ms
old perm on 8 byte 781.5958ms
```