### PR TITLE
Detect and error on chained offset_of expressions.

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -3146,6 +3146,13 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 			}
 
 			ast_node(se, SelectorExpr, arg0);
+			if (unparen_expr(se->expr)->kind == Ast_SelectorExpr) {
+				gbString x = expr_to_string(arg0);
+				error(ce->args[0], "Chained expressions are not allowed for '%.*s', got '%s' ", LIT(builtin_name), x);
+				gb_string_free(x);
+				return false;
+
+			}
 
 			Operand x = {};
 			check_expr(c, &x, se->expr);


### PR DESCRIPTION
Fixes #5851.

This change likely requires approval from @gingerBill: it disallows chained selector expressions in `offset_of`, rather than silently returning the wrong value.

To support expressions like `offset_of(a.b.c)` would require walking the tree back and accumulating the offsets. I'm not sure how desirable that is, and it seems to me that if someone wants to be precise with offset calculations, they would be a bit more careful than deep chaining into nested structs.

If however, that is the preference, I can take a crack at that instead.