### PR TITLE
Fix #soa pointer field access through using

### DIFF
--- a/src/llvm_backend_expr.cpp
+++ b/src/llvm_backend_expr.cpp
@@ -6659,7 +6659,15 @@ gb_internal lbAddr lb_build_addr_internal(lbProcedure *p, Ast *expr) {
 				return lb_addr(lb_find_value_from_entity(p->module, e));
 			}
 
-			lbAddr addr = lb_build_addr(p, se->expr);
+			lbAddr addr = {};
+			if (is_type_soa_pointer(tav.type)) {
+				// auto-deref p.bar, where p is an #soa pointer;
+				// same lowering as an explicit p^.bar so `using` paths
+				// go through lbAddr_SoaVariable instead of deep-GEP on the fat pointer
+				addr = lb_addr_soa_variable_from_soa_ptr(p, lb_build_expr(p, se->expr));
+			} else {
+				addr = lb_build_addr(p, se->expr);
+			}
 
 			// NOTE(harold): Only allow ivar pseudo field access on indirect selectors.
 			//				 It is incoherent otherwise as Objective-C objects are zero-sized.

--- a/src/llvm_backend_utility.cpp
+++ b/src/llvm_backend_utility.cpp
@@ -1557,27 +1557,25 @@ gb_internal lbValue lb_emit_deep_field_gep(lbProcedure *p, lbValue e, Selection 
 		type = core_type(type);
 
 		if (type->kind == Type_SoaPointer) {
+			// #soa pointer is {^container, index}; index into the selected
+			// column, then keep walking remaining selection indices (e.g. `using`)
 			lbValue addr = lb_emit_struct_ep(p, e, 0);
-			lbValue index = lb_emit_struct_ep(p, e, 1);
+			lbValue soa_index = lb_emit_struct_ep(p, e, 1);
 			addr = lb_emit_load(p, addr);
-			index = lb_emit_load(p, index);
+			soa_index = lb_emit_load(p, soa_index);
 
-			i32 first_index = sel.index[0];
-			Selection sub_sel = sel;
-			sub_sel.index.data += 1;
-			sub_sel.index.count -= 1;
-
-			lbValue arr = lb_emit_struct_ep(p, addr, first_index);
+			lbValue arr = lb_emit_struct_ep(p, addr, index);
 
 			Type *t = base_type(type_deref(addr.type));
 			GB_ASSERT(is_type_soa_struct(t));
 
 			if (t->Struct.soa_kind == StructSoa_Fixed) {
-				e = lb_emit_array_ep(p, arr, index);
+				e = lb_emit_array_ep(p, arr, soa_index);
 			} else {
-				e = lb_emit_ptr_offset(p, lb_emit_load(p, arr), index);
+				e = lb_emit_ptr_offset(p, lb_emit_load(p, arr), soa_index);
 			}
 			e.type = alloc_type_multi_pointer_to_pointer(e.type);
+			type = type_deref(e.type);
 
 		} else if (is_type_quaternion(type)) {
 			e = lb_emit_struct_ep(p, e, index);

--- a/tests/core/runtime/test_core_runtime.odin
+++ b/tests/core/runtime/test_core_runtime.odin
@@ -884,6 +884,59 @@ test_soa_for_in_addr :: proc(t: ^testing.T) {
 	testing.expect_value(t, arr.y[1], 20)
 }
 
+// field access through an #soa pointer when the field is reached via `using`
+@(test)
+test_soa_pointer_using_field :: proc(t: ^testing.T) {
+	fixed: #soa[3]struct {
+		using foo: struct {
+			bar: int,
+		},
+	}
+	fixed[1].bar = 2
+	testing.expect_value(t, fixed.foo[1].bar, 2)
+
+	p := &fixed[1]
+	testing.expect_value(t, p.bar, 2)
+	p.bar = 3
+	testing.expect_value(t, fixed[1].bar, 3)
+	testing.expect_value(t, p^.bar, 3)
+	testing.expect_value(t, p.foo.bar, 3)
+
+	// nested using
+	nested: #soa[2]struct {
+		using inner: struct {
+			using mid: struct {
+				x: int,
+			},
+			y: int,
+		},
+		z: int,
+	}
+	nested[0] = {x = 1, y = 2, z = 3}
+	np := &nested[0]
+	testing.expect_value(t, np.x, 1)
+	testing.expect_value(t, np.y, 2)
+	testing.expect_value(t, np.z, 3)
+	np.x = 10
+	np.y = 20
+	np.z = 30
+	testing.expect_value(t, nested.inner[0].mid.x, 10)
+	testing.expect_value(t, nested.inner[0].y, 20)
+	testing.expect_value(t, nested.z[0], 30)
+
+	// slice / dynamic kinds use a different column representation
+	dyn := make(#soa[dynamic]struct {
+		using foo: struct {
+			bar: int,
+		},
+	}, 2)
+	defer delete(dyn)
+	dp := &dyn[1]
+	dp.bar = 7
+	testing.expect_value(t, dyn[1].bar, 7)
+	testing.expect_value(t, dyn.foo[1].bar, 7)
+}
+
 @(test)
 test_soa_array_allocator_resize :: proc(t: ^testing.T) {
 


### PR DESCRIPTION
## Summary
- Fixes `#soa` pointer field access through `using` (`baz := &arr[1]; baz.bar = 2`), which ICEd in `lb_emit_deep_field_gep`.
- Closes #7513.

## Test plan
- [x] `./odin test tests/core/runtime` (release build)
- [x] Confirm `test_soa_pointer_using_field` covers the #7513 snippet, nested `using`, and `#soa[dynamic]`