### PR TITLE
vendor/box3d: Support BOX3D_SHARED on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,8 @@ vendor/box2d/lib/box2d_windows_amd64_sse2.lib filter=lfs diff=lfs merge=lfs -tex
 vendor/box3d/lib/linux-amd64/libbox3d.a filter=lfs diff=lfs merge=lfs -text
 vendor/box3d/lib/darwin/libbox3d.a filter=lfs diff=lfs merge=lfs -text
 vendor/box3d/lib/box3d.lib filter=lfs diff=lfs merge=lfs -text
+vendor/box3d/lib/box3d.dll filter=lfs diff=lfs merge=lfs -text
+vendor/box3d/lib/box3ddll.lib filter=lfs diff=lfs merge=lfs -text
 vendor/box3d/lib/box3d_wasm.o filter=lfs diff=lfs merge=lfs -text
 vendor/miniaudio/lib/miniaudio.lib filter=lfs diff=lfs merge=lfs -text
 vendor/sdl3/SDL3.dll filter=lfs diff=lfs merge=lfs -text

--- a/vendor/box3d/box3d.odin
+++ b/vendor/box3d/box3d.odin
@@ -15,6 +15,7 @@ LIB_PATH :: (
 	else "lib/linux-amd64/libbox3d.a" when ODIN_OS == .Linux && ODIN_ARCH == .amd64 && !BOX3D_SHARED
 	else "lib/linux-arm64/libbox3d.a" when ODIN_OS == .Linux && ODIN_ARCH == .arm64 && !BOX3D_SHARED
 	else "lib/darwin/libbox3d.a"      when ODIN_OS == .Darwin && (ODIN_ARCH == .amd64 || ODIN_ARCH == .arm64) && !BOX3D_SHARED
+	else "lib/box3ddll.lib"           when ODIN_OS == .Windows && BOX3D_SHARED
 	else "lib/box3d.lib"              when ODIN_OS == .Windows
 	else ""
 )

--- a/vendor/box3d/lib/box3d.dll
+++ b/vendor/box3d/lib/box3d.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54e6efb0afbbc9de26917a757bd1ee1183d77f9f9f00fc6b990efe40fe767c51
+size 1127936

--- a/vendor/box3d/lib/box3ddll.lib
+++ b/vendor/box3d/lib/box3ddll.lib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5e41f6a2dab56ad8cae617c26ab33f6afe5f465ed4837cfd833c6350a3507f2
+size 140368

--- a/vendor/box3d/src/build.bat
+++ b/vendor/box3d/src/build.bat
@@ -17,5 +17,11 @@ if errorlevel 1 (
     exit /b 1
 )
 
+cl -nologo -MT -TC -O2 -LD -std:c17 -Dbox3d_EXPORTS -I"include" src\*.c -link -out:..\lib\box3d.dll -implib:..\lib\box3ddll.lib
+if errorlevel 1 (
+    popd
+    exit /b 1
+)
+
 del "*.obj"
 popd


### PR DESCRIPTION
Currently using box3d in my project, which makes use of DLL hot-reloading. It has some internal state that I have 0 control over and doesn't survive across DLL boundaries, which is a bit of a problem since it's statically linked in my game DLL.