### PR TITLE
Implement tests for the mem.Scratch allocator

### DIFF
--- a/tests/core/mem/test_core_mem.odin
+++ b/tests/core/mem/test_core_mem.odin
@@ -324,6 +324,56 @@ test_buddy :: proc(t: ^testing.T) {
 }
 
 @test
+test_scratch_memory_reuse :: proc(t: ^testing.T) {
+	SIZE :: 8192
+
+	sa : mem.Scratch_Allocator
+
+	// The scratch allocator should not use the backing allocator, since all
+	// allocation sizes are less than SIZE.
+	mem.scratch_init(&sa, SIZE)
+	defer mem.scratch_destroy(&sa)
+
+	a, a_err := mem.scratch_alloc_bytes(&sa, 4096)
+	testing.expect(t, a_err == nil)
+
+	b, b_err := mem.scratch_alloc_bytes(&sa, 2048)
+	testing.expect(t, b_err == nil)
+
+	// Will cause a memory reset, reusing the backing memory at offset 0.
+	c, c_err := mem.scratch_alloc_bytes(&sa, 4096)
+	testing.expect(t, c_err == nil)
+
+	fail_if_allocations_overlap(t, a, b)
+	testing.expect(t, raw_data(a) == raw_data(c), "Memory not reused")
+	testing.expect(t, len(sa.leaked_allocations) == 0, "Backing allocator used")
+}
+
+@test
+test_scratch_backing_allocator :: proc(t: ^testing.T) {
+	SIZE :: 8192
+
+	sa : mem.Scratch_Allocator
+	mem.scratch_init(&sa, SIZE)
+	defer mem.scratch_destroy(&sa)
+
+	// Will be allocated in the scratch memory
+	a, a_err := mem.scratch_alloc(&sa, 4096)
+	testing.expect(t, a_err == nil)
+
+	// Will be allocated by the backing allocator
+	b, b_err := mem.scratch_alloc(&sa, 8193)
+	testing.expect(t, b_err == nil)
+
+	testing.expect(t, a == raw_data(sa.data))
+	testing.expect(
+		t,
+		len(sa.leaked_allocations) == 1 && raw_data(sa.leaked_allocations[0]) == b,
+		"Backing allocator not used",
+	)
+}
+
+@test
 test_rollback :: proc(t: ^testing.T) {
 	N :: 4096
 	buf: [N]u8


### PR DESCRIPTION
Adds more tests to ensure the correctness of the mem.Scratch allocator.

Works with commit fa0ef23, which merged PR #7516.
Fails with odin release dev-2026-09 (a2fb372b7), as expected.

Checks that the backing memory of the scratch allocator gets reused upon memory depletion.
Checks that the backing allocator only gets used when allocations bigger than the backing memory are requested.