### PR TITLE
Fixes simd_approx_recip and simd_approx_recip_sqrt

### DIFF
--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -1522,17 +1522,13 @@ gb_internal bool lb_llvm_simd_bulk_op_unary(lbProcedure *p, lbValue arg, LLVMVal
 
 	LLVMValueRef val = arg.value;
 	unsigned count = cast(unsigned)vt->SimdVector.count;
-	Type *elem = base_type(vt->SimdVector.elem);
 
 	if (count < default_width) {
 		LLVMValueRef *grow_indices   = gb_alloc_array(temporary_allocator(), LLVMValueRef, default_width);
 		LLVMValueRef *shrink_indices = gb_alloc_array(temporary_allocator(), LLVMValueRef, count);
 
 		for (unsigned i = 0; i < count; i++) {
-			ExactValue idx = is_type_float(elem) ?
-				exact_value_float(cast(f64)i) :
-				exact_value_u64(i);
-			shrink_indices[i] = lb_const_value(p->module, elem, idx).value;
+			shrink_indices[i] = lb_const_value(p->module, t_u32, exact_value_u64(i)).value;
 			grow_indices[i]   = shrink_indices[i];
 		}
 		for (unsigned i = count; i < default_width; i++) {
@@ -1558,8 +1554,8 @@ gb_internal bool lb_llvm_simd_bulk_op_unary(lbProcedure *p, lbValue arg, LLVMVal
 		LLVMValueRef *parts = gb_alloc_array(temporary_allocator(), LLVMValueRef, parts_count);
 		for (unsigned i = 0; i < parts_count; i++) {
 			LLVMValueRef *indices = gb_alloc_array(temporary_allocator(), LLVMValueRef, default_width);
-			for (unsigned i = 0; i < default_width; i++) {
-				indices[i] = lb_const_value(p->module, t_u32, exact_value_u64(4*i+0)).value;
+			for (unsigned j = 0; j < default_width; j++) {
+				indices[j] = lb_const_value(p->module, t_u32, exact_value_u64(i*default_width + j)).value;
 			}
 
 			parts[i] = LLVMBuildShuffleVector(p->builder, val, val, LLVMConstVector(indices, default_width), "");

--- a/tests/internal/test_simd_lane_counts.odin
+++ b/tests/internal/test_simd_lane_counts.odin
@@ -1,6 +1,7 @@
 package test_internal
 
 import "base:intrinsics"
+import "core:math"
 import "core:simd"
 import "core:testing"
 
@@ -243,4 +244,44 @@ simd_extract_accepts_a_runtime_index :: proc(t: ^testing.T) {
 	w := intrinsics.simd_replace(v, i, u32(99))
 	testing.expect_value(t, intrinsics.simd_extract(w, 2), u32(99))
 	testing.expect_value(t, intrinsics.simd_extract(w, 0), u32(10))
+}
+
+// simd_approx_recip and simd_approx_recip_sqrt
+
+@(test)
+simd_approx_recip :: proc(t: ^testing.T) {
+
+	check_approx_recip_width :: proc(t: ^testing.T, $N: int, loc := #caller_location) {
+
+		TOLERANCE :: 1e-3
+
+		v: #simd[N]f32
+		for i in 0..<N {
+			v = intrinsics.simd_replace(v, i, f32(i + 1))
+		}
+
+		r := intrinsics.simd_approx_recip(v)
+		s := intrinsics.simd_approx_recip_sqrt(v)
+		for i in 0..<N {
+			x := intrinsics.simd_extract(v, i)
+
+			want := 1 / x
+			got  := intrinsics.simd_extract(r, i)
+			testing.expectf(t, abs(got - want) <= TOLERANCE * want,
+				"simd_approx_recip(#simd[%d]f32) lane %d: got %v, want ~%v", N, i, got, want, loc = loc)
+
+			want_sqrt := 1 / math.sqrt(x)
+			got_sqrt  := intrinsics.simd_extract(s, i)
+			testing.expectf(t, abs(got_sqrt - want_sqrt) <= TOLERANCE * want_sqrt,
+				"simd_approx_recip_sqrt(#simd[%d]f32) lane %d: got %v, want ~%v", N, i, got_sqrt, want_sqrt, loc = loc)
+		}
+	}
+
+	check_approx_recip_width(t, 1)
+	check_approx_recip_width(t, 2)
+	check_approx_recip_width(t, 4)
+	check_approx_recip_width(t, 8)
+	check_approx_recip_width(t, 16)
+	check_approx_recip_width(t, 32)
+	check_approx_recip_width(t, 64)
 }


### PR DESCRIPTION
simd_approx_recip and simd_approx_recip_sqrt build lane masks incorrectly when the lane count is either larger or smaller than the default intrinsic width. Minimal example for simd_approx_recip in https://github.com/odin-lang/Odin/issues/7305, which this also fixes.