### PR TITLE
chore: description of core:sys/posix signal.odin Sig BLOCK is incorrect

### DIFF
--- a/core/sys/posix/signal.odin
+++ b/core/sys/posix/signal.odin
@@ -333,8 +333,7 @@ SS_Flag_Bits :: enum c.int {
 SS_Flags :: bit_set[SS_Flag_Bits; c.int]
 
 Sig :: enum c.int {
-	// Resulting set is the union of the current set and the signal set and the complement of
-	// the signal set pointed to by the argument.
+	// Resulting set is the union of the current set and the signal set.
 	BLOCK   = SIG_BLOCK,
 	// Resulting set is the intersection of the current set and the complement of the signal set
 	// pointed to by the argument.


### PR DESCRIPTION
As per the manual page for sigprocmask the behaviour of BLOCK is simply to return the union of the current mask and set argument, this part of the comment appears to have been accidentally copied from the UNBLOCK behaviour and is needlessly confusing.


```
SIGPROCMASK(2)                              System Calls Manual                             SIGPROCMASK(2)

NAME
     sigprocmask – manipulate current signal mask

SYNOPSIS
     #include <signal.h>

     int
     sigprocmask(int how, const sigset_t *restrict set, sigset_t *restrict oset);

DESCRIPTION
     The sigprocmask() function examines and/or changes the current signal mask (those signals that are
     blocked from delivery).  Signals are blocked if they are members of the current signal mask set.

     If set is not null, the action of sigprocmask() depends on the value of the parameter how.  The
     signal mask is changed as a function of the specified set and the current mask.  The function is
     specified by how using one of the following values from ⟨signal.h⟩:

     SIG_BLOCK    The new mask is the union of the current mask and the specified set.
```

Current comment states
```odin
Sig :: enum c.int {
	// Resulting set is the union of the current set and the signal set and the complement of
	// the signal set pointed to by the argument.
	BLOCK   = SIG_BLOCK,
```