### PR TITLE
Improve error message for constant indexing

### DIFF
--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -12211,7 +12211,7 @@ gb_internal ExprKind check_index_expr(CheckerContext *c, Operand *o, Ast *node, 
 			gbString str = expr_to_string(o->expr);
 			error(o->expr, "Cannot index a constant '%s' with a variable index", str);
 			if (!build_context.terse_errors) {
-				error_line("\tSuggestion: store the constant into a variable or index it with a constant\n");
+				error_line("\tSuggestion: store the constant into a variable or index it with a constant index\n");
 			}
 			gb_string_free(str);
 			o->mode = Addressing_Invalid;

--- a/src/check_expr.cpp
+++ b/src/check_expr.cpp
@@ -12209,9 +12209,9 @@ gb_internal ExprKind check_index_expr(CheckerContext *c, Operand *o, Ast *node, 
 		if (index < 0) {
 			ERROR_BLOCK();
 			gbString str = expr_to_string(o->expr);
-			error(o->expr, "Cannot index a constant '%s'", str);
+			error(o->expr, "Cannot index a constant '%s' with a variable index", str);
 			if (!build_context.terse_errors) {
-				error_line("\tSuggestion: store the constant into a variable in order to index it with a variable index\n");
+				error_line("\tSuggestion: store the constant into a variable or index it with a constant\n");
 			}
 			gb_string_free(str);
 			o->mode = Addressing_Invalid;


### PR DESCRIPTION
Currently, the error message implies that constants cannot be indexed at all, which is wrong. They can be indexed *with other constants*. The new error message should make it clear.

Simple test case
```odin
package main

main :: proc () {
	Test :: [1]int {1}
	y: int
	x := Test[y]
}
```

Before:
```
Error: Cannot index a constant 'Test'
    x := Test[y]
         ^~~^
    Suggestion: store the constant into a variable in order to index it with a variable index
```

After
```
Error: Cannot index a constant 'Test' with a variable index
	x := Test[y]
	     ^~~^
	Suggestion: store the constant into a variable or index it with a constant index
```