### PR TITLE
Fixes simd_select and simd_runtime_swizzle operand construction

### DIFF
--- a/src/llvm_backend_proc.cpp
+++ b/src/llvm_backend_proc.cpp
@@ -1708,6 +1708,9 @@ gb_internal lbValue lb_build_builtin_simd_proc(lbProcedure *p, Ast *expr, TypeAn
 		}
 	}
 
+	// NOTE: runtime operands must be built exactly once,
+	// a rebuilt operand is emitted again and calls will reevaluate (side effects included);
+	// consts (e.g. simd_shuffle's indices) may be rebuilt
 	lbValue arg0 = {}; if (ce->args.count > 0) arg0 = lb_build_expr(p, ce->args[0]);
 	lbValue arg1 = {}; if (ce->args.count > 1) arg1 = lb_build_expr(p, ce->args[1]);
 	lbValue arg2 = {}; if (ce->args.count > 2) arg2 = lb_build_expr(p, ce->args[2]);
@@ -2125,8 +2128,8 @@ gb_internal lbValue lb_build_builtin_simd_proc(lbProcedure *p, Ast *expr, TypeAn
 	case BuiltinProc_simd_select:
 		{
 			LLVMValueRef cond = arg0.value;
-			LLVMValueRef x = lb_build_expr(p, ce->args[1]).value;
-			LLVMValueRef y = lb_build_expr(p, ce->args[2]).value;
+			LLVMValueRef x = arg1.value;
+			LLVMValueRef y = arg2.value;
 
 			cond = LLVMBuildICmp(p->builder, LLVMIntNE, cond, LLVMConstNull(LLVMTypeOf(cond)), "");
 			res.value = LLVMBuildSelect(p->builder, cond, x, y, "");
@@ -2136,7 +2139,7 @@ gb_internal lbValue lb_build_builtin_simd_proc(lbProcedure *p, Ast *expr, TypeAn
 	case BuiltinProc_simd_runtime_swizzle:
 		{
 			LLVMValueRef src = arg0.value;
-			LLVMValueRef indices = lb_build_expr(p, ce->args[1]).value;
+			LLVMValueRef indices = arg1.value;
 			
 			Type *vt = base_type(arg0.type);
 			GB_ASSERT(vt->kind == Type_SimdVector);

--- a/tests/internal/test_simd.odin
+++ b/tests/internal/test_simd.odin
@@ -144,6 +144,68 @@ swizzle_may_widen_its_operand :: proc(t: ^testing.T) {
 	testing.expect_value(t, intrinsics.simd_extract(w, 7), u32(4))
 }
 
+// simd_select takes lane i from the 1st operand where the mask lane is nonzero/true
+// and from the 2nd otherwise
+@(test)
+simd_select_const_ops :: proc(t: ^testing.T) {
+	mask: #simd[4]i32 = {7, 0, -1, 0}
+	x:    #simd[4]i32 = {1, 2, 3, 4}
+	y:    #simd[4]i32 = {5, 6, 7, 8}
+	testing.expect_value(t, simd.to_array(intrinsics.simd_select(mask, x, y)), [4]i32{1, 6, 3, 8})
+
+	bmask: #simd[4]b32 = {false, true, true, false}
+	fx:    #simd[4]f32 = {1.5, 2.5, 3.5, 4.5}
+	fy:    #simd[4]f32 = {-1, -2, -3, -4}
+	testing.expect_value(t, simd.to_array(intrinsics.simd_select(bmask, fx, fy)), [4]f32{-1, 2.5, 3.5, -4})
+}
+
+// simd_runtime_swizzle reads src[indices[i]] into lane i
+@(test)
+simd_runtime_swizzle_const_ops :: proc(t: ^testing.T) {
+	bytes:   #simd[16]u8 = {0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150}
+	reverse: #simd[16]u8 = {15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+	testing.expect_value(t, simd.to_array(intrinsics.simd_runtime_swizzle(bytes, reverse)),
+		[16]u8{150, 140, 130, 120, 110, 100, 90, 80, 70, 60, 50, 40, 30, 20, 10, 0})
+
+	words:  #simd[4]u32 = {100, 200, 300, 400}
+	rotate: #simd[4]u32 = {1, 2, 3, 0}
+	testing.expect_value(t, simd.to_array(intrinsics.simd_runtime_swizzle(words, rotate)), [4]u32{200, 300, 400, 100})
+
+	halves: #simd[8]i16 = {0, 1, 2, 3, 4, 5, 6, 7}
+	dup:    #simd[8]i16 = {0, 0, 3, 3, 5, 5, 7, 7}
+	testing.expect_value(t, simd.to_array(intrinsics.simd_runtime_swizzle(halves, dup)), [8]i16{0, 0, 3, 3, 5, 5, 7, 7})
+}
+
+// runtime operands must evaluate once
+@(test)
+simd_select_runtime_ops :: proc(t: ^testing.T) {
+	calls: i32 = 0
+	mask: #simd[4]i32 = {1, 0, -1, 0}
+
+	count_calls :: proc(c: ^i32, site: i32) -> #simd[4]i32 {
+		c^ += 1
+		return (#simd[4]i32)(site*100 + c^)
+	}
+
+	r := intrinsics.simd_select(mask, count_calls(&calls, 1), count_calls(&calls, 2))
+	testing.expect_value(t, simd.to_array(r), [4]i32{101, 202, 101, 202})
+}
+
+// runtime operands must evaluate once
+@(test)
+simd_runtime_swizzle_runtime_ops :: proc(t: ^testing.T) {
+	calls: u16 = 0
+	src: #simd[8]u16 = {0, 1, 2, 3, 4, 5, 6, 7}
+
+	count_calls :: proc(c: ^u16) -> #simd[8]u16 {
+		c^ += 1
+		return (#simd[8]u16)(c^)
+	}
+
+	r := intrinsics.simd_runtime_swizzle(src, count_calls(&calls))
+	testing.expect_value(t, simd.to_array(r), [8]u16{1, 1, 1, 1, 1, 1, 1, 1})
+}
+
 // A pairwise operation folds adjacent lanes within each operand, so it needs an even lane
 // count -- `base:intrinsics` declares `LANES % 2 == 0`. At one lane it has nothing to pair
 // with and silently switches to combining the two operands instead, which is why that width


### PR DESCRIPTION
simd_select and simd_runtime_swizzle build and evaluate operands twice:

```odin
package main
import "core:fmt"
import "base:intrinsics"

main :: proc() {
	calls: u32 = 0
	src: #simd[4]u32 = {0, 1, 2, 3}

	count_calls :: proc(c: ^u32) -> #simd[4]u32 {
		c^ += 1
		return (#simd[4]u32)(c^)
	}

	res := intrinsics.simd_runtime_swizzle(src, count_calls(&calls))
    fmt.println(res) // -> <2, 2, 2, 2>, must be <1, 1, 1, 1>
}
```

(the PR also renames tests/internal/test_simd_lane_counts.odin to test_simd.odin, cause it already contains a bunch of tests not related to lanes)