### PR TITLE
intrinsics.type_elem_type() added case for Type_FixedCapacityDynamicArray

### DIFF
--- a/src/check_builtin.cpp
+++ b/src/check_builtin.cpp
@@ -6948,12 +6948,13 @@ gb_internal bool check_builtin_procedure(CheckerContext *c, Operand *operand, As
 				case Basic_quaternion256: operand->type = t_f64; break;
 				}
 				break;
-			case Type_Pointer:         operand->type = bt->Pointer.elem;         break;
-			case Type_Array:           operand->type = bt->Array.elem;           break;
-			case Type_EnumeratedArray: operand->type = bt->EnumeratedArray.elem; break;
-			case Type_Slice:           operand->type = bt->Slice.elem;           break;
-			case Type_DynamicArray:    operand->type = bt->DynamicArray.elem;    break;
-			case Type_SimdVector:      operand->type = bt->SimdVector.elem;      break;
+			case Type_Pointer:                   operand->type = bt->Pointer.elem;                   break;
+			case Type_Array:                     operand->type = bt->Array.elem;                     break;
+			case Type_EnumeratedArray:           operand->type = bt->EnumeratedArray.elem;           break;
+			case Type_Slice:                     operand->type = bt->Slice.elem;                     break;
+			case Type_DynamicArray:              operand->type = bt->DynamicArray.elem;              break;
+			case Type_FixedCapacityDynamicArray: operand->type = bt->FixedCapacityDynamicArray.elem; break;
+			case Type_SimdVector:                operand->type = bt->SimdVector.elem;                break;
 			}
 		}
 		operand->mode = Addressing_Type;


### PR DESCRIPTION
Little oversight ; intrinsics.type_elem_type() did not work for Fixed Capacity Dynamic Array and would just return the same type instead of it's element type.

[core:reflect](https://github.com/odin-lang/Odin/blob/104048516a778f2152a691a48a048d9a0a611177/core/reflect/reflect.odin#L221) does it correctly already.