### PR TITLE
simd_abs codegen improvement + fix for unsigned integers

### DIFF
--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -1816,15 +1816,18 @@ gb_internal lbValue lb_build_builtin_simd_proc(lbProcedure *p, Ast *expr, TypeAn
 		return res;
 	case BuiltinProc_simd_abs:
 		if (is_float) {
-			LLVMValueRef pos = arg0.value;
-			LLVMValueRef neg = LLVMBuildFNeg(p->builder, pos, "");
-			LLVMValueRef cond = LLVMBuildFCmp(p->builder, LLVMRealOGT, pos, neg, "");
-			res.value = LLVMBuildSelect(p->builder, cond, pos, neg, "");
+			LLVMTypeRef types[1] = {LLVMTypeOf(arg0.value)};
+			LLVMValueRef args[1] = {arg0.value};
+			res.value = lb_call_intrinsic(p, "llvm.fabs", args, gb_count_of(args), types, gb_count_of(types));
+		} else if (is_signed) {
+			LLVMTypeRef types[1] = {LLVMTypeOf(arg0.value)};
+			// is_int_min_poison=false, so abs(min(T)) = min(T) and not poison
+			LLVMValueRef is_int_min_poison = lb_const_bool(p->module, t_llvm_bool, false).value;
+			LLVMValueRef args[2] = {arg0.value, is_int_min_poison};
+			res.value = lb_call_intrinsic(p, "llvm.abs", args, gb_count_of(args), types, gb_count_of(types));
 		} else {
-			LLVMValueRef pos = arg0.value;
-			LLVMValueRef neg = LLVMBuildNeg(p->builder, pos, "");
-			LLVMValueRef cond = LLVMBuildICmp(p->builder, is_signed ? LLVMIntSGT : LLVMIntUGT, pos, neg, "");
-			res.value = LLVMBuildSelect(p->builder, cond, pos, neg, "");
+			// unsigned integers -> |x| = x
+			res.value = arg0.value;
 		}
 		return res;
 	case BuiltinProc_simd_min:

--- a/tests/internal/test_abs.odin
+++ b/tests/internal/test_abs.odin
@@ -1,5 +1,6 @@
 package test_internal
 
+import "base:intrinsics"
 import "core:testing"
 
 @(private="file")
@@ -165,4 +166,27 @@ abs_f64_variable :: proc(t: ^testing.T) {
 	testing.expect_value(t, abs(not_const(min(f64be))), max(f64be))
 	testing.expect_value(t, abs(not_const(max(f64be))), max(f64be))
 	testing.expect_value(t, abs(not_const(f64be(-.12345))), .12345)
+}
+
+@(test)
+simd_abs_variable :: proc(t: ^testing.T) {
+	// signed ints -> abs(min(T)) wraps to min(T)
+	i32x4 := intrinsics.simd_abs(not_const(#simd[4]i32{min(i32), -1, 0, max(i32)}))
+	testing.expect_value(t, transmute([4]i32)i32x4, [4]i32{min(i32), 1, 0, max(i32)})
+	i8x16 := intrinsics.simd_abs(not_const(#simd[16]i8{min(i8), -1, 0, max(i8), -2, 2, -3, 3, -4, 4, -5, 5, -6, 6, -7, 7}))
+	testing.expect_value(t, transmute([16]i8)i8x16, [16]i8{min(i8), 1, 0, max(i8), 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7})
+
+	// unsigned ints
+	u32x4 := intrinsics.simd_abs(not_const(#simd[4]u32{0, 1, 100, max(u32)}))
+	testing.expect_value(t, transmute([4]u32)u32x4, [4]u32{0, 1, 100, max(u32)})
+	u8x16 := intrinsics.simd_abs(not_const(#simd[16]u8{0, 1, 100, 200, 255, 128, 127, 2, 3, 4, 5, 6, 7, 8, 9, 10}))
+	testing.expect_value(t, transmute([16]u8)u8x16, [16]u8{0, 1, 100, 200, 255, 128, 127, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+
+	// floats
+	f32x4 := intrinsics.simd_abs(not_const(#simd[4]f32{0., -0., -1., -.12345}))
+	f32_expected := [4]f32{0., 0., 1., .12345}
+	testing.expect_value(t, transmute([4]u32)f32x4, transmute([4]u32)f32_expected)
+	f64x2 := intrinsics.simd_abs(not_const(#simd[2]f64{-0., min(f64)}))
+	f64_expected := [2]f64{0., max(f64)}
+	testing.expect_value(t, transmute([2]u64)f64x2, transmute([2]u64)f64_expected)
 }


### PR DESCRIPTION
This changes the simd_abs intrinsic to use the llvm.abs and llvm.fabs intrinsics instead of an explicit neg -> cmp -> select chain.

LLVM already recognizes and replaces this chain with llvm.abs for integers, but it doesn't do it for floats.
On Linux, x64, o:speed, def target (SSE), LLVM22, for 32-bit floats the current chain lowers to a xorps, maxps sequence and the llvm.fabs intrinsic lowers to a sign clearing instruction (andps) and is around 1.4x-1.6x faster (for L1 accesses, on i5-7400), with higher gains when the abs dependency chain is longer. The code size is also significantly smaller (less instructions emitted). Similar gains for f64.

For f16, the current version lowers to a libcall (no half float extension on the default target) and the PR is around 110x faster (simple sign bit clear) on the same CPU at o:speed.

For v3 targets (AVX), smaller performance gains due to the code already using the three operand instruction version (1 micro op less than SSE), but gains still rise to ~1.6x for dependency chains (for f32 and f64), and around 4x for f16 (the v3 target has the half float extensions enabled).

Note that the current version returns abs(0.0) = -0.0 and for the PR llvm.fabs changes this to abs(0.0) = 0.0. I guess, this is the reason LLVM doesn't fold the original chain to llvm.fabs in the first place.


Previous discussion for the scalar case here: https://github.com/odin-lang/Odin/pull/4797


The current version also effectively does `max(a, -a)` for unsigned integers (not that anyone would be using simd_abs with unsigned), the PR fixes it by simply returning `a` in this case:
```odin
v: #simd[4]u32 = {100, 200, 1, 2}
intrinsics.simd_abs(v)   //  -> {4294967196, 4294967096, 4294967295, 4294967294}
``` 

A small test added to tests/internal/test_abs.odin